### PR TITLE
Make currentPath a slice

### DIFF
--- a/consensus/diffs.go
+++ b/consensus/diffs.go
@@ -117,11 +117,11 @@ func (s *State) commitDiffSet(bn *blockNode, dir DiffDirection) {
 		// Current node must be the input node's parent if applying, and
 		// current node must be the input node if reverting.
 		if dir == DiffApply {
-			if bn.parent.block.ID() != s.currentBlockID {
+			if bn.parent.block.ID() != s.currentBlockID() {
 				panic("applying a block node when it's not a valid successor")
 			}
 		} else {
-			if bn.block.ID() != s.currentBlockID {
+			if bn.block.ID() != s.currentBlockID() {
 				panic("applying a block node when it's not a valid successor")
 			}
 		}
@@ -141,13 +141,9 @@ func (s *State) commitDiffSet(bn *blockNode, dir DiffDirection) {
 
 	// Update the State's metadata
 	if dir == DiffApply {
-		s.currentBlockID = bn.block.ID()
-
 		s.currentPath = append(s.currentPath, bn.block.ID())
 		s.delayedSiacoinOutputs[bn.height] = bn.delayedSiacoinOutputs
 	} else {
-		s.currentBlockID = bn.parent.block.ID()
-
 		s.currentPath = s.currentPath[:len(s.currentPath)-1]
 		delete(s.delayedSiacoinOutputs, bn.height)
 	}
@@ -168,13 +164,12 @@ func (s *State) generateAndApplyDiff(bn *blockNode) (err error) {
 		}
 
 		// Current node must be the input node's parent.
-		if bn.parent.block.ID() != s.currentBlockID {
+		if bn.parent.block.ID() != s.currentBlockID() {
 			panic("applying a block node when it's not a valid successor")
 		}
 	}
 
 	// Update the state to point to the new block.
-	s.currentBlockID = bn.block.ID()
 	s.currentPath = append(s.currentPath, bn.block.ID())
 	s.delayedSiacoinOutputs[s.height()] = make(map[SiacoinOutputID]SiacoinOutput)
 

--- a/consensus/diffs.go
+++ b/consensus/diffs.go
@@ -143,12 +143,12 @@ func (s *State) commitDiffSet(bn *blockNode, dir DiffDirection) {
 	if dir == DiffApply {
 		s.currentBlockID = bn.block.ID()
 
-		s.currentPath[bn.height] = bn.block.ID()
+		s.currentPath = append(s.currentPath, bn.block.ID())
 		s.delayedSiacoinOutputs[bn.height] = bn.delayedSiacoinOutputs
 	} else {
 		s.currentBlockID = bn.parent.block.ID()
 
-		delete(s.currentPath, bn.height)
+		s.currentPath = s.currentPath[:len(s.currentPath)-1]
 		delete(s.delayedSiacoinOutputs, bn.height)
 	}
 }
@@ -175,7 +175,7 @@ func (s *State) generateAndApplyDiff(bn *blockNode) (err error) {
 
 	// Update the state to point to the new block.
 	s.currentBlockID = bn.block.ID()
-	s.currentPath[bn.height] = bn.block.ID()
+	s.currentPath = append(s.currentPath, bn.block.ID())
 	s.delayedSiacoinOutputs[s.height()] = make(map[SiacoinOutputID]SiacoinOutput)
 
 	// diffsGenerated is set to true as soon as we start changing the set of

--- a/consensus/fork.go
+++ b/consensus/fork.go
@@ -26,10 +26,14 @@ func (s *State) invalidateNode(node *blockNode) {
 // set of nodes between the common parent and 'bn', starting from the former.
 func (s *State) backtrackToCurrentPath(bn *blockNode) []*blockNode {
 	path := []*blockNode{bn}
-	for s.currentPath[bn.height] != bn.block.ID() {
+	for {
+		// stop when we reach the common parent
+		if bn.height <= s.height() && s.currentPath[bn.height] == bn.block.ID() {
+			break
+		}
+
 		bn = bn.parent
-		// prepend, not append
-		path = append([]*blockNode{bn}, path...)
+		path = append([]*blockNode{bn}, path...) // prepend, not append
 
 		// Sanity check - all block nodes should have a parent except the
 		// genesis block, and this loop should break before reaching the

--- a/consensus/fork.go
+++ b/consensus/fork.go
@@ -59,7 +59,7 @@ func (s *State) rewindToNode(bn *blockNode) {
 	}
 
 	// Rewind blocks until we reach 'bn'.
-	for s.currentBlockID != bn.block.ID() {
+	for s.currentBlockID() != bn.block.ID() {
 		cur := s.currentBlockNode()
 		s.commitDiffSet(cur, DiffRevert)
 	}

--- a/consensus/info.go
+++ b/consensus/info.go
@@ -18,11 +18,10 @@ type StateInfo struct {
 
 // blockAtHeight returns the block on the current path with the given height.
 func (s *State) blockAtHeight(height BlockHeight) (b Block, exists bool) {
-	bn, exists := s.blockMap[s.currentPath[height]]
-	if !exists {
-		return
+	exists = height <= s.height()
+	if exists {
+		b = s.blockMap[s.currentPath[height]].block
 	}
-	b = bn.block
 	return
 }
 
@@ -38,7 +37,7 @@ func (s *State) currentBlockWeight() *big.Rat {
 
 // height returns the current height of the state.
 func (s *State) height() BlockHeight {
-	return s.blockMap[s.currentBlockID].height
+	return BlockHeight(len(s.currentPath) - 1)
 }
 
 // output returns the unspent SiacoinOutput associated with the given ID. If
@@ -151,15 +150,7 @@ func (s *State) BlocksSince(id BlockID) (removedBlocks, addedBlocks []BlockID, e
 	}
 
 	// Get all the IDs going forward from the common parent.
-	for height := path[0].height + 1; ; height++ {
-		if _, exists := s.currentPath[height]; !exists {
-			break
-		}
-
-		node := s.blockMap[s.currentPath[height]]
-		addedBlocks = append(addedBlocks, node.block.ID())
-	}
-
+	addedBlocks = s.currentPath[path[0].height+1:]
 	return
 }
 

--- a/consensus/info.go
+++ b/consensus/info.go
@@ -25,9 +25,14 @@ func (s *State) blockAtHeight(height BlockHeight) (b Block, exists bool) {
 	return
 }
 
+// currentBlockID returns the ID of the current block.
+func (s *State) currentBlockID() BlockID {
+	return s.currentPath[s.height()]
+}
+
 // currentBlockNode returns the blockNode of the current block.
 func (s *State) currentBlockNode() *blockNode {
-	return s.blockMap[s.currentBlockID]
+	return s.blockMap[s.currentBlockID()]
 }
 
 // currentBlockWeight returns the weight of the current block.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -23,10 +23,8 @@ type State struct {
 	blockMap  map[BlockID]*blockNode
 	badBlocks map[BlockID]struct{}
 
-	// currentPath and currentBlockID track which blocks are currently accepted
-	// as the longest known blockchain.
-	currentPath    []BlockID
-	currentBlockID BlockID
+	// The currentPath is the longest known blockchain.
+	currentPath []BlockID
 
 	// These are the consensus variables, referred to as the "consensus set."
 	// All nodes with the same current path must have the same consensus set.
@@ -98,7 +96,6 @@ func createGenesisState(genesisTime Timestamp, fundUnlockHash UnlockHash, claimU
 
 	// Fill out the consensus information for the genesis block.
 	s.currentPath[0] = genesisBlock.ID()
-	s.currentBlockID = genesisBlock.ID()
 	s.siacoinOutputs[genesisBlock.MinerPayoutID(0)] = SiacoinOutput{
 		Value:      CalculateCoinbase(0),
 		UnlockHash: ZeroUnlockHash,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -25,7 +25,7 @@ type State struct {
 
 	// currentPath and currentBlockID track which blocks are currently accepted
 	// as the longest known blockchain.
-	currentPath    map[BlockHeight]BlockID
+	currentPath    []BlockID
 	currentBlockID BlockID
 
 	// These are the consensus variables, referred to as the "consensus set."
@@ -73,7 +73,7 @@ func createGenesisState(genesisTime Timestamp, fundUnlockHash UnlockHash, claimU
 		blockMap:  make(map[BlockID]*blockNode),
 		badBlocks: make(map[BlockID]struct{}),
 
-		currentPath: make(map[BlockHeight]BlockID),
+		currentPath: make([]BlockID, 1),
 
 		siacoinOutputs:        make(map[SiacoinOutputID]SiacoinOutput),
 		fileContracts:         make(map[FileContractID]FileContract),

--- a/consensus/testconsistency.go
+++ b/consensus/testconsistency.go
@@ -15,23 +15,22 @@ func (ct *ConsensusTester) CurrentPathCheck() {
 
 	currentNode := ct.currentBlockNode()
 	for i := ct.Height(); i != 0; i-- {
-		// Check that the CurrentPath entry exists.
-		id, exists := ct.currentPath[i]
-		if !exists {
-			ct.Error("current path is empty for a height with a known block.")
+		// Check that the node has a corresponding entry in the blockMap
+		if _, exists := ct.blockMap[currentNode.block.ID()]; !exists {
+			ct.Error("currentPath has diverged from blockMap")
 		}
 
-		// Check that the CurrentPath entry contains the correct block id.
-		if currentNode.block.ID() != id {
-			ct.Error("current path does not have correct id!")
+		// Check that the CurrentPath entry contains the correct block ID.
+		if currentNode.block.ID() != ct.currentPath[i] {
+			ct.Error("current path does not have correct ID!")
 		}
 
-		// Check that each parent is one less in height than its child.
+		// Check that the node's height is correct.
 		if currentNode.height != currentNode.parent.height+1 {
 			ct.Error("heights are messed up")
 		}
 
-		currentNode = ct.blockMap[currentNode.block.ParentID]
+		currentNode = currentNode.parent
 	}
 }
 

--- a/consensus/testconsistency.go
+++ b/consensus/testconsistency.go
@@ -116,7 +116,6 @@ func (s *State) consensusSetHash() crypto.Hash {
 	// Create a slice of hashes representing all items of interest.
 	tree := crypto.NewTree()
 	tree.PushObject(s.blockRoot.block)
-	tree.PushObject(s.currentBlockID)
 	tree.PushObject(s.height())
 	tree.PushObject(s.currentBlockNode().target)
 	tree.PushObject(s.currentBlockNode().depth)

--- a/consensus/validtransaction.go
+++ b/consensus/validtransaction.go
@@ -180,17 +180,15 @@ func (s *State) storageProofSegment(fcid FileContractID) (index uint64, err erro
 		return
 	}
 
-	// Get the id of the trigger block, which is the block at height fc.Start -
-	// 1.
+	// Get the ID of the trigger block.
 	triggerHeight := fc.Start - 1
-	triggerBlock, exists := s.blockAtHeight(triggerHeight)
-	if !exists {
+	if triggerHeight > s.height() {
 		err = errors.New("no block found at contract trigger block height")
 		return
 	}
-	triggerID := triggerBlock.ID()
+	triggerID := s.currentPath[triggerHeight]
 
-	// Get the index by appending the file contract id to the trigger block and
+	// Get the index by appending the file contract ID to the trigger block and
 	// taking the hash, then converting the hash to a numerical value and
 	// modding it against the number of segments in the file. The result is a
 	// random number in range [0, numSegments]. The probability is very
@@ -211,7 +209,7 @@ func (s *State) validStorageProofs(t Transaction) error {
 	for _, sp := range t.StorageProofs {
 		fc, exists := s.fileContracts[sp.ParentID]
 		if !exists {
-			return errors.New("unrecognized file contract id in storage proof")
+			return errors.New("unrecognized file contract ID in storage proof")
 		}
 
 		// Check that the storage proof itself is valid.


### PR DESCRIPTION
This turned out to be simpler than expected, mostly because the syntax for map access and slice access is the same. The only trouble I had was with `s.height()`; originally I had it return `len(s.currentPath)`, which is 1 too big.

Just comparing test times, the speed-up seems pretty minimal, though I'd be interested in running a real benchmark. This is less of an efficiency thing and more of a simplicity thing anyway, though.

This made it easy to write `BlockRange`, which is now used in `Synchronize`. The semantics are a little weird because of the +1 thing. Maybe `height` should return `len(s.currentPath)` after all? Anyway, this is nice because `Synchronize` is now guaranteed to draw from `currentPath`.