### PR TITLE
Host Announcement Debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install: fmt
 	go install ./...
 
 clean:
-	rm -rf host release whitepaper.aux whitepaper.log whitepaper.pdf sia/test.wallet sia/hostdir*
+	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf sia/test.wallet sia/hostdir* sia/renterDownload
 
 test: clean install
 	go test -short ./...

--- a/consensus/contracts.go
+++ b/consensus/contracts.go
@@ -210,7 +210,7 @@ func (s *State) applyContractMaintenance(td *TransactionDiff) (diffs []OutputDif
 		contractProgress := s.Height() - contract.Start
 		if s.Height() > contract.Start && contractProgress%contract.ChallengeWindow == 0 {
 			// If the proof was missed for this window, add an output.
-			cd := &ContractDiff{
+			cd := ContractDiff{
 				Contract:             openContract.FileContract,
 				ContractID:           openContract.ContractID,
 				New:                  false,
@@ -225,6 +225,7 @@ func (s *State) applyContractMaintenance(td *TransactionDiff) (diffs []OutputDif
 			}
 			openContract.WindowSatisfied = false
 			cd.NewOpenContract = *openContract
+			td.ContractDiffs = append(td.ContractDiffs, cd)
 		}
 
 		// Check for a terminated contract.

--- a/sia/core.go
+++ b/sia/core.go
@@ -131,10 +131,6 @@ func CreateCore(config Config) (c *Core, err error) {
 	if err != nil {
 		return
 	}
-	err = c.UpdateHost(hostInfo.Announcement)
-	if err != nil {
-		return
-	}
 	err = c.hostDB.Update(0, nil, []consensus.Block{genesisBlock})
 	if err != nil {
 		return
@@ -153,6 +149,13 @@ func CreateCore(config Config) (c *Core, err error) {
 	if err == network.ErrNoPeers {
 		fmt.Println("Warning: no peers responded to bootstrap request. Add peers manually to enable bootstrapping.")
 	} else if err != nil {
+		return
+	}
+
+	// TODO: Move this back up or something. The defaults are all being set in
+	// weird hacky places.
+	err = c.UpdateHost(hostInfo.Announcement)
+	if err != nil {
 		return
 	}
 

--- a/sia/host.go
+++ b/sia/host.go
@@ -1,6 +1,7 @@
 package sia
 
 import (
+	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/sia/components"
 )
 
@@ -10,8 +11,22 @@ func (c *Core) HostInfo() (components.HostInfo, error) {
 
 // TODO: Make a better UpdateHost thing.
 func (c *Core) UpdateHost(announcement components.HostAnnouncement) error {
+	info, err := c.host.HostInfo()
+	if err != nil {
+		return err
+	}
+	// TODO: This stuff should not happen here, it should be managed by
+	// hostSetConfigHandler.
+	announcementUpdate := info.Announcement
+	announcementUpdate.IPAddress = c.server.Address()
+	announcementUpdate.TotalStorage = announcement.TotalStorage
+	announcementUpdate.MaxFilesize = announcement.MaxFilesize
+	announcementUpdate.MinTolerance = announcement.MinTolerance
+	announcementUpdate.Price = announcement.Price
+	announcementUpdate.Burn = announcement.Burn
+
 	update := components.HostUpdate{
-		Announcement:    announcement,
+		Announcement:    announcementUpdate,
 		Height:          c.Height(),
 		HostDir:         c.hostDir,
 		TransactionChan: c.transactionChan,
@@ -19,4 +34,12 @@ func (c *Core) UpdateHost(announcement components.HostAnnouncement) error {
 	}
 
 	return c.host.UpdateHost(update)
+}
+
+func (c *Core) AnnounceHost(freezeVolume consensus.Currency, freezeUnlockHeight consensus.BlockHeight) (err error) {
+	_, err = c.host.AnnounceHost(freezeVolume, freezeUnlockHeight)
+	if err != nil {
+		return
+	}
+	return
 }

--- a/sia/host/host.go
+++ b/sia/host/host.go
@@ -54,6 +54,10 @@ func New(state *consensus.State, wallet components.Wallet) (h *Host, err error) 
 		return
 	}
 
+	addr, _, err := wallet.CoinAddress()
+	if err != nil {
+		return
+	}
 	h = &Host{
 		state:  state,
 		wallet: wallet,
@@ -61,10 +65,12 @@ func New(state *consensus.State, wallet components.Wallet) (h *Host, err error) 
 		announcement: components.HostAnnouncement{
 			MaxFilesize:        4 * 1000 * 1000,
 			MaxDuration:        1008, // One week.
-			MinChallengeWindow: 3,
-			MinTolerance:       1,
+			MinChallengeWindow: 20,
+			MaxChallengeWindow: 100,
+			MinTolerance:       2,
 			Price:              1,
 			Burn:               1,
+			CoinAddress:        addr,
 		},
 
 		contracts: make(map[consensus.ContractID]contractObligation),

--- a/sia/host/proofs.go
+++ b/sia/host/proofs.go
@@ -127,7 +127,7 @@ func (h *Host) createStorageProof(entry ContractEntry, heightForProof consensus.
 		err = errors.New("no record of that file")
 		return
 	}
-	fullname := h.hostDir + contractObligation.filename
+	fullname := filepath.Join(h.hostDir, contractObligation.filename)
 
 	// Open the file.
 	file, err := os.Open(fullname)

--- a/sia/host_test.go
+++ b/sia/host_test.go
@@ -14,23 +14,12 @@ func testHostAnnouncement(t *testing.T, c *Core) {
 	prevSize := c.hostDB.Size()
 
 	// Add test settings to the host.
-	coinAddress, _, err := c.wallet.CoinAddress()
-	if err != nil {
-		t.Fatal(err)
-	}
 	hostAnnouncement := components.HostAnnouncement{
-		IPAddress:          c.server.Address(),
-		TotalStorage:       10 * 1000,
-		MinFilesize:        64,
-		MaxFilesize:        2 * 1000,
-		MinDuration:        20,
-		MaxDuration:        52 * 1008,
-		MinChallengeWindow: 50,
-		MaxChallengeWindow: 200,
-		MinTolerance:       5,
-		Price:              2,
-		Burn:               2,
-		CoinAddress:        coinAddress,
+		TotalStorage: 10 * 1000,
+		MaxFilesize:  2 * 1000,
+		MinTolerance: 5,
+		Price:        2,
+		Burn:         2,
 	}
 	c.UpdateHost(hostAnnouncement)
 

--- a/sia/hostdb/hostentries.go
+++ b/sia/hostdb/hostentries.go
@@ -26,6 +26,19 @@ import (
 // price. This is also a bit simplistic however, because we're not sure what
 // the host might be charging for bandwidth.
 func entryWeight(entry components.HostEntry) consensus.Currency {
+	// Catch a divide by 0 error, and let all hosts have at least some weight.
+	//
+	// TODO: Perhaps there's a better way to do this.
+	if entry.Price == 0 {
+		entry.Price = 1
+	}
+	if entry.Burn == 0 {
+		entry.Burn = 1
+	}
+	if entry.Freeze == 0 {
+		entry.Freeze = 1
+	}
+
 	adjustedBurn := float64(entry.Burn)
 	adjustedFreeze := float64(entry.Freeze)
 	adjustedPrice := math.Sqrt(float64(entry.Price))

--- a/sia/renter/rent.go
+++ b/sia/renter/rent.go
@@ -182,7 +182,7 @@ func (r *Renter) RentSmallFile(rsfp components.RentSmallFileParameters) (err err
 	var pieces []FilePiece
 	for i := 0; i < rsfp.TotalPieces; i++ {
 		var piece FilePiece
-		piece, err = r.proposeSmallContract(rsfp.FullFile, consensus.BlockHeight(2000))
+		piece, err = r.proposeSmallContract(rsfp.FullFile, consensus.BlockHeight(800))
 		if err != nil {
 			return
 		}

--- a/siad/apihost.go
+++ b/siad/apihost.go
@@ -44,5 +44,10 @@ func (d *daemon) hostSetConfigHandler(w http.ResponseWriter, req *http.Request) 
 		http.Error(w, "Could not update host:"+err.Error(), 400)
 	}
 
+	err = d.core.AnnounceHost(1, d.core.Height()+20) // A freeze volume and unlock height.
+	if err != nil {
+		http.Error(w, "Could not update host:"+err.Error(), 400)
+	}
+
 	writeSuccess(w)
 }

--- a/siad/main.go
+++ b/siad/main.go
@@ -115,7 +115,7 @@ func main() {
 
 	// Set default values, which have the lowest priority.
 	defaultConfigFile := path.Join(siaDir, "config")
-	defaultHostDir := path.Join(siaDir, "host")
+	defaultHostDir := path.Join(siaDir, "hostdir")
 	defaultStyleDir := path.Join(siaDir, "style")
 	defaultDownloadDir := "~/Downloads"
 	defaultWalletFile := path.Join(siaDir, "sia.wallet")

--- a/siad/main.go
+++ b/siad/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"code.google.com/p/gcfg"
 	"github.com/mitchellh/go-homedir"
@@ -114,11 +114,11 @@ func main() {
 	})
 
 	// Set default values, which have the lowest priority.
-	defaultConfigFile := path.Join(siaDir, "config")
-	defaultHostDir := path.Join(siaDir, "hostdir")
-	defaultStyleDir := path.Join(siaDir, "style")
+	defaultConfigFile := filepath.Join(siaDir, "config")
+	defaultHostDir := filepath.Join(siaDir, "hostdir")
+	defaultStyleDir := filepath.Join(siaDir, "style")
 	defaultDownloadDir := "~/Downloads"
-	defaultWalletFile := path.Join(siaDir, "sia.wallet")
+	defaultWalletFile := filepath.Join(siaDir, "sia.wallet")
 	root.PersistentFlags().StringVarP(&config.Siad.APIaddr, "api-addr", "a", "localhost:9980", "which host:port is used to communicate with the user")
 	root.PersistentFlags().StringVarP(&config.Siacore.RPCaddr, "rpc-addr", "r", ":9988", "which port is used when talking to other nodes on the network")
 	root.PersistentFlags().BoolVarP(&config.Siacore.NoBootstrap, "no-bootstrap", "n", false, "disable bootstrapping on this run")

--- a/siad/web.go
+++ b/siad/web.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"path/filepath"
 )
 
 // webIndex loads a partial page according to the http request and composes it
@@ -14,9 +14,9 @@ func (d *daemon) webIndex(w http.ResponseWriter, req *http.Request) {
 	var fileToLoad string
 	if req.URL.Path == "/" {
 		// Make a special case for the index.
-		fileToLoad = path.Join(d.styleDir, "index.html")
+		fileToLoad = filepath.Join(d.styleDir, "index.html")
 	} else {
-		fileToLoad = path.Join(d.styleDir, "index.html#") + req.URL.Path
+		fileToLoad = filepath.Join(d.styleDir, "index.html#") + req.URL.Path
 	}
 
 	// Load the partial file.


### PR DESCRIPTION
Host announcing wasn't working in the api. There were actually a few issues that were preventing things from running smoothly.

This PR fixes all of those things, although in a hacky way that definitely needs to be revisited. The problem is really that announcing yourself as a host should be it's own call, but it's too late tonight to make that actually happen. Additionally, the way that HostUpdate currently works is completely wrong and should be like that at all. Additionally, the way the API leaves a bunch of values blank in the HostUpdate struct is also incorrect, it needs to fill in the old values instead of just leaving some blank.

But that was going to be difficult, so I moved the code elsewhere.