### PR TITLE
Further testing

### DIFF
--- a/Standard.md
+++ b/Standard.md
@@ -1,17 +1,18 @@
+Standard Transaction Rules
+==========================
+
 Some transactions will not be accepted by miners unless they appear in a block.
 This is equivalent to the 'IsStandard' function in Bitcoin. This file dictates
 the rules for standard Sia transactions.
 
-----------------------
--- Transaction Size --
-----------------------
+Transaction Size
+----------------
 
 Consensus rules limit the size of a block, but not the size of a transaction.
-Standard rules however limit the size of a single transaction to 64kb.
+Standard rules however limit the size of a single transaction to 16kb.
 
-------------------------
--- Double Spend Rules --
-------------------------
+Double Spend Rules
+------------------
 
 When two conflicting transactions are seen, the first transaction is the only
 one that is kept. If the blockchain reorganizes, the transaction that is kept
@@ -25,32 +26,21 @@ certain minimum. For the near future, there are no plans to prioritize
 transactions with substantially higher fees. Other mining software may take
 alternative approaches.
 
--------------------------
--- Storage Proof Rules --
--------------------------
+Storage Proof Rule
+------------------
 
-Storage Proof transactions should not have dependent transactions.  Meaning,
-any outputs created in a storage proof transaction should not be spent until
-the storage proof is confirmed by the blockchain.
+Transaction pools will track multiple conflicting storage proofs. If there are
+two competing reorgs, it is in the best interest of the network to keep storage
+proofs for each reorg, because proofs may only be valid on a subset of reorgs.
 
-These restrictions are in place because storage proofs can be easily
-invalidated by a blockchain reorg - if the trigger block changes, the proof
-will be invalidated. Storage proofs can by any reorg, where standard
-transactions can only be invalidated by a doublespend (which requires a
-signature from the double spender).
+Signature Algorithms
+--------------------
 
-This also means that transaction pools will track multiple conflicting storage
-proofs. If there are two competing reorgs, it is in the best interest of the
-network to keep storage proofs for each reorg, because each proof will only be
-valid on one reorg.
+Miners will reject transactions that have public keys using algorithms that the
+miner does not understand.
 
-Storage proofs are prioritized by the transaction pool. Because of their
-priority, they are ignored if there is any aribtrary data, or if there is more
-than one input, one output, one miner fee, and a collection of storage proofs.
-
---------------------------
--- Arbitrary Data Usage --
---------------------------
+Arbitrary Data Usage
+--------------------
 
 Arbitrary data can be used to make verifiable announcements, or to have other
 protocols sit on top of Sia. The arbitrary data can also be used for soft

--- a/consensus/blocks_test.go
+++ b/consensus/blocks_test.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+// currentTime returns a Timestamp of the current time.
+func currentTime() Timestamp {
+	return Timestamp(time.Now().Unix())
+}
+
 // mineTestingBlock accepts a bunch of parameters for a block and then grinds
 // blocks until a block with the appropriate target is found.
 func mineTestingBlock(parent BlockID, timestamp Timestamp, minerPayouts []SiacoinOutput, txns []Transaction, target Target) (b Block, err error) {
@@ -38,7 +43,7 @@ func nullMinerPayouts(height BlockHeight) []SiacoinOutput {
 // mineValidBlock picks valid/legal parameters for a block and then uses them
 // to call mineTestingBlock.
 func mineValidBlock(s *State) (b Block, err error) {
-	return mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), nil, s.CurrentTarget())
+	return mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), nil, s.CurrentTarget())
 }
 
 // testBlockTimestamps submits a block to the state with a timestamp that is
@@ -56,7 +61,7 @@ func testBlockTimestamps(t *testing.T, s *State) {
 	}
 
 	// Create a block with a timestamp that is too late.
-	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix())+10+FutureThreshold, nullMinerPayouts(s.Height()+1), nil, s.CurrentTarget())
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), currentTime()+10+FutureThreshold, nullMinerPayouts(s.Height()+1), nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +147,7 @@ func testLargeBlock(t *testing.T, s *State) {
 	txns[0] = Transaction{
 		ArbitraryData: []string{bigData},
 	}
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), txns, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), txns, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +169,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 	// goes to the hash of the empty spend conditions.
 	var sc SpendConditions
 	payout := []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height() + 1), SpendHash: sc.CoinAddress()}}
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), payout, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +191,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 		SiacoinOutput{Value: NewCurrency64(250), SpendHash: sc.CoinAddress()},
 		SiacoinOutput{Value: NewCurrency64(500), SpendHash: sc.CoinAddress()},
 	}
-	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), currentTime(), payout, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +217,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 
 	// Create a block with a too large payout.
 	payout = []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height()), SpendHash: sc.CoinAddress()}}
-	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), currentTime(), payout, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +233,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 
 	// Create a block with a too small payout.
 	payout = []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height() + 2), SpendHash: sc.CoinAddress()}}
-	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), currentTime(), payout, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +275,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 		SiacoinOutput{Value: NewCurrency64(650), SpendHash: sc.CoinAddress()},
 		SiacoinOutput{Value: NewCurrency64(75), SpendHash: sc.CoinAddress()},
 	}
-	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, []Transaction{txn1, txn2}, s.CurrentTarget())
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), currentTime(), payout, []Transaction{txn1, txn2}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,7 +327,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 		SiacoinOutput{Value: NewCurrency64(650), SpendHash: sc.CoinAddress()},
 		SiacoinOutput{Value: NewCurrency64(75), SpendHash: sc.CoinAddress()},
 	}
