### PR TITLE
Unbounded Currency

### DIFF
--- a/consensus/applytransaction.go
+++ b/consensus/applytransaction.go
@@ -121,12 +121,7 @@ func (s *State) applyStorageProofs(bn *blockNode, t Transaction) {
 		// Get the portion of the contract that goes into the siafund pool and
 		// add it to the siafund pool.
 		poolPortion, _ := SplitContractPayout(fc.Payout)
-		err := s.siafundPool.Add(poolPortion)
-		if DEBUG {
-			if err != nil {
-				panic(err)
-			}
-		}
+		s.siafundPool = s.siafundPool.Add(poolPortion)
 
 		// Add all of the outputs in the ValidProofOutputs of the contract.
 		for i, output := range fc.ValidProofOutputs {
@@ -168,22 +163,8 @@ func (s *State) applySiafundInputs(bn *blockNode, t Transaction) {
 		}
 
 		// Calculate the volume of siacoins to put in the claim output.
-		claimPortion := s.siafundPool
 		sfo := s.siafundOutputs[sfi.ParentID]
-		err := claimPortion.Sub(sfo.ClaimStart)
-		if err != nil {
-			if DEBUG {
-				panic("error while handling claim portion")
-			}
-			continue
-		}
-		err = claimPortion.Div(NewCurrency64(SiafundCount))
-		if err != nil {
-			if DEBUG {
-				panic("error while handling claim portion")
-			}
-			continue
-		}
+		claimPortion := s.siafundPool.Sub(sfo.ClaimStart).Div(NewCurrency64(SiafundCount))
 
 		// Add the claim output to the delayed set of outputs.
 		sco := SiacoinOutput{

--- a/consensus/blocks.go
+++ b/consensus/blocks.go
@@ -56,20 +56,14 @@ func (s *State) checkMinerPayouts(b Block) (err error) {
 	subsidy := CalculateCoinbase(parentNode.height + 1)
 	for _, txn := range b.Transactions {
 		for _, fee := range txn.MinerFees {
-			err = subsidy.Add(fee)
-			if err != nil {
-				return
-			}
+			subsidy = subsidy.Add(fee)
 		}
 	}
 
 	// Find the sum of the miner payouts.
 	var payoutSum Currency
 	for _, payout := range b.MinerPayouts {
-		err = payoutSum.Add(payout.Value)
-		if err != nil {
-			return
-		}
+		payoutSum = payoutSum.Add(payout.Value)
 	}
 
 	// Return an error if the subsidy isn't equal to the payouts.
@@ -116,8 +110,7 @@ func (s *State) validHeader(b Block) (err error) {
 	}
 
 	// Check that the block is the correct size.
-	encodedBlock := encoding.Marshal(b)
-	if len(encodedBlock) > BlockSizeLimit {
+	if len(encoding.Marshal(b)) > BlockSizeLimit {
 		return LargeBlockErr
 	}
 

--- a/consensus/blocks_test.go
+++ b/consensus/blocks_test.go
@@ -203,8 +203,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 			NewCurrency64(250),
 		},
 	}
-	coinbasePayout = CalculateCoinbase(s.Height() + 1)
-	coinbasePayout.Add(NewCurrency64(25))
+	coinbasePayout = CalculateCoinbase(s.Height() + 1).Add(NewCurrency64(25))
 	payout = []SiacoinOutput{
 		SiacoinOutput{Value: coinbasePayout},
 		SiacoinOutput{Value: NewCurrency64(650), UnlockHash: sc.UnlockHash()},
@@ -255,8 +254,7 @@ func testMinerPayouts(t *testing.T, s *State) {
 			NewCurrency64(50),
 		},
 	}
-	coinbasePayout = CalculateCoinbase(s.Height() + 1)
-	coinbasePayout.Add(NewCurrency64(25))
+	coinbasePayout = CalculateCoinbase(s.Height() + 1).Add(NewCurrency64(25))
 	payout = []SiacoinOutput{
 		SiacoinOutput{Value: coinbasePayout},
 		SiacoinOutput{Value: NewCurrency64(650), UnlockHash: sc.UnlockHash()},

--- a/consensus/complete_test.go
+++ b/consensus/complete_test.go
@@ -58,7 +58,7 @@ func rewindApplyCheck(t *testing.T, s *State) {
 func currencyCheck(t *testing.T, s *State) {
 	siafunds := NewCurrency64(0)
 	for _, siafundOutput := range s.siafundOutputs {
-		siafunds.Add(siafundOutput.Value)
+		siafunds = siafunds.Add(siafundOutput.Value)
 	}
 	if siafunds.Cmp(NewCurrency64(SiafundCount)) != 0 {
 		t.Error("siafunds inconsistency")
@@ -66,16 +66,15 @@ func currencyCheck(t *testing.T, s *State) {
 
 	expectedSiacoins := NewCurrency64(0)
 	for i := BlockHeight(0); i <= s.Height(); i++ {
-		expectedSiacoins.Add(CalculateCoinbase(i))
+		expectedSiacoins = expectedSiacoins.Add(CalculateCoinbase(i))
 	}
-	siacoins := NewCurrency64(0)
+	siacoins := s.siafundPool
 	for _, output := range s.siacoinOutputs {
-		siacoins.Add(output.Value)
+		siacoins = siacoins.Add(output.Value)
 	}
 	for _, contract := range s.fileContracts {
-		siacoins.Add(contract.Payout)
+		siacoins = siacoins.Add(contract.Payout)
 	}
-	siacoins.Add(s.siafundPool)
 	if siacoins.Cmp(expectedSiacoins) != 0 {
 		t.Error(siacoins)
 		t.Error(expectedSiacoins)

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -83,19 +83,12 @@ func (a *assistant) mineCurrentBlock(minerPayouts []SiacoinOutput, txns []Transa
 // miner fee total.
 func (a *assistant) payouts(height BlockHeight, feeTotal Currency) (payouts []SiacoinOutput) {
 	// Get the total miner subsidy.
-	valueRemaining := CalculateCoinbase(height)
-	err := valueRemaining.Add(feeTotal)
-	if err != nil {
-		a.tester.Fatal(err)
-	}
+	valueRemaining := CalculateCoinbase(height).Add(feeTotal)
 
 	// Create several payouts that the assistant can spend, then append a
 	// 'remainder' payout.
 	for i := 0; i < 12; i++ {
-		err := valueRemaining.Sub(NewCurrency64(1e6))
-		if err != nil {
-			a.tester.Fatal(err)
-		}
+		valueRemaining = valueRemaining.Sub(NewCurrency64(1e6))
 		payouts = append(payouts, SiacoinOutput{Value: NewCurrency64(1e6), UnlockHash: a.unlockHash})
 	}
 	payouts = append(payouts, SiacoinOutput{Value: valueRemaining, UnlockHash: a.unlockHash})

--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -15,48 +15,61 @@ type Currency struct {
 	i big.Int
 }
 
+// NewCurrency creates a Currency value from a big.Int.
 func NewCurrency(b *big.Int) (c Currency) {
 	c.i = *b
 	return
 }
 
+// NewCurrency64 creates a Currency value from a uint64.
 func NewCurrency64(x uint64) (c Currency) {
 	c.i.SetUint64(x)
 	return
 }
 
+// Big returns the value of c as a *big.Int. Importantly, it does not provide
+// access to the c's internal big.Int object, only a copy. This is in
+// accordance with the immutability constraint described above.
 func (c Currency) Big() *big.Int {
 	return new(big.Int).Set(&c.i)
 }
 
+// Cmp compares two Currency values. The return value follows the convention
+// of the math/big package.
 func (c Currency) Cmp(y Currency) int {
 	return c.i.Cmp(&y.i)
 }
 
+// IsZero returns true if c's value is 0.
 func (c Currency) IsZero() bool {
 	return c.i.Sign() == 0
 }
 
+// Add returns a new Currency value y = c + x.
 func (c Currency) Add(x Currency) (y Currency) {
 	y.i.Add(&c.i, &x.i)
 	return
 }
 
+// Sub returns a new Currency value y = c - x.
 func (c Currency) Sub(x Currency) (y Currency) {
 	y.i.Sub(&c.i, &x.i)
 	return
 }
 
+// Mult returns a new Currency value y = c * x.
 func (c Currency) Mul(x Currency) (y Currency) {
 	y.i.Mul(&c.i, &x.i)
 	return
 }
 
+// Div returns a new Currency value y = c / x.
 func (c Currency) Div(x Currency) (y Currency) {
 	y.i.Div(&c.i, &x.i)
 	return
 }
 
+// MulFloat returns a new Currency value y = c * x, where x is a float64.
 func (c Currency) MulFloat(x float64) (y Currency) {
 	yRat := new(big.Rat).Mul(
 		new(big.Rat).SetInt(&c.i),
@@ -66,6 +79,7 @@ func (c Currency) MulFloat(x float64) (y Currency) {
 	return
 }
 
+// Sqrt returns a new Currency value y = sqrt(c)
 func (c Currency) Sqrt() (y Currency) {
 	f, _ := new(big.Rat).SetInt(&c.i).Float64()
 	sqrt := new(big.Rat).SetFloat64(math.Sqrt(f))
@@ -104,10 +118,12 @@ func (c *Currency) UnmarshalSia(b []byte) int {
 	return 1 + n
 }
 
+// MarshalJSON implements the json.Marshaler interface.
 func (c Currency) MarshalJSON() ([]byte, error) {
 	return c.i.MarshalJSON()
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (c *Currency) UnmarshalJSON(b []byte) error {
 	return c.i.UnmarshalJSON(b)
 }

--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -25,39 +25,39 @@ func NewCurrency64(x uint64) (c Currency) {
 	return
 }
 
-func (c *Currency) Big() *big.Int {
+func (c Currency) Big() *big.Int {
 	return &c.i
 }
 
-func (c *Currency) Cmp(y Currency) int {
+func (c Currency) Cmp(y Currency) int {
 	return c.i.Cmp(&y.i)
 }
 
-func (c *Currency) IsZero() bool {
+func (c Currency) IsZero() bool {
 	return c.i.Sign() == 0
 }
 
-func (c *Currency) Add(x Currency) (y Currency) {
+func (c Currency) Add(x Currency) (y Currency) {
 	y.i.Add(&c.i, &x.i)
 	return
 }
 
-func (c *Currency) Sub(x Currency) (y Currency) {
+func (c Currency) Sub(x Currency) (y Currency) {
 	y.i.Sub(&c.i, &x.i)
 	return
 }
 
-func (c *Currency) Mul(x Currency) (y Currency) {
+func (c Currency) Mul(x Currency) (y Currency) {
 	y.i.Mul(&c.i, &x.i)
 	return
 }
 
-func (c *Currency) Div(x Currency) (y Currency) {
+func (c Currency) Div(x Currency) (y Currency) {
 	y.i.Div(&c.i, &x.i)
 	return
 }
 
-func (c *Currency) MulFloat(x float64) (y Currency) {
+func (c Currency) MulFloat(x float64) (y Currency) {
 	yRat := new(big.Rat).Mul(
 		new(big.Rat).SetInt(&c.i),
 		new(big.Rat).SetFloat64(x),
@@ -66,14 +66,14 @@ func (c *Currency) MulFloat(x float64) (y Currency) {
 	return
 }
 
-func (c *Currency) Sqrt() (y Currency) {
+func (c Currency) Sqrt() (y Currency) {
 	f, _ := new(big.Rat).SetInt(&c.i).Float64()
 	sqrt := new(big.Rat).SetFloat64(math.Sqrt(f))
 	y.i.Div(sqrt.Num(), sqrt.Denom())
 	return
 }
 
-func (c *Currency) RoundDown(nearest int64) error {
+func (c Currency) RoundDown(nearest int64) error {
 	round := big.NewInt(nearest)
 	c.i.Div(&c.i, round)
 	c.i.Mul(&c.i, round)

--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -103,3 +103,11 @@ func (c *Currency) UnmarshalSia(b []byte) int {
 	c.i.SetBytes(b[:n])
 	return 1 + n
 }
+
+func (c Currency) MarshalJSON() ([]byte, error) {
+	return c.i.MarshalJSON()
+}
+
+func (c *Currency) UnmarshalJSON(b []byte) error {
+	return c.i.UnmarshalJSON(b)
+}

--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -26,7 +26,7 @@ func NewCurrency64(x uint64) (c Currency) {
 }
 
 func (c Currency) Big() *big.Int {
-	return &c.i
+	return new(big.Int).Set(&c.i)
 }
 
 func (c Currency) Cmp(y Currency) int {

--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -73,11 +73,11 @@ func (c Currency) Sqrt() (y Currency) {
 	return
 }
 
-func (c Currency) RoundDown(nearest int64) error {
-	round := big.NewInt(nearest)
-	c.i.Div(&c.i, round)
-	c.i.Mul(&c.i, round)
-	return nil
+// RoundDown returns the largest multiple of n <= c.
+func (c Currency) RoundDown(n uint64) (y Currency) {
+	diff := new(big.Int).Mod(&c.i, new(big.Int).SetUint64(n))
+	y.i.Sub(&c.i, diff)
+	return
 }
 
 // MarshalSia implements the encoding.SiaMarshaler interface. It returns the

--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -1,50 +1,27 @@
 package consensus
 
 import (
-	"errors"
+	"math"
 	"math/big"
 )
 
-var (
-	ErrOverflow = errors.New("Currency overflowed 128 bits")
-)
-
-// A Currency is a 128-bit unsigned integer. Currency operations are performed
-// via math/big.
-//
-// The Currency object also keeps track of whether an overflow has occurred
-// during arithmetic operations. Once the 'overflow' flag has been set to
-// true, all subsequent operations will return an error, and the result of the
-// operation is undefined. This flag can never be reset; a new Currency must
-// be created. Callers can also manually check for overflow using the Overflow
-// method.
-//
-// TODO: Find better names for the currency variables.
+// A Currency represents a number of siacoins or siafunds. Internally, a
+// Currency value is unbounded; however, Currency values sent over the wire
+// protocol are subject to a maximum size of 255 bytes (approximately 10^614).
+// Unlike the math/big library, whose methods modify their receiver, all
+// arithmetic Currency methods return a new value. This is necessary to
+// preserve the immutability of types containing Currency fields.
 type Currency struct {
-	i  big.Int
-	of bool // has an overflow ever occurred?
+	i big.Int
 }
 
-func NewCurrency(b *big.Int) (c Currency, err error) {
-	if b.BitLen() > 128 || b.Sign() < 0 {
-		c.of = true
-		err = ErrOverflow
-		return
-	}
+func NewCurrency(b *big.Int) (c Currency) {
 	c.i = *b
 	return
 }
 
-func NewCurrency64(x uint64) Currency {
-	// no possibility of error
-	c, _ := NewCurrency(new(big.Int).SetUint64(x))
-	return c
-}
-
-func (c *Currency) SetBig(b *big.Int) (err error) {
-	oldOF := c.of
-	*c, err = NewCurrency(b)
-	c.of = c.of || oldOF // preserve overflow flag
+func NewCurrency64(x uint64) (c Currency) {
+	c.i.SetUint64(x)
 	return
 }
 
@@ -52,91 +29,77 @@ func (c *Currency) Big() *big.Int {
 	return &c.i
 }
 
-func (c *Currency) Add(y Currency) error {
-	if c.of {
-		return ErrOverflow
-	}
-	return c.SetBig(c.i.Add(&c.i, &y.i))
-}
-
-func (c *Currency) Sub(y Currency) error {
-	if c.of {
-		return ErrOverflow
-	}
-	return c.SetBig(c.i.Sub(&c.i, &y.i))
-}
-
-func (c *Currency) Mul(y Currency) error {
-	if c.of {
-		return ErrOverflow
-	}
-	return c.SetBig(c.i.Mul(&c.i, &y.i))
-}
-
-func (c *Currency) MulFloat(x float64) (err error) {
-	if c.of {
-		return ErrOverflow
-	}
-
-	cBig := c.Big()
-	cRat := new(big.Rat).SetInt(cBig)
-	xRat := new(big.Rat).SetFloat64(x)
-	cRat.Mul(cRat, xRat)
-	*c, err = NewCurrency(c.Big().Div(cRat.Num(), cRat.Denom()))
-	if err != nil {
-		return
-	}
-	return
-}
-
-func (c *Currency) Div(y Currency) error {
-	if c.of {
-		return ErrOverflow
-	}
-	return c.SetBig(c.i.Div(&c.i, &y.i))
-}
-
-func (c *Currency) Sqrt() *Currency {
-	f, _ := new(big.Rat).SetInt(&c.i).Float64()
-	rat := new(big.Rat).SetFloat64(f)
-	s, _ := NewCurrency(new(big.Int).Div(rat.Num(), rat.Denom()))
-	s.of = c.of // preserve overflow
-	return &s
-}
-
-func (c *Currency) RoundDown(nearest int64) error {
-	if c.of {
-		return ErrOverflow
-	}
-	round := big.NewInt(nearest)
-	c.i.Div(&c.i, round)
-	c.i.Mul(&c.i, round)
-	return nil
+func (c *Currency) Cmp(y Currency) int {
+	return c.i.Cmp(&y.i)
 }
 
 func (c *Currency) IsZero() bool {
 	return c.i.Sign() == 0
 }
 
-func (c *Currency) Cmp(y Currency) int {
-	return c.i.Cmp(&y.i)
+func (c *Currency) Add(x Currency) (y Currency) {
+	y.i.Add(&c.i, &x.i)
+	return
 }
 
-func (c *Currency) Overflow() bool {
-	return c.of
+func (c *Currency) Sub(x Currency) (y Currency) {
+	y.i.Sub(&c.i, &x.i)
+	return
 }
 
+func (c *Currency) Mul(x Currency) (y Currency) {
+	y.i.Mul(&c.i, &x.i)
+	return
+}
+
+func (c *Currency) Div(x Currency) (y Currency) {
+	y.i.Div(&c.i, &x.i)
+	return
+}
+
+func (c *Currency) MulFloat(x float64) (y Currency) {
+	yRat := new(big.Rat).Mul(
+		new(big.Rat).SetInt(&c.i),
+		new(big.Rat).SetFloat64(x),
+	)
+	y.i.Div(yRat.Num(), yRat.Denom())
+	return
+}
+
+func (c *Currency) Sqrt() (y Currency) {
+	f, _ := new(big.Rat).SetInt(&c.i).Float64()
+	sqrt := new(big.Rat).SetFloat64(math.Sqrt(f))
+	y.i.Div(sqrt.Num(), sqrt.Denom())
+	return
+}
+
+func (c *Currency) RoundDown(nearest int64) error {
+	round := big.NewInt(nearest)
+	c.i.Div(&c.i, round)
+	c.i.Mul(&c.i, round)
+	return nil
+}
+
+// MarshalSia implements the encoding.SiaMarshaler interface. It returns the
+// byte-slice representation of the Currency's internal big.Int, prepended
+// with a single byte indicating the length of the slice. This implies a
+// maximum encodable value of 2^(255 * 8), or approximately 10^614.
+//
+// Note that as the bytes of the big.Int correspond to the absolute value of
+// the integer, there is no way to marshal a negative Currency.
 func (c Currency) MarshalSia() []byte {
-	b := make([]byte, 16)
-	copy(b, c.i.Bytes())
-	return b
+	b := c.i.Bytes()
+	return append(
+		[]byte{byte(len(b))},
+		b...,
+	)
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface. See
+// MarshalSia for a description of how Currency values are marshalled.
 func (c *Currency) UnmarshalSia(b []byte) int {
-	var err error
-	*c, err = NewCurrency(new(big.Int).SetBytes(b[:16]))
-	if err != nil {
-		return -1
-	}
-	return 16
+	var n int
+	n, b = int(b[0]), b[1:]
+	c.i.SetBytes(b[:n])
+	return 1 + n
 }

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -307,14 +307,6 @@ func CalculateCoinbase(height BlockHeight) (c Currency) {
 func SplitContractPayout(payout Currency) (poolPortion Currency, outputPortion Currency) {
 	poolPortion = payout.MulFloat(SiafundPortion).RoundDown(SiafundCount)
 	outputPortion = payout.Sub(poolPortion)
-
-	// Sanity check - pool portion plus output portion should equal payout.
-	if DEBUG {
-		if poolPortion.Add(outputPortion).Cmp(payout) != 0 {
-			panic("siacoins not split correctly during splitContractPayout")
-		}
-	}
-
 	return
 }
 

--- a/modules/host/contractcreation.go
+++ b/modules/host/contractcreation.go
@@ -79,12 +79,6 @@ func (h *Host) considerTerms(terms modules.ContractTerms) error {
 // verifyContract verifies that the values in the FileContract match the
 // ContractTerms agreed upon.
 func verifyContract(contract consensus.FileContract, terms modules.ContractTerms, merkleRoot crypto.Hash) error {
-	payout := terms.Price
-	err := payout.Add(terms.Collateral)
-	if err != nil {
-		return err
-	}
-
 	switch {
 	case contract.FileSize != terms.FileSize:
 		return errors.New("bad FileSize")
@@ -95,7 +89,7 @@ func verifyContract(contract consensus.FileContract, terms modules.ContractTerms
 	case contract.Expiration != terms.StartHeight+(terms.WindowSize*consensus.BlockHeight(terms.NumWindows)):
 		return errors.New("bad End")
 
-	case contract.Payout.Cmp(payout) != 0:
+	case terms.Price.Add(terms.Collateral).Cmp(contract.Payout) != 0:
 		return errors.New("bad Payout")
 
 	// TODO: reconstruct how the terms work.
@@ -119,14 +113,7 @@ func verifyContract(contract consensus.FileContract, terms modules.ContractTerms
 func (h *Host) acceptContract(txn consensus.Transaction) error {
 	contract := txn.FileContracts[0]
 	duration := uint64(contract.Expiration - contract.Start)
-
-	penalty := h.Collateral
-	penalty.Mul(consensus.NewCurrency64(contract.FileSize))
-	err := penalty.Mul(consensus.NewCurrency64(duration))
-	// TODO: move this check to a different function?
-	if err != nil {
-		return err
-	}
+	penalty := h.Collateral.Mul(consensus.NewCurrency64(contract.FileSize)).Mul(consensus.NewCurrency64(duration))
 
 	id, err := h.wallet.RegisterTransaction(txn)
 	if err != nil {

--- a/modules/host/contractcreation.go
+++ b/modules/host/contractcreation.go
@@ -113,7 +113,9 @@ func verifyContract(contract consensus.FileContract, terms modules.ContractTerms
 func (h *Host) acceptContract(txn consensus.Transaction) error {
 	contract := txn.FileContracts[0]
 	duration := uint64(contract.Expiration - contract.Start)
-	penalty := h.Collateral.Mul(consensus.NewCurrency64(contract.FileSize)).Mul(consensus.NewCurrency64(duration))
+	filesizeCost := consensus.NewCurrency64(contract.FileSize)
+	durationCost := consensus.NewCurrency64(duration)
+	penalty := h.Collateral.Mul(filesizeCost).Mul(durationCost)
 
 	id, err := h.wallet.RegisterTransaction(txn)
 	if err != nil {

--- a/modules/hostdb/announcements.go
+++ b/modules/hostdb/announcements.go
@@ -32,7 +32,8 @@ func findHostAnnouncements(height consensus.BlockHeight, b consensus.Block) (ann
 			}
 
 			// calculate freeze and check for sane value
-			freeze := consensus.NewCurrency64(uint64(ha.SpendConditions.Timelock - height)).Mul(t.SiacoinOutputs[ha.FreezeIndex].Value)
+			timelockCost := consensus.NewCurrency64(uint64(ha.SpendConditions.Timelock - height))
+			freeze := timelockCost.Mul(t.SiacoinOutputs[ha.FreezeIndex].Value)
 			if freeze.IsZero() {
 				continue
 			}

--- a/modules/hostdb/announcements.go
+++ b/modules/hostdb/announcements.go
@@ -32,9 +32,8 @@ func findHostAnnouncements(height consensus.BlockHeight, b consensus.Block) (ann
 			}
 
 			// calculate freeze and check for sane value
-			freeze := consensus.NewCurrency64(uint64(ha.SpendConditions.Timelock - height))
-			err = freeze.Mul(t.SiacoinOutputs[ha.FreezeIndex].Value)
-			if err != nil || freeze.IsZero() {
+			freeze := consensus.NewCurrency64(uint64(ha.SpendConditions.Timelock - height)).Mul(t.SiacoinOutputs[ha.FreezeIndex].Value)
+			if freeze.IsZero() {
 				continue
 			}
 

--- a/modules/hostdb/entries.go
+++ b/modules/hostdb/entries.go
@@ -1,8 +1,6 @@
 package hostdb
 
 import (
-	"math/big"
-
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/modules"
 )
@@ -26,7 +24,7 @@ import (
 // We take the square of the price to heavily emphasize hosts that have a low
 // price. This is also a bit simplistic however, because we're not sure what
 // the host might be charging for bandwidth.
-func entryWeight(entry modules.HostEntry) (weight *big.Int) {
+func entryWeight(entry modules.HostEntry) consensus.Currency {
 	// Catch a divide by 0 error, and let all hosts have at least some weight.
 	//
 	// TODO: Perhaps there's a better way to do this.
@@ -41,9 +39,5 @@ func entryWeight(entry modules.HostEntry) (weight *big.Int) {
 	}
 
 	// weight := entry.Freeze * entry.Collateral / sqrt(entry.Price)
-	weight = new(big.Int).Set(entry.Freeze.Big())
-	weight.Mul(weight, entry.Collateral.Big())
-	weight.Div(weight, entry.Price.Sqrt().Big())
-
-	return
+	return entry.Freeze.Mul(entry.Collateral).Div(entry.Price.Sqrt())
 }

--- a/modules/hostdb/hostdb.go
+++ b/modules/hostdb/hostdb.go
@@ -168,10 +168,10 @@ func (hdb *HostDB) RandomHost() (h modules.HostEntry, err error) {
 
 	// Get a random number between 0 and state.TotalWeight and then scroll
 	// through state.HostList until at least that much weight has been passed.
-	randWeight, err := rand.Int(rand.Reader, hdb.hostTree.weight)
+	randWeight, err := rand.Int(rand.Reader, hdb.hostTree.weight.Big())
 	if err != nil {
 		return
 	}
 	// no possibility of error
-	return hdb.hostTree.entryAtWeight(randWeight)
+	return hdb.hostTree.entryAtWeight(consensus.NewCurrency(randWeight))
 }

--- a/modules/hostdb/weightedlist_test.go
+++ b/modules/hostdb/weightedlist_test.go
@@ -20,7 +20,7 @@ func uniformTreeVerification(hdb *HostDB, numEntries int, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedWeight := new(big.Int).Mul(big.NewInt(int64(numEntries)), entryWeight(randomHost))
+	expectedWeight := consensus.NewCurrency64(uint64(numEntries)).Mul(entryWeight(randomHost))
 	if hdb.hostTree.weight.Cmp(expectedWeight) != 0 {
 		t.Error("Expected weight is incorrect")
 	}

--- a/modules/miner/mine.go
+++ b/modules/miner/mine.go
@@ -31,12 +31,7 @@ func (m *Miner) blockForWork() (b consensus.Block) {
 	subsidy := consensus.CalculateCoinbase(height + 1)
 	for _, txn := range m.transactions {
 		for _, fee := range txn.MinerFees {
-			subsidy.Add(fee)
-		}
-	}
-	if consensus.DEBUG {
-		if subsidy.Overflow() {
-			panic("miner received overflowing transaction set from transaction pool")
+			subsidy = subsidy.Add(fee)
 		}
 	}
 	output := consensus.SiacoinOutput{Value: subsidy, UnlockHash: m.address}

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -28,10 +28,12 @@ func (r *Renter) createContractTransaction(host modules.HostEntry, terms modules
 	duration := terms.WindowSize * consensus.BlockHeight(terms.NumWindows)
 
 	// Determine our portion of the payout.
-	fund := host.Price.Mul(consensus.NewCurrency64(uint64(duration))).Mul(consensus.NewCurrency64(terms.FileSize))
+	filesizeCost := consensus.NewCurrency64(terms.FileSize)
+	durationCost := consensus.NewCurrency64(uint64(duration))
+	fund := host.Price.Mul(filesizeCost).Mul(durationCost)
 
 	// Determine the host portion of the payout.
-	collateral := host.Collateral.Mul(consensus.NewCurrency64(uint64(duration))).Mul(consensus.NewCurrency64(terms.FileSize))
+	collateral := host.Collateral.Mul(filesizeCost).Mul(durationCost)
 
 	// Determine the total payout.
 	payout := fund.Add(collateral)

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -25,30 +25,16 @@ var (
 // the contract was never set, so I added it in. I might be doing the math
 // wrong.
 func (r *Renter) createContractTransaction(host modules.HostEntry, terms modules.ContractTerms, merkleRoot crypto.Hash) (txn consensus.Transaction, err error) {
-	// Determine our portion of the payout.
 	duration := terms.WindowSize * consensus.BlockHeight(terms.NumWindows)
-	fund := host.Price
-	fund.Mul(consensus.NewCurrency64(uint64(duration)))
-	err = fund.Mul(consensus.NewCurrency64(terms.FileSize))
-	if err != nil {
-		return
-	}
+
+	// Determine our portion of the payout.
+	fund := host.Price.Mul(consensus.NewCurrency64(uint64(duration))).Mul(consensus.NewCurrency64(terms.FileSize))
 
 	// Determine the host portion of the payout.
-	collateral := host.Collateral
-	collateral.Mul(consensus.NewCurrency64(uint64(duration)))
-	err = collateral.Mul(consensus.NewCurrency64(terms.FileSize))
-	if err != nil {
-		return
-	}
+	collateral := host.Collateral.Mul(consensus.NewCurrency64(uint64(duration))).Mul(consensus.NewCurrency64(terms.FileSize))
 
 	// Determine the total payout.
-	var payout consensus.Currency
-	payout.Add(fund)
-	err = payout.Add(collateral)
-	if err != nil {
-		return
-	}
+	payout := fund.Add(collateral)
 
 	// Determine the valid proof payout sum (payout - siafund fee)
 	_, validPayout := consensus.SplitContractPayout(payout)
@@ -64,11 +50,8 @@ func (r *Renter) createContractTransaction(host modules.HostEntry, terms modules
 		MissedProofOutputs: []consensus.SiacoinOutput{consensus.SiacoinOutput{Value: payout, UnlockHash: consensus.ZeroUnlockHash}},
 	}
 
-	// Add a miner fee to the funding.
-	err = fund.Add(minerFee)
-	if err != nil {
-		return
-	}
+	// Add a miner fee to the fund.
+	fund = fund.Add(minerFee)
 
 	// Create the transaction.
 	id, err := r.wallet.RegisterTransaction(txn)

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -33,10 +33,7 @@ func (tp *TransactionPool) checkInputs(t consensus.Transaction) (inputSum consen
 				return
 			}
 
-			err = inputSum.Add(output.Value)
-			if err != nil {
-				return
-			}
+			inputSum = inputSum.Add(output.Value)
 			continue
 		}
 
@@ -54,10 +51,7 @@ func (tp *TransactionPool) checkInputs(t consensus.Transaction) (inputSum consen
 				return
 			}
 
-			err = inputSum.Add(output.Value)
-			if err != nil {
-				return
-			}
+			inputSum = inputSum.Add(output.Value)
 			continue
 		}
 
@@ -79,14 +73,8 @@ func (tp *TransactionPool) validTransaction(t consensus.Transaction) (err error)
 		return
 	}
 
-	// Get the output sum.
-	outputSum, err := t.SiacoinOutputSum()
-	if err != nil {
-		return
-	}
-
 	// Check that the inputs equal the outputs.
-	if inputSum.Cmp(outputSum) != 0 {
+	if inputSum.Cmp(t.SiacoinOutputSum()) != 0 {
 		err = errors.New("input sum does not equal output sum")
 		return
 	}

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -2,7 +2,6 @@ package modules
 
 import (
 	"errors"
-	"math/big"
 
 	"github.com/NebulousLabs/Sia/consensus"
 )
@@ -19,7 +18,7 @@ type Wallet interface {
 	// Balance returns the total number of coins accessible to the wallet. If
 	// full == true, the number of coins returned will also include coins that
 	// have been spent in unconfirmed transactions.
-	Balance(full bool) *big.Int
+	Balance(full bool) consensus.Currency
 
 	// CoinAddress return an address into which coins can be paid.
 	CoinAddress() (consensus.UnlockHash, consensus.UnlockConditions, error)

--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -1,13 +1,13 @@
 package wallet
 
 import (
-	"math/big"
+	"github.com/NebulousLabs/Sia/consensus"
 )
 
 // WalletInfo contains basic information about the wallet.
 type WalletInfo struct {
-	Balance      *big.Int
-	FullBalance  *big.Int
+	Balance      consensus.Currency
+	FullBalance  consensus.Currency
 	NumAddresses int
 }
 

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -66,8 +66,7 @@ func (w *Wallet) FundTransaction(id string, amount consensus.Currency) error {
 	}
 
 	// Add a refund output if needed.
-	refund := total.Sub(amount)
-	if !refund.IsZero() {
+	if total.Cmp(amount) > 0 {
 		coinAddress, _, err := w.coinAddress()
 		if err != nil {
 			return err
@@ -76,7 +75,7 @@ func (w *Wallet) FundTransaction(id string, amount consensus.Currency) error {
 		txn.SiacoinOutputs = append(
 			txn.SiacoinOutputs,
 			consensus.SiacoinOutput{
-				Value:      refund,
+				Value:      total.Sub(amount),
 				UnlockHash: coinAddress,
 			},
 		)

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -66,12 +66,8 @@ func (w *Wallet) FundTransaction(id string, amount consensus.Currency) error {
 	}
 
 	// Add a refund output if needed.
-	//
-	// TODO: I may be mistaken, but is this code block right? Don't you want to
-	// make the refund IFF err == nil?
-	refund := total
-	err = refund.Sub(amount)
-	if err != nil && !refund.IsZero() {
+	refund := total.Sub(amount)
+	if !refund.IsZero() {
 		coinAddress, _, err := w.coinAddress()
 		if err != nil {
 			return err


### PR DESCRIPTION
The `Currency` type can no longer overflow. However, its `MarshalSia` method restricts the length prefix to one byte, giving a maximum value of 2^(255 * 8) =~ 10^614. Larger values can be used internally, but will fail to encode correctly.

Also, `Currency` arithmetic will always return a new value. This means that you often have to write `sum = sum.Add(value)` instead of just `sum.Add(value)`, but it isn't a big deal. Plus, you can chain operations now, and they're 10x more readable.
This change might have introduced some sneaky bugs. When I changed the return value from an `error` to a `Currency`, all the places where we had `err = x.Add(y)` threw compiler errors. But the places where we just had `x.Add(y)` were silent, so I had to hunt them all down manually. Hopefully I got them all.

Large-scale review of the consensus package is next.