### PR TITLE
Host DB Testing

### DIFF
--- a/consensus/testenvironment.go
+++ b/consensus/testenvironment.go
@@ -50,6 +50,14 @@ func (ct *ConsensusTester) MineCurrentBlock(txns []Transaction) (b Block) {
 	return MineTestingBlock(ct.CurrentBlock().ID(), CurrentTimestamp(), minerPayouts, txns, ct.CurrentTarget())
 }
 
+// MineAndSubmitCurrentBlock is a shortcut function that calls MineCurrentBlock
+// and then submits it to the state.
+func (ct *ConsensusTester) MineAndSubmitCurrentBlock(txns []Transaction) error {
+	minerPayouts := ct.Payouts(ct.Height()+1, txns)
+	block := MineTestingBlock(ct.CurrentBlock().ID(), CurrentTimestamp(), minerPayouts, txns, ct.CurrentTarget())
+	return ct.AcceptBlock(block)
+}
+
 // Payouts returns a block with 12 payouts worth 1e6 and a final payout that
 // makes the total payout amount add up correctly. This produces a large set of
 // outputs that can be used for testing.

--- a/modules/hostdb/entries.go
+++ b/modules/hostdb/entries.go
@@ -18,6 +18,8 @@ var (
 
 	// Convenience variables for doing currency math. Originally we were just
 	// using MulFloat but this was causing precision problems during testing.
+	// The actual functionality of the program isn't affected by loss of
+	// precision, it just makes testing simpler.
 	currencyZero     = consensus.NewCurrency64(0)
 	currencyOne      = consensus.NewCurrency64(1)
 	currencyTwo      = consensus.NewCurrency64(2)
@@ -29,7 +31,10 @@ var (
 
 // entryWeight returns the weight of an entry according to the price and
 // collateral of the entry. The current general equation is:
-//		(collateral / price^2).
+//		(collateral / price^2)
+//
+// The collateral is clamped so that it is not treated as being less than 0.5x
+// the price or more than 2x the price.
 func entryWeight(entry modules.HostEntry) (weight consensus.Currency) {
 	// Clamp the collateral to between 0.5x and 2x the price.
 	collateral := entry.Collateral
@@ -50,10 +55,17 @@ func entryWeight(entry modules.HostEntry) (weight consensus.Currency) {
 	return baseWeight.Mul(collateral).Div(price).Div(price)
 }
 
-// insertCompleteHostEntry inserts a host entry without making a network call
-// to the host to grab the settings.
+// insertCompleteHostEntry inserts a host entry into the host tree, removing
+// any conflicts. The host settings are assummed to be correct.
 func (hdb *HostDB) insertCompleteHostEntry(entry *modules.HostEntry) {
+	// If there's already a host of the same id, remove that host.
 	hostname := entry.IPAddress.Host()
+	priorEntry, exists := hdb.activeHosts[hostname]
+	if exists {
+		priorEntry.remove()
+	}
+
+	// Insert the updated entry into the host tree.
 	if hdb.hostTree == nil {
 		hdb.hostTree = createNode(nil, *entry)
 		hdb.activeHosts[hostname] = hdb.hostTree
@@ -63,7 +75,9 @@ func (hdb *HostDB) insertCompleteHostEntry(entry *modules.HostEntry) {
 	}
 }
 
-// insertActiveHost adds a host to the active set of hosts.
+// insertActiveHost takes a host entry and queries the host for its settings.
+// Once it has the settings, it inserts it into the host tree. If it cannot get
+// the settings, it gives up and quits.
 func (hdb *HostDB) threadedInsertActiveHost(entry *modules.HostEntry) {
 	// Get the settings from the host. Host is removed from the set of active
 	// hosts if no response is given.
@@ -73,32 +87,31 @@ func (hdb *HostDB) threadedInsertActiveHost(entry *modules.HostEntry) {
 		return
 	}
 
-	// If there's already a host of the same id, remove it. This is done in an
-	// anonymous function so that 'defer Unlock' can be used.
-	hostname := entry.IPAddress.Host()
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
-
-	priorEntry, exists := hdb.activeHosts[hostname]
-	if exists {
-		priorEntry.remove()
-	}
 	entry.HostSettings = hs
+
 	hdb.insertCompleteHostEntry(entry)
 }
 
-// threadedInsert adds a host entry to the state. The entry is passed by
-// pointer because multiple locations are using the same data, and each should
-// get any changes.
-func (hdb *HostDB) insert(entry *modules.HostEntry) {
+// insert adds a host entry to the state. The host is guaranteed to make it
+// into the set of all hosts. The host will only make it into the set of active
+// hosts if there are no previous hosts that exist at the same ip address (this
+// is to make it more difficult for a single host to sybil the network). If the
+// host is at the same ip address and port number as the existing host, then
+// it's assumed to be the same host, and an update is made.
+//
+// Once the entry has been added to the database, all calls use pointers to the
+// entry. This is because some of the calls modify the entry (under a lock) and
+// everyone needs to receive the modifications.
+func (hdb *HostDB) insert(entry modules.HostEntry) {
 	// Add the host to allHosts.
-	hdb.allHosts[entry.IPAddress] = entry
+	hdb.allHosts[entry.IPAddress] = &entry
 
-	// Active entries are stored by address, sans port number. This limits each
-	// IP to advertising 1 host. If a host already exists for this IP Addresss,
-	// see if it's got the same full address. If so, update the settings for
-	// the host. If not, don't add it to the set of active hosts, the existing
-	// one takes priority.
+	// Check if there is another host in the set of active hosts with the same
+	// ip address. If there is, this host is not given precedent. The exception
+	// is if this host has the same full address (including port number), in
+	// which case it's assumed that the host is trying to post an update.
 	hostname := entry.IPAddress.Host()
 	priorEntry, exists := hdb.activeHosts[hostname]
 	if exists {
@@ -107,22 +120,15 @@ func (hdb *HostDB) insert(entry *modules.HostEntry) {
 		}
 	}
 
-	go hdb.threadedInsertActiveHost(entry)
+	go hdb.threadedInsertActiveHost(&entry)
 }
 
 // Remove deletes an entry from the hostdb.
 func (hdb *HostDB) remove(addr network.Address) error {
-	// Remove the host from the set of all hosts.
-	_, exists := hdb.allHosts[addr]
-	if exists {
-		delete(hdb.allHosts, addr)
-	}
-
-	// Strip the port (see insert), then check the set of active hosts for an
-	// entry.
-	hostname := addr.Host()
+	delete(hdb.allHosts, addr)
 
 	// See if the node is in the set of active hosts.
+	hostname := addr.Host()
 	node, exists := hdb.activeHosts[hostname]
 	if exists {
 		delete(hdb.activeHosts, hostname)
@@ -139,11 +145,11 @@ func (hdb *HostDB) FlagHost(addr network.Address) error {
 	return hdb.Remove(addr)
 }
 
-// Insert is the thread-safe version of insert.
+// Insert attempts to insert a host entry into the database.
 func (hdb *HostDB) Insert(entry modules.HostEntry) error {
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
-	hdb.insert(&entry)
+	hdb.insert(entry)
 	return nil
 }
 

--- a/modules/hostdb/entries_test.go
+++ b/modules/hostdb/entries_test.go
@@ -48,3 +48,43 @@ func TestEntryWeight(t *testing.T) {
 		t.Error("unexpected weight for light host entry")
 	}
 }
+
+// TestInsertAllHosts inserts a few items into the hostdb and checks that
+// allHosts updates as expected.
+func TestInsertAllHosts(t *testing.T) {
+	hdbt := CreateHostDBTester(t)
+
+	// Insert a standard entry using the exported function.
+	normalEntry := modules.HostEntry{
+		IPAddress: ":2501",
+	}
+	err := hdbt.Insert(normalEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hdbt.allHosts) != 1 {
+		t.Error("expecting 1 host in allHosts, got", len(hdbt.allHosts))
+	}
+
+	// Insert the entry again, the size of allHosts should not change.
+	err = hdbt.Insert(normalEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hdbt.allHosts) != 1 {
+		t.Error("expecting 1 host in allHosts, got", len(hdbt.allHosts))
+	}
+
+	// Insert an entry that has the same host but a different port. allHosts
+	// should increase to 2 total in size.
+	sameHostEntry := modules.HostEntry{
+		IPAddress: ":2502",
+	}
+	err = hdbt.Insert(sameHostEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hdbt.allHosts) != 2 {
+		t.Error("expecting 2 hosts in allHosts, got", len(hdbt.allHosts))
+	}
+}

--- a/modules/hostdb/entries_test.go
+++ b/modules/hostdb/entries_test.go
@@ -1,0 +1,50 @@
+package hostdb
+
+import (
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// TestEntryWeight submits multiple entries to get weighed and checks that the
+// results match the expected.
+func TestEntryWeight(t *testing.T) {
+	// Create a normal host entry and check that the weight comes back as the
+	// expected value.
+	normalEntry := modules.HostEntry{
+		HostSettings: modules.HostSettings{
+			Price:      currencyTen,
+			Collateral: currencyTen,
+		},
+	}
+	expectedWeight := baseWeight.Mul(currencyTen).Div(currencyTen).Div(currencyTen)
+	if expectedWeight.Cmp(entryWeight(normalEntry)) != 0 {
+		t.Error("unexpected weight for normal host entry")
+	}
+
+	// Create a collateral heavy host entry and check that the weight comes
+	// back as the expected value.
+	heavyCollateralEntry := modules.HostEntry{
+		HostSettings: modules.HostSettings{
+			Price:      currencyTen,
+			Collateral: currencyThousand,
+		},
+	}
+	expectedWeight = baseWeight.Mul(currencyTwenty).Div(currencyTen).Div(currencyTen)
+	if expectedWeight.Cmp(entryWeight(heavyCollateralEntry)) != 0 {
+		t.Error("unexpected weight for heavy host entry")
+	}
+
+	// Create a collateral light host entry and check that the weight comes
+	// back as the expected value.
+	lightCollateralEntry := modules.HostEntry{
+		HostSettings: modules.HostSettings{
+			Price:      currencyTen,
+			Collateral: currencyTwo,
+		},
+	}
+	expectedWeight = baseWeight.Mul(currencyFive).Div(currencyTen).Div(currencyTen)
+	if expectedWeight.Cmp(entryWeight(lightCollateralEntry)) != 0 {
+		t.Error("unexpected weight for light host entry")
+	}
+}

--- a/modules/hostdb/hostdb.go
+++ b/modules/hostdb/hostdb.go
@@ -15,7 +15,8 @@ var (
 )
 
 // The HostDB is a database of potential hosts. It assigns a weight to each
-// host based on their hosting parameters.
+// host based on their hosting parameters, and then can select hosts at random
+// for uploading files.
 type HostDB struct {
 	state       *consensus.State
 	recentBlock consensus.BlockID

--- a/modules/hostdb/update.go
+++ b/modules/hostdb/update.go
@@ -64,8 +64,7 @@ func (hdb *HostDB) update() {
 			continue
 		}
 		for _, entry := range findHostAnnouncements(block) {
-			hdb.allHosts[entry.IPAddress] = &entry
-			go hdb.threadedInsert(&entry)
+			hdb.insert(&entry)
 		}
 	}
 


### PR DESCRIPTION
There's not a whole lot happening in this PR. I wrote a few tests to check that inactive hosts were working correctly. Checking that active hosts are working correctly is going to require making fake RPCs... we're just going to have to leave this to the integration testing for this week.

I completely refactored insert, now it's got a lot less side effects and more standard/expected behavior. insert puts stuff into the full set, then determines if it belongs in the active set. threadedActiveInsert gets the host settings and gives up if the host is offline. If the host is online, it grabs the settings and calls insertCompleteHostEntry, which removes any conflicts and then inserts the host.

Each of these functions is independent, and can be called without problems or side effects individually.

The docstrings might not be perfect. I tried to go through and fix them all.