### PR TITLE
Fix upload/download

### DIFF
--- a/network/rpc.go
+++ b/network/rpc.go
@@ -7,21 +7,12 @@ import (
 	"github.com/NebulousLabs/Andromeda/encoding"
 )
 
-// HandlerName truncates a string to 8 bytes. If len(name) < 8, the remaining
-// bytes are 0.
-func HandlerName(name string) []byte {
-	b := make([]byte, 8)
-	copy(b, name)
-	return b
-}
-
 // RPC performs a Remote Procedure Call by sending the procedure name and
 // encoded argument, and decoding the response into the supplied object.
 // 'resp' must be a pointer. If arg is nil, no object is sent. If 'resp' is
 // nil, no response is read.
 func (na *NetAddress) RPC(name string, arg, resp interface{}) error {
 	return na.Call(name, func(conn net.Conn) error {
-		conn.Write(HandlerName(name))
 		var data []byte
 		if arg != nil {
 			data = encoding.Marshal(arg)
@@ -77,7 +68,7 @@ func (tcps *TCPServer) Register(name string, fn interface{}) {
 		panic("registered function has wrong type signature")
 	}
 
-	ident := string(rpcName(name))
+	ident := string(handlerName(name))
 	tcps.Lock()
 	tcps.handlerMap[ident] = handler
 	tcps.Unlock()

--- a/siad/renter.go
+++ b/siad/renter.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/NebulousLabs/Andromeda/encoding"
 	"github.com/NebulousLabs/Andromeda/hash"
-	"github.com/NebulousLabs/Andromeda/network"
 	"github.com/NebulousLabs/Andromeda/siacore"
 )
 
@@ -85,11 +84,7 @@ func (e *Environment) ClientProposeContract(filename string) (err error) {
 	e.wallet.SignTransaction(&t, coveredFields)
 
 	// Negotiate the contract to the host.
-	err = host.IPAddress.Call(func(conn net.Conn) error {
-		// write header
-		if _, err := conn.Write(network.HandlerName("NegotiateContract")); err != nil {
-			return err
-		}
+	err = host.IPAddress.Call("NegotiateContract", func(conn net.Conn) error {
 		// send contract
 		if _, err := encoding.WriteObject(conn, t); err != nil {
 			return err
@@ -127,11 +122,7 @@ func (e *Environment) Download(filename string) (err error) {
 	if !ok {
 		return errors.New("no file entry for file: " + filename)
 	}
-	return fe.Host.IPAddress.Call(func(conn net.Conn) error {
-		// write header
-		if _, err := conn.Write(network.HandlerName("RetrieveFile")); err != nil {
-			return err
-		}
+	return fe.Host.IPAddress.Call("RetrieveFile", func(conn net.Conn) error {
 		// send filehash
 		if _, err := encoding.WriteObject(conn, fe.Contract.FileMerkleRoot); err != nil {
 			return err


### PR DESCRIPTION
The upload and download network calls weren't writing headers, so they couldn't be handled properly. This has been addressed by adding the header to the `Call` method.
