### PR TITLE
graceful http shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ dependencies:
 	go get -u github.com/inconshreveable/go-update
 	go get -u github.com/agl/ed25519
 	go get -u golang.org/x/crypto/twofish
+	go get -u github.com/stretchr/graceful
 
 # Cross Compile - makes binaries for windows, linux, and mac, 32 and 64 bit.
 xc:

--- a/siad/api.go
+++ b/siad/api.go
@@ -55,14 +55,14 @@ func (d *daemon) handle(addr string) {
 	mux.HandleFunc("/mutextest", d.mutexTestHandler)
 
 	// create graceful HTTP server
-	d.srv = &graceful.Server{
+	d.apiServer = &graceful.Server{
 		Timeout: apiTimeout,
 		Server:  &http.Server{Addr: addr, Handler: mux},
 	}
 
 	// graceful will run until it catches a signal.
 	// it can also be stopped manually by stopHandler.
-	d.srv.ListenAndServe()
+	d.apiServer.ListenAndServe()
 }
 
 // writeJSON writes the object to the ResponseWriter. If the encoding fails, an

--- a/siad/apimisc.go
+++ b/siad/apimisc.go
@@ -35,7 +35,7 @@ func (d *daemon) stopHandler(w http.ResponseWriter, req *http.Request) {
 	writeSuccess(w)
 
 	// send stop signal
-	d.srv.Stop(1e9)
+	d.apiServer.Stop(1e9)
 }
 
 func (d *daemon) syncHandler(w http.ResponseWriter, req *http.Request) {

--- a/siad/apimisc.go
+++ b/siad/apimisc.go
@@ -32,10 +32,10 @@ func (d *daemon) statusHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func (d *daemon) stopHandler(w http.ResponseWriter, req *http.Request) {
-	d.core.Close()
 	writeSuccess(w)
+
 	// send stop signal
-	d.stop <- struct{}{}
+	d.srv.Stop(1e9)
 }
 
 func (d *daemon) syncHandler(w http.ResponseWriter, req *http.Request) {

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -29,7 +29,7 @@ type daemon struct {
 
 	template *template.Template
 
-	srv *graceful.Server
+	apiServer *graceful.Server
 }
 
 func startDaemon(config Config) (err error) {


### PR DESCRIPTION
Apologies to Seve (again).

Only bummer here is that our ability to handle "/stop" calls versus interrupts is a bit limited. But I wasn't using that for anything anyway, except to print "Caught deadly signal" in the event of an interrupt.