### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,15 @@ dependencies:
 	go get -u github.com/agl/ed25519
 	go get -u golang.org/x/crypto/twofish
 	go get -u github.com/stretchr/graceful
+	go get -u github.com/laher/goxc
 
-release: clean dependencies test test-long install-release
+release: clean dependencies test test-long
+	go install -tags=release ./...
 
 # Cross Compile - makes binaries for windows, linux, and mac, 32 and 64 bit.
 xc: release
 	goxc -arch="amd64" -bc="linux windows darwin" -d=release -pv=0.2.0          \
-		-br=developer -pr=beta -include=example-config,LICENSE*,README*  \
-		-tasks-=deb,deb-dev,deb-source -build-tags=release
+		-br=release -pr=beta -include=example-config,LICENSE*,README*           \
+		-tasks-=deb,deb-dev,deb-source,go-test
 
 .PHONY: all fmt install clean test test-long whitepaper dependencies release xc

--- a/consensus/blocks.go
+++ b/consensus/blocks.go
@@ -164,5 +164,8 @@ func (s *State) AcceptBlock(b Block) (err error) {
 		}
 	}
 
+	// Notify subscribers that the state has adjusted.
+	s.notifySubscribers()
+
 	return
 }

--- a/consensus/buildrelease.go
+++ b/consensus/buildrelease.go
@@ -1,4 +1,4 @@
-// +build release
+// +build !test,!dev
 
 package consensus
 

--- a/consensus/notifications.go
+++ b/consensus/notifications.go
@@ -10,8 +10,9 @@ import (
 func (s *State) Subscribe() (alert chan struct{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	alert = make(chan struct{})
+	alert = make(chan struct{}, 1)
 	s.subscriptions = append(s.subscriptions, alert)
+	alert <- struct{}{}
 	return
 }
 

--- a/consensus/notifications.go
+++ b/consensus/notifications.go
@@ -12,7 +12,6 @@ func (s *State) Subscribe() (alert chan struct{}) {
 	defer s.mu.Unlock()
 	alert = make(chan struct{}, 1)
 	s.subscriptions = append(s.subscriptions, alert)
-	alert <- struct{}{}
 	return
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -202,13 +202,10 @@ func (s *State) EarliestTimestamp() Timestamp {
 	return s.currentBlockNode().earliestChildTimestamp()
 }
 
-// Cheater function.
-func (s *State) MinerVars() (parent BlockID, txns []Transaction, target Target, earliestTimestamp Timestamp) {
+func (s *State) RLock() {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	parent = s.currentBlockNode().Block.ID()
-	txns = s.transactionPoolDump()
-	target = s.currentBlockNode().Target
-	earliestTimestamp = s.currentBlockNode().earliestChildTimestamp()
-	return
+}
+
+func (s *State) RUnlock() {
+	s.mu.RUnlock()
 }

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -78,14 +78,10 @@ func (m *Miner) SetThreads(threads int) error {
 // TODO: checkUpdate will only update the miner if something has been sent down
 // a channel.
 func (m *Miner) checkUpdate() {
-	m.parent, m.transactions, m.target, m.earliestTimestamp = m.state.MinerVars()
-
-	/*
-		select {
-		case <-m.stateSubscription:
-			m.parent, m.transactions, m.target, m.earliestTimestamp = m.state.MinerVars()
-		default:
-			// nothing to do
-		}
-	*/
+	select {
+	case <-m.stateSubscription:
+		m.parent, m.transactions, m.target, m.earliestTimestamp = m.state.MinerVars()
+	default:
+		// nothing to do
+	}
 }

--- a/siad/miner_test.go
+++ b/siad/miner_test.go
@@ -10,6 +10,9 @@ func mineSingleBlock(t *testing.T, d *daemon) {
 	_, found, err := d.miner.SolveBlock()
 	for !found && err == nil {
 		_, found, err = d.miner.SolveBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
The miner now pulls updates as intended.

Also `make release` and `make xc` should work as intended too, which was not previously the case.

I'm not sure how build flags work in goxc, setting -build-tags=release wasn't doing the trick. So I also modified the build tags in buildrelease.go as a workaround. It's probably for the better anyway, now someone naively running `go install` won't be greeted with an excessive amount of errors, but instead will be greeted with a binary that has release constants.