### PR TITLE
Transaction Pool

### DIFF
--- a/sia/state.go
+++ b/sia/state.go
@@ -21,13 +21,6 @@ type State struct {
 	// FutureBlocks
 	// OrphanBlocks
 
-	// The transaction pool works by storing a list of outputs that are
-	// spent by transactions in the pool, and pointing to the transaction
-	// that spends them. That makes it really easy to look up conflicts as
-	// new transacitons arrive, and also easy to remove transactions from
-	// the pool (delete every input used in the transaction.)
-	TransactionPool map[OutputID]*Transaction
-
 	ConsensusState ConsensusState
 }
 
@@ -47,4 +40,11 @@ type ConsensusState struct {
 
 	UnspentOutputs map[OutputID]Output
 	SpentOutputs   map[OutputID]Output
+
+	// The transaction pool works by storing a list of outputs that are
+	// spent by transactions in the pool, and pointing to the transaction
+	// that spends them. That makes it really easy to look up conflicts as
+	// new transacitons arrive, and also easy to remove transactions from
+	// the pool (delete every input used in the transaction.)
+	TransactionPool map[OutputID]*Transaction
 }

--- a/sia/verify.go
+++ b/sia/verify.go
@@ -17,13 +17,13 @@ type InputSignatures struct {
 
 func (s *State) addTransactionToPool(t *Transaction) {
 	for _, input := range t.Inputs {
-		s.TransactionPool[input.OutputID] = t
+		s.ConsensusState.TransactionPool[input.OutputID] = t
 	}
 }
 
 func (s *State) removeTransactionFromPool(t *Transaction) {
 	for _, input := range t.Inputs {
-		delete(s.TransactionPool, input.OutputID)
+		delete(s.ConsensusState.TransactionPool, input.OutputID)
 	}
 }
 
@@ -32,7 +32,7 @@ func (s *State) AcceptTransaction(t *Transaction) (err error) {
 	// Check that the transaction is not in conflict with the transaction
 	// pool.
 	for _, input := range t.Inputs {
-		_, exists := s.TransactionPool[input.OutputID]
+		_, exists := s.ConsensusState.TransactionPool[input.OutputID]
 		if exists {
 			err = errors.New("conflicting transaction exists in transaction pool")
 		}


### PR DESCRIPTION
Creates a transaction pool, adds transactions to it as it sees them.

Removes transactions from the pool if they are added in a block.

Adds them back into the pool when rewinding the block.

Pretty simple. Uses a map that tracks which outputs are being spent, which is how you resolve conclicts. Adds all outputs to the map when adding a transction, and removes all outputs from the map when removing the transaction. Not completely intuitive but super simple.
