### PR TITLE
fixes for file uploading

### DIFF
--- a/sia/components/wallet.go
+++ b/sia/components/wallet.go
@@ -1,7 +1,13 @@
 package components
 
 import (
+	"errors"
+
 	"github.com/NebulousLabs/Sia/consensus"
+)
+
+var (
+	LowBalanceErr = errors.New("Insufficient Balance")
 )
 
 type WalletInfo struct {

--- a/sia/core.go
+++ b/sia/core.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/network"
@@ -160,6 +161,47 @@ func CreateCore(config Config) (c *Core, err error) {
 	}
 
 	return
+}
+
+func (c *Core) ScanMutexes() {
+	var state, host, hostdb, miner, renter, wallet int
+	go func() {
+		c.state.Lock()
+		c.state.Unlock()
+		state++
+	}()
+	go func() {
+		c.host.HostInfo()
+		host++
+	}()
+	go func() {
+		c.hostDB.Size()
+		hostdb++
+	}()
+	go func() {
+		c.miner.Threads()
+		miner++
+	}()
+	go func() {
+		c.renter.RentInfo()
+		renter++
+	}()
+	go func() {
+		c.wallet.WalletInfo()
+		wallet++
+	}()
+
+	go func() {
+		fmt.Println("mutex testing has started.")
+		time.Sleep(time.Second * 10)
+		fmt.Println("mutext testing results (0 means deadlock, 1 means success):")
+		fmt.Println("State: ", state)
+		fmt.Println("Host: ", host)
+		fmt.Println("HostDB: ", hostdb)
+		fmt.Println("Miner: ", miner)
+		fmt.Println("Renter: ", renter)
+		fmt.Println("Wallet: ", wallet)
+	}()
 }
 
 // Close does any finishing maintenence before the environment can be garbage

--- a/sia/renter/rent.go
+++ b/sia/renter/rent.go
@@ -178,6 +178,8 @@ func (r *Renter) RentSmallFile(rsfp components.RentSmallFileParameters) (err err
 	_, exists := r.files[rsfp.Nickname]
 	if exists {
 		return errors.New("file of that nickname already exists")
+	} else if rsfp.Nickname == "" {
+		return errors.New("cannot use empty string for nickname")
 	}
 	r.mu.RUnlock()
 

--- a/sia/renter/renter.go
+++ b/sia/renter/renter.go
@@ -33,6 +33,9 @@ type Renter struct {
 }
 
 func (r *Renter) RentInfo() (ri components.RentInfo, err error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	for key := range r.files {
 		ri.Files = append(ri.Files, key)
 	}

--- a/sia/wallet/outputs.go
+++ b/sia/wallet/outputs.go
@@ -2,9 +2,9 @@ package wallet
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/NebulousLabs/Sia/consensus"
+	"github.com/NebulousLabs/Sia/sia/components"
 	"github.com/NebulousLabs/Sia/signatures"
 )
 
@@ -63,7 +63,12 @@ func (w *Wallet) findOutputs(amount consensus.Currency) (spendableOutputs []*spe
 
 	// This code will only be reached if total < amount, meaning insufficient
 	// funds.
-	err = fmt.Errorf("insufficient funds, requested %v but only have %v", amount, total)
+	//
+	// TODO: Figure out some way to return a named error that also contains
+	// custom information.
+	// err = fmt.Errorf("insufficient funds, requested %v but only have %v", amount, total)
+	err = components.LowBalanceErr
+
 	return
 }
 

--- a/siad/api.go
+++ b/siad/api.go
@@ -44,6 +44,7 @@ func (d *daemon) handle(addr string) {
 	http.HandleFunc("/update/check", d.updateCheckHandler)
 	http.HandleFunc("/update/apply", d.updateApplyHandler)
 	http.HandleFunc("/stop", d.stopHandler)
+	http.HandleFunc("/mutextest", d.mutexTestHandler)
 
 	http.ListenAndServe(addr, nil)
 }
@@ -125,4 +126,8 @@ func (d *daemon) updateApplyHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	writeSuccess(w)
+}
+
+func (d *daemon) mutexTestHandler(w http.ResponseWriter, req *http.Request) {
+	d.core.ScanMutexes()
 }


### PR DESCRIPTION
This should prevent files from not appearing if you don't have enough outputs.

This is a dirty fix for something that's actually the fault of the wallet and the transaction pool (the transaction pool needs a way to recognize transaction dependencies before the wallet can chain transactions). Again, a pretty easy fix in theory but it's going to take a few hours to get right.

Plus we're at the point where we'll be writing a great deal more tests, which will slow down new features even more.