-	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, []Transaction{txn1, txn2}, s.CurrentTarget())
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), currentTime(), payout, []Transaction{txn1, txn2}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +342,7 @@ func testMissedTarget(t *testing.T, s *State) {
 	// Mine a block that doesn't meet the target.
 	b := Block{
 		ParentID:  s.CurrentBlock().ID(),
-		Timestamp: Timestamp(time.Now().Unix()),
+		Timestamp: currentTime(),
 	}
 	for b.CheckTarget(s.CurrentTarget()) && b.Nonce < 1000*1000 {
 		b.Nonce++
@@ -393,37 +398,37 @@ func testRepeatBlock(t *testing.T, s *State) {
 // TestBlockTimestamps creates a new state and uses it to call
 // testBlockTimestamps.
 func TestBlockTimestamps(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testBlockTimestamps(t, s)
 }
 
 // TestEmptyBlock creates a new state and uses it to call testEmptyBlock.
 func TestEmptyBlock(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testEmptyBlock(t, s)
 }
 
 // TestLargeBlock creates a new state and uses it to call testLargeBlock.
 func TestLargeBlock(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testLargeBlock(t, s)
 }
 
 // TestMinerPayouts creates a new state and uses it to call testMinerPayouts.
 func TestMinerPayouts(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testMinerPayouts(t, s)
 }
 
 // TestMissedTarget creates a new state and uses it to call testMissedTarget.
 func TestMissedTarget(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testMissedTarget(t, s)
 }
 
 // TestRepeatBlock creates a new state and uses it to call testRepeatBlock.
 func TestRepeatBlock(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testRepeatBlock(t, s)
 }
 

--- a/consensus/blocks_test.go
+++ b/consensus/blocks_test.go
@@ -156,10 +156,9 @@ func testLargeBlock(t *testing.T, s *State) {
 // testMinerPayouts tries to submit miner payouts in various legal and illegal
 // forms and verifies that the state handles the payouts correctly each time.
 //
-// CONTRIBUTE: Increased testing would be nice. We need to test across multiple
-// payouts, multiple fees, payouts that are too high, payouts that are too low,
-// and several other potential ways that someone might slip illegal payouts
-// through.
+// CONTRIBUTE: We need to test across multiple payouts, multiple fees, payouts
+// that are too high, payouts that are too low, and several other potential
+// ways that someone might slip illegal payouts through.
 func testMinerPayouts(t *testing.T, s *State) {
 	// Create a block with a single legal payout, no miner fees. The payout
 	// goes to the hash of the empty spend conditions.

--- a/consensus/blocks_test.go
+++ b/consensus/blocks_test.go
@@ -7,7 +7,7 @@ import (
 
 // mineTestingBlock accepts a bunch of parameters for a block and then grinds
 // blocks until a block with the appropriate target is found.
-func mineTestingBlock(parent BlockID, timestamp Timestamp, minerPayouts []Output, txns []Transaction, target Target) (b Block, err error) {
+func mineTestingBlock(parent BlockID, timestamp Timestamp, minerPayouts []SiacoinOutput, txns []Transaction, target Target) (b Block, err error) {
 	b = Block{
 		ParentID:     parent,
 		Timestamp:    timestamp,
@@ -27,9 +27,9 @@ func mineTestingBlock(parent BlockID, timestamp Timestamp, minerPayouts []Output
 // nullMinerPayouts returns an []Output for the miner payouts field of a block
 // so that the block can be valid. It assumes the block will be at whatever
 // height you use as input.
-func nullMinerPayouts(height BlockHeight) []Output {
-	return []Output{
-		Output{
+func nullMinerPayouts(height BlockHeight) []SiacoinOutput {
+	return []SiacoinOutput{
+		SiacoinOutput{
 			Value: CalculateCoinbase(height),
 		},
 	}
@@ -164,7 +164,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 	// Create a block with a single legal payout, no miner fees. The payout
 	// goes to the hash of the empty spend conditions.
 	var sc SpendConditions
-	payout := []Output{Output{Value: CalculateCoinbase(s.Height() + 1), SpendHash: sc.CoinAddress()}}
+	payout := []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height() + 1), SpendHash: sc.CoinAddress()}}
 	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
@@ -180,10 +180,10 @@ func testMinerPayouts(t *testing.T, s *State) {
 	}
 
 	// Create a block with multiple miner payouts.
-	payout = []Output{
-		Output{Value: CalculateCoinbase(s.Height()+1) - 750, SpendHash: sc.CoinAddress()},
-		Output{Value: 250, SpendHash: sc.CoinAddress()},
-		Output{Value: 500, SpendHash: sc.CoinAddress()},
+	payout = []SiacoinOutput{
+		SiacoinOutput{Value: CalculateCoinbase(s.Height()+1) - 750, SpendHash: sc.CoinAddress()},
+		SiacoinOutput{Value: 250, SpendHash: sc.CoinAddress()},
+		SiacoinOutput{Value: 500, SpendHash: sc.CoinAddress()},
 	}
 	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
 	if err != nil {
@@ -210,7 +210,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 	}
 
 	// Create a block with a too large payout.
-	payout = []Output{Output{Value: CalculateCoinbase(s.Height()), SpendHash: sc.CoinAddress()}}
+	payout = []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height()), SpendHash: sc.CoinAddress()}}
 	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
@@ -226,7 +226,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 	}
 
 	// Create a block with a too small payout.
-	payout = []Output{Output{Value: CalculateCoinbase(s.Height() + 2), SpendHash: sc.CoinAddress()}}
+	payout = []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height() + 2), SpendHash: sc.CoinAddress()}}
 	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
@@ -243,8 +243,8 @@ func testMinerPayouts(t *testing.T, s *State) {
 
 	// Test legal multiple payouts when there are multiple miner fees.
 	txn1 := Transaction{
-		Inputs: []Input{
-			Input{OutputID: output250},
+		SiacoinInputs: []SiacoinInput{
+			SiacoinInput{OutputID: output250},
 		},
 		MinerFees: []Currency{
 			Currency(50),
@@ -253,8 +253,8 @@ func testMinerPayouts(t *testing.T, s *State) {
 		},
 	}
 	txn2 := Transaction{
-		Inputs: []Input{
-			Input{OutputID: output500},
+		SiacoinInputs: []SiacoinInput{
+			SiacoinInput{OutputID: output500},
 		},
 		MinerFees: []Currency{
 			Currency(100),
@@ -262,7 +262,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 			Currency(250),
 		},
 	}
-	payout = []Output{Output{Value: CalculateCoinbase(s.Height()+1) + 25}, Output{Value: 650, SpendHash: sc.CoinAddress()}, Output{Value: 75, SpendHash: sc.CoinAddress()}}
+	payout = []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height()+1) + 25}, SiacoinOutput{Value: 650, SpendHash: sc.CoinAddress()}, SiacoinOutput{Value: 75, SpendHash: sc.CoinAddress()}}
 	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, []Transaction{txn1, txn2}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
@@ -289,8 +289,8 @@ func testMinerPayouts(t *testing.T, s *State) {
 
 	// Test too large multiple payouts when there are multiple miner fees.
 	txn1 = Transaction{
-		Inputs: []Input{
-			Input{OutputID: output650},
+		SiacoinInputs: []SiacoinInput{
+			SiacoinInput{OutputID: output650},
 		},
 		MinerFees: []Currency{
 			Currency(100),
@@ -299,8 +299,8 @@ func testMinerPayouts(t *testing.T, s *State) {
 		},
 	}
 	txn2 = Transaction{
-		Inputs: []Input{
-			Input{OutputID: output75},
+		SiacoinInputs: []SiacoinInput{
+			SiacoinInput{OutputID: output75},
 		},
 		MinerFees: []Currency{
 			Currency(10),
@@ -308,7 +308,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 			Currency(50),
 		},
 	}
-	payout = []Output{Output{Value: CalculateCoinbase(s.Height()+1) + 25}, Output{Value: 650, SpendHash: sc.CoinAddress()}, Output{Value: 75, SpendHash: sc.CoinAddress()}}
+	payout = []SiacoinOutput{SiacoinOutput{Value: CalculateCoinbase(s.Height()+1) + 25}, SiacoinOutput{Value: 650, SpendHash: sc.CoinAddress()}, SiacoinOutput{Value: 75, SpendHash: sc.CoinAddress()}}
 	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), payout, []Transaction{txn1, txn2}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)

--- a/consensus/complete_test.go
+++ b/consensus/complete_test.go
@@ -106,6 +106,9 @@ func orderedTestBattery(t *testing.T, states ...*State) {
 		testInvalidSignature(t, s)
 		testSingleOutput(t, s)
 		testUnsignedTransaction(t, s)
+
+		// contracts_test.go tests
+		testContractCreation(t, s)
 	}
 }
 

--- a/consensus/complete_test.go
+++ b/consensus/complete_test.go
@@ -5,8 +5,7 @@ import (
 	"time"
 )
 
-// TODO: Add a consistency check for the number of coins in the state, and the
-// subsidies at each block.
+// TODO: Add the 100block waiting outputs to the currency tallying.
 
 // currentPathCheck looks at every block listed in currentPath and verifies
 // that every block from current to genesis matches the block listed in
@@ -94,12 +93,19 @@ func consistencyChecks(t *testing.T, states ...*State) {
 // blocks to more effectively test things like diffs and forking.
 func orderedTestBattery(t *testing.T, states ...*State) {
 	for _, s := range states {
+		// blocks_test.go tests
 		testBlockTimestamps(t, s)
 		testEmptyBlock(t, s)
 		testLargeBlock(t, s)
 		testMinerPayouts(t, s)
 		testMissedTarget(t, s)
 		testRepeatBlock(t, s)
+
+		// transactions_test.go tests
+		testForeignSignature(t, s)
+		testInvalidSignature(t, s)
+		testSingleOutput(t, s)
+		testUnsignedTransaction(t, s)
 	}
 }
 

--- a/consensus/complete_test.go
+++ b/consensus/complete_test.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"testing"
-	"time"
 )
 
 // TODO: Add the 100block waiting outputs to the currency tallying.
@@ -129,7 +128,7 @@ func TestEverything(t *testing.T) {
 	// ahead of the other. We'll show all of the blocks to the other state,
 	// which will cause it to fork and rewind the entire diverse set of blocks
 	// and then apply an entirely different diverse set of blocks.
-	genesisTime := Timestamp(time.Now().Unix() - 1)
+	genesisTime := currentTime() - 1
 	s0 := CreateGenesisState(genesisTime)
 	s1 := CreateGenesisState(genesisTime)
 
@@ -139,7 +138,7 @@ func TestEverything(t *testing.T) {
 	}
 
 	// Get each on a separate fork.
-	b0, err := mineTestingBlock(s0.CurrentBlock().ID(), Timestamp(time.Now().Unix()-1), nullMinerPayouts(s0.Height()+1), nil, s0.CurrentTarget())
+	b0, err := mineTestingBlock(s0.CurrentBlock().ID(), currentTime()-1, nullMinerPayouts(s0.Height()+1), nil, s0.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +146,7 @@ func TestEverything(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b1, err := mineTestingBlock(s1.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s1.Height()+1), nil, s1.CurrentTarget())
+	b1, err := mineTestingBlock(s1.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s1.Height()+1), nil, s1.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +199,7 @@ func TestEverything(t *testing.T) {
 		SiacoinInputs:  []SiacoinInput{input},
 		SiacoinOutputs: []SiacoinOutput{SiacoinOutput{}},
 	}
-	b, err := mineTestingBlock(s0.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s0.Height()+1), []Transaction{badTxn}, s0.CurrentTarget())
+	b, err := mineTestingBlock(s0.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s0.Height()+1), []Transaction{badTxn}, s0.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/complete_test.go
+++ b/consensus/complete_test.go
@@ -109,6 +109,7 @@ func orderedTestBattery(t *testing.T, states ...*State) {
 
 		// contracts_test.go tests
 		testContractCreation(t, s)
+		testStorageProofSubmit(t, s)
 	}
 }
 

--- a/consensus/contracts.go
+++ b/consensus/contracts.go
@@ -91,7 +91,7 @@ func (s *State) applyContract(contract FileContract, id ContractID) (cd Contract
 func (s *State) applyStorageProof(sp StorageProof) (od OutputDiff, cd ContractDiff) {
 	// Calculate the new output and its id.
 	contract := s.openContracts[sp.ContractID]
-	output := Output{
+	output := SiacoinOutput{
 		Value:     contract.Payout,
 		SpendHash: contract.ValidProofAddress,
 	}
@@ -118,7 +118,7 @@ func (s *State) applyStorageProof(sp StorageProof) (od OutputDiff, cd ContractDi
 // on a file contract.
 func (s *State) applyMissedProof(contract FileContract, id ContractID) (od OutputDiff, cd ContractDiff) {
 	// Create the output for the missed proof.
-	output := Output{
+	output := SiacoinOutput{
 		Value:     contract.Payout,
 		SpendHash: contract.MissedProofAddress,
 	}

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -82,7 +82,7 @@ func contractTxn(t *testing.T, s *State, delay BlockHeight, duration BlockHeight
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	rawSig, err := crypto.SignBytes(sigHash, sk)
+	rawSig, err := crypto.SignHash(sigHash, sk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	rawSig, err := crypto.SignBytes(sigHash, sk)
+	rawSig, err := crypto.SignHash(sigHash, sk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"testing"
-	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -36,7 +35,7 @@ func contractTxn(t *testing.T, s *State, delay BlockHeight, duration BlockHeight
 	}
 
 	// Mine the block that creates the output.
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), minerPayouts, nil, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), minerPayouts, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +116,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	}
 
 	// Mine the block that creates the output.
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), minerPayouts, nil, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), minerPayouts, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +175,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	txn.Signatures[0].Signature = encoding.Marshal(rawSig)
 
 	// Put the transaction into a block.
-	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +211,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 // checks that the contract is accepted.
 func testContractCreation(t *testing.T, s *State) {
 	txn := contractTxn(t, s, 2, 25*1000)
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +232,7 @@ func testContractCreation(t *testing.T, s *State) {
 func testMissedProof(t *testing.T, s *State) {
 	// Get the transaction with the contract that will not be fulfilled.
 	txn := contractTxn(t, s, 2, 1)
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +284,7 @@ func testStorageProofSubmit(t *testing.T, s *State) {
 		t.Fatal("file contract doesn't exist in state")
 	}
 
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,19 +312,19 @@ func testStorageProofSubmit(t *testing.T, s *State) {
 // TestContractCreation creates a new state and uses it to call
 // testContractCreation.
 func TestContractCreation(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testContractCreation(t, s)
 }
 
 // TestMissedProof creates a new state and uses it to call testMissedProof.
 func TestMissedProof(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testMissedProof(t, s)
 }
 
 // TestStorageProofSubmit creates a new state and uses it to call
 // testStorageProofSubmit.
 func TestStorageProofSubmit(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testStorageProofSubmit(t, s)
 }

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -1,14 +1,17 @@
 package consensus
 
 import (
+	"bytes"
+	"crypto/rand"
 	"testing"
 	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/hash"
 )
 
 // contractTxn funds and returns a transaction with a file contract.
-func contractTxn(t *testing.T, s *State) (txn Transaction) {
+func contractTxn(t *testing.T, s *State, delay BlockHeight, duration BlockHeight) (txn Transaction) {
 	// Create the keys and a siacoin output that adds coins to the keys.
 	sk, pk, err := crypto.GenerateSignatureKeys()
 	if err != nil {
@@ -52,8 +55,8 @@ func contractTxn(t *testing.T, s *State) (txn Transaction) {
 	}
 	contract := FileContract{
 		FileSize: 4000,
-		Start:    s.height() + 3,
-		End:      s.height() + 25*1000,
+		Start:    s.height() + delay,
+		End:      s.height() + delay + duration,
 		Payout:   12 * 1000,
 	}
 	txn = Transaction{
@@ -78,10 +81,122 @@ func contractTxn(t *testing.T, s *State) (txn Transaction) {
 	return
 }
 
-// testContractCreation adds a block with a transaction to the state and checks
-// that the contract creation mechanisms work.
+// storageProofTxn funds a contract, puts it in the state, and then returns a
+// transaction with a storage proof for the contract.
+func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
+	// Create the keys and a siacoin output that adds coins to the keys.
+	sk, pk, err := crypto.GenerateSignatureKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendConditions := SpendConditions{
+		NumSignatures: 1,
+		PublicKeys: []SiaPublicKey{
+			SiaPublicKey{
+				Algorithm: ED25519Identifier,
+				Key:       pk[:],
+			},
+		},
+	}
+	coinAddress := spendConditions.CoinAddress()
+	minerPayouts := []SiacoinOutput{
+		SiacoinOutput{
+			Value:     CalculateCoinbase(s.height() + 1),
+			SpendHash: coinAddress,
+		},
+	}
+
+	// Mine the block that creates the output.
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), minerPayouts, nil, s.CurrentTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.AcceptBlock(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the file that the storage proof happens over.
+	simpleFile := make([]byte, 4000)
+	rand.Read(simpleFile)
+
+	// Create the transaction that spends the output.
+	input := SiacoinInput{
+		OutputID:        b.MinerPayoutID(0),
+		SpendConditions: spendConditions,
+	}
+	output := SiacoinOutput{
+		Value:     CalculateCoinbase(s.height()) - 12*1000,
+		SpendHash: ZeroAddress,
+	}
+	merkleRoot, err := hash.BytesMerkleRoot(simpleFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract := FileContract{
+		FileMerkleRoot: merkleRoot,
+		FileSize:       4000,
+		Start:          s.height() + 2,
+		End:            s.height() + 2 + 25*1000,
+		Payout:         12 * 1000,
+	}
+	txn = Transaction{
+		SiacoinInputs:  []SiacoinInput{input},
+		SiacoinOutputs: []SiacoinOutput{output},
+		FileContracts:  []FileContract{contract},
+	}
+
+	// Sign the transaction.
+	sig := TransactionSignature{
+		InputID:        input.OutputID,
+		CoveredFields:  CoveredFields{WholeTransaction: true},
+		PublicKeyIndex: 0,
+	}
+	txn.Signatures = append(txn.Signatures, sig)
+	sigHash := txn.SigHash(0)
+	encodedSig, err := crypto.SignBytes(sigHash[:], sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn.Signatures[0].Signature = encodedSig[:]
+
+	// Put the transaction into a block.
+	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.AcceptBlock(b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create the transaction that has the storage proof.
+	cid = txn.FileContractID(0)
+	segmentIndex, err := s.StorageProofSegment(cid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	numSegments := hash.CalculateSegments(4000)
+	segment, hashes, err := hash.BuildReaderProof(bytes.NewReader(simpleFile), numSegments, segmentIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp := StorageProof{
+		ContractID: txn.FileContractID(0),
+		Segment:    segment,
+		HashSet:    hashes,
+	}
+	txn = Transaction{
+		StorageProofs: []StorageProof{sp},
+	}
+
+	return
+}
+
+// testContractCreation adds a block with a file contract to the state and
+// checks that the contract is accepted.
 func testContractCreation(t *testing.T, s *State) {
-	txn := contractTxn(t, s)
+	txn := contractTxn(t, s, 2, 25*1000)
 	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
@@ -98,9 +213,41 @@ func testContractCreation(t *testing.T, s *State) {
 	}
 }
 
+// testStorageProofSubmit adds a block with a valid storage proof to the state
+// and checks that it is accepted, ending the contract supplying an output to
+// the person.
+func testStorageProofSubmit(t *testing.T, s *State) {
+	txn, cid := storageProofTxn(t, s)
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.AcceptBlock(b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that the storage proof made it into the state.
+	_, exists := s.openContracts[cid]
+	if exists {
+		t.Error("file contract still in state even though a proof for it has been submitted")
+	}
+	_, exists = s.unspentOutputs[cid.StorageProofOutputID(true)]
+	if !exists {
+		t.Error("storage proof output not in state after storage proof was submitted")
+	}
+}
+
 // TestContractCreation creates a new state and uses it to call
 // testContractCreation.
 func TestContractCreation(t *testing.T) {
 	s := CreateGenesisState(Timestamp(time.Now().Unix()))
 	testContractCreation(t, s)
+}
+
+// TestStorageProofSubmit creates a new state and uses it to call
+// testStorageProofSubmit.
+func TestStorageProofSubmit(t *testing.T) {
+	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	testStorageProofSubmit(t, s)
 }

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -126,7 +126,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	}
 
 	// Create the file that the storage proof happens over.
-	simpleFile := make([]byte, 4000)
+	simpleFile := make([]byte, 4e3)
 	rand.Read(simpleFile)
 
 	// Create the transaction that spends the output.
@@ -149,9 +149,9 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	}
 	contract := FileContract{
 		FileMerkleRoot: merkleRoot,
-		FileSize:       4000,
+		FileSize:       4e3,
 		Start:          s.height() + 2,
-		End:            s.height() + 2 + 25*1000,
+		End:            s.height() + 2 + 25e3,
 		Payout:         NewCurrency64(12e3),
 	}
 	txn = Transaction{
@@ -190,7 +190,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	numSegments := hash.CalculateSegments(4000)
+	numSegments := hash.CalculateSegments(4e3)
 	segment, hashes, err := hash.BuildReaderProof(bytes.NewReader(simpleFile), numSegments, segmentIndex)
 	if err != nil {
 		t.Fatal(err)
@@ -210,7 +210,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 // testContractCreation adds a block with a file contract to the state and
 // checks that the contract is accepted.
 func testContractCreation(t *testing.T, s *State) {
-	txn := contractTxn(t, s, 2, 25*1000)
+	txn := contractTxn(t, s, 2, 25e3)
 	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/hash"
 )
 
@@ -22,7 +23,7 @@ func contractTxn(t *testing.T, s *State, delay BlockHeight, duration BlockHeight
 		PublicKeys: []SiaPublicKey{
 			SiaPublicKey{
 				Algorithm: ED25519Identifier,
-				Key:       pk[:],
+				Key:       encoding.Marshal(pk),
 			},
 		},
 	}
@@ -77,11 +78,11 @@ func contractTxn(t *testing.T, s *State, delay BlockHeight, duration BlockHeight
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	encodedSig, err := crypto.SignBytes(sigHash[:], sk)
+	rawSig, err := crypto.SignBytes(sigHash[:], sk)
 	if err != nil {
 		t.Fatal(err)
 	}
-	txn.Signatures[0].Signature = encodedSig[:]
+	txn.Signatures[0].Signature = encoding.Marshal(rawSig)
 	return
 }
 
@@ -98,7 +99,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 		PublicKeys: []SiaPublicKey{
 			SiaPublicKey{
 				Algorithm: ED25519Identifier,
-				Key:       pk[:],
+				Key:       encoding.Marshal(pk),
 			},
 		},
 	}
@@ -158,11 +159,11 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	encodedSig, err := crypto.SignBytes(sigHash[:], sk)
+	rawSig, err := crypto.SignBytes(sigHash[:], sk)
 	if err != nil {
 		t.Fatal(err)
 	}
-	txn.Signatures[0].Signature = encodedSig[:]
+	txn.Signatures[0].Signature = encoding.Marshal(rawSig)
 
 	// Put the transaction into a block.
 	b, err = mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -1,6 +1,106 @@
 package consensus
 
-// import (
-// "testing"
-// "time"
-// )
+import (
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/crypto"
+)
+
+// contractTxn funds and returns a transaction with a file contract.
+func contractTxn(t *testing.T, s *State) (txn Transaction) {
+	// Create the keys and a siacoin output that adds coins to the keys.
+	sk, pk, err := crypto.GenerateSignatureKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendConditions := SpendConditions{
+		NumSignatures: 1,
+		PublicKeys: []SiaPublicKey{
+			SiaPublicKey{
+				Algorithm: ED25519Identifier,
+				Key:       pk[:],
+			},
+		},
+	}
+	coinAddress := spendConditions.CoinAddress()
+	minerPayouts := []SiacoinOutput{
+		SiacoinOutput{
+			Value:     CalculateCoinbase(s.height() + 1),
+			SpendHash: coinAddress,
+		},
+	}
+
+	// Mine the block that creates the output.
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), minerPayouts, nil, s.CurrentTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.AcceptBlock(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the transaction that spends the output.
+	input := SiacoinInput{
+		OutputID:        b.MinerPayoutID(0),
+		SpendConditions: spendConditions,
+	}
+	output := SiacoinOutput{
+		Value:     CalculateCoinbase(s.height()) - 12*1000,
+		SpendHash: ZeroAddress,
+	}
+	contract := FileContract{
+		FileSize: 4000,
+		Start:    s.height() + 3,
+		End:      s.height() + 25*1000,
+		Payout:   12 * 1000,
+	}
+	txn = Transaction{
+		SiacoinInputs:  []SiacoinInput{input},
+		SiacoinOutputs: []SiacoinOutput{output},
+		FileContracts:  []FileContract{contract},
+	}
+
+	// Sign the transaction.
+	sig := TransactionSignature{
+		InputID:        input.OutputID,
+		CoveredFields:  CoveredFields{WholeTransaction: true},
+		PublicKeyIndex: 0,
+	}
+	txn.Signatures = append(txn.Signatures, sig)
+	sigHash := txn.SigHash(0)
+	encodedSig, err := crypto.SignBytes(sigHash[:], sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn.Signatures[0].Signature = encodedSig[:]
+	return
+}
+
+// testContractCreation adds a block with a transaction to the state and checks
+// that the contract creation mechanisms work.
+func testContractCreation(t *testing.T, s *State) {
+	txn := contractTxn(t, s)
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.AcceptBlock(b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that the contract made it into the state.
+	_, exists := s.openContracts[txn.FileContractID(0)]
+	if !exists {
+		t.Error("file contract not found found in state after being created")
+	}
+}
+
+// TestContractCreation creates a new state and uses it to call
+// testContractCreation.
+func TestContractCreation(t *testing.T) {
+	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	testContractCreation(t, s)
+}

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -82,7 +82,7 @@ func contractTxn(t *testing.T, s *State, delay BlockHeight, duration BlockHeight
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	rawSig, err := crypto.SignBytes(sigHash[:], sk)
+	rawSig, err := crypto.SignBytes(sigHash, sk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func storageProofTxn(t *testing.T, s *State) (txn Transaction, cid ContractID) {
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	rawSig, err := crypto.SignBytes(sigHash[:], sk)
+	rawSig, err := crypto.SignBytes(sigHash, sk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/contracts_test.go
+++ b/consensus/contracts_test.go
@@ -1,0 +1,6 @@
+package consensus
+
+// import (
+// "testing"
+// "time"
+// )

--- a/consensus/diffs.go
+++ b/consensus/diffs.go
@@ -20,7 +20,7 @@ import (
 type OutputDiff struct {
 	New    bool
 	ID     OutputID
-	Output Output
+	Output SiacoinOutput
 }
 
 type ContractDiff struct {

--- a/consensus/fork.go
+++ b/consensus/fork.go
@@ -200,14 +200,14 @@ func (s *State) forkBlockchain(newNode *blockNode) (err error) {
 			continue
 		}
 
-		// If the diffs have not been generated, call generateAndApply.
+		// If the diffs have not been generated, call generateAndApplyDiff.
 		err = s.generateAndApplyDiff(backtrackNodes[i])
 		if err != nil {
 			// Invalidate and delete all of the nodes after the bad block.
 			s.invalidateNode(backtrackNodes[i])
 
 			// Rewind the validated blocks
-			for j := 0; j < i; j++ { // reverse all the blocks we applied.
+			for j := 0; j < len(appliedNodes)-1; j++ { // reverse all the blocks we applied.
 				s.invertRecentBlock()
 			}
 

--- a/consensus/info.go
+++ b/consensus/info.go
@@ -41,14 +41,14 @@ func (s *State) height() BlockHeight {
 
 // State.Output returns the Output associated with the id provided for input,
 // but only if the output is a part of the utxo set.
-func (s *State) output(id OutputID) (output Output, exists bool) {
+func (s *State) output(id OutputID) (output SiacoinOutput, exists bool) {
 	output, exists = s.unspentOutputs[id]
 	return
 }
 
 // Sorted UtxoSet returns all of the unspent transaction outputs sorted
 // according to the numerical value of their id.
-func (s *State) sortedUtxoSet() (sortedOutputs []Output) {
+func (s *State) sortedUtxoSet() (sortedOutputs []SiacoinOutput) {
 	// Get all of the outputs in string form and sort the strings.
 	var unspentOutputStrings []string
 	for outputID := range s.unspentOutputs {
@@ -203,7 +203,7 @@ func (s *State) HeightOfBlock(bid BlockID) (height BlockHeight, exists bool) {
 
 // Output returns the output associated with an OutputID, returning an error if
 // the output is not found.
-func (s *State) Output(id OutputID) (output Output, exists bool) {
+func (s *State) Output(id OutputID) (output SiacoinOutput, exists bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.output(id)
@@ -211,7 +211,7 @@ func (s *State) Output(id OutputID) (output Output, exists bool) {
 
 // Sorted UtxoSet returns all of the unspent transaction outputs sorted
 // according to the numerical value of their id.
-func (s *State) SortedUtxoSet() []Output {
+func (s *State) SortedUtxoSet() []SiacoinOutput {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.sortedUtxoSet()

--- a/consensus/signatures.go
+++ b/consensus/signatures.go
@@ -12,7 +12,6 @@ import (
 // nonexistent objects in the transaction.
 
 var (
-	InvalidSignatureErr  = errors.New("signature is invalid")
 	MissingSignaturesErr = errors.New("transaction has inputs with missing signatures")
 )
 
@@ -175,8 +174,9 @@ func (s *State) validSignatures(t Transaction) (err error) {
 			}
 
 			sigHash := t.SigHash(i)
-			if !crypto.VerifyBytes(sigHash, decodedPK, decodedSig) {
-				return InvalidSignatureErr
+			err = crypto.VerifyHash(sigHash, decodedPK, decodedSig)
+			if err != nil {
+				return err
 			}
 		default:
 			// If we don't recognize the identifier, assume that the signature

--- a/consensus/signatures.go
+++ b/consensus/signatures.go
@@ -175,7 +175,7 @@ func (s *State) validSignatures(t Transaction) (err error) {
 			}
 
 			sigHash := t.SigHash(i)
-			if !crypto.VerifyBytes(sigHash[:], decodedPK, decodedSig) {
+			if !crypto.VerifyBytes(sigHash, decodedPK, decodedSig) {
 				return InvalidSignatureErr
 			}
 		default:

--- a/consensus/signatures.go
+++ b/consensus/signatures.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
 )
 
 // TODO: when testing the covered fields stuff, antagonistically try to cause
@@ -162,11 +163,13 @@ func (s *State) validSignatures(t Transaction) (err error) {
 		switch publicKey.Algorithm {
 		case ED25519Identifier:
 			// Decode the public key and signature.
-			decodedPK, err := crypto.DecodePublicKey(publicKey.Key)
+			var decodedPK crypto.PublicKey
+			err := encoding.Unmarshal(publicKey.Key, &decodedPK)
 			if err != nil {
 				return err
 			}
-			decodedSig, err := crypto.DecodeSignature(sig.Signature)
+			var decodedSig crypto.Signature
+			err = encoding.Unmarshal(sig.Signature, &decodedSig)
 			if err != nil {
 				return err
 			}

--- a/consensus/signatures.go
+++ b/consensus/signatures.go
@@ -47,9 +47,9 @@ func (t Transaction) validCoveredFields() (err error) {
 		// Check that all fields are empty if `WholeTransaction` is set.
 		cf := sig.CoveredFields
 		if cf.WholeTransaction {
-			if len(cf.Inputs) != 0 ||
+			if len(cf.SiacoinInputs) != 0 ||
 				len(cf.MinerFees) != 0 ||
-				len(cf.Outputs) != 0 ||
+				len(cf.SiacoinOutputs) != 0 ||
 				len(cf.FileContracts) != 0 ||
 				len(cf.StorageProofs) != 0 ||
 				len(cf.SiafundInputs) != 0 ||
@@ -63,7 +63,7 @@ func (t Transaction) validCoveredFields() (err error) {
 		// Check that all fields are sorted, and without repeat values, and
 		// that all elements point to objects that exists within the
 		// transaction.
-		err = sortedUnique(cf.Inputs, len(cf.Inputs)-1)
+		err = sortedUnique(cf.SiacoinInputs, len(cf.SiacoinInputs)-1)
 		if err != nil {
 			return
 		}
@@ -71,7 +71,7 @@ func (t Transaction) validCoveredFields() (err error) {
 		if err != nil {
 			return
 		}
-		err = sortedUnique(cf.Outputs, len(cf.Outputs)-1)
+		err = sortedUnique(cf.SiacoinOutputs, len(cf.SiacoinOutputs)-1)
 		if err != nil {
 			return
 		}
@@ -115,7 +115,7 @@ func (s *State) validSignatures(t Transaction) (err error) {
 
 	// Create the InputSignatures object for each input.
 	sigMap := make(map[OutputID]*InputSignatures)
-	for i, input := range t.Inputs {
+	for i, input := range t.SiacoinInputs {
 		_, exists := sigMap[input.OutputID]
 		if exists {
 			return errors.New("output spent twice in the same transaction.")

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -37,7 +37,7 @@ type State struct {
 	currentPath           map[BlockHeight]BlockID
 	siafundPool           Currency
 	unspentSiafundOutputs map[OutputID]SiafundOutput
-	unspentOutputs        map[OutputID]Output
+	unspentOutputs        map[OutputID]SiacoinOutput
 	openContracts         map[ContractID]FileContract
 
 	mu sync.RWMutex
@@ -53,7 +53,7 @@ func CreateGenesisState(genesisTime Timestamp) (s *State) {
 		blockMap:              make(map[BlockID]*blockNode),
 		currentPath:           make(map[BlockHeight]BlockID),
 		openContracts:         make(map[ContractID]FileContract),
-		unspentOutputs:        make(map[OutputID]Output),
+		unspentOutputs:        make(map[OutputID]SiacoinOutput),
 		unspentSiafundOutputs: make(map[OutputID]SiafundOutput),
 	}
 
@@ -71,7 +71,7 @@ func CreateGenesisState(genesisTime Timestamp) (s *State) {
 	// Fill out the consensus informaiton for the genesis block.
 	s.currentBlockID = genesisBlock.ID()
 	s.currentPath[BlockHeight(0)] = genesisBlock.ID()
-	s.unspentOutputs[genesisBlock.MinerPayoutID(0)] = Output{
+	s.unspentOutputs[genesisBlock.MinerPayoutID(0)] = SiacoinOutput{
 		Value:     CalculateCoinbase(0),
 		SpendHash: ZeroAddress,
 	}

--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -4,6 +4,10 @@ import (
 	"errors"
 )
 
+var (
+	MissingOutputErr = errors.New("transaction spends a nonexisting output")
+)
+
 // validStorageProofs checks that a transaction follows the limitations placed
 // on transactions with storage proofs.
 func (t Transaction) validStorageProofs() bool {
@@ -30,7 +34,7 @@ func (s *State) validInput(input SiacoinInput) (err error) {
 	// Check the input spends an existing and valid output.
 	_, exists := s.unspentOutputs[input.OutputID]
 	if !exists {
-		err = errors.New("transaction spends a nonexisting output")
+		err = MissingOutputErr
 		return
 	}
 

--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -11,7 +11,7 @@ func (t Transaction) validStorageProofs() bool {
 		return true
 	}
 
-	if len(t.Outputs) != 0 {
+	if len(t.SiacoinOutputs) != 0 {
 		return false
 	}
 	if len(t.FileContracts) != 0 {
@@ -26,7 +26,7 @@ func (t Transaction) validStorageProofs() bool {
 
 // validInput returns err = nil if the input is valid within the current state,
 // otherwise returns an error explaining what wasn't valid.
-func (s *State) validInput(input Input) (err error) {
+func (s *State) validInput(input SiacoinInput) (err error) {
 	// Check the input spends an existing and valid output.
 	_, exists := s.unspentOutputs[input.OutputID]
 	if !exists {
@@ -60,7 +60,7 @@ func (s *State) validTransaction(t Transaction) (err error) {
 
 	// Validate each input and get the total amount of Currency.
 	inputSum := Currency(0)
-	for _, input := range t.Inputs {
+	for _, input := range t.SiacoinInputs {
 		// Check that the input is valid.
 		err = s.validInput(input)
 		if err != nil {
@@ -106,7 +106,7 @@ func (s *State) validTransaction(t Transaction) (err error) {
 // ConsensusState, updating the list of contracts, outputs, etc.
 func (s *State) applyTransaction(t Transaction) (outputDiffs []OutputDiff, contractDiffs []ContractDiff) {
 	// Remove all inputs from the unspent outputs list.
-	for _, input := range t.Inputs {
+	for _, input := range t.SiacoinInputs {
 		// Sanity check - the input must exist within the blockchain, should
 		// have already been verified.
 		if DEBUG {
@@ -126,7 +126,7 @@ func (s *State) applyTransaction(t Transaction) (outputDiffs []OutputDiff, contr
 	}
 
 	// Add all finanacial outputs to the unspent outputs list.
-	for i, output := range t.Outputs {
+	for i, output := range t.SiacoinOutputs {
 		// Sanity check - the output must not exist within the state, should
 		// have already been verified.
 		if DEBUG {
@@ -175,7 +175,7 @@ func (t Transaction) OutputSum() (sum Currency) {
 	}
 
 	// Add the outputs
-	for _, output := range t.Outputs {
+	for _, output := range t.SiacoinOutputs {
 		sum += output.Value
 	}
 

--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -130,7 +130,7 @@ func (s *State) applyTransaction(t Transaction) (outputDiffs []OutputDiff, contr
 		// Sanity check - the output must not exist within the state, should
 		// have already been verified.
 		if DEBUG {
-			_, exists := s.unspentOutputs[t.OutputID(i)]
+			_, exists := s.unspentOutputs[t.SiacoinOutputID(i)]
 			if exists {
 				panic("applying a  transaction with an invalid new output")
 			}
@@ -138,10 +138,10 @@ func (s *State) applyTransaction(t Transaction) (outputDiffs []OutputDiff, contr
 
 		diff := OutputDiff{
 			New:    true,
-			ID:     t.OutputID(i),
+			ID:     t.SiacoinOutputID(i),
 			Output: output,
 		}
-		s.unspentOutputs[t.OutputID(i)] = output
+		s.unspentOutputs[t.SiacoinOutputID(i)] = output
 		outputDiffs = append(outputDiffs, diff)
 	}
 

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -1,0 +1,1 @@
+package consensus

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -1,1 +1,93 @@
 package consensus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/crypto"
+)
+
+// signedOutputTxn funds itself by mining a block, and then uses the funds to
+// create a signed output that is valid.
+func signedOutputTxn(t *testing.T, s *State) (txn Transaction) {
+	// Create the keys and a siacoin output that adds coins to the keys.
+	sk, pk, err := crypto.GenerateSignatureKeys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendConditions := SpendConditions{
+		NumSignatures: 1,
+		PublicKeys: []SiaPublicKey{
+			SiaPublicKey{
+				Algorithm: ED25519Identifier,
+				Key:       pk[:],
+			},
+		},
+	}
+	coinAddress := spendConditions.CoinAddress()
+	minerPayouts := []SiacoinOutput{
+		SiacoinOutput{
+			Value:     CalculateCoinbase(s.height() + 1),
+			SpendHash: coinAddress,
+		},
+	}
+
+	// Mine the block that creates the output.
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), minerPayouts, nil, s.CurrentTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.AcceptBlock(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the transaction that spends the output.
+	input := SiacoinInput{
+		OutputID:        b.MinerPayoutID(0),
+		SpendConditions: spendConditions,
+	}
+	output := SiacoinOutput{
+		Value:     CalculateCoinbase(s.height()),
+		SpendHash: ZeroAddress,
+	}
+	txn = Transaction{
+		SiacoinInputs:  []SiacoinInput{input},
+		SiacoinOutputs: []SiacoinOutput{output},
+	}
+
+	// Sign the transaction.
+	sig := TransactionSignature{
+		InputID:        input.OutputID,
+		CoveredFields:  CoveredFields{WholeTransaction: true},
+		PublicKeyIndex: 0,
+	}
+	txn.Signatures = append(txn.Signatures, sig)
+	sigHash := txn.SigHash(0)
+	encodedSig, err := crypto.SignBytes(sigHash[:], sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn.Signatures[0].Signature = encodedSig[:]
+	return
+}
+
+// testSingleOutput creates a block with one transaction that has inputs and
+// outputs, and verifies that the output is accepted into the state.
+func testSingleOutput(t *testing.T, s *State) {
+	txn := signedOutputTxn(t, s)
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.AcceptBlock(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSingleOutput creates a new state and uses it to call testSingleOutput.
+func TestSingleOutput(t *testing.T) {
+	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	testSingleOutput(t, s)
+}

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -64,7 +64,7 @@ func signedOutputTxn(t *testing.T, s *State, algorithm Identifier) (txn Transact
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	rawSig, err := crypto.SignBytes(sigHash[:], sk)
+	rawSig, err := crypto.SignBytes(sigHash, sk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"testing"
-	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -34,7 +33,7 @@ func signedOutputTxn(t *testing.T, s *State, algorithm Identifier) (txn Transact
 	}
 
 	// Mine the block that creates the output.
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), minerPayouts, nil, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), minerPayouts, nil, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +81,7 @@ func testForeignSignature(t *testing.T, s *State) {
 	nonAlgorithm[0] = ' '
 	txn := signedOutputTxn(t, s, nonAlgorithm)
 	txn.Signatures[0].Signature[0]++
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +101,7 @@ func testForeignSignature(t *testing.T, s *State) {
 func testInvalidSignature(t *testing.T, s *State) {
 	txn := signedOutputTxn(t, s, ED25519Identifier)
 	txn.Signatures[0].Signature[1]++
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +115,7 @@ func testInvalidSignature(t *testing.T, s *State) {
 // outputs, and verifies that the output is accepted into the state.
 func testSingleOutput(t *testing.T, s *State) {
 	txn := signedOutputTxn(t, s, ED25519Identifier)
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +136,7 @@ func testSingleOutput(t *testing.T, s *State) {
 func testUnsignedTransaction(t *testing.T, s *State) {
 	txn := signedOutputTxn(t, s, ED25519Identifier)
 	txn.Signatures = nil
-	b, err := mineTestingBlock(s.CurrentBlock().ID(), Timestamp(time.Now().Unix()), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
+	b, err := mineTestingBlock(s.CurrentBlock().ID(), currentTime(), nullMinerPayouts(s.Height()+1), []Transaction{txn}, s.CurrentTarget())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,26 +149,26 @@ func testUnsignedTransaction(t *testing.T, s *State) {
 // TestForeignSignature creates a new state and uses it to call
 // testForeignSignature.
 func TestForeignSignature(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testForeignSignature(t, s)
 }
 
 // TestInvalidSignature creates a new state and uses it to call
 // testInvalidSignature.
 func TestInvalidSignature(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testInvalidSignature(t, s)
 }
 
 // TestSingleOutput creates a new state and uses it to call testSingleOutput.
 func TestSingleOutput(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testSingleOutput(t, s)
 }
 
 // TestUnsignedTransaction creates a new state and uses it to call
 // testUnsignedTransaction.
 func TestUnsignedTransaction(t *testing.T) {
-	s := CreateGenesisState(Timestamp(time.Now().Unix()))
+	s := CreateGenesisState(currentTime())
 	testUnsignedTransaction(t, s)
 }

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -64,7 +64,7 @@ func signedOutputTxn(t *testing.T, s *State, algorithm Identifier) (txn Transact
 	}
 	txn.Signatures = append(txn.Signatures, sig)
 	sigHash := txn.SigHash(0)
-	rawSig, err := crypto.SignBytes(sigHash, sk)
+	rawSig, err := crypto.SignHash(sigHash, sk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func testInvalidSignature(t *testing.T, s *State) {
 		t.Fatal(err)
 	}
 	err = s.AcceptBlock(b)
-	if err != InvalidSignatureErr {
+	if err != crypto.ErrInvalidSignature {
 		t.Fatal(err)
 	}
 }

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -244,10 +244,11 @@ func (t Transaction) FileContractID(i int) ContractID {
 	))
 }
 
-// OutputID gets the id of an output in the transaction, which is derived from
-// marshalling all of the fields in the transaction except for the signatures
-// and then appending the string "siacoin output" and the index of the output.
-func (t Transaction) OutputID(i int) OutputID {
+// SiacoinOutputID gets the id of an output in the transaction, which is
+// derived from marshalling all of the fields in the transaction except for the
+// signatures and then appending the string "siacoin output" and the index of
+// the output.
+func (t Transaction) SiacoinOutputID(i int) OutputID {
 	return OutputID(hash.HashAll(
 		SiacoinOutputIdentifier,
 		t.SiacoinInputs,

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -49,16 +49,16 @@ type Block struct {
 	ParentID     BlockID
 	Nonce        uint64
 	Timestamp    Timestamp
-	MinerPayouts []Output
+	MinerPayouts []SiacoinOutput
 	Transactions []Transaction
 }
 
 // A Transaction is an update to the state of the network, can move money
 // around, make contracts, etc.
 type Transaction struct {
-	Inputs         []Input
+	SiacoinInputs  []SiacoinInput
 	MinerFees      []Currency
-	Outputs        []Output
+	SiacoinOutputs []SiacoinOutput
 	FileContracts  []FileContract
 	StorageProofs  []StorageProof
 	SiafundInputs  []SiafundInput
@@ -69,7 +69,7 @@ type Transaction struct {
 
 // An Input contains the ID of the output it's trying to spend, and the spend
 // conditions that unlock the output.
-type Input struct {
+type SiacoinInput struct {
 	OutputID        OutputID
 	SpendConditions SpendConditions
 }
@@ -93,7 +93,7 @@ type SpendConditions struct {
 
 // An Output contains a volume of currency and a 'CoinAddress', which is just a
 // hash of the spend conditions which unlock the output.
-type Output struct {
+type SiacoinOutput struct {
 	Value     Currency
 	SpendHash CoinAddress
 }
@@ -167,9 +167,9 @@ type TransactionSignature struct {
 // empty except for the Signatures field.
 type CoveredFields struct {
 	WholeTransaction bool
-	Inputs           []uint64
+	SiacoinInputs    []uint64
 	MinerFees        []uint64
-	Outputs          []uint64
+	SiacoinOutputs   []uint64
 	FileContracts    []uint64
 	StorageProofs    []uint64
 	SiafundInputs    []uint64
@@ -229,9 +229,9 @@ func (b Block) MinerPayoutID(i int) OutputID {
 func (t Transaction) FileContractID(i int) ContractID {
 	return ContractID(hash.HashAll(
 		FileContractIdentifier,
-		t.Inputs,
+		t.SiacoinInputs,
 		t.MinerFees,
-		t.Outputs,
+		t.SiacoinOutputs,
 		t.FileContracts,
 		t.StorageProofs,
 		t.SiafundInputs,
@@ -247,9 +247,9 @@ func (t Transaction) FileContractID(i int) ContractID {
 func (t Transaction) OutputID(i int) OutputID {
 	return OutputID(hash.HashAll(
 		SiacoinOutputIdentifier,
-		t.Inputs,
+		t.SiacoinInputs,
 		t.MinerFees,
-		t.Outputs,
+		t.SiacoinOutputs,
 		t.FileContracts,
 		t.StorageProofs,
 		t.SiafundInputs,
@@ -274,9 +274,9 @@ func (fcID ContractID) StorageProofOutputID(proofValid bool) (outputID OutputID)
 func (t Transaction) SiafundOutputID(i int) OutputID {
 	return OutputID(hash.HashAll(
 		SiafundOutputIdentifier,
-		t.Inputs,
+		t.SiacoinInputs,
 		t.MinerFees,
-		t.Outputs,
+		t.SiacoinOutputs,
 		t.FileContracts,
 		t.StorageProofs,
 		t.SiafundInputs,
@@ -306,9 +306,9 @@ func (t Transaction) SigHash(i int) hash.Hash {
 	var signedData []byte
 	if cf.WholeTransaction {
 		signedData = encoding.MarshalAll(
-			t.Inputs,
+			t.SiacoinInputs,
 			t.MinerFees,
-			t.Outputs,
+			t.SiacoinOutputs,
 			t.FileContracts,
 			t.StorageProofs,
 			t.SiafundInputs,
@@ -322,11 +322,11 @@ func (t Transaction) SigHash(i int) hash.Hash {
 		for _, minerFee := range cf.MinerFees {
 			signedData = append(signedData, encoding.Marshal(t.MinerFees[minerFee])...)
 		}
-		for _, input := range cf.Inputs {
-			signedData = append(signedData, encoding.Marshal(t.Inputs[input])...)
+		for _, input := range cf.SiacoinInputs {
+			signedData = append(signedData, encoding.Marshal(t.SiacoinInputs[input])...)
 		}
-		for _, output := range cf.Outputs {
-			signedData = append(signedData, encoding.Marshal(t.Outputs[output])...)
+		for _, output := range cf.SiacoinOutputs {
+			signedData = append(signedData, encoding.Marshal(t.SiacoinOutputs[output])...)
 		}
 		for _, contract := range cf.FileContracts {
 			signedData = append(signedData, encoding.Marshal(t.FileContracts[contract])...)

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -219,7 +219,10 @@ func (b Block) MerkleRoot() hash.Hash {
 
 // MinerPayoutID returns the ID of the payout at the given index.
 func (b Block) MinerPayoutID(i int) OutputID {
-	return OutputID(hash.HashAll(b.ID(), i))
+	return OutputID(hash.HashAll(
+		b.ID(),
+		i,
+	))
 }
 
 // FileContractID returns the id of a file contract given the index of the

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -78,36 +78,12 @@ func TestEncryption(t *testing.T) {
 	if err == nil {
 		t.Fatal("Was able to decrypt using bad padding")
 	}
-}
 
-// TestPadding encrypts and decrypts a byte slice that invokes every possible
-// padding length.
-func TestPadding(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	// Try to trigger a panic with nil values.
+	EncryptBytes(key, nil)
+	DecryptBytes(key, nil, iv, padding)
+	DecryptBytes(key, ciphertext, nil, padding)
 
-	// Encrypt and decrypt for all of the potential padded values and see that
-	// padding is handled correctly.
-	for i := 256; i < 256+BlockSize; i++ {
-		key, err := GenerateEncryptionKey()
-		if err != nil {
-			t.Fatal(err)
-		}
-		plaintext := make([]byte, i)
-		rand.Read(plaintext)
-		ciphertext, iv, padding, err := EncryptBytes(key, plaintext)
-		if err != nil {
-			t.Fatal(err)
-		}
-		decryptedPlaintext, err := DecryptBytes(key, ciphertext, iv, padding)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if bytes.Compare(plaintext, decryptedPlaintext) != 0 {
-			t.Fatal("Encrypted and decrypted zero plaintext do not match for i = ", i)
-		}
-	}
 }
 
 // TestEntropy encrypts and then decrypts a zero plaintext, checking that the
@@ -140,5 +116,35 @@ func TestEntropy(t *testing.T) {
 	zip.Close()
 	if b.Len() < cipherSize {
 		t.Error("supposedly high entropy ciphertext has been compressed!")
+	}
+}
+
+// TestPadding encrypts and decrypts a byte slice that invokes every possible
+// padding length.
+func TestPadding(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	// Encrypt and decrypt for all of the potential padded values and see that
+	// padding is handled correctly.
+	for i := 256; i < 256+BlockSize; i++ {
+		key, err := GenerateEncryptionKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		plaintext := make([]byte, i)
+		rand.Read(plaintext)
+		ciphertext, iv, padding, err := EncryptBytes(key, plaintext)
+		if err != nil {
+			t.Fatal(err)
+		}
+		decryptedPlaintext, err := DecryptBytes(key, ciphertext, iv, padding)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Compare(plaintext, decryptedPlaintext) != 0 {
+			t.Fatal("Encrypted and decrypted zero plaintext do not match for i = ", i)
+		}
 	}
 }

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -19,35 +19,6 @@ type (
 	Signature *[ed25519.SignatureSize]byte
 )
 
-// DecodePublicKey takes a bytes slice and returns the corresponding public
-// key. An error is returned if the byte slice is the wrong length.
-//
-// TODO: Depricate in favor of encoding.Unmarshal
-func DecodePublicKey(encodedPK []byte) (pk PublicKey, err error) {
-	if len(encodedPK) != PublicKeySize {
-		err = errors.New("public key is invalid size")
-		return
-	}
-
-	var epk [PublicKeySize]byte
-	copy(epk[:], encodedPK)
-	pk = PublicKey(&epk)
-	return
-}
-
-// TODO: Depricate in favor of encoding.Unmarshal
-func DecodeSignature(encodedSig []byte) (sig Signature, err error) {
-	if len(encodedSig) != SignatureSize {
-		err = errors.New("Signature is invalid size")
-		return
-	}
-
-	var esig [SignatureSize]byte
-	copy(esig[:], encodedSig)
-	sig = Signature(&esig)
-	return
-}
-
 // GenerateKeyPair creates a public-secret keypair that can be used to sign and
 // verify messages.
 func GenerateSignatureKeys() (sk SecretKey, pk PublicKey, err error) {

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"crypto/rand"
+	"errors"
 
 	"github.com/agl/ed25519"
 )
@@ -17,6 +18,32 @@ type (
 	SecretKey *[ed25519.PrivateKeySize]byte
 	Signature *[ed25519.SignatureSize]byte
 )
+
+// DecodePublicKey takes a bytes slice and returns the corresponding public
+// key. An error is returned if the byte slice is the wrong length.
+func DecodePublicKey(encodedPK []byte) (pk PublicKey, err error) {
+	if len(encodedPK) != PublicKeySize {
+		err = errors.New("public key is invalid size")
+		return
+	}
+
+	var epk [PublicKeySize]byte
+	copy(epk[:], encodedPK)
+	pk = PublicKey(&epk)
+	return
+}
+
+func DecodeSignature(encodedSig []byte) (sig Signature, err error) {
+	if len(encodedSig) != SignatureSize {
+		err = errors.New("Signature is invalid size")
+		return
+	}
+
+	var esig [SignatureSize]byte
+	copy(esig[:], encodedSig)
+	sig = Signature(&esig)
+	return
+}
 
 // GenerateKeyPair creates a public-secret keypair that can be used to sign and
 // verify messages.

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 
 	"github.com/agl/ed25519"
+
+	"github.com/NebulousLabs/Sia/hash"
 )
 
 const (
@@ -30,31 +32,24 @@ func GenerateSignatureKeys() (sk SecretKey, pk PublicKey, err error) {
 }
 
 // SignBytes signs a message using a secret key.
-func SignBytes(data []byte, sk SecretKey) (sig Signature, err error) {
-	if len(data) != 32 {
-		err = errors.New("will only sign 32 byte hashes!")
-		return
-	}
+func SignBytes(data hash.Hash, sk SecretKey) (sig Signature, err error) {
 	if sk == nil {
 		err = errors.New("cannot sign with nil key")
 		return
 	}
-	sig = ed25519.Sign(sk, data)
+	sig = ed25519.Sign(sk, data[:])
 	return
 }
 
 // VerifyBytes uses a public key and input data to verify a signature.
 //
 // TODO: Switch VerifyBytes to also returning an error.
-func VerifyBytes(data []byte, pk PublicKey, sig Signature) bool {
-	if len(data) != 32 {
-		return false
-	}
+func VerifyBytes(data hash.Hash, pk PublicKey, sig Signature) bool {
 	if pk == nil {
 		return false
 	}
 	if sig == nil {
 		return false
 	}
-	return ed25519.Verify(pk, data, sig)
+	return ed25519.Verify(pk, data[:], sig)
 }

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -21,6 +21,8 @@ type (
 
 // DecodePublicKey takes a bytes slice and returns the corresponding public
 // key. An error is returned if the byte slice is the wrong length.
+//
+// TODO: Depricate in favor of encoding.Unmarshal
 func DecodePublicKey(encodedPK []byte) (pk PublicKey, err error) {
 	if len(encodedPK) != PublicKeySize {
 		err = errors.New("public key is invalid size")
@@ -33,6 +35,7 @@ func DecodePublicKey(encodedPK []byte) (pk PublicKey, err error) {
 	return
 }
 
+// TODO: Depricate in favor of encoding.Unmarshal
 func DecodeSignature(encodedSig []byte) (sig Signature, err error) {
 	if len(encodedSig) != SignatureSize {
 		err = errors.New("Signature is invalid size")
@@ -57,11 +60,30 @@ func GenerateSignatureKeys() (sk SecretKey, pk PublicKey, err error) {
 
 // SignBytes signs a message using a secret key.
 func SignBytes(data []byte, sk SecretKey) (sig Signature, err error) {
+	if len(data) != 32 {
+		err = errors.New("will only sign 32 byte hashes!")
+		return
+	}
+	if sk == nil {
+		err = errors.New("cannot sign with nil key")
+		return
+	}
 	sig = ed25519.Sign(sk, data)
 	return
 }
 
 // VerifyBytes uses a public key and input data to verify a signature.
+//
+// TODO: Switch VerifyBytes to also returning an error.
 func VerifyBytes(data []byte, pk PublicKey, sig Signature) bool {
+	if len(data) != 32 {
+		return false
+	}
+	if pk == nil {
+		return false
+	}
+	if sig == nil {
+		return false
+	}
 	return ed25519.Verify(pk, data, sig)
 }

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -58,11 +58,11 @@ func TestSigning(t *testing.T) {
 	if testing.Short() {
 		iterations = 5
 	} else {
-		iterations = 5000
+		iterations = 500
 	}
 
 	// Try a bunch of signatures because at one point there was a library that
-	// worked around 98% of the time. Tests would usually pass, but 5000
+	// worked around 98% of the time. Tests would usually pass, but 500
 	// iterations would always cause a failure.
 	for i := 0; i < iterations; i++ {
 		// Generate the keys.

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/hash"
 )
 
 // Creates and encodes a public key, and verifies that it decodes correctly,
@@ -30,8 +31,8 @@ func TestSignatureEncoding(t *testing.T) {
 	}
 
 	// Create a signature using the secret key.
-	signedData := make([]byte, 32)
-	rand.Read(signedData)
+	var signedData hash.Hash
+	rand.Read(signedData[:])
 	sig, err := SignBytes(signedData, sk)
 	if err != nil {
 		t.Fatal(err)
@@ -72,8 +73,8 @@ func TestSigning(t *testing.T) {
 		}
 
 		// Generate and sign the data.
-		randData := make([]byte, 32)
-		rand.Read(randData)
+		var randData hash.Hash
+		rand.Read(randData[:])
 		sig, err := SignBytes(randData, sk)
 		if err != nil {
 			t.Fatal(err)
@@ -104,10 +105,10 @@ func TestSigning(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data := make([]byte, 32)
-	SignBytes(nil, nil)
+	var data hash.Hash
 	SignBytes(data, nil)
-	VerifyBytes(nil, nil, nil)
+	SignBytes(data, nil)
+	VerifyBytes(data, nil, nil)
 	VerifyBytes(data, nil, nil)
 	VerifyBytes(data, pk, nil)
 }

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -33,7 +33,7 @@ func (h *Host) Announce(addr network.Address, freezeVolume consensus.Currency, f
 	if err != nil {
 		return
 	}
-	output := consensus.Output{
+	output := consensus.SiacoinOutput{
 		Value:     freezeVolume,
 		SpendHash: spendHash,
 	}

--- a/modules/hostdb/announcements.go
+++ b/modules/hostdb/announcements.go
@@ -27,12 +27,12 @@ func findHostAnnouncements(height consensus.BlockHeight, b consensus.Block) (ann
 			}
 
 			// check that spend conditions are valid
-			if ha.SpendConditions.CoinAddress() != t.Outputs[ha.FreezeIndex].SpendHash {
+			if ha.SpendConditions.CoinAddress() != t.SiacoinOutputs[ha.FreezeIndex].SpendHash {
 				continue
 			}
 
 			// calculate freeze
-			freeze := uint64(ha.SpendConditions.TimeLock-height) * uint64(t.Outputs[ha.FreezeIndex].Value)
+			freeze := uint64(ha.SpendConditions.TimeLock-height) * uint64(t.SiacoinOutputs[ha.FreezeIndex].Value)
 
 			// check for sane freeze value
 			if freeze <= 0 {

--- a/modules/miner/mine.go
+++ b/modules/miner/mine.go
@@ -34,8 +34,8 @@ func (m *Miner) blockForWork() (b consensus.Block) {
 			subsidy += fee
 		}
 	}
-	output := consensus.Output{Value: subsidy, SpendHash: m.address}
-	b.MinerPayouts = []consensus.Output{output}
+	output := consensus.SiacoinOutput{Value: subsidy, SpendHash: m.address}
+	b.MinerPayouts = []consensus.SiacoinOutput{output}
 
 	// If we've got a time earlier than the earliest legal timestamp, set the
 	// timestamp equal to the earliest legal timestamp.

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -131,18 +131,18 @@ func (tp *TransactionPool) addTransaction(t consensus.Transaction) {
 		// Sanity check - this output should not already exist in newOutputs or
 		// outputs.
 		if consensus.DEBUG {
-			_, exists := tp.newOutputs[t.OutputID(i)]
+			_, exists := tp.newOutputs[t.SiacoinOutputID(i)]
 			if exists {
 				panic("trying to add an output that already exists?")
 			}
-			_, exists = tp.outputs[t.OutputID(i)]
+			_, exists = tp.outputs[t.SiacoinOutputID(i)]
 			if exists {
 				panic("trying to add an output that already exists?")
 			}
 		}
 
-		tp.outputs[t.OutputID(i)] = output
-		tp.newOutputs[t.OutputID(i)] = ut
+		tp.outputs[t.SiacoinOutputID(i)] = output
+		tp.newOutputs[t.SiacoinOutputID(i)] = ut
 	}
 
 	tp.addTransactionToTail(ut)

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -10,7 +10,7 @@ import (
 // the confirmed set of outputs or in the unconfirmed set of outputs.
 // checkInputs also returns the sum of all the inputs in the transaction.
 func (tp *TransactionPool) checkInputs(t consensus.Transaction) (inputSum consensus.Currency, err error) {
-	for _, input := range t.Inputs {
+	for _, input := range t.SiacoinInputs {
 		// Check that this output has not already been spent by an unconfirmed
 		// transaction.
 		_, exists := tp.outputs[input.OutputID]
@@ -108,7 +108,7 @@ func (tp *TransactionPool) addTransaction(t consensus.Transaction) {
 
 	// Go through the inputs and them to the used outputs list, updating the
 	// requirements and dependents as necessary.
-	for _, input := range t.Inputs {
+	for _, input := range t.SiacoinInputs {
 		// Sanity check - this input should not already be in the usedOutputs
 		// list.
 		if consensus.DEBUG {
@@ -127,7 +127,7 @@ func (tp *TransactionPool) addTransaction(t consensus.Transaction) {
 	}
 
 	// Add each new output to the list of outputs and newOutputs.
-	for i, output := range t.Outputs {
+	for i, output := range t.SiacoinOutputs {
 		// Sanity check - this output should not already exist in newOutputs or
 		// outputs.
 		if consensus.DEBUG {

--- a/modules/transactionpool/dump.go
+++ b/modules/transactionpool/dump.go
@@ -98,7 +98,7 @@ func (tp *TransactionPool) OutputDiffs() (diffs []consensus.OutputDiff) {
 		for i, output := range txn.SiacoinOutputs {
 			diff := consensus.OutputDiff{
 				New:    true,
-				ID:     txn.OutputID(i),
+				ID:     txn.SiacoinOutputID(i),
 				Output: output,
 			}
 			diffs = append(diffs, diff)

--- a/modules/transactionpool/dump.go
+++ b/modules/transactionpool/dump.go
@@ -73,7 +73,7 @@ func (tp *TransactionPool) OutputDiffs() (diffs []consensus.OutputDiff) {
 	currentTxn := tp.head
 	for currentTxn != nil {
 		txn := currentTxn.transaction
-		for _, input := range txn.Inputs {
+		for _, input := range txn.SiacoinInputs {
 			diff := consensus.OutputDiff{
 				New: false,
 				ID:  input.OutputID,
@@ -95,7 +95,7 @@ func (tp *TransactionPool) OutputDiffs() (diffs []consensus.OutputDiff) {
 			diffs = append(diffs, diff)
 		}
 
-		for i, output := range txn.Outputs {
+		for i, output := range txn.SiacoinOutputs {
 			diff := consensus.OutputDiff{
 				New:    true,
 				ID:     txn.OutputID(i),

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	TransactionSizeLimit = 64 * 1024
+	TransactionSizeLimit = 16 * 1024
 )
 
 // standard implements the rules outlined in Standard.md, and will return an
@@ -19,19 +19,6 @@ func (tp *TransactionPool) IsStandardTransaction(t consensus.Transaction) (err e
 	if len(encoding.Marshal(t)) > TransactionSizeLimit {
 		err = errors.New("transaction is too large")
 		return
-	}
-
-	// Check that transactions with storage proofs follow the storage proof
-	// rules.
-	if len(t.StorageProofs) != 0 {
-		if len(t.Inputs) > 1 ||
-			len(t.MinerFees) > 1 ||
-			len(t.Outputs) > 1 ||
-			len(t.FileContracts) != 0 ||
-			len(t.ArbitraryData) != 0 {
-			err = errors.New("transaction has storage proofs but does not follow the storage proof rules")
-			return
-		}
 	}
 
 	// TODO: Check that the arbitrary data is either prefixed with 'NonSia' or

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -21,6 +21,9 @@ func (tp *TransactionPool) IsStandardTransaction(t consensus.Transaction) (err e
 		return
 	}
 
+	// TODO: Check that the public keys in every transaction use only
+	// algorithms that are recognized by the consensus package.
+
 	// TODO: Check that the arbitrary data is either prefixed with 'NonSia' or
 	// is prefixed with 'HostAnnouncement' plus follows rules for making a host
 	// announcement.

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -40,7 +40,7 @@ type TransactionPool struct {
 	// Outputs contains a list of outputs that have been created by unconfirmed
 	// transactions. This list will not include outputs created by storage
 	// proofs.
-	outputs map[consensus.OutputID]consensus.Output
+	outputs map[consensus.OutputID]consensus.SiacoinOutput
 
 	// newOutputs is a mapping from an OutputID to the unconfirmed transaction
 	// that created the output. usedOutputs is a mapping to the unconfirmed
@@ -70,7 +70,7 @@ func New(state *consensus.State) (tp *TransactionPool, err error) {
 		state:       state,
 		recentBlock: state.CurrentBlock().ID(),
 
-		outputs: make(map[consensus.OutputID]consensus.Output),
+		outputs: make(map[consensus.OutputID]consensus.SiacoinOutput),
 
 		newOutputs:  make(map[consensus.OutputID]*unconfirmedTransaction),
 		usedOutputs: make(map[consensus.OutputID]*unconfirmedTransaction),

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -66,7 +66,7 @@ func (tp *TransactionPool) update() {
 
 			// Find any transactions in our set that are dependent on this
 			// transaction.
-			for i := range txn.Outputs {
+			for i := range txn.SiacoinOutputs {
 				dependent, exists := tp.usedOutputs[txn.OutputID(i)]
 				if exists {
 					ut.dependents[dependent] = struct{}{}
@@ -92,7 +92,7 @@ func (tp *TransactionPool) update() {
 	// occur with transactions that got accepted.
 	for _, block := range addedBlocks {
 		for _, txn := range block.Transactions {
-			for _, input := range txn.Inputs {
+			for _, input := range txn.SiacoinInputs {
 				conflict, exists := tp.usedOutputs[input.OutputID]
 				if exists {
 					tp.removeTransactionFromPool(conflict)

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -67,7 +67,7 @@ func (tp *TransactionPool) update() {
 			// Find any transactions in our set that are dependent on this
 			// transaction.
 			for i := range txn.SiacoinOutputs {
-				dependent, exists := tp.usedOutputs[txn.OutputID(i)]
+				dependent, exists := tp.usedOutputs[txn.SiacoinOutputID(i)]
 				if exists {
 					ut.dependents[dependent] = struct{}{}
 					dependent.requirements[ut] = struct{}{}

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -39,7 +39,7 @@ type Wallet interface {
 
 	// AddOutput adds an output to a transaction. It returns the index of the
 	// output in the transaction.
-	AddOutput(id string, output consensus.Output) (uint64, error)
+	AddOutput(id string, output consensus.SiacoinOutput) (uint64, error)
 
 	// AddFileContract adds a file contract to a transaction.
 	AddFileContract(id string, fc consensus.FileContract) error

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -19,10 +19,10 @@ func (w *Wallet) timelockedCoinAddress(unlockHeight consensus.BlockHeight) (coin
 		PublicKeys: []consensus.SiaPublicKey{
 			consensus.SiaPublicKey{
 				Algorithm: consensus.ED25519Identifier,
+				Key:       pk[:],
 			},
 		},
 	}
-	copy(spendConditions.PublicKeys[0].Key, pk[:])
 	coinAddress = spendConditions.CoinAddress()
 
 	// Create a spendableAddress for the keys and add it to the
@@ -68,10 +68,10 @@ func (w *Wallet) coinAddress() (coinAddress consensus.CoinAddress, spendConditio
 		PublicKeys: []consensus.SiaPublicKey{
 			consensus.SiaPublicKey{
 				Algorithm: consensus.ED25519Identifier,
+				Key:       pk[:],
 			},
 		},
 	}
-	copy(spendConditions.PublicKeys[0].Key, pk[:])
 	coinAddress = spendConditions.CoinAddress()
 
 	// Add the address to the set of spendable addresses.

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
 )
 
 // TimelockedCoinAddress returns an address that can only be spent after block
@@ -19,7 +20,7 @@ func (w *Wallet) timelockedCoinAddress(unlockHeight consensus.BlockHeight) (coin
 		PublicKeys: []consensus.SiaPublicKey{
 			consensus.SiaPublicKey{
 				Algorithm: consensus.ED25519Identifier,
-				Key:       pk[:],
+				Key:       encoding.Marshal(pk),
 			},
 		},
 	}
@@ -68,7 +69,7 @@ func (w *Wallet) coinAddress() (coinAddress consensus.CoinAddress, spendConditio
 		PublicKeys: []consensus.SiaPublicKey{
 			consensus.SiaPublicKey{
 				Algorithm: consensus.ED25519Identifier,
-				Key:       pk[:],
+				Key:       encoding.Marshal(pk),
 			},
 		},
 	}

--- a/modules/wallet/outputs.go
+++ b/modules/wallet/outputs.go
@@ -16,7 +16,7 @@ import (
 // wallet's spent counter, then it has been spent since the previous reset.
 type knownOutput struct {
 	id     consensus.OutputID
-	output consensus.Output
+	output consensus.SiacoinOutput
 
 	spendable bool
 	age       int

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -54,12 +54,12 @@ func (w *Wallet) FundTransaction(id string, amount consensus.Currency) error {
 	// Create and add all of the inputs.
 	for _, knownOutput := range knownOutputs {
 		key := w.keys[knownOutput.output.SpendHash]
-		newInput := consensus.Input{
+		newInput := consensus.SiacoinInput{
 			OutputID:        knownOutput.id,
 			SpendConditions: key.spendConditions,
 		}
-		openTxn.inputs = append(openTxn.inputs, len(txn.Inputs))
-		txn.Inputs = append(txn.Inputs, newInput)
+		openTxn.inputs = append(openTxn.inputs, len(txn.SiacoinInputs))
+		txn.SiacoinInputs = append(txn.SiacoinInputs, newInput)
 
 		// Set the age of the knownOutput to prevent accidental double spends.
 		knownOutput.age = w.age
@@ -72,9 +72,9 @@ func (w *Wallet) FundTransaction(id string, amount consensus.Currency) error {
 			return err
 		}
 
-		txn.Outputs = append(
-			txn.Outputs,
-			consensus.Output{
+		txn.SiacoinOutputs = append(
+			txn.SiacoinOutputs,
+			consensus.SiacoinOutput{
 				Value:     total - amount,
 				SpendHash: coinAddress,
 			},
@@ -100,7 +100,7 @@ func (w *Wallet) AddMinerFee(id string, fee consensus.Currency) error {
 
 // AddOutput adds an output to the transaction, but will not add any inputs.
 // It returns the index of the output in the transaction.
-func (w *Wallet) AddOutput(id string, output consensus.Output) (index uint64, err error) {
+func (w *Wallet) AddOutput(id string, output consensus.SiacoinOutput) (index uint64, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -110,8 +110,8 @@ func (w *Wallet) AddOutput(id string, output consensus.Output) (index uint64, er
 		return
 	}
 
-	openTxn.transaction.Outputs = append(openTxn.transaction.Outputs, output)
-	index = uint64(len(openTxn.transaction.Outputs) - 1)
+	openTxn.transaction.SiacoinOutputs = append(openTxn.transaction.SiacoinOutputs, output)
+	index = uint64(len(openTxn.transaction.SiacoinOutputs) - 1)
 	return
 }
 
@@ -178,11 +178,11 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensu
 		for i := range txn.MinerFees {
 			coveredFields.MinerFees = append(coveredFields.MinerFees, uint64(i))
 		}
-		for i := range txn.Inputs {
-			coveredFields.Inputs = append(coveredFields.Inputs, uint64(i))
+		for i := range txn.SiacoinInputs {
+			coveredFields.SiacoinInputs = append(coveredFields.SiacoinInputs, uint64(i))
 		}
-		for i := range txn.Outputs {
-			coveredFields.Outputs = append(coveredFields.Outputs, uint64(i))
+		for i := range txn.SiacoinOutputs {
+			coveredFields.SiacoinOutputs = append(coveredFields.SiacoinOutputs, uint64(i))
 		}
 		for i := range txn.FileContracts {
 			coveredFields.FileContracts = append(coveredFields.FileContracts, uint64(i))
@@ -201,7 +201,7 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensu
 
 	// For each input in the transaction that we added, provide a signature.
 	for _, inputIndex := range openTxn.inputs {
-		input := txn.Inputs[inputIndex]
+		input := txn.SiacoinInputs[inputIndex]
 		sig := consensus.TransactionSignature{
 			InputID:        input.OutputID,
 			CoveredFields:  coveredFields,

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -222,7 +222,7 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensu
 
 		// Get the signature.
 		var encodedSig crypto.Signature
-		encodedSig, err = crypto.SignBytes(sigHash, secKey)
+		encodedSig, err = crypto.SignHash(sigHash, secKey)
 		if err != nil {
 			return
 		}

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -222,7 +222,7 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensu
 
 		// Get the signature.
 		var encodedSig crypto.Signature
-		encodedSig, err = crypto.SignBytes(sigHash[:], secKey)
+		encodedSig, err = crypto.SignBytes(sigHash, secKey)
 		if err != nil {
 			return
 		}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -94,7 +94,7 @@ func New(state *consensus.State, tpool modules.TransactionPool, filename string)
 // is submitted to the miner pool, but is also returned.
 func (w *Wallet) SpendCoins(amount consensus.Currency, dest consensus.CoinAddress) (t consensus.Transaction, err error) {
 	// Create and send the transaction.
-	output := consensus.Output{
+	output := consensus.SiacoinOutput{
 		Value:     amount,
 		SpendHash: dest,
 	}


### PR DESCRIPTION
I change Standard.md to be an actual markdown file.

I renamed Transaction.Output and Transaction.Input to SiacoinOutput and SiacoinInput respectively, because there are siafunds as well.

I added a forking test to make sure the state rewinds and reapplies correctly (it didn't, but now it does).

I added contract testing, transaction testing, and expanded the crypto package a little bit to check for nil stuff.

I changed to using `encoding.Marshal` and `encoding.Unmarshal` instead of doing it manually. This may have introduced regressions, but only in packages that have minimal to no testing. The bugs should pop up immediately once we add testing.

The consensus testing suite is a bit of a mess right now. The functions could be more oragnized, and it could use better tooling in general. I've decided to let it be messy for now though, because the testing is now pretty thorough (74%!) and we don't need to test it to death before we return to working on the user experience. I think we can come back in a few weeks and do organizational cleanup, and improve the testing tooling.

Pretty much all that remains at this point is the 100 block limit and the siafunds, and testing for each. (We also need to test the exported functions).