### PR TITLE
siad tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: fmt REBUILD
 # development.
 clean:
 	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf         \
-		*.wallet *_test cover hostdir*
+		*.wallet *_test cover hostdir* siad/walletDir*
 
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.

--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 )
@@ -127,4 +128,10 @@ func (c Currency) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (c *Currency) UnmarshalJSON(b []byte) error {
 	return c.i.UnmarshalJSON(b)
+}
+
+// Scan implements the fmt.Scanner interface, allowing Currency values to be
+// scanned from text.
+func (c *Currency) Scan(s fmt.ScanState, ch rune) error {
+	return c.i.Scan(s, ch)
 }

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -87,6 +87,8 @@ func (g *Gateway) RelayTransaction(t consensus.Transaction) (err error) {
 
 // Info returns metadata about the Gateway.
 func (g *Gateway) Info() (info modules.GatewayInfo) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 	for peer := range g.peers {
 		info.Peers = append(info.Peers, peer)
 	}

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -81,6 +81,7 @@ func (g *Gateway) RelayBlock(b consensus.Block) (err error) {
 
 // RelayTransaction relays a transaction, both locally and to the network.
 func (g *Gateway) RelayTransaction(t consensus.Transaction) (err error) {
+	// no locking necessary
 	go g.threadedBroadcast("AcceptTransaction", t, nil)
 	return
 }

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -50,7 +50,7 @@ func (g *Gateway) Bootstrap(bootstrapPeer network.Address) (err error) {
 	}
 
 	// announce ourselves to new peers
-	g.broadcast("AddMe", g.tcps.Address(), nil)
+	go g.threadedBroadcast("AddMe", g.tcps.Address(), nil)
 
 	return
 }
@@ -75,13 +75,13 @@ func (g *Gateway) RelayBlock(b consensus.Block) (err error) {
 		return errors.New("block added, but it does not extend the state height.")
 	}
 
-	g.broadcast("RelayBlock", b, nil)
+	go g.threadedBroadcast("RelayBlock", b, nil)
 	return
 }
 
 // RelayTransaction relays a transaction, both locally and to the network.
 func (g *Gateway) RelayTransaction(t consensus.Transaction) (err error) {
-	g.broadcast("AcceptTransaction", t, nil)
+	go g.threadedBroadcast("AcceptTransaction", t, nil)
 	return
 }
 

--- a/modules/gateway/helpers.go
+++ b/modules/gateway/helpers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"math/rand"
+	"sync"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/network"
@@ -36,10 +37,23 @@ func (g *Gateway) randomPeer() (network.Address, error) {
 	return "", ErrNoPeers
 }
 
