### PR TITLE
Add make cover to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - make dependencies
   - make
 
-script: make test-long
+script: make test-long && make cover


### PR DESCRIPTION
When looking at travis builds, we'll get a good idea of our test coverage. It just puts that statistic somewhere accessible.