### PR TITLE
Atomic wallet saving

### DIFF
--- a/consensus/currency.go
+++ b/consensus/currency.go
@@ -96,6 +96,11 @@ func (c Currency) RoundDown(n uint64) (y Currency) {
 	return
 }
 
+// String implements the fmt.Stringer interface.
+func (c Currency) String() string {
+	return c.i.String()
+}
+
 // MarshalSia implements the encoding.SiaMarshaler interface. It returns the
 // byte-slice representation of the Currency's internal big.Int, prepended
 // with a single byte indicating the length of the slice. This implies a

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/consensus"
@@ -105,10 +106,12 @@ func New(state *consensus.State, tpool modules.TransactionPool, filename string)
 	}
 
 	// If the wallet file already exists, try to load it.
+	// TODO: log warning if no file found?
 	if fileExists(filename) {
 		// lock not necessary here because no one else has access to w
 		err = w.load(filename)
 		if err != nil {
+			err = fmt.Errorf("couldn't load wallet file %s: %v", filename, err)
 			return
 		}
 	}

--- a/siac/main.go
+++ b/siac/main.go
@@ -23,7 +23,7 @@ const (
 func get(call string) (resp *http.Response, err error) {
 	resp, err = http.Get(hostname + call)
 	if err != nil {
-		return
+		return nil, errors.New("no response from daemon")
 	}
 	// check error code
 	if resp.StatusCode != 200 {


### PR DESCRIPTION
This is untested, but only because the bug is difficult to reproduce (and hopefully impossible once this is merged).

The `String` method allows for proper printing when a currency is passed to things like `fmt.Println` or used with the `"%v"` format specifier.