### PR TITLE
Save/Load Wallet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: fmt REBUILD
 # development.
 clean:
 	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf         \
-		sia.wallet sia/test.wallet sia/hostdir* sia/renterDownload cover
+		*.wallet cover
 
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	tcpsPort int = 10500
+	tcpsPort  int = 10500
+	walletNum int = 0
 )
 
 // A HostTester contains a consensus tester and a host, and provides a set of
@@ -40,7 +41,7 @@ func CreateHostTester(t *testing.T) (ht *HostTester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w, err := wallet.New(ct.State, tp, "")
+	w, err := wallet.New(ct.State, tp, "../../host_test"+strconv.Itoa(walletNum)+".wallet")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -27,7 +27,7 @@ func TestMiner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w, err := wallet.New(s, tpool, "")
+	w, err := wallet.New(s, tpool, "../../miner_test.wallet")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	tcpsPort int = 11000
+	tcpsPort  int = 11000
+	walletNum int = 0
 )
 
 // A RenterTester contains a consensus tester and a renter, and provides a set
@@ -45,7 +46,7 @@ func CreateRenterTester(t *testing.T) (rt *RenterTester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w, err := wallet.New(ct.State, tp, "")
+	w, err := wallet.New(ct.State, tp, "../../renter_test"+strconv.Itoa(walletNum)+".wallet")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -31,22 +31,17 @@ func (w *Wallet) timelockedCoinAddress(unlockHeight consensus.BlockHeight) (coin
 	// unlocked, also add it to the list of currently spendable addresses. It
 	// needs to go in both though in case there is a reorganization of the
 	// blockchain.
-	newKey := &key{
+	w.keys[coinAddress] = &key{
+		spendable:        w.state.Height() >= unlockHeight,
 		unlockConditions: unlockConditions,
 		secretKey:        sk,
 
 		outputs: make(map[consensus.SiacoinOutputID]*knownOutput),
 	}
-	if unlockHeight <= w.state.Height() {
-		newKey.spendable = true
-	}
-	w.keys[coinAddress] = newKey
 
 	// Add this key to the list of addresses that get unlocked at
 	// `unlockHeight`
-	heightAddrs := w.timelockedKeys[unlockHeight]
-	heightAddrs = append(heightAddrs, coinAddress)
-	w.timelockedKeys[unlockHeight] = heightAddrs
+	w.timelockedKeys[unlockHeight] = append(w.timelockedKeys[unlockHeight], coinAddress)
 
 	// Save the wallet state, which now includes the new address.
 	err = w.save()

--- a/modules/wallet/files.go
+++ b/modules/wallet/files.go
@@ -30,7 +30,6 @@ func (w *Wallet) save() (err error) {
 
 	// Write the data to file.
 	// TODO: Instead of using WriteFile, write to a temp file and then do a move.
-	// TODO: append instead of overwriting everything.
 	err = ioutil.WriteFile(w.filename, encoding.Marshal(keySlice), 0666)
 	if err != nil {
 		return

--- a/modules/wallet/files.go
+++ b/modules/wallet/files.go
@@ -1,112 +1,80 @@
 package wallet
 
 import (
-	// "io/ioutil"
-	// "os"
+	"errors"
+	"io/ioutil"
+	"os"
 
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/crypto"
-	// "github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/encoding"
 )
 
-// Key is how we serialize and store spendable addresses on disk.
-//
-// TODO: When recreating this file, perhaps there are more intelligent things
-// that can be done than just saving the keys. Otherwise at start the wallet
-// needs to do a full catchup on the state, which involves requesting the diffs
-// of every single block.
-type Key struct {
-	UnlockConditions consensus.UnlockConditions
-	SecretKey        crypto.SecretKey
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
 }
 
+type savedKey struct {
+	SecretKey        crypto.SecretKey
+	UnlockConditions consensus.UnlockConditions
+}
+
+// save writes the contents of a wallet to a file.
 func (w *Wallet) save() (err error) {
-	/*
-		// Add every known spendable address + secret key.
-		var i int
-		keys := make([]Key, len(w.addresses))
-		for _, address := range w.addresses {
-			key := Key{
-				SpendConditions: address.spendConditions,
-				SecretKey:       address.secretKey,
-			}
-			keys[i] = key
-			i++
-		}
+	// convert key map to a slice
+	keySlice := make([]savedKey, 0, len(w.keys))
+	for _, key := range w.keys {
+		keySlice = append(keySlice, savedKey{key.secretKey, key.unlockConditions})
+	}
 
-		timelockedKeys := make([]AddressKey, len(w.timelockedAddresses))
-		for _, address := range w.timelockedAddresses {
-			key := Key{
-				SpendConditions: address.spendConditions,
-				SecretKey:       address.secretKey,
-			}
-			timelockedKeys[i] = key
-			i++
-		}
-
-		// Write the file.
-		fileData := encoding.MarshalAll(keys, timelockedKeys)
-		if err != nil {
-			return
-		}
-		// TODO: Instead of using WriteFile, write to a temp file and then do a move,
-		// this is an action that should probably appear in a library somewhere.
-		err = ioutil.WriteFile(w.saveFilename, fileData, 0666)
-		if err != nil {
-			return
-		}
-	*/
+	// Write the data to file.
+	// TODO: Instead of using WriteFile, write to a temp file and then do a move.
+	// TODO: append instead of overwriting everything.
+	err = ioutil.WriteFile(w.filename, encoding.Marshal(keySlice), 0666)
+	if err != nil {
+		return
+	}
 
 	return
 }
 
-// Save implements the core.Wallet interface.
-func (w *Wallet) Save() (err error) {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-	return w.save()
-}
+// load reads the contents of a wallet from a file.
+func (w *Wallet) load(filename string) (err error) {
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return
+	}
+	var savedKeys []savedKey
+	err = encoding.Unmarshal(contents, &savedKeys)
+	if err != nil {
+		return
+	}
 
-// Load implements the core.Wallet interface.
-//
-// TODO TODO TODO: update load so that it also loads timelocked keys.
-func (w *Wallet) Load(filename string) (err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	/*
-		// Check if the file exists, then read it into memory.
-		//
-		// If there is no existing wallet file, the wallet assumes that the higher
-		// level process (core or daemon) has already approved the filename, and
-		// that a wallet simply doesn't exist yet. A new wallet file will be
-		// created next time wallet.Save() is called.
-		//
-		// TODO: wallet should not return nil upon load if the file it's trying to
-		// load doesn't exist.
-		if _, err = os.Stat(filename); os.IsNotExist(err) {
-			err = nil
-			return
-		}
-		contents, err := ioutil.ReadFile(filename)
-		if err != nil {
-			return
+	height := w.state.Height()
+	for _, skey := range savedKeys {
+		// Create an entry in w.keys for each savedKey.
+		w.keys[skey.UnlockConditions.UnlockHash()] = &key{
+			spendable:        height >= skey.UnlockConditions.Timelock,
+			unlockConditions: skey.UnlockConditions,
+			secretKey:        skey.SecretKey,
+			outputs:          make(map[consensus.SiacoinOutputID]*knownOutput),
 		}
 
-		// Unmarshal the spendable addresses and put them into the wallet.
-		var keys []AddressKey
-		err = encoding.Unmarshal(contents, &keys)
-		if err != nil {
-			return
+		// If Timelock != 0, also add to set of timelockedKeys.
+		if tl := skey.UnlockConditions.Timelock; tl != 0 {
+			w.timelockedKeys[tl] = append(w.timelockedKeys[tl], skey.UnlockConditions.UnlockHash())
 		}
-		for _, key := range keys {
-			newSpendableAddress := &spendableAddress{
-				spendableOutputs: make(map[consensus.OutputID]*spendableOutput),
-				spendConditions:  key.SpendConditions,
-				secretKey:        key.SecretKey,
-			}
-			w.spendableAddresses[key.SpendConditions.CoinAddress()] = newSpendableAddress
-		}
-	*/
+	}
+
+	// To calculate the outputs for each key, we need to scan the entire
+	// blockchain. This is done by setting w.recentBlock to the genesis block
+	// and calling w.update.
+	genesisBlock, exists := w.state.BlockAtHeight(0)
+	if !exists {
+		return errors.New("could not fetch genesis block")
+	}
+	w.recentBlock = genesisBlock.ID()
+	w.update()
 	return
 }

--- a/modules/wallet/files_test.go
+++ b/modules/wallet/files_test.go
@@ -1,0 +1,40 @@
+package wallet
+
+import (
+	"testing"
+)
+
+// TestSaveLoad tests that saving and loading a wallet restores its data.
+func TestSaveLoad(t *testing.T) {
+	wt := NewWalletTester(t)
+	// add an output to the wallet
+	wt.testCoinAddress()
+
+	// save wallet data
+	err := wt.save()
+	if err != nil {
+		wt.Fatal(err)
+	}
+
+	// create a new wallet using the saved data
+	newWallet, err := New(wt.state, wt.tpool, wt.filename)
+	if err != nil {
+		wt.Fatal(err)
+	}
+
+	// check that the wallets match
+	for mapKey := range wt.keys {
+		if _, exists := newWallet.keys[mapKey]; !exists {
+			wt.Fatal("Loaded wallet is missing a key")
+		}
+	}
+	for mapKey := range wt.timelockedKeys {
+		if _, exists := newWallet.timelockedKeys[mapKey]; !exists {
+			wt.Fatal("Loaded wallet is missing a time-locked key")
+		}
+	}
+
+	if wt.Balance(true).Cmp(newWallet.Balance(true)) != 0 {
+		wt.Fatal("Loaded wallet has wrong balance")
+	}
+}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -104,9 +104,13 @@ func New(state *consensus.State, tpool modules.TransactionPool, filename string)
 		transactions: make(map[string]*openTransaction),
 	}
 
-	err = w.Load(filename)
-	if err != nil {
-		return
+	// If the wallet file already exists, try to load it.
+	if fileExists(filename) {
+		// lock not necessary here because no one else has access to w
+		err = w.load(filename)
+		if err != nil {
+			return
+		}
 	}
 
 	return

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/NebulousLabs/Sia/network"
 )
 
+// global variables used to prevent conflicts
 var (
-	tcpsPort int = 10000
+	tcpsPort  int = 10000
+	walletNum int = 0
 )
 
 // A Wallet tester contains a ConsensusTester and has a bunch of helpful
@@ -38,10 +40,11 @@ func NewWalletTester(t *testing.T) (wt *WalletTester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wt.Wallet, err = New(wt.State, tpool, "")
+	wt.Wallet, err = New(wt.State, tpool, "../../wallet_test"+strconv.Itoa(walletNum)+".wallet")
 	if err != nil {
 		t.Fatal(err)
 	}
+	walletNum++
 
 	return
 }


### PR DESCRIPTION
Pretty straightforward. The only thing a wallet saves is that `{UnlockConditions, SecretKey}` pair of each entry in its `w.keys` map. This means that saves are relatively efficient. Loads, on the other hand, require rebuilding both the `w.keys` map and the `w.timelockedKeys` map. More importantly, they require reconstructing all of the outputs associated with a key, which means rescanning the blockchain from the beginning. Fortunately, loads are much less frequent than saves, so this isn't a huge deal. In the future we can worry about making them more efficient (probably by saving the outputs and then adjusting them as needed to account for consensus changes).