### PR TITLE
Fix wallet saving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: fmt REBUILD
 # development.
 clean:
 	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf         \
-		*.wallet *_test */*_test hostdir* siad/walletDir* siad/hostDir*
+		*.wallet* *_test */*_test hostdir* siad/walletDir* siad/hostDir*
 
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.

--- a/modules/wallet/files.go
+++ b/modules/wallet/files.go
@@ -27,16 +27,17 @@ func (w *Wallet) save() (err error) {
 	for _, key := range w.keys {
 		keySlice = append(keySlice, savedKey{key.secretKey, key.unlockConditions})
 	}
+	walletData := encoding.Marshal(keySlice)
 
-	// Write the data to a temp file
-	err = ioutil.WriteFile(w.filename+"_temp", encoding.Marshal(keySlice), 0666)
+	// Write the wallet data to a backup file, in case something goes wrong
+	err = ioutil.WriteFile(w.filename+".backup", walletData, 0666)
 	if err != nil {
 		return
 	}
-	// Atomically overwrite the old wallet file with the new wallet file.
-	err = os.Rename(w.filename+"_temp", w.filename)
+	// Overwrite the wallet file.
+	err = ioutil.WriteFile(w.filename, walletData, 0666)
 	if err != nil {
-		// TODO: instruct user to recover wallet from w.filename+"_temp"
+		// TODO: instruct user to recover wallet from w.filename+".backup"
 		return
 	}
 


### PR DESCRIPTION
`os.Rename` fails on Windows if the destination already exists. Now we simply create a backup and then overwrite the old file.