### PR TITLE
Fix state freezing

### DIFF
--- a/consensus/blocks.go
+++ b/consensus/blocks.go
@@ -92,9 +92,9 @@ func (s *State) validateHeader(parent *BlockNode, b *Block) (err error) {
 	if skew > FutureThreshold {
 		go func(skew Timestamp, b Block) {
 			time.Sleep(time.Duration(skew-FutureThreshold) * time.Second)
-			s.Lock()
+			// s.Lock()
 			s.AcceptBlock(b)
-			s.Unlock()
+			// s.Unlock()
 		}(skew, *b)
 		err = FutureBlockErr
 		return


### PR DESCRIPTION
Sometimes the state would freeze during regular usage of the program.
Though we were unable to track down the exact source of the problem, the
simple truth is that the state mutexing does not follow the conventions,
as it was written before the conventions.

The only way to be certain about a fix is to completely overhaul how the
state manages mutexes, so in the meantime I've just made some dangerous
changes that will allow race conditions through sometimes. They will
also probably prevent deadlock, though since we can't consistently
trigger the error I'm not certain.

This unfortunately goes on the list of things that we hope to fix during
architecture week.