### PR TITLE
Hostdb auto update

### DIFF
--- a/consensus/notifications.go
+++ b/consensus/notifications.go
@@ -3,10 +3,10 @@ package consensus
 // notifySubscribers sends an empty struct to every single remaining
 // subscriber, indicating that the consensus set has changed.
 func (s *State) notifySubscribers() {
-	for _, sub := range s.subscriptions {
+	for _, subscriber := range s.subscriptions {
 		// If the channel is already full, don't block.
 		select {
-		case sub <- struct{}{}:
+		case subscriber <- struct{}{}:
 		default:
 		}
 	}
@@ -18,7 +18,6 @@ func (s *State) SubscribeToConsensusChanges() <-chan struct{} {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	c := make(chan struct{}, 1)
-	s.subscriptions[s.subscriptionCounter] = c
-	s.subscriptionCounter++
+	s.subscriptions = append(s.subscriptions, c)
 	return c
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -51,8 +51,7 @@ type State struct {
 	// listend on by modules. An empty struct is thrown down the channel any
 	// time that the consensus set of the state changes. subscriptionCounter
 	// only ever increments, and prevents collisions in the map.
-	subscriptions       map[int]chan struct{}
-	subscriptionCounter int
+	subscriptions []chan struct{}
 
 	// Per convention, all exported functions in the consensus package can be
 	// called concurrently. The state mutex helps to orchestrate thread safety.
@@ -77,8 +76,6 @@ func createGenesisState(genesisTime Timestamp, fundUnlockHash UnlockHash, claimU
 		fileContracts:         make(map[FileContractID]FileContract),
 		siafundOutputs:        make(map[SiafundOutputID]SiafundOutput),
 		delayedSiacoinOutputs: make(map[BlockHeight]map[SiacoinOutputID]SiacoinOutput),
-
-		subscriptions: make(map[int]chan struct{}),
 	}
 
 	// Create the genesis block and add it as the BlockRoot.

--- a/modules/hostdb/entries.go
+++ b/modules/hostdb/entries.go
@@ -158,7 +158,6 @@ func (hdb *HostDB) Insert(entry modules.HostEntry) error {
 func (hdb *HostDB) NumHosts() int {
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
-	hdb.update()
 
 	if hdb.hostTree == nil {
 		return 0
@@ -171,7 +170,6 @@ func (hdb *HostDB) NumHosts() int {
 func (hdb *HostDB) RandomHost() (h modules.HostEntry, err error) {
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
-	hdb.update()
 
 	if len(hdb.activeHosts) == 0 {
 		err = errors.New("no hosts found")

--- a/modules/hostdb/hostdb.go
+++ b/modules/hostdb/hostdb.go
@@ -51,5 +51,8 @@ func New(s *consensus.State, g modules.Gateway) (hdb *HostDB, err error) {
 		activeHosts: make(map[string]*hostNode),
 		allHosts:    make(map[modules.NetAddress]*modules.HostEntry),
 	}
+
+	go hdb.threadedConsensusListen()
+
 	return
 }

--- a/modules/hostdb/update.go
+++ b/modules/hostdb/update.go
@@ -41,9 +41,6 @@ func findHostAnnouncements(b consensus.Block) (announcements []modules.HostEntry
 // for host announcements. The threading is careful to avoid holding a lock
 // while network communication is happening.
 func (hdb *HostDB) update() {
-	hdb.state.RLock()
-	defer hdb.state.RUnlock()
-
 	// Get the blocks that have been added since the previous update.
 	_, appliedBlocks, err := hdb.state.BlocksSince(hdb.recentBlock)
 	if err != nil {
@@ -52,7 +49,6 @@ func (hdb *HostDB) update() {
 			panic("hostdb got an error when calling hdb.state.BlocksSince")
 		}
 	}
-	hdb.recentBlock = hdb.state.CurrentBlock().ID()
 
 	// Add hosts announced in blocks that were applied.
 	for _, blockID := range appliedBlocks {
@@ -66,6 +62,7 @@ func (hdb *HostDB) update() {
 		for _, entry := range findHostAnnouncements(block) {
 			hdb.insert(entry)
 		}
+		hdb.recentBlock = blockID
 	}
 
 	return

--- a/modules/hostdb/update.go
+++ b/modules/hostdb/update.go
@@ -70,3 +70,15 @@ func (hdb *HostDB) update() {
 
 	return
 }
+
+// threadedConsensusListen listens on a state subscription and updates every
+// time that there's a new block.
+func (hdb *HostDB) threadedConsensusListen() {
+	sub := hdb.state.SubscribeToConsensusChanges()
+	for {
+		hdb.mu.Lock()
+		hdb.update()
+		hdb.mu.Unlock()
+		<-sub
+	}
+}

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -106,8 +106,8 @@ func (m *Miner) updateBlockInfo() {
 // had actually changed, but this greatly increased the complexity of the code,
 // and I'm not even sure it made things run faster.
 func (m *Miner) update() {
-	m.state.RLock()
-	defer m.state.RUnlock()
+	counter := m.state.RLock("miner update")
+	defer m.state.RUnlock("miner update", counter)
 	m.updateTransactionSet()
 	m.updateBlockInfo()
 }

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -123,8 +123,8 @@ func (tp *TransactionPool) removeConflictingTransactions(t consensus.Transaction
 // transactions that are in conflict with new transactions, and also removing
 // any transactions that have entered the blockchain.
 func (tp *TransactionPool) update() {
-	tp.state.RLock()
-	defer tp.state.RUnlock()
+	counter := tp.state.RLock("tpool update")
+	defer tp.state.RUnlock("tpool update", counter)
 
 	// Get the block diffs since the previous update.
 	var removedBlocks, addedBlocks []consensus.Block

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -49,8 +49,8 @@ func (w *Wallet) applyDiff(scod consensus.SiacoinOutputDiff, dir consensus.DiffD
 // the transaction pool will update it's own understanding of the consensus
 // set. (This is currently true).
 func (w *Wallet) update() error {
-	w.state.RLock()
-	defer w.state.RUnlock()
+	counter := w.state.RLock("wallet update")
+	defer w.state.RUnlock("wallet update", counter)
 
 	// Remove all of the diffs that have been applied by the unconfirmed set of
 	// transactions.

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -76,7 +76,7 @@ func (dt *daemonTester) mineBlock() {
 	for {
 		_, solved, err := dt.miner.SolveBlock()
 		if err != nil {
-			dt.Fatal("Mining faild:", err)
+			dt.Fatal("Mining failed:", err)
 		} else if solved {
 			// SolveBlock automatically puts the block into the consensus set.
 			break


### PR DESCRIPTION
After this the hostdb is now automatically updating.

To help find an error, I introduced a safer type of mutex to the state. I think I'm going to make a new type of lock, perhaps in the same fashion as `merkletree`, that will help determine when and where deadlock is happening. Between the new type of lock and the race libraries, we should be able to keep tighter control on our mutexes.