### PR TITLE
Catch Up fixes

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	timeout   = time.Second * 5
+	timeout   = time.Second * 10
 	maxMsgLen = 1 << 24
 )
 

--- a/sia/synchronize.go
+++ b/sia/synchronize.go
@@ -2,6 +2,7 @@ package sia
 
 import (
 	"errors"
+	"time"
 
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/network"
@@ -101,6 +102,9 @@ func (c *Core) CatchUp(peer network.Address) {
 	// recursively. Furthermore, if there is a reorg that's greater than 100
 	// blocks, CatchUp is going to fail outright.
 	if err != nil && err.Error() == moreBlocksErr.Error() {
+		// sleep long enough for state to accept all blocks
+		// TODO: this needs to be replaced by a more deterministic wait.
+		time.Sleep(time.Second)
 		go c.CatchUp(peer)
 	}
 }

--- a/sia/synchronize.go
+++ b/sia/synchronize.go
@@ -35,8 +35,9 @@ func (c *Core) SendBlocks(knownBlocks [32]consensus.BlockID) (blocks []consensus
 		return
 	}
 
-	// Send over all blocks from the first known block.
-	for i := highest; i < highest+MaxCatchUpBlocks; i++ {
+	// Send blocks, starting with the child of the most recent known block.
+	start := highest + 1
+	for i := start; i < start+MaxCatchUpBlocks; i++ {
 		b, err := c.state.BlockAtHeight(i)
 		if err != nil {
 			break
@@ -45,7 +46,7 @@ func (c *Core) SendBlocks(knownBlocks [32]consensus.BlockID) (blocks []consensus
 	}
 
 	// If more blocks are available, send a benign error
-	if _, maxErr := c.state.BlockAtHeight(highest + MaxCatchUpBlocks); maxErr == nil {
+	if _, maxErr := c.state.BlockAtHeight(start + MaxCatchUpBlocks); maxErr == nil {
 		err = moreBlocksErr
 	}
 

--- a/sia/synchronize.go
+++ b/sia/synchronize.go
@@ -14,18 +14,52 @@ const (
 
 var moreBlocksErr = errors.New("more blocks are available")
 
+// blockHistory returns up to 32 BlockIDs, starting with the 12 most recent
+// BlockIDs and then doubling in step size until the genesis block is reached.
+// The genesis block is always included. This array of BlockIDs is used to
+// establish a shared commonality between peers during synchronization.
+func (c *Core) blockHistory() (blockIDs [32]consensus.BlockID) {
+	knownBlocks := make([]consensus.BlockID, 0, 32)
+	step := consensus.BlockHeight(1)
+	for height := c.state.Height(); ; height -= step {
+		block, err := c.state.BlockAtHeight(height)
+		if err != nil {
+			// faulty state; log high-priority error
+			return
+		}
+		knownBlocks = append(knownBlocks, block.ID())
+
+		// after 12, start doubling
+		if len(knownBlocks) >= 12 {
+			step *= 2
+		}
+
+		// this check has to come before height -= step;
+		// otherwise we might underflow
+		if height <= step {
+			break
+		}
+	}
+
+	// always include the genesis block
+	genesis, _ := c.state.BlockAtHeight(0)
+	knownBlocks = append(knownBlocks, genesis.ID())
+
+	copy(blockIDs[:], knownBlocks)
+	return
+}
+
 // SendBlocks takes a list of block ids as input, and sends all blocks from
 func (c *Core) SendBlocks(knownBlocks [32]consensus.BlockID) (blocks []consensus.Block, err error) {
 	// Find the most recent block from knownBlocks that is in our current path.
 	found := false
-	var highest consensus.BlockHeight
+	var start consensus.BlockHeight
 	for _, id := range knownBlocks {
 		height, err := c.state.HeightOfBlock(id)
 		if err == nil {
 			found = true
-			if height > highest {
-				highest = height
-			}
+			start = height + 1 // start at child
+			break
 		}
 	}
 	if !found {
@@ -37,7 +71,6 @@ func (c *Core) SendBlocks(knownBlocks [32]consensus.BlockID) (blocks []consensus
 	}
 
 	// Send blocks, starting with the child of the most recent known block.
-	start := highest + 1
 	for i := start; i < start+MaxCatchUpBlocks; i++ {
 		b, err := c.state.BlockAtHeight(i)
 		if err != nil {
@@ -60,35 +93,8 @@ func (c *Core) SendBlocks(knownBlocks [32]consensus.BlockID) (blocks []consensus
 // these blocks to find the most recent block seen by both peers, and then
 // transmits blocks sequentially until the requester is fully synchronized.
 func (c *Core) CatchUp(peer network.Address) {
-	knownBlocks := make([]consensus.BlockID, 0, 32)
-	for i := consensus.BlockHeight(0); i < 12; i++ {
-		block, badBlockErr := c.state.BlockAtHeight(c.state.Height() - i)
-		if badBlockErr != nil {
-			break
-		}
-		knownBlocks = append(knownBlocks, block.ID())
-	}
-
-	backtrace := consensus.BlockHeight(12)
-	for i := 12; i < 31; i++ {
-		backtrace *= 2
-		block, badBlockErr := c.state.BlockAtHeight(c.state.Height() - backtrace)
-		if badBlockErr != nil {
-			break
-		}
-		knownBlocks = append(knownBlocks, block.ID())
-	}
-	// always include the genesis block
-	genesis, _ := c.state.BlockAtHeight(0)
-	knownBlocks = append(knownBlocks, genesis.ID())
-
-	// prepare for RPC
 	var newBlocks []consensus.Block
-	var blockArray [32]consensus.BlockID
-	copy(blockArray[:], knownBlocks)
-
-	// unlock state during network I/O
-	err := peer.RPC("SendBlocks", blockArray, &newBlocks)
+	err := peer.RPC("SendBlocks", c.blockHistory(), &newBlocks)
 	if err != nil && err.Error() != moreBlocksErr.Error() {
 		// log error
 		// TODO: try a different peer?


### PR DESCRIPTION
`CatchUp` should be more reliable now. It still deadlocks sometimes (see #283) but at least you don't get 50% duplicate blocks anymore.