-func (g *Gateway) broadcast(name string, arg, resp interface{}) {
-	for peer := range g.peers {
-		peer.RPC(name, arg, resp)
+// threadedBroadcast broadcasts an RPC to all of the Gateway's peers. The
+// calls are run in parallel.
+func (g *Gateway) threadedBroadcast(name string, arg, resp interface{}) {
+	// get peer list
+	g.mu.RLock()
+	peers := g.peers
+	g.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	wg.Add(len(peers))
+	for peer := range peers {
+		go func(peer network.Address) {
+			peer.RPC(name, arg, resp)
+			wg.Done()
+		}(peer)
 	}
+	wg.Wait()
 }
 
 func (g *Gateway) save(filename string) error {

--- a/modules/host.go
+++ b/modules/host.go
@@ -49,6 +49,8 @@ type Host interface {
 	// SetConfig sets the hosting parameters of the host.
 	SetSettings(HostSettings)
 
+	Settings() (HostSettings, error)
+
 	// Info returns info about the host, including its hosting parameters, the
 	// amount of storage remaining, and the number of active contracts.
 	Info() HostInfo

--- a/modules/miner/info.go
+++ b/modules/miner/info.go
@@ -42,9 +42,9 @@ func (m *Miner) Info() (MinerInfo, error) {
 		info.State = "Turning Off"
 	} else if m.desiredThreads == m.runningThreads {
 		info.State = "On"
-	} else if m.desiredThreads < m.runningThreads {
-		info.State = "Turning On"
 	} else if m.desiredThreads > m.runningThreads {
+		info.State = "Turning On"
+	} else if m.desiredThreads < m.runningThreads {
 		info.State = "Decreasing number of threads."
 	} else {
 		info.State = "Miner is in an ERROR state!"

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -23,5 +23,5 @@ type Renter interface {
 	Upload(UploadParams) error
 	Download(nickname, filepath string) error
 	Rename(currentName, newName string) error
-	Info() (RentInfo, error)
+	Info() RentInfo
 }

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -10,6 +10,13 @@ var (
 	LowBalanceErr = errors.New("Insufficient Balance")
 )
 
+// WalletInfo contains basic information about the wallet.
+type WalletInfo struct {
+	Balance      consensus.Currency
+	FullBalance  consensus.Currency
+	NumAddresses int
+}
+
 // Wallet in an interface that helps to build and sign transactions. The user
 // can make a new transaction-in-progress by calling Register, and then can
 // add outputs, fees, etc. This gives other modules full flexibility in
@@ -74,4 +81,8 @@ type Wallet interface {
 	// signature. After being signed, the transaction is deleted from the
 	// wallet and must be reregistered if more changes are to be made.
 	SignTransaction(id string, wholeTransaction bool) (consensus.Transaction, error)
+
+	Info() WalletInfo
+
+	SpendCoins(amount consensus.Currency, dest consensus.UnlockHash) (consensus.Transaction, error)
 }

--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -1,26 +1,17 @@
 package wallet
 
 import (
-	"github.com/NebulousLabs/Sia/consensus"
+	"github.com/NebulousLabs/Sia/modules"
 )
 
-// WalletInfo contains basic information about the wallet.
-type WalletInfo struct {
-	Balance      consensus.Currency
-	FullBalance  consensus.Currency
-	NumAddresses int
-}
-
 // Info fills out and returns a WalletInfo struct.
-func (w *Wallet) Info() (status WalletInfo, err error) {
+func (w *Wallet) Info() modules.WalletInfo {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
-	status = WalletInfo{
+	return modules.WalletInfo{
 		Balance:      w.Balance(false),
 		FullBalance:  w.Balance(true),
 		NumAddresses: len(w.keys),
 	}
-
-	return
 }

--- a/siac/peercmd.go
+++ b/siac/peercmd.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/NebulousLabs/Sia/network"
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 var (
@@ -57,14 +57,14 @@ func peerremovecmd(addr string) {
 }
 
 func peerstatuscmd() {
-	var peers []network.Address
-	err := getAPI("/peer/status", &peers)
+	var info modules.GatewayInfo
+	err := getAPI("/peer/status", &info)
 	if err != nil {
 		fmt.Println("Could not get peer status:", err)
 		return
 	}
-	fmt.Println(len(peers), "active peers:")
-	for _, peer := range peers {
+	fmt.Println(len(info.Peers), "active peers:")
+	for _, peer := range info.Peers {
 		fmt.Println("\t", peer)
 	}
 }

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/NebulousLabs/Sia/modules/wallet"
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 var (
@@ -63,7 +63,7 @@ func walletsendcmd(amount, dest string) {
 }
 
 func walletstatuscmd() {
-	status := new(wallet.WalletInfo)
+	status := new(modules.WalletInfo)
 	err := getAPI("/wallet/status", status)
 	if err != nil {
 		fmt.Println("Could not get wallet status:", err)

--- a/siad/api.go
+++ b/siad/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/stretchr/graceful"
 )
@@ -22,7 +23,7 @@ func handleHTTPRequest(mux *http.ServeMux, url string, handler http.HandlerFunc)
 	})
 }
 
-func (d *daemon) listen(addr string) {
+func (d *daemon) listen(addr string) error {
 	mux := http.NewServeMux()
 
 	// Host API Calls
@@ -71,12 +72,13 @@ func (d *daemon) listen(addr string) {
 	}
 
 	// graceful will run until it catches a signal.
-	// it can also be stopped manually by stopHandler.
-	//
-	// TODO: this fails silently. The error should be checked, but then it
-	// will print an error even if interrupted normally. Need a better
-	// solution.
-	d.apiServer.ListenAndServe()
+	// It can also be stopped manually by stopHandler.
+	err := d.apiServer.ListenAndServe()
+	// despite its name, graceful still propogates this benign error
+	if err != nil && strings.HasSuffix(err.Error(), "use of closed network connection") {
+		err = nil
+	}
+	return err
 }
 
 // writeJSON writes the object to the ResponseWriter. If the encoding fails, an

--- a/siad/api.go
+++ b/siad/api.go
@@ -23,7 +23,7 @@ func handleHTTPRequest(mux *http.ServeMux, url string, handler http.HandlerFunc)
 	})
 }
 
-func (d *daemon) listen(addr string) error {
+func (d *daemon) initAPI(addr string) {
 	mux := http.NewServeMux()
 
 	// Host API Calls
@@ -70,7 +70,9 @@ func (d *daemon) listen(addr string) error {
 		Timeout: apiTimeout,
 		Server:  &http.Server{Addr: addr, Handler: mux},
 	}
+}
 
+func (d *daemon) listen() error {
 	// graceful will run until it catches a signal.
 	// It can also be stopped manually by stopHandler.
 	err := d.apiServer.ListenAndServe()

--- a/siad/apiwallet.go
+++ b/siad/apiwallet.go
@@ -15,8 +15,9 @@ func (d *daemon) walletAddressHandler(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	// TODO: Explain what's happening here, and why it doesn't look like all of
-	// the other calls.
+	// Since coinAddress is not a struct, we define one here so that writeJSON
+	// writes an object instead of a bare value. In addition, we transmit the
+	// coinAddress as a hex-encoded string rather than a byte array.
 	writeJSON(w, struct {
 		Address string
 	}{fmt.Sprintf("%x", coinAddress)})
@@ -27,7 +28,7 @@ func (d *daemon) walletSendHandler(w http.ResponseWriter, req *http.Request) {
 	// Scan the inputs.
 	var amount consensus.Currency
 	var dest consensus.UnlockHash
-	_, err := fmt.Sscan(req.FormValue("amount"), &amount)
+	err := amount.UnmarshalJSON([]byte(req.FormValue("amount")))
 	if err != nil {
 		writeError(w, "Malformed amount", 400)
 		return

--- a/siad/apiwallet.go
+++ b/siad/apiwallet.go
@@ -56,10 +56,5 @@ func (d *daemon) walletSendHandler(w http.ResponseWriter, req *http.Request) {
 // walletStatusHandler returns a struct containing wallet information, like the
 // balance.
 func (d *daemon) walletStatusHandler(w http.ResponseWriter, req *http.Request) {
-	walletStatus, err := d.wallet.Info()
-	if err != nil {
-		writeError(w, "Failed to get wallet info", 500)
-		return
-	}
-	writeJSON(w, walletStatus)
+	writeJSON(w, d.wallet.Info())
 }

--- a/siad/apiwallet.go
+++ b/siad/apiwallet.go
@@ -28,16 +28,15 @@ func (d *daemon) walletSendHandler(w http.ResponseWriter, req *http.Request) {
 	// Scan the inputs.
 	var amount consensus.Currency
 	var dest consensus.UnlockHash
-	err := amount.UnmarshalJSON([]byte(req.FormValue("amount")))
+	_, err := fmt.Sscan(req.FormValue("amount"), &amount)
 	if err != nil {
 		writeError(w, "Malformed amount", 400)
 		return
 	}
 
 	// Parse the string into an address.
-	destString := req.FormValue("dest")
 	var destAddressBytes []byte
-	_, err = fmt.Sscanf(destString, "%x", &destAddressBytes)
+	_, err = fmt.Sscanf(req.FormValue("dest"), "%x", &destAddressBytes)
 	if err != nil {
 		writeError(w, "Malformed coin address", 400)
 		return

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/graceful"
 
 	"github.com/NebulousLabs/Sia/consensus"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/gateway"
 	"github.com/NebulousLabs/Sia/modules/host"
 	"github.com/NebulousLabs/Sia/modules/hostdb"
@@ -35,16 +36,15 @@ type DaemonConfig struct {
 }
 
 type daemon struct {
-	// Modules. TODO: Implement all modules.
 	state   *consensus.State
-	tpool   *transactionpool.TransactionPool
+	tpool   modules.TransactionPool
 	network *network.TCPServer
-	wallet  *wallet.Wallet
+	wallet  modules.Wallet
 	miner   *miner.Miner
-	host    *host.Host
-	hostDB  *hostdb.HostDB
-	renter  *renter.Renter
-	gateway *gateway.Gateway
+	host    modules.Host
+	hostDB  modules.HostDB
+	renter  modules.Renter
+	gateway modules.Gateway
 
 	styleDir    string
 	downloadDir string

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -98,7 +98,7 @@ func newDaemon(config DaemonConfig) (d *daemon, err error) {
 
 // initRPC registers all of the daemon's RPC handlers
 func (d *daemon) initRPC() (err error) {
-	err = d.network.RegisterRPC("AcceptBlock", d.gateway.RelayBlock)
+	err = d.network.RegisterRPC("RelayBlock", d.gateway.RelayBlock)
 	if err != nil {
 		return
 	}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -110,6 +110,10 @@ func (d *daemon) initRPC() (err error) {
 	if err != nil {
 		return
 	}
+	err = d.network.RegisterRPC("SharePeers", d.gateway.SharePeers)
+	if err != nil {
+		return
+	}
 	err = d.network.RegisterRPC("SendBlocks", d.gateway.SendBlocks)
 	if err != nil {
 		return

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -90,8 +90,14 @@ func newDaemon(config DaemonConfig) (d *daemon, err error) {
 		return
 	}
 
-	// register RPC handlers
-	// TODO: register all RPCs in a separate function
+	d.initRPC()
+	d.initAPI(config.APIAddr)
+
+	return
+}
+
+// initRPC registers all of the daemon's RPC handlers
+func (d *daemon) initRPC() (err error) {
 	err = d.network.RegisterRPC("AcceptBlock", d.gateway.RelayBlock)
 	if err != nil {
 		return

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -60,7 +60,7 @@ func (dt *daemonTester) get(call string) (resp *http.Response) {
 	if resp.StatusCode != http.StatusOK {
 		errResp, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		dt.Fatalf("GET %s returned error %v: %v", resp.StatusCode, errResp)
+		dt.Fatalf("GET %s returned error %v: %s", call, resp.StatusCode, errResp)
 	}
 	return
 }

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+
+	"github.com/NebulousLabs/Sia/network"
 )
 
 var (
@@ -46,6 +48,10 @@ func newDaemonTester(t *testing.T) *daemonTester {
 	RPCPort++
 
 	return &daemonTester{d, t}
+}
+
+func (dt *daemonTester) Address() network.Address {
+	return dt.network.Address()
 }
 
 // get wraps a GET request with a status code check, such that if the GET does

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -1,6 +1,18 @@
 package main
 
-func testingDaemon() (d *daemon, err error) {
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type daemonTester struct {
+	*daemon
+	*testing.T
+}
+
+func newDaemonTester(t *testing.T) *daemonTester {
 	dc := DaemonConfig{
 		APIAddr: ":9020",
 		RPCAddr: ":9021",
@@ -14,11 +26,54 @@ func testingDaemon() (d *daemon, err error) {
 		WalletDir: "walletDir",
 	}
 
-	d, err = newDaemon(dc)
+	d, err := newDaemon(dc)
 	if err != nil {
-		return
+		t.Fatal("Could not create daemon:", err)
 	}
+	go func() {
+		listenErr := d.listen()
+		if listenErr != nil {
+			t.Fatal("API server quit:", listenErr)
+		}
+	}()
 
-	go d.listen(dc.APIAddr)
+	return &daemonTester{d, t}
+}
+
+// get wraps a GET request with a status code check, such that if the GET does
+// not return 200, the error will be read and returned. The response body is
+// not closed.
+func (dt *daemonTester) get(call string) (resp *http.Response) {
+	resp, err := http.Get("http://localhost" + dt.apiServer.Addr + call)
+	if err != nil {
+		dt.Fatalf("GET %s failed: %v", call, err)
+	}
+	// check error code
+	if resp.StatusCode != http.StatusOK {
+		errResp, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		dt.Fatalf("GET %s returned error %v: %v", resp.StatusCode, errResp)
+	}
 	return
+}
+
+// getAPI makes an API call and decodes the response.
+func (dt *daemonTester) getAPI(call string, obj interface{}) {
+	resp := dt.get(call)
+	defer resp.Body.Close()
+	err := json.NewDecoder(resp.Body).Decode(obj)
+	if err != nil {
+		dt.Fatalf("Could not decode API response: %s", call)
+	}
+	return
+}
+
+// callAPI makes an API call and discards the response.
+func (dt *daemonTester) callAPI(call string) {
+	dt.get(call).Body.Close()
+}
+
+// TestCreateDaemon creates a daemonTester and immediately stops it.
+func TestCreateDaemon(t *testing.T) {
+	newDaemonTester(t).callAPI("/stop")
 }

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/NebulousLabs/Sia/consensus"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/network"
 )
 
@@ -18,6 +20,7 @@ var (
 type daemonTester struct {
 	*daemon
 	*testing.T
+	rpcChan chan struct{}
 }
 
 func newDaemonTester(t *testing.T) *daemonTester {
@@ -38,6 +41,13 @@ func newDaemonTester(t *testing.T) *daemonTester {
 	if err != nil {
 		t.Fatal("Could not create daemon:", err)
 	}
+	dt := &daemonTester{d, t, make(chan struct{}, 10)}
+
+	// overwrite RPCs with special testing RPCs
+	dt.network.RegisterRPC("AddMe", dt.addMe)
+	dt.network.RegisterRPC("RelayBlock", dt.relayBlock)
+	dt.network.RegisterRPC("AcceptTransaction", dt.acceptTransaction)
+
 	go func() {
 		listenErr := d.listen()
 		if listenErr != nil {
@@ -47,11 +57,53 @@ func newDaemonTester(t *testing.T) *daemonTester {
 	APIPort++
 	RPCPort++
 
-	return &daemonTester{d, t}
+	return dt
 }
 
-func (dt *daemonTester) Address() network.Address {
+func (dt *daemonTester) address() network.Address {
 	return dt.network.Address()
+}
+
+func (dt *daemonTester) addMe(peer network.Address) error {
+	err := dt.gateway.AddMe(peer)
+	dt.rpcChan <- struct{}{}
+	return err
+}
+
+func (dt *daemonTester) relayBlock(b consensus.Block) error {
+	err := dt.gateway.RelayBlock(b)
+	dt.rpcChan <- struct{}{}
+	return err
+}
+
+func (dt *daemonTester) acceptTransaction(t consensus.Transaction) error {
+	err := dt.tpool.AcceptTransaction(t)
+	dt.rpcChan <- struct{}{}
+	return err
+}
+
+// mineMoney mines 5 blocks, enough for the coinbase to be accepted by the
+// wallet. This may take a while.
+func (dt *daemonTester) mineBlock() {
+	// get old balance
+	var info modules.WalletInfo
+	dt.getAPI("/wallet/status", &info)
+	oldBalance := info.Balance
+	for i := 0; i < 5; i++ {
+		for {
+			_, solved, err := dt.miner.SolveBlock()
+			if err != nil {
+				dt.Fatal("Mining failed:", err)
+			} else if solved {
+				break
+			}
+		}
+		<-dt.rpcChan
+	}
+	dt.getAPI("/wallet/status", &info)
+	if info.FullBalance.Cmp(oldBalance) <= 0 {
+		dt.Fatal("Mining did not increase balance")
+	}
 }
 
 // get wraps a GET request with a status code check, such that if the GET does

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -41,7 +41,7 @@ func newDaemonTester(t *testing.T) *daemonTester {
 	if err != nil {
 		t.Fatal("Could not create daemon:", err)
 	}
-	dt := &daemonTester{d, t, make(chan struct{}, 10)}
+	dt := &daemonTester{d, t, make(chan struct{})}
 
 	// overwrite RPCs with special testing RPCs
 	dt.network.RegisterRPC("AddMe", dt.addMe)
@@ -72,7 +72,7 @@ func (dt *daemonTester) addMe(peer network.Address) error {
 
 func (dt *daemonTester) relayBlock(b consensus.Block) error {
 	err := dt.gateway.RelayBlock(b)
-	dt.rpcChan <- struct{}{}
+	//dt.rpcChan <- struct{}{}
 	return err
 }
 
@@ -98,7 +98,6 @@ func (dt *daemonTester) mineBlock() {
 				break
 			}
 		}
-		<-dt.rpcChan
 	}
 	dt.getAPI("/wallet/status", &info)
 	if info.FullBalance.Cmp(oldBalance) <= 0 {

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -34,7 +34,7 @@ func newDaemonTester(t *testing.T) *daemonTester {
 
 		DownloadDir: "downloadDir",
 
-		WalletDir: "walletDir",
+		WalletDir: "walletDir" + strconv.Itoa(APIPort),
 	}
 
 	d, err := newDaemon(dc)

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -4,7 +4,13 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"testing"
+)
+
+var (
+	APIPort int = 9020
+	RPCPort int = 9120
 )
 
 type daemonTester struct {
@@ -14,12 +20,12 @@ type daemonTester struct {
 
 func newDaemonTester(t *testing.T) *daemonTester {
 	dc := DaemonConfig{
-		APIAddr: ":9020",
-		RPCAddr: ":9021",
+		APIAddr: ":" + strconv.Itoa(APIPort),
+		RPCAddr: ":" + strconv.Itoa(RPCPort),
 
 		HostDir: "hostDir",
 
-		Threads: 2,
+		Threads: 1,
 
 		DownloadDir: "downloadDir",
 
@@ -36,6 +42,8 @@ func newDaemonTester(t *testing.T) *daemonTester {
 			t.Fatal("API server quit:", listenErr)
 		}
 	}()
+	APIPort++
+	RPCPort++
 
 	return &daemonTester{d, t}
 }

--- a/siad/main.go
+++ b/siad/main.go
@@ -114,7 +114,7 @@ func startEnvironment(*cobra.Command, []string) {
 		go d.bootstrap()
 	}
 	// listen for API requests
-	err = d.listen(daemonConfig.APIAddr)
+	err = d.listen()
 	if err != nil {
 		fmt.Println("API server quit unexpectedly:", err)
 	}

--- a/siad/main.go
+++ b/siad/main.go
@@ -106,7 +106,7 @@ func startEnvironment(*cobra.Command, []string) {
 	}
 	d, err := newDaemon(daemonConfig)
 	if err != nil {
-		fmt.Println("Failed to start daemon:", err)
+		fmt.Println("Failed to create daemon:", err)
 		return
 	}
 	// join the network
@@ -114,7 +114,10 @@ func startEnvironment(*cobra.Command, []string) {
 		go d.bootstrap()
 	}
 	// listen for API requests
-	d.listen(daemonConfig.APIAddr)
+	err = d.listen(daemonConfig.APIAddr)
+	if err != nil {
+		fmt.Println("API server quit unexpectedly:", err)
+	}
 }
 
 func version(*cobra.Command, []string) {

--- a/siad/miner_test.go
+++ b/siad/miner_test.go
@@ -1,29 +1,33 @@
 package main
 
 import (
-	"fmt"
 	"testing"
+	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/miner"
 )
 
 func (dt *daemonTester) testMining() {
+	if testing.Short() {
+		dt.Skip()
+	}
+
 	// start miner
 	dt.callAPI("/miner/start?threads=1")
 	// check that miner has started
 	var minerstatus miner.MinerInfo
 	dt.getAPI("/miner/status", &minerstatus)
-	fmt.Println(minerstatus)
 	if minerstatus.State != "On" {
 		dt.Fatal("Miner did not start")
 	}
+	time.Sleep(1000 * time.Millisecond)
 	dt.callAPI("/miner/stop")
 	// check balance
 	var walletstatus modules.WalletInfo
 	dt.getAPI("/wallet/status", &walletstatus)
-	if walletstatus.Balance.Sign() <= 0 {
-		dt.Fatal("Mining did not increase wallet balance")
+	if walletstatus.FullBalance.Sign() <= 0 {
+		dt.Fatalf("Mining did not increase wallet balance: %v", walletstatus.FullBalance.Big())
 	}
 }
 

--- a/siad/miner_test.go
+++ b/siad/miner_test.go
@@ -8,10 +8,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules/miner"
 )
 
-// TestMining starts the miner, mines a few blocks, and checks that the wallet
-// balance increased.
-func TestMining(t *testing.T) {
-	dt := newDaemonTester(t)
+func (dt *daemonTester) testMining() {
 	// start miner
 	dt.callAPI("/miner/start?threads=1")
 	// check that miner has started
@@ -28,4 +25,11 @@ func TestMining(t *testing.T) {
 	if walletstatus.Balance.Sign() <= 0 {
 		dt.Fatal("Mining did not increase wallet balance")
 	}
+}
+
+// TestMining starts the miner, mines a few blocks, and checks that the wallet
+// balance increased.
+func TestMining(t *testing.T) {
+	dt := newDaemonTester(t)
+	dt.testMining()
 }

--- a/siad/miner_test.go
+++ b/siad/miner_test.go
@@ -1,31 +1,31 @@
 package main
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/modules/miner"
 )
 
-// mineSingleBlock mines a single block and then uses the blocking function
-// processBlock to integrate the block with the state.
-func mineSingleBlock(t *testing.T, d *daemon) {
-	_, found, err := d.miner.SolveBlock()
-	for !found && err == nil {
-		_, found, err = d.miner.SolveBlock()
-		if err != nil {
-			t.Fatal(err)
-		}
+// TestMining starts the miner, mines a few blocks, and checks that the wallet
+// balance increased.
+func TestMining(t *testing.T) {
+	dt := newDaemonTester(t)
+	// start miner
+	dt.callAPI("/miner/start?threads=1")
+	// check that miner has started
+	var minerstatus miner.MinerInfo
+	dt.getAPI("/miner/status", &minerstatus)
+	fmt.Println(minerstatus)
+	if minerstatus.State != "On" {
+		dt.Fatal("Miner did not start")
 	}
-	if err != nil {
-		t.Error(err)
+	dt.callAPI("/miner/stop")
+	// check balance
+	var walletstatus modules.WalletInfo
+	dt.getAPI("/wallet/status", &walletstatus)
+	if walletstatus.Balance.Sign() <= 0 {
+		dt.Fatal("Mining did not increase wallet balance")
 	}
 }
-
-/*
-func testMinerDeadlocking(t *testing.T, d *daemon) {
-	d.miner.Threads()
-	d.miner.SetThreads(2)
-	d.miner.StartMining()
-	d.miner.Threads()
-	d.miner.StopMining()
-	d.miner.Threads()
-}
-*/

--- a/siad/peer_test.go
+++ b/siad/peer_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// TestPeering tests that peers are properly announced and relayed throughout
+// the network.
+func TestPeering(t *testing.T) {
+	// create three peers
+	peer1 := newDaemonTester(t)
+	peer2 := newDaemonTester(t)
+	peer3 := newDaemonTester(t)
+	// add peer3 to peer2
+	peer2.callAPI("/peer/add?addr=" + string(peer3.Address()))
+	// peer3 should now be in peer2's peer list
+	var info modules.GatewayInfo
+	peer2.getAPI("/peer/status", &info)
+	if len(info.Peers) != 1 || info.Peers[0] != peer3.Address() {
+		t.Fatal("/peer/add did not add peer", peer3.Address())
+	}
+	// have peer1 bootstrap to peer2
+	err := peer1.gateway.Bootstrap(peer2.Address())
+	if err != nil {
+		t.Fatal("bootstrap failed:", err)
+	}
+	// peer1 should now have both peer2 and peer3
+	peer1.getAPI("/peer/status", &info)
+	if len(info.Peers) != 2 {
+		t.Fatal("bootstrap peer did not share its peers")
+	}
+	// peer3 should have received peer1 via peer2. Note that it does not have
+	// peer2 though, because peer2 did not use the "AddMe" RPC.
+	peer3.getAPI("/peer/status", &info)
+	if len(info.Peers) != 1 || info.Peers[0] != peer1.Address() {
+		t.Fatal("bootstrap peer did not relay the bootstrapping peer")
+	}
+}

--- a/siad/wallet_test.go
+++ b/siad/wallet_test.go
@@ -1,59 +1,38 @@
 package main
 
-/*
 import (
 	"testing"
 
-	"github.com/NebulousLabs/Sia/consensus"
+	"github.com/NebulousLabs/Sia/modules"
 )
 
-// testSendToSelf does a send from the wallet to itself, and checks that all of
-// the balance reporting at each step makes sense, and then checks that all of
-// the coins are still sendable.
-func testSendToSelf(t *testing.T, c *Core) {
-	if c.wallet.Balance(false) == 0 {
-		t.Error("c.wallet is empty.")
-		return
+func (dt *daemonTester) testSendCoins() {
+	// get current balance
+	var oldstatus modules.WalletInfo
+	dt.getAPI("/wallet/status", &oldstatus)
+	// get a new address
+	var addr struct {
+		Address string
 	}
-	originalBalance := c.wallet.Balance(false)
-
-	// Get a new coin address from the wallet and send the coins to yourself.
-	dest, _, err := c.wallet.CoinAddress()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	_, err = c.wallet.SpendCoins(c.wallet.Balance(false)-10, dest)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	// Process the transaction and check the balance, which should now be 0.
-	//
-	// TODO: This error checking is hacky, instead should use some sort of
-	// synchronization technique.
-	if c.wallet.Balance(false) != 0 {
-		t.Error("Expecting a balance of 0, got", c.wallet.Balance(false))
-	}
-
-	// Mine the block and check the balance, which should now be
-	// originalBalance + Coinbase.
-	// mineSingleBlock(t, c)
-	if c.wallet.Balance(false) != originalBalance+consensus.CalculateCoinbase(c.state.Height()) {
-		t.Errorf("Expecting a balance of %v, got %v", originalBalance+consensus.CalculateCoinbase(c.state.Height()), c.wallet.Balance(false))
-	}
-	if c.wallet.Balance(false) != c.wallet.Balance(true) {
-		t.Errorf("Expecting balance and full balance to be equal, but instead they are false: %v, full: %v", c.wallet.Balance(false), c.wallet.Balance(true))
+	dt.getAPI("/wallet/address", &addr)
+	// send 3e4 coins to the address
+	dt.callAPI("/wallet/send?amount=30000&dest=" + addr.Address)
+	// get updated balance
+	var newstatus modules.WalletInfo
+	dt.getAPI("/wallet/status", &newstatus)
+	// compare balances
+	// TODO: need a better way to test this
+	if newstatus.FullBalance.Cmp(oldstatus.FullBalance) != 0 {
+		dt.Fatal("Balance should not have changed:\n\told: %v\n\tnew: %v", newstatus.FullBalance.Big(), oldstatus.FullBalance.Big())
 	}
 }
 
-// testWalletInfo calles wallet.Info to see if an error is thrown. Also make sure
-// there is no deadlock.
-func testWalletInfo(t *testing.T, c *Core) {
-	_, err := c.wallet.WalletInfo()
-	if err != nil {
-		t.Error(err)
-	}
+// TestSendCoins creates two addresses and sends coins from one to the other.
+// The first balance should decrease, and the second balance should increase
+// proportionally.
+func TestSendCoins(t *testing.T) {
+	dt := newDaemonTester(t)
+	// need to mine a few coins first
+	dt.testMining()
+	dt.testSendCoins()
 }
-*/

--- a/siad/wallet_test.go
+++ b/siad/wallet_test.go
@@ -30,10 +30,11 @@ func TestSendCoins(t *testing.T) {
 
 	// send 3e4 coins from the sender to the receiver
 	sender.callAPI("/wallet/send?amount=30000&dest=" + addr.Address)
-
 	// wait until the transaction is relayed to the receiver
 	<-receiver.rpcChan
 	<-receiver.rpcChan
+	<-sender.rpcChan
+	<-sender.rpcChan
 
 	// get updated balances
 	var newSenderStatus modules.WalletInfo

--- a/siad/wallet_test.go
+++ b/siad/wallet_test.go
@@ -13,8 +13,8 @@ func TestSendCoins(t *testing.T) {
 	sender := newDaemonTester(t)
 	receiver := newDaemonTester(t)
 	miner := newDaemonTester(t)
-	sender.gateway.AddPeer(miner.network.Address())
-	miner.gateway.AddPeer(receiver.network.Address())
+	sender.gateway.AddPeer(miner.Address())
+	miner.gateway.AddPeer(receiver.Address())
 
 	// need to mine a few coins first
 	sender.testMining()

--- a/siad/wallet_test.go
+++ b/siad/wallet_test.go
@@ -6,33 +6,49 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 )
 
-func (dt *daemonTester) testSendCoins() {
-	// get current balance
-	var oldstatus modules.WalletInfo
-	dt.getAPI("/wallet/status", &oldstatus)
-	// get a new address
-	var addr struct {
-		Address string
-	}
-	dt.getAPI("/wallet/address", &addr)
-	// send 3e4 coins to the address
-	dt.callAPI("/wallet/send?amount=30000&dest=" + addr.Address)
-	// get updated balance
-	var newstatus modules.WalletInfo
-	dt.getAPI("/wallet/status", &newstatus)
-	// compare balances
-	// TODO: need a better way to test this
-	if newstatus.FullBalance.Cmp(oldstatus.FullBalance) != 0 {
-		dt.Fatal("Balance should not have changed:\n\told: %v\n\tnew: %v", newstatus.FullBalance.Big(), oldstatus.FullBalance.Big())
-	}
-}
-
 // TestSendCoins creates two addresses and sends coins from one to the other.
 // The first balance should decrease, and the second balance should increase
 // proportionally.
 func TestSendCoins(t *testing.T) {
-	dt := newDaemonTester(t)
+	sender := newDaemonTester(t)
+	receiver := newDaemonTester(t)
+	miner := newDaemonTester(t)
+	sender.gateway.AddPeer(miner.network.Address())
+	miner.gateway.AddPeer(receiver.network.Address())
+
 	// need to mine a few coins first
-	dt.testMining()
-	dt.testSendCoins()
+	sender.testMining()
+
+	// get current balances
+	var oldSenderStatus modules.WalletInfo
+	sender.getAPI("/wallet/status", &oldSenderStatus)
+	var oldReceiverStatus modules.WalletInfo
+	receiver.getAPI("/wallet/status", &oldReceiverStatus)
+
+	// get an address from the receiver
+	var addr struct {
+		Address string
+	}
+	receiver.getAPI("/wallet/address", &addr)
+
+	// send 3e4 coins from the sender to the receiver
+	sender.callAPI("/wallet/send?amount=30000&dest=" + addr.Address)
+
+	// mine a block to get the transaction into the blockchain
+	miner.testMining()
+
+	// get updated balances
+	var newSenderStatus modules.WalletInfo
+	sender.getAPI("/wallet/status", &newSenderStatus)
+	var newReceiverStatus modules.WalletInfo
+	receiver.getAPI("/wallet/status", &newReceiverStatus)
+
+	// sender balance should have gone down
+	if newSenderStatus.FullBalance.Cmp(oldSenderStatus.FullBalance) >= 0 {
+		t.Fatalf("Sender balance should have gone down:\n\told: %v\n\tnew: %v", oldSenderStatus.FullBalance.Big(), newSenderStatus.FullBalance.Big())
+	}
+	// receiver balance should have gone up
+	if newReceiverStatus.FullBalance.Cmp(oldReceiverStatus.FullBalance) <= 0 {
+		t.Fatalf("Receiver balance should have gone up:\n\told: %v\n\tnew: %v", oldReceiverStatus.FullBalance.Big(), newReceiverStatus.FullBalance.Big())
+	}
 }

--- a/siad/wallet_test.go
+++ b/siad/wallet_test.go
@@ -33,8 +33,8 @@ func TestSendCoins(t *testing.T) {
 	// wait until the transaction is relayed to the receiver
 	<-receiver.rpcChan
 	<-receiver.rpcChan
-	<-sender.rpcChan
-	<-sender.rpcChan
+	//<-sender.rpcChan
+	//<-sender.rpcChan
 
 	// get updated balances
 	var newSenderStatus modules.WalletInfo

--- a/siad/wallet_test.go
+++ b/siad/wallet_test.go
@@ -11,13 +11,10 @@ import (
 // proportionally.
 func TestSendCoins(t *testing.T) {
 	sender := newDaemonTester(t)
-	receiver := newDaemonTester(t)
-	miner := newDaemonTester(t)
-	sender.gateway.AddPeer(miner.Address())
-	miner.gateway.AddPeer(receiver.Address())
+	receiver := sender.addPeer()
 
 	// need to mine a few coins first
-	sender.testMining()
+	sender.mineBlock()
 
 	// get current balances
 	var oldSenderStatus modules.WalletInfo
@@ -34,8 +31,9 @@ func TestSendCoins(t *testing.T) {
 	// send 3e4 coins from the sender to the receiver
 	sender.callAPI("/wallet/send?amount=30000&dest=" + addr.Address)
 
-	// mine a block to get the transaction into the blockchain
-	miner.testMining()
+	// wait until the transaction is relayed to the receiver
+	<-receiver.rpcChan
+	<-receiver.rpcChan
 
 	// get updated balances
 	var newSenderStatus modules.WalletInfo


### PR DESCRIPTION
See #362 for a list of completed tests.

Preliminary testing revealed that a lot of siad internals were completely broken. Host, Renter, and Wallet did not satisfy their respective interfaces. Miner doesn't have an interface at all. The Gateway was calling `"AcceptBlock"` even though that RPC is registered to `"RelayBlock"`. `"SharePeers"` wasn't registered at all (it used to be registered by the TCPServer). I guess the moral is that RPCs are tricky business, although I don't know of a way to make them safer. There isn't really a way to check their correctness at compile time.

~~The mining tests are pretty hacky; they just start the miner and wait for a second. We need a much more reliable mechanism for mining, similar to the `ConsensusTester.MineCurrentBlock` method.~~
I added a naive function for accomplishing this. Maybe when you take it over you can make better use of the ConsensusTester.

~~There is one serious problem that I left unaddressed, which is that transactions cannot be relayed between synchronized peers. It seems that this causes an infinite loop: peer1 accepts a transaction and relays it via the Gateway to peer2. Then peer2 accepts the transaction and relays it back to peer1. The chain should stop there, but instead it seems peer1 will relay back to peer2 again, and the transaction will bounce between them forever. Perhaps the Transaction Pool is not rejecting duplicate transactions?~~
This was actually caused by synchronous broadcasts, which are fixed now. However, the fix was kind of hacky. It requires you to keep track of all the RPCs going on behind the scenes. Hopefully we can work out a better method soon.