### PR TITLE
RPC errors

### DIFF
--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -19,21 +19,9 @@ func ReadPrefix(r io.Reader, maxLen uint64) ([]byte, error) {
 		return nil, fmt.Errorf("length %d exceeds maxLen of %d", dataLen, maxLen)
 	}
 	// read dataLen bytes
-	var data []byte
-	buf := make([]byte, 1024)
-	var total uint64
-	for total = 0; total < dataLen; {
-		n, err := r.Read(buf)
-		if err != nil {
-			return nil, err
-		}
-		data = append(data, buf[:n]...)
-		total += uint64(n)
-	}
-	if total != dataLen {
-		return nil, errors.New("length mismatch")
-	}
-	return data, nil
+	data := make([]byte, dataLen)
+	_, err := io.ReadFull(r, data)
+	return data, err
 }
 
 // ReadObject reads and decodes a length-prefixed and marshalled object.

--- a/network/handlers.go
+++ b/network/handlers.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"errors"
 	"net"
 
 	"github.com/NebulousLabs/Sia/encoding"
@@ -48,11 +47,14 @@ func (tcps *TCPServer) addRemote(conn net.Conn) (err error) {
 	connHost, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
 	addrHost, _, _ := net.SplitHostPort(string(addr))
 	if connHost != addrHost {
-		return errors.New("supplied hostname does not match connection's hostname")
+		_, err = encoding.WriteObject(conn, "supplied hostname does not match connection's hostname")
+		return
 	}
 	// check that the host is reachable on this port
-	if Ping(addr) {
-		tcps.AddPeer(addr)
+	if !Ping(addr) {
+		_, err = encoding.WriteObject(conn, "supplied hostname did not respond to ping")
+		return
 	}
+	tcps.AddPeer(addr)
 	return
 }

--- a/network/network.go
+++ b/network/network.go
@@ -116,7 +116,6 @@ func (tcps *TCPServer) handleConn(conn net.Conn) {
 	if ok {
 		fn(conn)
 		// TODO: log error
-		// no wait, send the error?
 	}
 	return
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -9,6 +10,8 @@ type Foo struct{}
 func (f Foo) Bar(i uint32) (s string, err error) {
 	if i == 0xdeadbeef {
 		s = "bar"
+	} else {
+		err = errors.New("wrong number")
 	}
 	return
 }
@@ -31,7 +34,7 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	if foo != "foo" {
-		t.Fatalf("Foo was not called")
+		t.Fatal("Foo was not called")
 	}
 
 	var bar string
@@ -40,7 +43,13 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	if bar != "bar" {
-		t.Fatalf("Bar was not called")
+		t.Fatal("Bar was not called")
+	}
+
+	// wrong number should produce an error
+	err = tcps.myAddr.RPC("Bar", 0xbadbeef, &bar)
+	if err == nil || err.Error() != "wrong number" {
+		t.Fatal("Bar returned nil or incorrect error:", err)
 	}
 }
 

--- a/sia/peers.go
+++ b/sia/peers.go
@@ -6,11 +6,6 @@ import (
 	"github.com/NebulousLabs/Sia/network"
 )
 
-// AddPeer adds a peer.
-func (c *Core) AddPeer(addr network.Address) {
-	c.server.AddPeer(addr)
-}
-
 // initializeNetwork registers the rpcs and bootstraps to the network,
 // downlading all of the blocks and establishing a peer list.
 func (c *Core) initializeNetwork(addr string, nobootstrap bool) (err error) {
@@ -25,12 +20,17 @@ func (c *Core) initializeNetwork(addr string, nobootstrap bool) (err error) {
 	// c.server.Register("NegotiateContract", c.NegotiateContract)
 	// c.server.Register("RetrieveFile", c.RetrieveFile)
 
+	// Start listener thread
+	go c.listen()
+
+	// If we aren't bootstrapping, then we're done.
+	// TODO: this means the CatchUp thread isn't spawned.
+	// It should probably be spawned after the first peer connects.
 	if nobootstrap {
-		go c.listen()
 		return
 	}
 
-	// establish an initial peer list
+	// Establish an initial peer list
 	if err = c.server.Bootstrap(); err != nil {
 		return
 	}
@@ -38,22 +38,22 @@ func (c *Core) initializeNetwork(addr string, nobootstrap bool) (err error) {
 	// Download the blockchain, getting blocks one batch at a time until an
 	// empty batch is sent.
 	go func() {
-		// Catch up the first time.
-		go c.CatchUp(c.server.RandomPeer())
-
 		// Every 2 minutes call CatchUp() on a random peer. This will help to
 		// resolve synchronization issues and keep everybody on the same page
 		// with regards to the longest chain. It's a bit of a hack but will
 		// make the network substantially more robust.
 		for {
-			time.Sleep(time.Minute * 2)
 			go c.CatchUp(c.RandomPeer())
+			time.Sleep(time.Minute * 2)
 		}
 	}()
 
-	go c.listen()
+	return
+}
 
-	return nil
+// AddPeer adds a peer.
+func (c *Core) AddPeer(addr network.Address) {
+	c.server.AddPeer(addr)
 }
 
 // RemovePeer removes a peer.


### PR DESCRIPTION
RPCs now send and receive errors. Registered functions like `SendBlocks` that return an error will write that error to the connection. If it's a `net.Conn` function like `RetrieveFile`, you have to write the error manually. All existing RPCs have been updated to make use of errors. However, there still isn't much logic for processing specific RPC errors, except in `CatchUp`, which now looks for a specific "more blocks are available" error.