### PR TITLE
Fix encoding bug

### DIFF
--- a/sia/encoding.go
+++ b/sia/encoding.go
@@ -6,11 +6,17 @@ import (
 	"reflect"
 )
 
-// A Marshaler can be encoded to, and decoded from, a byte slice.
-// Note: UnmarshalSia may be passed a byte slice containing more than one encoded type.
-// It should return the number of bytes used to decode itself.
+// A Marshaler can be encoded as a byte slice.
+// Marshaler and Unmarshaler are separate interfaces because Unmarshaler must
+// have a pointer receiver, while Marshaler does not.
 type Marshaler interface {
 	MarshalSia() []byte
+}
+
+// An Unmarshaler can be decoded from a byte slice.
+// UnmarshalSia may be passed a byte slice containing more than one encoded type.
+// It should return the number of bytes used to decode itself.
+type Unmarshaler interface {
 	UnmarshalSia([]byte) int
 }
 
@@ -138,10 +144,10 @@ func Unmarshal(b []byte, v interface{}) (err error) {
 
 func unmarshal(b []byte, val reflect.Value) (consumed int) {
 	// check for UnmarshalSia interface first
-	if u, ok := val.Interface().(Marshaler); ok {
+	if u, ok := val.Interface().(Unmarshaler); ok {
 		return u.UnmarshalSia(b)
 	} else if val.CanAddr() {
-		if m, ok := val.Addr().Interface().(Marshaler); ok {
+		if m, ok := val.Addr().Interface().(Unmarshaler); ok {
 			return m.UnmarshalSia(b)
 		}
 	}
@@ -194,7 +200,7 @@ func unmarshal(b []byte, val reflect.Value) (consumed int) {
 		}
 		return
 	}
-	panic("could not unmarshal type " + val.Type().String())
+	panic("unknown type")
 	return
 }
 

--- a/sia/encoding_test.go
+++ b/sia/encoding_test.go
@@ -28,7 +28,21 @@ type (
 	test4 struct {
 		P *test0
 	}
+	// private field -- need to implement MarshalSia/UnmarshalSia
+	test5 struct {
+		s string
+	}
 )
+
+func (t test5) MarshalSia() []byte {
+	return append([]byte{byte(len(t.s))}, []byte(t.s)...)
+}
+
+func (t *test5) UnmarshalSia(b []byte) int {
+	n, b := int(b[0]), b[1:]
+	t.s = string(b[:n])
+	return n + 1
+}
 
 var testStructs = []interface{}{
 	test0{65537, "foo"},
@@ -36,9 +50,10 @@ var testStructs = []interface{}{
 	test2{test0{65537, "foo"}},
 	test3{test2{test0{65537, "foo"}}},
 	test4{&test0{65537, "foo"}},
+	test5{"foo"},
 }
 
-var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}}
+var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}}
 
 func TestEncoding(t *testing.T) {
 	for i := range testStructs {


### PR DESCRIPTION
Combining the Marshaler and Unmarshaler interfaces had an unintended consequence. UnmarshalSia requires a pointer receiver, so it couldn't be satisfied by non-pointer types. And since the interfaces were combined, this meant non-pointer types couldn't be recognized as Marshalers either. Splitting them apart again fixes the problem.
