### PR TITLE
Wallet Update

### DIFF
--- a/consensus/blocks.go
+++ b/consensus/blocks.go
@@ -153,8 +153,5 @@ func (s *State) AcceptBlock(b Block) (err error) {
 		return
 	}
 
-	// Notify subscribers that the blockchain has updated.
-	s.notifySubscribers()
-
 	return
 }

--- a/consensus/diffs.go
+++ b/consensus/diffs.go
@@ -1,5 +1,9 @@
 package consensus
 
+import (
+	"errors"
+)
+
 // A block is composed of many transactions. Blocks that have transactions that
 // depend on other transactions, but the transactions must all be applied in a
 // deterministic order. Transactions cannot have inter-dependencies, meaning
@@ -85,4 +89,18 @@ func (s *State) commitContractDiff(cd ContractDiff, forward bool) {
 
 		delete(s.openContracts, cd.ID)
 	}
+}
+
+func (s *State) BlockOutputDiffs(id BlockID) (diffs []OutputDiff, err error) {
+	node, exists := s.blockMap[id]
+	if !exists {
+		err = errors.New("requested an unknown block")
+		return
+	}
+	if !node.DiffsGenerated {
+		err = errors.New("diffs have not been generated for the requested block.")
+		return
+	}
+	diffs = node.OutputDiffs
+	return
 }

--- a/consensus/notifications.go
+++ b/consensus/notifications.go
@@ -4,31 +4,6 @@ import (
 	"errors"
 )
 
-// Subscribe allows a module to subscribe to the state, which means that it'll
-// receive a notification (in the form of an empty struct) each time the state
-// gets a new block.
-func (s *State) Subscribe() (alert chan struct{}) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	alert = make(chan struct{}, 1)
-	s.subscriptions = append(s.subscriptions, alert)
-	return
-}
-
-// notifySubscribers sends a ConsensusChange notification to every subscriber.
-// It is threaded because there have been weird delays when using this function
-// under a lock.
-func (s *State) notifySubscribers() {
-	for _, sub := range s.subscriptions {
-		select {
-		case sub <- struct{}{}:
-			// Receiver has been notified of an update.
-		default:
-			// Receiver already has notification to check for updates.
-		}
-	}
-}
-
 // OutputDiffsSince returns a set of output diffs representing how the state
 // has changed since block `id`. OutputDiffsSince will flip the `new` value for
 // diffs that got reversed.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -51,9 +51,6 @@ type State struct {
 	unspentOutputs map[OutputID]Output
 	openContracts  map[ContractID]FileContract
 
-	// TODO: docstring
-	subscriptions []chan struct{}
-
 	mu sync.RWMutex
 }
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -74,12 +74,6 @@ func New(state *consensus.State, wallet modules.Wallet) (h *Host, err error) {
 		contracts: make(map[consensus.ContractID]contractObligation),
 	}
 
-	// Subscribe to the state and begin listening for updates.
-	// TODO: Get all changes/diffs from the genesis to current block in a way
-	// that doesn't cause a race condition with the subscription.
-	updateChan := state.Subscribe()
-	go h.threadedConsensusListen(updateChan)
-
 	return
 }
 

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -29,9 +29,8 @@ type unconfirmedTransaction struct {
 // confirmed by a block. Transactions with storage proofs are handled
 // separately for reasons discussed in Standard.md
 type TransactionPool struct {
-	state             *consensus.State
-	stateSubscription chan struct{}
-	recentBlock       consensus.BlockID
+	state       *consensus.State
+	recentBlock consensus.BlockID
 
 	// The head and tail of the linked list of transactions that can be put
 	// into blocks.
@@ -68,9 +67,8 @@ func New(state *consensus.State) (tp *TransactionPool, err error) {
 	}
 
 	tp = &TransactionPool{
-		state:             state,
-		stateSubscription: state.Subscribe(),
-		recentBlock:       state.CurrentBlock().ID(),
+		state:       state,
+		recentBlock: state.CurrentBlock().ID(),
 
 		outputs: make(map[consensus.OutputID]consensus.Output),
 
@@ -79,8 +77,6 @@ func New(state *consensus.State) (tp *TransactionPool, err error) {
 
 		storageProofs: make(map[consensus.BlockHeight]map[hash.Hash]consensus.Transaction),
 	}
-
-	go tp.threadedUpdate()
 
 	return
 }

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -20,6 +20,9 @@ func (tp *TransactionPool) removeTransactionFromPool(ut *unconfirmedTransaction)
 }
 
 func (tp *TransactionPool) update() {
+	tp.state.RLock()
+	defer tp.state.RUnlock()
+
 	// Get the block diffs since the previous update.
 	removedBlocksIDs, addedBlocksIDs, err := tp.state.BlocksSince(tp.recentBlock)
 	if err != nil {
@@ -97,4 +100,6 @@ func (tp *TransactionPool) update() {
 			}
 		}
 	}
+
+	tp.recentBlock = tp.state.CurrentBlock().ID()
 }

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -98,15 +98,3 @@ func (tp *TransactionPool) update() {
 		}
 	}
 }
