### PR TITLE
Debug

### DIFF
--- a/siad/api.go
+++ b/siad/api.go
@@ -46,6 +46,7 @@ func (d *daemon) listen(addr string) {
 	mux.HandleFunc("/sync", d.syncHandler)
 
 	// Debugging API Calls
+	mux.HandleFunc("/constants", d.debugConstantsHandler)
 	mux.HandleFunc("/mutextest", d.mutexTestHandler)
 
 	// create graceful HTTP server
@@ -77,9 +78,4 @@ func writeSuccess(w http.ResponseWriter) {
 	writeJSON(w, struct {
 		Success bool
 	}{true})
-}
-
-func (d *daemon) mutexTestHandler(w http.ResponseWriter, req *http.Request) {
-	// TODO: Bring back.
-	// d.core.ScanMutexes()
 }

--- a/siad/api.go
+++ b/siad/api.go
@@ -46,8 +46,8 @@ func (d *daemon) listen(addr string) {
 	mux.HandleFunc("/sync", d.syncHandler)
 
 	// Debugging API Calls
-	mux.HandleFunc("/constants", d.debugConstantsHandler)
-	mux.HandleFunc("/mutextest", d.mutexTestHandler)
+	mux.HandleFunc("/debug/constants", d.debugConstantsHandler)
+	mux.HandleFunc("/debug/mutextest", d.mutexTestHandler)
 
 	// create graceful HTTP server
 	d.apiServer = &graceful.Server{

--- a/siad/apidebug.go
+++ b/siad/apidebug.go
@@ -60,4 +60,5 @@ func (d *daemon) debugConstantsHandler(w http.ResponseWriter, req *http.Request)
 func (d *daemon) mutexTestHandler(w http.ResponseWriter, req *http.Request) {
 	// TODO: Bring back.
 	// d.core.ScanMutexes()
+	http.Error(w, "mutex test has been disabled", http.StatusInternalServerError)
 }

--- a/siad/apidebug.go
+++ b/siad/apidebug.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"math/big"
+	"net/http"
+
+	"github.com/NebulousLabs/Sia/consensus"
+)
+
+// SiaConstants is a struct listing all of the constants in use.
+type SiaConstants struct {
+	GenesisTimestamp      consensus.Timestamp
+	BlockSizeLimit        int
+	BlockFrequency        int
+	TargetWindow          int
+	MedianTimestampWindow int
+	FutureThreshold       int
+	SiafundCount          int
+	MaturityDelay         int
+	SiafundPortion        float64
+
+	InitialCoinbase int
+	MinimumCoinbase int
+	CoinbaseAugment *big.Int
+
+	RootTarget consensus.Target
+	RootDepth  consensus.Target
+
+	MaxAdjustmentUp   *big.Rat
+	MaxAdjustmentDown *big.Rat
+}
+
+// debugConstantsHandler prints a json file containing all of the constants.
+func (d *daemon) debugConstantsHandler(w http.ResponseWriter, req *http.Request) {
+	sc := SiaConstants{
+		GenesisTimestamp:      consensus.GenesisTimestamp,
+		BlockSizeLimit:        consensus.BlockSizeLimit,
+		BlockFrequency:        consensus.BlockFrequency,
+		TargetWindow:          consensus.TargetWindow,
+		MedianTimestampWindow: consensus.MedianTimestampWindow,
+		FutureThreshold:       consensus.FutureThreshold,
+		SiafundCount:          consensus.SiafundCount,
+		MaturityDelay:         consensus.MaturityDelay,
+		SiafundPortion:        consensus.SiafundPortion,
+
+		InitialCoinbase: consensus.InitialCoinbase,
+		MinimumCoinbase: consensus.MinimumCoinbase,
+		CoinbaseAugment: consensus.CoinbaseAugment,
+
+		RootTarget: consensus.RootTarget,
+		RootDepth:  consensus.RootDepth,
+
+		MaxAdjustmentUp:   consensus.MaxAdjustmentUp,
+		MaxAdjustmentDown: consensus.MaxAdjustmentDown,
+	}
+
+	writeJSON(w, sc)
+}
+
+func (d *daemon) mutexTestHandler(w http.ResponseWriter, req *http.Request) {
+	// TODO: Bring back.
+	// d.core.ScanMutexes()
+}


### PR DESCRIPTION
Moved the debugging api calls to '/debug', and added a call that spits out all of the constants, which is helpful for peace of mind. Seve and I were using that call today.