### PR TITLE
Graceful shutdown

### DIFF
--- a/sia/core.go
+++ b/sia/core.go
@@ -205,6 +205,7 @@ func (c *Core) ScanMutexes() {
 
 // Close does any finishing maintenence before the environment can be garbage
 // collected. Right now that just means closing the server.
+// TODO: save wallet
 func (c *Core) Close() {
 	c.server.Close()
 }

--- a/siac/main.go
+++ b/siac/main.go
@@ -18,7 +18,8 @@ const (
 )
 
 // get wraps a GET request with a status code check, such that if the GET does
-// not return 200, the error will be read and returned.
+// not return 200, the error will be read and returned. The response body is
+// not closed.
 func get(call string) (resp *http.Response, err error) {
 	resp, err = http.Get(hostname + call)
 	if err != nil {
@@ -38,11 +39,11 @@ func getAPI(call string, obj interface{}) (err error) {
 	if err != nil {
 		return
 	}
+	defer resp.Body.Close()
 	err = json.NewDecoder(resp.Body).Decode(obj)
 	if err != nil {
 		return
 	}
-	resp.Body.Close()
 	return
 }
 

--- a/siad/api.go
+++ b/siad/api.go
@@ -48,7 +48,8 @@ func (d *daemon) handle(addr string) {
 	// For debugging purposes only
 	http.HandleFunc("/mutextest", d.mutexTestHandler)
 
-	http.ListenAndServe(addr, nil)
+	go http.ListenAndServe(addr, nil)
+	<-d.stop
 }
 
 // writeJSON writes the object to the ResponseWriter. If the encoding fails, an

--- a/siad/apimisc.go
+++ b/siad/apimisc.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	"os"
 )
 
 func (d *daemon) updateCheckHandler(w http.ResponseWriter, req *http.Request) {
@@ -33,9 +32,10 @@ func (d *daemon) statusHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func (d *daemon) stopHandler(w http.ResponseWriter, req *http.Request) {
-	// TODO: more graceful shutdown?
 	d.core.Close()
-	os.Exit(0)
+	writeSuccess(w)
+	// send stop signal
+	d.stop <- struct{}{}
 }
 
 func (d *daemon) syncHandler(w http.ResponseWriter, req *http.Request) {

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -21,6 +21,8 @@ type daemon struct {
 	downloadDir string
 
 	template *template.Template
+
+	stop chan struct{}
 }
 
 func startDaemon(config Config) (err error) {
@@ -36,6 +38,7 @@ func startDaemon(config Config) (err error) {
 	d := &daemon{
 		styleDir:    config.Siad.StyleDirectory,
 		downloadDir: config.Siad.DownloadDirectory,
+		stop:        make(chan struct{}),
 	}
 
 	state, _ := consensus.CreateGenesisState() // the `_` is not of type error.


### PR DESCRIPTION
siad no longer terminates via `os.Exit`, but simply by returning. It accomplishes this by waiting on a channel. It can also be killed via interrupt, and will attempt to shutdown cleanly. I'd like it to save the wallet file before closing; however, the Wallet interface no longer has a `Save` method, so right now there's no way to do it cleanly. (It can be done "uncleanly," via type assertion, but I opted not to do so.)