-
-// threadedUpdate listens on a channel from the state for updates, and when an
-// update is announced the transaction pool gets updated.
-func (tp *TransactionPool) threadedUpdate() {
-	for _ = range tp.stateSubscription {
-		tp.state.RLock()
-		tp.mu.Lock()
-		tp.update()
-		tp.mu.Unlock()
-		tp.state.RUnlock()
-	}
-}

--- a/modules/wallet/outputs.go
+++ b/modules/wallet/outputs.go
@@ -37,6 +37,8 @@ type key struct {
 // `total`, which is the sum of all the outputs. It does not adjust the outputs
 // in any way.
 func (w *Wallet) findOutputs(amount consensus.Currency) (knownOutputs []*knownOutput, total consensus.Currency, err error) {
+	w.update()
+
 	if amount == consensus.Currency(0) {
 		err = errors.New("cannot fund 0 coins") // should this be an error or nil?
 		return
@@ -74,6 +76,7 @@ func (w *Wallet) findOutputs(amount consensus.Currency) (knownOutputs []*knownOu
 func (w *Wallet) Balance(full bool) (total consensus.Currency) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
+	w.update()
 
 	// Iterate through all outputs and tally them up.
 	for _, key := range w.keys {
@@ -91,65 +94,4 @@ func (w *Wallet) Balance(full bool) (total consensus.Currency) {
 		}
 	}
 	return
-}
-
-// Update implements the core.Wallet interface.
-func (w *Wallet) Update(diffs []consensus.OutputDiff) error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	/*
-		for _, diff := range diffs {
-			if diff.New {
-				if spendableAddress, exists := w.spendableAddresses[diff.Output.SpendHash]; exists {
-					spendableAddress.spendableOutputs[diff.ID] = &spendableOutput{
-						spendable: true,
-						id:        diff.ID,
-						output:    diff.Output,
-					}
-				}
-			} else {
-				if spendableAddress, exists := w.spendableAddresses[diff.Output.SpendHash]; exists {
-					if spendableOutput, exists := spendableAddress.spendableOutputs[diff.ID]; exists {
-						spendableOutput.spendable = false
-					} else {
-						panic("output should exist!")
-					}
-				}
-			}
-		}
-
-		height := w.state.Height()
-		if height < w.prevHeight {
-			// Since the height is reduced, a bunch of previously unlocked outputs
-			// are now locked, so we need to delete them from the spendable outputs
-			// list.
-			//
-			// The for loop iterates over (height, prevHeight]
-			for i := height + 1; i <= w.prevHeight; i++ {
-				// timelockedSpendableAddresses contains a list of
-				// spendableAddresses that get unlocked at the given height. Delete
-				// each from the map of spendable addresses.
-				for _, spendableAddy := range w.timelockedSpendableAddresses[i] {
-					coinAddress := spendableAddy.spendConditions.CoinAddress()
-					delete(w.spendableAddresses, coinAddress)
-				}
-			}
-		} else {
-			// Since the height is increased, a bunch of previously locked outputs
-			// are now unlocked, so we need to add them to the spendable output
-			// list.
-			//
-			// The for loop iterates over (prevHeight, height]
-			for i := w.prevHeight + 1; i <= height; i++ {
-				for _, spendableAddy := range w.timelockedSpendableAddresses[i] {
-					coinAddress := spendableAddy.spendConditions.CoinAddress()
-					w.spendableAddresses[coinAddress] = spendableAddy
-				}
-			}
-		}
-		w.prevHeight = height
-	*/
-
-	return nil
 }

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -1,62 +1,96 @@
 package wallet
 
 import (
-// "github.com/NebulousLabs/Sia/consensus"
+	"github.com/NebulousLabs/Sia/consensus"
 )
 
-func (w *Wallet) update() error {
-	/*
-		for _, diff := range diffs {
-			if diff.New {
-				if spendableAddress, exists := w.spendableAddresses[diff.Output.SpendHash]; exists {
-					spendableAddress.spendableOutputs[diff.ID] = &spendableOutput{
-						spendable: true,
-						id:        diff.ID,
-						output:    diff.Output,
-					}
+// applyDiff will take the output and either add or delete it from the set of
+// outputs known to the wallet. If adding is true, then new outputs will be
+// added and expired outputs will be deleted. If adding is false, then new
+// outputs will be deleted and expired outputs will be added.
+func (w *Wallet) applyDiff(diff consensus.OutputDiff, adding bool) {
+	isNew := diff.New
+	if !adding {
+		isNew = !isNew
+	}
+
+	// See if the output in the diff is known to the wallet.
+	key, exists := w.keys[diff.Output.SpendHash]
+	if !exists {
+		return
+	}
+
+	// Add the output if `isNew` is set, remove it otherwise.
+	if isNew {
+		output, exists := key.outputs[diff.ID]
+		if exists {
+			if consensus.DEBUG {
+				if output.spendable {
+					panic("output is market as spendable, but it's new?")
 				}
-			} else {
-				if spendableAddress, exists := w.spendableAddresses[diff.Output.SpendHash]; exists {
-					if spendableOutput, exists := spendableAddress.spendableOutputs[diff.ID]; exists {
-						spendableOutput.spendable = false
-					} else {
-						panic("output should exist!")
-					}
-				}
+			}
+			output.spendable = true
+		} else {
+			ko := &knownOutput{
+				id:        diff.ID,
+				output:    diff.Output,
+				spendable: true,
+			}
+			key.outputs[diff.ID] = ko
+		}
+	} else {
+		output, exists := key.outputs[diff.ID]
+		if consensus.DEBUG {
+			if !exists {
+				panic("trying to delete an output that doesn't exist?")
 			}
 		}
 
-		height := w.state.Height()
-		if height < w.prevHeight {
-			// Since the height is reduced, a bunch of previously unlocked outputs
-			// are now locked, so we need to delete them from the spendable outputs
-			// list.
-			//
-			// The for loop iterates over (height, prevHeight]
-			for i := height + 1; i <= w.prevHeight; i++ {
-				// timelockedSpendableAddresses contains a list of
-				// spendableAddresses that get unlocked at the given height. Delete
-				// each from the map of spendable addresses.
-				for _, spendableAddy := range w.timelockedSpendableAddresses[i] {
-					coinAddress := spendableAddy.spendConditions.CoinAddress()
-					delete(w.spendableAddresses, coinAddress)
-				}
-			}
-		} else {
-			// Since the height is increased, a bunch of previously locked outputs
-			// are now unlocked, so we need to add them to the spendable output
-			// list.
-			//
-			// The for loop iterates over (prevHeight, height]
-			for i := w.prevHeight + 1; i <= height; i++ {
-				for _, spendableAddy := range w.timelockedSpendableAddresses[i] {
-					coinAddress := spendableAddy.spendConditions.CoinAddress()
-					w.spendableAddresses[coinAddress] = spendableAddy
-				}
-			}
+		output.spendable = false
+	}
+}
+
+func (w *Wallet) update() error {
+	w.state.RLock()
+	defer w.state.RUnlock()
+
+	// Remove all of the diffs that have been applied by the unconfirmed set of
+	// transactions.
+	for _, diff := range w.unconfirmedDiffs {
+		w.applyDiff(diff, false)
+	}
+
+	// Apply the diffs in the state that have happened since the last update.
+	removedBlocks, addedBlocks, err := w.state.BlocksSince(w.recentBlock)
+	if err != nil {
+		return err
+	}
+	for _, id := range removedBlocks {
+		diffs, err := w.state.BlockOutputDiffs(id)
+		if err != nil {
+			return err
 		}
-		w.prevHeight = height
-	*/
+		for _, diff := range diffs {
+			w.applyDiff(diff, false)
+		}
+	}
+	for _, id := range addedBlocks {
+		diffs, err := w.state.BlockOutputDiffs(id)
+		if err != nil {
+			return err
+		}
+		for _, diff := range diffs {
+			w.applyDiff(diff, true)
+		}
+	}
+
+	// Get, apply, and store the unconfirmed diffs currently available in the transaction pool.
+	w.unconfirmedDiffs = w.tpool.OutputDiffs()
+	for _, diff := range w.unconfirmedDiffs {
+		w.applyDiff(diff, true)
+	}
+
+	w.recentBlock = w.state.CurrentBlock().ID()
 
 	return nil
 }

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -1,0 +1,62 @@
+package wallet
+
+import (
+// "github.com/NebulousLabs/Sia/consensus"
+)
+
+func (w *Wallet) update() error {
+	/*
+		for _, diff := range diffs {
+			if diff.New {
+				if spendableAddress, exists := w.spendableAddresses[diff.Output.SpendHash]; exists {
+					spendableAddress.spendableOutputs[diff.ID] = &spendableOutput{
+						spendable: true,
+						id:        diff.ID,
+						output:    diff.Output,
+					}
+				}
+			} else {
+				if spendableAddress, exists := w.spendableAddresses[diff.Output.SpendHash]; exists {
+					if spendableOutput, exists := spendableAddress.spendableOutputs[diff.ID]; exists {
+						spendableOutput.spendable = false
+					} else {
+						panic("output should exist!")
+					}
+				}
+			}
+		}
+
+		height := w.state.Height()
+		if height < w.prevHeight {
+			// Since the height is reduced, a bunch of previously unlocked outputs
+			// are now locked, so we need to delete them from the spendable outputs
+			// list.
+			//
+			// The for loop iterates over (height, prevHeight]
+			for i := height + 1; i <= w.prevHeight; i++ {
+				// timelockedSpendableAddresses contains a list of
+				// spendableAddresses that get unlocked at the given height. Delete
+				// each from the map of spendable addresses.
+				for _, spendableAddy := range w.timelockedSpendableAddresses[i] {
+					coinAddress := spendableAddy.spendConditions.CoinAddress()
+					delete(w.spendableAddresses, coinAddress)
+				}
+			}
+		} else {
+			// Since the height is increased, a bunch of previously locked outputs
+			// are now unlocked, so we need to add them to the spendable output
+			// list.
+			//
+			// The for loop iterates over (prevHeight, height]
+			for i := w.prevHeight + 1; i <= height; i++ {
+				for _, spendableAddy := range w.timelockedSpendableAddresses[i] {
+					coinAddress := spendableAddy.spendConditions.CoinAddress()
+					w.spendableAddresses[coinAddress] = spendableAddy
+				}
+			}
+		}
+		w.prevHeight = height
+	*/
+
+	return nil
+}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -21,8 +21,10 @@ const (
 // The wallet contains a list of addresses and the methods to spend them (the
 // keys), as well as an interactive way to construct and sign transactions.
 type Wallet struct {
-	state *consensus.State
-	tpool modules.TransactionPool
+	state            *consensus.State
+	tpool            modules.TransactionPool
+	recentBlock      consensus.BlockID
+	unconfirmedDiffs []consensus.OutputDiff
 
 	// Location of the wallet's file, for saving and loading keys.
 	filename string


### PR DESCRIPTION
The wallet now updates when you ask for the balance. The update should be thread-safe and accurate, and should include unconfirmed transactions (excluding those with storage proofs, but our software will never put money sends in the same transaction as a storage proof).

Also not tested.

My future plans are to bring back the api, and then add a bunch of testing around the wallet and tpool and consensus code to make sure things are running smoothly.

Then we can test things live and see if we can check off points one and two in issue #296. My guess is that the synchronization code needs work.