### PR TITLE
add uploadpath call

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,27 +4,28 @@ Siad API
 Unless otherwise specified, API calls return the JSON object { "Success": true }.
 Errors are sent as plaintext, accompanied by an appropriate status code.
 
-| Path              | Params                       | Response                     |
-|:------------------|:-----------------------------|:-----------------------------|
-| /host/config      |                              | See HostInfo                 |
-| /host/setconfig   | See HostInfo                 |                              |
-| /miner/start      | `threads`                    |                              |
-| /miner/status     |                              | See MinerInfo                |
-| /miner/stop       |                              |                              |
-| /wallet/address   |                              | `{ "Address" }`              |
-| /wallet/send      | `amount`, `dest`             |                              |
-| /wallet/status    |                              | See WalletInfo               |
-| /file/upload      | `pieces`, `file`, `nickname` |                              |
-| /file/download    | `nickname`, `filename`       |                              |
-| /file/status      |                              | `[ "File" ]`                 |
-| /peer/add         | `addr`                       |                              |
-| /peer/remove      | `addr`                       |                              |
-| /peer/status      |                              | `[ "Address" ]`              |
-| /update/check     |                              | `{ "Available", "Version" }` |
-| /update/apply     | `version`                    |                              |
-| /status           |                              | See StateInfo                |
-| /stop             |                              |                              |
-| /sync             |                              |                              |
+| Path              | Params                           | Response                     |
+|:------------------|:---------------------------------|:-----------------------------|
+| /host/config      |                                  | See HostInfo                 |
+| /host/setconfig   | See HostInfo                     |                              |
+| /miner/start      | `threads`                        |                              |
+| /miner/status     |                                  | See MinerInfo                |
+| /miner/stop       |                                  |                              |
+| /wallet/address   |                                  | `{ "Address" }`              |
+| /wallet/send      | `amount`, `dest`                 |                              |
+| /wallet/status    |                                  | See WalletInfo               |
+| /file/upload      | `file`, `nickname`, `pieces`     |                              |
+| /file/uploadpath  | `filename`, `nickname`, `pieces` |                              |
+| /file/download    | `nickname`, `filename`           |                              |
+| /file/status      |                                  | `[ "File" ]`                 |
+| /peer/add         | `addr`                           |                              |
+| /peer/remove      | `addr`                           |                              |
+| /peer/status      |                                  | `[ "Address" ]`              |
+| /update/check     |                                  | `{ "Available", "Version" }` |
+| /update/apply     | `version`                        |                              |
+| /status           |                                  | See StateInfo                |
+| /stop             |                                  |                              |
+| /sync             |                                  |                              |
 
 HostInfo comprises the following values:
 ```

--- a/siac/filecmd.go
+++ b/siac/filecmd.go
@@ -17,7 +17,7 @@ var (
 	}
 
 	fileUploadCmd = &cobra.Command{
-		Use:   "upload [file] [nickname] [pieces]",
+		Use:   "upload [filename] [nickname] [pieces]",
 		Short: "Upload a file",
 		Long:  "Upload a file using a given nickname and split across 'pieces' hosts.",
 		Run:   wrap(fileuploadcmd),
@@ -38,13 +38,14 @@ var (
 	}
 )
 
-func fileuploadcmd(file, nickname, pieces string) {
-	err := callAPI(fmt.Sprintf("/file/upload?file=%s&nickname=%s&pieces=%s", file, nickname, pieces))
+// siac does not support /file/upload, only /file/uploadpath
+func fileuploadcmd(filename, nickname, pieces string) {
+	err := callAPI(fmt.Sprintf("/file/uploadpath?filename=%s&nickname=%s&pieces=%s", filename, nickname, pieces))
 	if err != nil {
 		fmt.Println("Could not upload file:", err)
 		return
 	}
-	fmt.Println("Uploaded", file, "as", nickname)
+	fmt.Println("Uploaded", filename, "as", nickname)
 }
 
 func filedownloadcmd(nickname, filename string) {

--- a/siad/api.go
+++ b/siad/api.go
@@ -30,6 +30,7 @@ func (d *daemon) handle(addr string) {
 
 	// File API Calls
 	http.HandleFunc("/file/upload", d.fileUploadHandler)
+	http.HandleFunc("/file/uploadpath", d.fileUploadPathHandler)
 	http.HandleFunc("/file/download", d.fileDownloadHandler)
 	http.HandleFunc("/file/status", d.fileStatusHandler)
 

--- a/siad/apifile.go
+++ b/siad/apifile.go
@@ -44,6 +44,27 @@ func (d *daemon) fileUploadHandler(w http.ResponseWriter, req *http.Request) {
 	writeSuccess(w)
 }
 
+func (d *daemon) fileUploadPathHandler(w http.ResponseWriter, req *http.Request) {
+	pieces, err := strconv.Atoi(req.FormValue("pieces"))
+	if err != nil {
+		http.Error(w, "Malformed pieces", 400)
+		return
+	}
+
+	// TODO: is "" a valid nickname? The renter should probably prevent this.
+	err = d.core.RentFile(components.RentFileParameters{
+		Filepath:    req.FormValue("filename"),
+		Nickname:    req.FormValue("nickname"),
+		TotalPieces: pieces,
+	})
+	if err != nil {
+		http.Error(w, "Upload failed: "+err.Error(), 500)
+		return
+	}
+
+	writeSuccess(w)
+}
+
 func (d *daemon) fileDownloadHandler(w http.ResponseWriter, req *http.Request) {
 	err := d.core.RenterDownload(req.FormValue("nickname"), filepath.Join(d.downloadDir, req.FormValue("filename")))
 	if err != nil {


### PR DESCRIPTION
Seve noticed that siac is not properly uploading files. This PR adds a new API call, `/file/uploadpath`, that takes a filename instead of reading file data from the connection.