### PR TITLE
Safelocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ clean:
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.
 test: clean fmt REBUILD
-	go test -short -tags=test -timeout=35s ./...
+	go test -short -tags=test -timeout=1s ./...
 
 # test-long does a forced rebuild of all packages, and then runs all tests
 # with the race libraries enabled. test-long aims to be
 # thorough.
 test-long: clean fmt REBUILD
-	go test -v -race -tags=test -timeout=240s ./...
+	go test -v -race -tags=test -timeout=180s ./...
 
 # cover runs the long tests and creats html files that show you which lines
 # have been hit during testing and how many times each line has been hit.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.
 test: clean fmt REBUILD
-	go test -short -tags=test -timeout=1s ./...
+	go test -short -tags=test -timeout=35s ./...
 
 # test-long does a forced rebuild of all packages, and then runs all tests
 # with the race libraries enabled. test-long aims to be

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ install: fmt REBUILD
 # development.
 clean:
 	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf         \
-		*.wallet* *_test */*_test hostdir* siad/walletDir* siad/hostDir*
+		*.wallet* *_test */*_test hostdir* siad/walletDir* siad/hostDir*        \
+		info.log
 
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.

--- a/consensus/accept.go
+++ b/consensus/accept.go
@@ -116,8 +116,8 @@ func (s *State) addBlockToTree(b Block) (err error) {
 // AcceptBlock will add blocks to the state, forking the blockchain if they are
 // on a fork that is heavier than the current fork.
 func (s *State) AcceptBlock(b Block) (err error) {
-	counter := s.mu.Lock("state AcceptBlock")
-	defer s.mu.Unlock("state AcceptBlock", counter)
+	counter := s.mu.Lock()
+	defer s.mu.Unlock(counter)
 
 	// Check maps for information about the block.
 	_, exists := s.badBlocks[b.ID()]

--- a/consensus/accept.go
+++ b/consensus/accept.go
@@ -116,8 +116,8 @@ func (s *State) addBlockToTree(b Block) (err error) {
 // AcceptBlock will add blocks to the state, forking the blockchain if they are
 // on a fork that is heavier than the current fork.
 func (s *State) AcceptBlock(b Block) (err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	counter := s.mu.Lock("state AcceptBlock")
+	defer s.mu.Unlock("state AcceptBlock", counter)
 
 	// Check maps for information about the block.
 	_, exists := s.badBlocks[b.ID()]

--- a/consensus/info.go
+++ b/consensus/info.go
@@ -99,15 +99,15 @@ func (s *State) sortedUsfoSet() []SiafundOutput {
 
 // BlockAtHeight returns the block on the current path with the given height.
 func (s *State) BlockAtHeight(height BlockHeight) (b Block, exists bool) {
-	counter := s.mu.RLock("state BlockAtHeight")
-	defer s.mu.RUnlock("state BlockAtHeight", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.blockAtHeight(height)
 }
 
 // Block returns the block associated with the given id.
 func (s *State) Block(id BlockID) (b Block, exists bool) {
-	counter := s.mu.RLock("state Block")
-	defer s.mu.RUnlock("state Block", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 
 	node, exists := s.blockMap[id]
 	if !exists {
@@ -120,8 +120,8 @@ func (s *State) Block(id BlockID) (b Block, exists bool) {
 // BlockRange returns a slice of the blocks that fall within the given range
 // [start, stop].
 func (s *State) BlockRange(start, stop BlockHeight) ([]Block, error) {
-	counter := s.mu.RLock("state BlockRange")
-	defer s.mu.RUnlock("state BlockRange", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 
 	if start > stop || stop > s.height() {
 		return nil, errors.New("invalid range")
@@ -143,8 +143,8 @@ func (s *State) BlockRange(start, stop BlockHeight) ([]Block, error) {
 
 // BlockOutputDiffs returns the SiacoinOutputDiffs for a given block.
 func (s *State) BlockOutputDiffs(id BlockID) (scods []SiacoinOutputDiff, err error) {
-	counter := s.mu.RLock("state BlockOutputDiffs")
-	defer s.mu.RUnlock("state BlockOutputDiffs", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 
 	node, exists := s.blockMap[id]
 	if !exists {
@@ -163,8 +163,8 @@ func (s *State) BlockOutputDiffs(id BlockID) (scods []SiacoinOutputDiff, err err
 // has changed since block 'id'. OutputDiffsSince will flip the `new` value for
 // diffs that got reversed.
 func (s *State) BlocksSince(id BlockID) (removedBlocks, addedBlocks []BlockID, err error) {
-	counter := s.mu.RLock("state BlocksSince")
-	defer s.mu.RUnlock("state BlocksSince", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 
 	node, exists := s.blockMap[id]
 	if !exists {
@@ -186,8 +186,8 @@ func (s *State) BlocksSince(id BlockID) (removedBlocks, addedBlocks []BlockID, e
 // FileContract returns the file contract associated with the 'id'. If the
 // contract does not exist, exists will be false.
 func (s *State) FileContract(id FileContractID) (fc FileContract, exists bool) {
-	counter := s.mu.RLock("state FileContract")
-	defer s.mu.RUnlock("state FileContract", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 
 	fc, exists = s.fileContracts[id]
 	return
@@ -195,38 +195,38 @@ func (s *State) FileContract(id FileContractID) (fc FileContract, exists bool) {
 
 // CurrentBlock returns the highest block on the tallest fork.
 func (s *State) CurrentBlock() Block {
-	counter := s.mu.RLock("state CurrentBlock")
-	defer s.mu.RUnlock("state CurrentBlock", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.currentBlockNode().block
 }
 
 // CurrentTarget returns the target of the next block that needs to be
 // submitted to the state.
 func (s *State) CurrentTarget() Target {
-	counter := s.mu.RLock("state CurrentTarget")
-	defer s.mu.RUnlock("state CurrentTarget", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.currentBlockNode().target
 }
 
 // EarliestTimestamp returns the earliest timestamp that the next block can
 // have in order for it to be considered valid.
 func (s *State) EarliestTimestamp() Timestamp {
-	counter := s.mu.RLock("state EarliestTimestamp")
-	defer s.mu.RUnlock("state EarliestTimestamp", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.currentBlockNode().earliestChildTimestamp()
 }
 
 // Height returns the height of the current blockchain (the longest fork).
 func (s *State) Height() BlockHeight {
-	counter := s.mu.RLock("state BlockHeight")
-	defer s.mu.RUnlock("state BlockHeight", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.height()
 }
 
 // HeightOfBlock returns the height of the block with the given ID.
 func (s *State) HeightOfBlock(bid BlockID) (height BlockHeight, exists bool) {
-	counter := s.mu.RLock("state HeightOfBlock")
-	defer s.mu.RUnlock("state HeightOfBlock", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 
 	bn, exists := s.blockMap[bid]
 	if !exists {
@@ -238,15 +238,15 @@ func (s *State) HeightOfBlock(bid BlockID) (height BlockHeight, exists bool) {
 
 // SiacoinOutput returns the siacoin output associated with the given ID.
 func (s *State) SiacoinOutput(id SiacoinOutputID) (output SiacoinOutput, exists bool) {
-	counter := s.mu.RLock("state SiacoinOutput")
-	defer s.mu.RUnlock("state SiacoinOutput", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.output(id)
 }
 
 // SiafundOutput returns the siafund output associated with the given ID.
 func (s *State) SiafundOutput(id SiafundOutputID) (output SiafundOutput, exists bool) {
-	counter := s.mu.RLock("state SiafundOutput")
-	defer s.mu.RUnlock("state SiafundOutput", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	output, exists = s.siafundOutputs[id]
 	return
 }
@@ -254,24 +254,24 @@ func (s *State) SiafundOutput(id SiafundOutputID) (output SiafundOutput, exists 
 // SortedUtxoSet returns all of the unspent transaction outputs sorted
 // according to the numerical value of their id.
 func (s *State) SortedUtxoSet() []SiacoinOutput {
-	counter := s.mu.RLock("state SortedUtxoSet")
-	defer s.mu.RUnlock("state SortedUtxoSet", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.sortedUscoSet()
 }
 
 // StorageProofSegment returns the segment to be used in the storage proof for
 // a given file contract.
 func (s *State) StorageProofSegment(fcid FileContractID) (index uint64, err error) {
-	counter := s.mu.RLock("state StorageProofSegment")
-	defer s.mu.RUnlock("state StorageProofSegment", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.storageProofSegment(fcid)
 }
 
 // ValidTransaction checks that a transaction is valid within the context of
 // the current consensus set.
 func (s *State) ValidTransaction(t Transaction) (err error) {
-	counter := s.mu.RLock("state ValidTransaction")
-	defer s.mu.RUnlock("state ValidTransaction", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.validTransaction(t)
 }
 
@@ -285,8 +285,8 @@ func (s *State) ValidTransaction(t Transaction) (err error) {
 // error if the state height is not sufficient to fulfill all of the
 // requirements of the transaction.
 func (s *State) ValidTransactionComponents(t Transaction) (err error) {
-	counter := s.mu.RLock("state ValidTransactionComponents")
-	defer s.mu.RUnlock("state ValidTransactionComponents", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 
 	// This will stop too-large transactions from accidentally being validated.
 	// This check doesn't happen when checking blocks, because the size of the
@@ -317,7 +317,7 @@ func (s *State) ValidTransactionComponents(t Transaction) (err error) {
 
 // ValidUnlockConditions checks that the conditions of uc have been met.
 func (s *State) ValidUnlockConditions(uc UnlockConditions, uh UnlockHash) (err error) {
-	counter := s.mu.RLock("state ValidUnlockConditions")
-	defer s.mu.RUnlock("state ValidUnlockConditions", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.validUnlockConditions(uc, uh)
 }

--- a/consensus/info.go
+++ b/consensus/info.go
@@ -99,15 +99,15 @@ func (s *State) sortedUsfoSet() []SiafundOutput {
 
 // BlockAtHeight returns the block on the current path with the given height.
 func (s *State) BlockAtHeight(height BlockHeight) (b Block, exists bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state BlockAtHeight")
+	defer s.mu.RUnlock("state BlockAtHeight", counter)
 	return s.blockAtHeight(height)
 }
 
 // Block returns the block associated with the given id.
 func (s *State) Block(id BlockID) (b Block, exists bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state Block")
+	defer s.mu.RUnlock("state Block", counter)
 
 	node, exists := s.blockMap[id]
 	if !exists {
@@ -120,8 +120,8 @@ func (s *State) Block(id BlockID) (b Block, exists bool) {
 // BlockRange returns a slice of the blocks that fall within the given range
 // [start, stop].
 func (s *State) BlockRange(start, stop BlockHeight) ([]Block, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state BlockRange")
+	defer s.mu.RUnlock("state BlockRange", counter)
 
 	if start > stop || stop > s.height() {
 		return nil, errors.New("invalid range")
@@ -143,8 +143,8 @@ func (s *State) BlockRange(start, stop BlockHeight) ([]Block, error) {
 
 // BlockOutputDiffs returns the SiacoinOutputDiffs for a given block.
 func (s *State) BlockOutputDiffs(id BlockID) (scods []SiacoinOutputDiff, err error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state BlockOutputDiffs")
+	defer s.mu.RUnlock("state BlockOutputDiffs", counter)
 
 	node, exists := s.blockMap[id]
 	if !exists {
@@ -163,8 +163,8 @@ func (s *State) BlockOutputDiffs(id BlockID) (scods []SiacoinOutputDiff, err err
 // has changed since block 'id'. OutputDiffsSince will flip the `new` value for
 // diffs that got reversed.
 func (s *State) BlocksSince(id BlockID) (removedBlocks, addedBlocks []BlockID, err error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state BlocksSince")
+	defer s.mu.RUnlock("state BlocksSince", counter)
 
 	node, exists := s.blockMap[id]
 	if !exists {
@@ -186,8 +186,8 @@ func (s *State) BlocksSince(id BlockID) (removedBlocks, addedBlocks []BlockID, e
 // FileContract returns the file contract associated with the 'id'. If the
 // contract does not exist, exists will be false.
 func (s *State) FileContract(id FileContractID) (fc FileContract, exists bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state FileContract")
+	defer s.mu.RUnlock("state FileContract", counter)
 
 	fc, exists = s.fileContracts[id]
 	return
@@ -195,38 +195,38 @@ func (s *State) FileContract(id FileContractID) (fc FileContract, exists bool) {
 
 // CurrentBlock returns the highest block on the tallest fork.
 func (s *State) CurrentBlock() Block {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state CurrentBlock")
+	defer s.mu.RUnlock("state CurrentBlock", counter)
 	return s.currentBlockNode().block
 }
 
 // CurrentTarget returns the target of the next block that needs to be
 // submitted to the state.
 func (s *State) CurrentTarget() Target {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state CurrentTarget")
+	defer s.mu.RUnlock("state CurrentTarget", counter)
 	return s.currentBlockNode().target
 }
 
 // EarliestTimestamp returns the earliest timestamp that the next block can
 // have in order for it to be considered valid.
 func (s *State) EarliestTimestamp() Timestamp {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state EarliestTimestamp")
+	defer s.mu.RUnlock("state EarliestTimestamp", counter)
 	return s.currentBlockNode().earliestChildTimestamp()
 }
 
 // Height returns the height of the current blockchain (the longest fork).
 func (s *State) Height() BlockHeight {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state BlockHeight")
+	defer s.mu.RUnlock("state BlockHeight", counter)
 	return s.height()
 }
 
 // HeightOfBlock returns the height of the block with the given ID.
 func (s *State) HeightOfBlock(bid BlockID) (height BlockHeight, exists bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state HeightOfBlock")
+	defer s.mu.RUnlock("state HeightOfBlock", counter)
 
 	bn, exists := s.blockMap[bid]
 	if !exists {
@@ -238,15 +238,15 @@ func (s *State) HeightOfBlock(bid BlockID) (height BlockHeight, exists bool) {
 
 // SiacoinOutput returns the siacoin output associated with the given ID.
 func (s *State) SiacoinOutput(id SiacoinOutputID) (output SiacoinOutput, exists bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state SiacoinOutput")
+	defer s.mu.RUnlock("state SiacoinOutput", counter)
 	return s.output(id)
 }
 
 // SiafundOutput returns the siafund output associated with the given ID.
 func (s *State) SiafundOutput(id SiafundOutputID) (output SiafundOutput, exists bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state SiafundOutput")
+	defer s.mu.RUnlock("state SiafundOutput", counter)
 	output, exists = s.siafundOutputs[id]
 	return
 }
@@ -254,24 +254,24 @@ func (s *State) SiafundOutput(id SiafundOutputID) (output SiafundOutput, exists 
 // SortedUtxoSet returns all of the unspent transaction outputs sorted
 // according to the numerical value of their id.
 func (s *State) SortedUtxoSet() []SiacoinOutput {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state SortedUtxoSet")
+	defer s.mu.RUnlock("state SortedUtxoSet", counter)
 	return s.sortedUscoSet()
 }
 
 // StorageProofSegment returns the segment to be used in the storage proof for
 // a given file contract.
 func (s *State) StorageProofSegment(fcid FileContractID) (index uint64, err error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state StorageProofSegment")
+	defer s.mu.RUnlock("state StorageProofSegment", counter)
 	return s.storageProofSegment(fcid)
 }
 
 // ValidTransaction checks that a transaction is valid within the context of
 // the current consensus set.
 func (s *State) ValidTransaction(t Transaction) (err error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state ValidTransaction")
+	defer s.mu.RUnlock("state ValidTransaction", counter)
 	return s.validTransaction(t)
 }
 
@@ -285,8 +285,8 @@ func (s *State) ValidTransaction(t Transaction) (err error) {
 // error if the state height is not sufficient to fulfill all of the
 // requirements of the transaction.
 func (s *State) ValidTransactionComponents(t Transaction) (err error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state ValidTransactionComponents")
+	defer s.mu.RUnlock("state ValidTransactionComponents", counter)
 
 	// This will stop too-large transactions from accidentally being validated.
 	// This check doesn't happen when checking blocks, because the size of the
@@ -317,7 +317,7 @@ func (s *State) ValidTransactionComponents(t Transaction) (err error) {
 
 // ValidUnlockConditions checks that the conditions of uc have been met.
 func (s *State) ValidUnlockConditions(uc UnlockConditions, uh UnlockHash) (err error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state ValidUnlockConditions")
+	defer s.mu.RUnlock("state ValidUnlockConditions", counter)
 	return s.validUnlockConditions(uc, uh)
 }

--- a/consensus/notifications.go
+++ b/consensus/notifications.go
@@ -15,8 +15,8 @@ func (s *State) notifySubscribers() {
 // SubscribeToConsensusChanges returns a channel that will be sent an empty
 // struct every time the consensus set changes.
 func (s *State) SubscribeToConsensusChanges() <-chan struct{} {
-	counter := s.mu.Lock("state SubscribeToConsensusChanges")
-	defer s.mu.Unlock("state SubscribeToConsensusChanges", counter)
+	counter := s.mu.Lock()
+	defer s.mu.Unlock(counter)
 	c := make(chan struct{}, 1)
 	s.subscriptions = append(s.subscriptions, c)
 	return c

--- a/consensus/notifications.go
+++ b/consensus/notifications.go
@@ -15,8 +15,8 @@ func (s *State) notifySubscribers() {
 // SubscribeToConsensusChanges returns a channel that will be sent an empty
 // struct every time the consensus set changes.
 func (s *State) SubscribeToConsensusChanges() <-chan struct{} {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	counter := s.mu.Lock("state SubscribeToConsensusChanges")
+	defer s.mu.Unlock("state SubscribeToConsensusChanges", counter)
 	c := make(chan struct{}, 1)
 	s.subscriptions = append(s.subscriptions, c)
 	return c

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -61,7 +61,7 @@ type State struct {
 	// mutex, as opposed to putting frequently accessed fields under separate
 	// mutexes. The performance advantage was decided to be not worth the
 	// complexity tradeoff.
-	mu sync.RWMutex
+	mu *sync.RWMutex
 }
 
 // createGenesisState returns a State containing only the genesis block. It

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -61,7 +61,7 @@ type State struct {
 	// mutex, as opposed to putting frequently accessed fields under separate
 	// mutexes. The performance advantage was decided to be not worth the
 	// complexity tradeoff.
-	mu *sync.RWMutex
+	mu sync.RWMutex
 }
 
 // createGenesisState returns a State containing only the genesis block. It

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -79,7 +79,7 @@ func createGenesisState(genesisTime Timestamp, fundUnlockHash UnlockHash, claimU
 		siafundOutputs:        make(map[SiafundOutputID]SiafundOutput),
 		delayedSiacoinOutputs: make(map[BlockHeight]map[SiacoinOutputID]SiacoinOutput),
 
-		mu: sync.New(5 * time.Second),
+		mu: sync.New(5*time.Second, 1),
 	}
 
 	// Create the genesis block and add it as the BlockRoot.
@@ -116,11 +116,11 @@ func CreateGenesisState() (s *State) {
 }
 
 // RLock will readlock the state.
-func (s *State) RLock(id string) int {
-	return s.mu.RLock(id)
+func (s *State) RLock() int {
+	return s.mu.RLock()
 }
 
 // RUnlock will readunlock the state.
-func (s *State) RUnlock(id string, counter int) {
-	s.mu.RUnlock(id, counter)
+func (s *State) RUnlock(counter int) {
+	s.mu.RUnlock(counter)
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1,8 +1,9 @@
 package consensus
 
 import (
-	"sync"
 	"time"
+
+	"github.com/NebulousLabs/Sia/sync"
 )
 
 // The ZeroUnlockHash and ZeroCurrency are convenience variables.
@@ -60,12 +61,7 @@ type State struct {
 	// mutex, as opposed to putting frequently accessed fields under separate
 	// mutexes. The performance advantage was decided to be not worth the
 	// complexity tradeoff.
-	mu sync.RWMutex
-
-	// These tools help track misuse of the state lock.
-	openLocks        map[int]string
-	openLocksCounter int
-	openLocksMutex   sync.Mutex
+	mu *sync.RWMutex
 }
 
 // createGenesisState returns a State containing only the genesis block. It
@@ -83,7 +79,7 @@ func createGenesisState(genesisTime Timestamp, fundUnlockHash UnlockHash, claimU
 		siafundOutputs:        make(map[SiafundOutputID]SiafundOutput),
 		delayedSiacoinOutputs: make(map[BlockHeight]map[SiacoinOutputID]SiacoinOutput),
 
-		openLocks: make(map[int]string),
+		mu: sync.New(5 * time.Second),
 	}
 
 	// Create the genesis block and add it as the BlockRoot.
@@ -121,43 +117,10 @@ func CreateGenesisState() (s *State) {
 
 // RLock will readlock the state.
 func (s *State) RLock(id string) int {
-	s.openLocksMutex.Lock()
-	counter := s.openLocksCounter
-	s.openLocks[counter] = id
-	s.openLocksCounter++
-	s.openLocksMutex.Unlock()
-
-	s.mu.RLock()
-
-	go func() {
-		time.Sleep(time.Second * 2)
-
-		s.openLocksMutex.Lock()
-		_, exists := s.openLocks[counter]
-		if exists {
-			if DEBUG {
-				panic("Externally enforced deadlock by " + id)
-			}
-			delete(s.openLocks, counter)
-			s.mu.RUnlock()
-		}
-		s.openLocksMutex.Unlock()
-	}()
-
-	return counter
+	return s.mu.RLock(id)
 }
 
 // RUnlock will readunlock the state.
 func (s *State) RUnlock(id string, counter int) {
-	s.openLocksMutex.Lock()
-	_, exists := s.openLocks[counter]
-	if !exists {
-		if DEBUG {
-			panic("unlock called, but after waiting too long, using id " + id)
-		}
-	} else {
-		delete(s.openLocks, counter)
-		s.mu.RUnlock()
-	}
-	s.openLocksMutex.Unlock()
+	s.mu.RUnlock(id, counter)
 }

--- a/consensus/testconsistency.go
+++ b/consensus/testconsistency.go
@@ -10,8 +10,8 @@ import (
 // that every block from current to genesis matches the block listed in
 // currentPath.
 func (ct *ConsensusTester) CurrentPathCheck() {
-	ct.mu.RLock()
-	defer ct.mu.RUnlock()
+	counter := ct.mu.RLock("state CurrentPathCheck")
+	defer ct.mu.RUnlock("state CurrentPathCheck", counter)
 
 	currentNode := ct.currentBlockNode()
 	for i := ct.Height(); i != 0; i-- {
@@ -38,8 +38,8 @@ func (ct *ConsensusTester) CurrentPathCheck() {
 // Then the state moves forwards to the initial starting place and verifies
 // that the state hash is the same.
 func (ct *ConsensusTester) RewindApplyCheck() {
-	ct.mu.Lock()
-	defer ct.mu.Unlock()
+	counter := ct.mu.Lock("state RewindApplyCheck")
+	defer ct.mu.Unlock("state RewindApplyCheck", counter)
 
 	csh := ct.consensusSetHash()
 	cn := ct.currentBlockNode()
@@ -54,8 +54,8 @@ func (ct *ConsensusTester) RewindApplyCheck() {
 // should be in the system, and then tallys up the outputs to see if that is
 // the case.
 func (ct *ConsensusTester) CurrencyCheck() {
-	ct.mu.RLock()
-	defer ct.mu.RUnlock()
+	counter := ct.mu.RLock("state CurrencyCheck")
+	defer ct.mu.RUnlock("state CurrencyCheck", counter)
 
 	siafunds := NewCurrency64(0)
 	for _, siafundOutput := range ct.siafundOutputs {
@@ -168,7 +168,7 @@ func (s *State) consensusSetHash() crypto.Hash {
 
 // StateHash returns the markle root of the current state of consensus.
 func (s *State) StateHash() crypto.Hash {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	counter := s.mu.RLock("state StateHash")
+	defer s.mu.RUnlock("state StateHash", counter)
 	return s.consensusSetHash()
 }

--- a/consensus/testconsistency.go
+++ b/consensus/testconsistency.go
@@ -10,8 +10,8 @@ import (
 // that every block from current to genesis matches the block listed in
 // currentPath.
 func (ct *ConsensusTester) CurrentPathCheck() {
-	counter := ct.mu.RLock("state CurrentPathCheck")
-	defer ct.mu.RUnlock("state CurrentPathCheck", counter)
+	counter := ct.mu.RLock()
+	defer ct.mu.RUnlock(counter)
 
 	currentNode := ct.currentBlockNode()
 	for i := ct.Height(); i != 0; i-- {
@@ -38,8 +38,8 @@ func (ct *ConsensusTester) CurrentPathCheck() {
 // Then the state moves forwards to the initial starting place and verifies
 // that the state hash is the same.
 func (ct *ConsensusTester) RewindApplyCheck() {
-	counter := ct.mu.Lock("state RewindApplyCheck")
-	defer ct.mu.Unlock("state RewindApplyCheck", counter)
+	counter := ct.mu.Lock()
+	defer ct.mu.Unlock(counter)
 
 	csh := ct.consensusSetHash()
 	cn := ct.currentBlockNode()
@@ -54,8 +54,8 @@ func (ct *ConsensusTester) RewindApplyCheck() {
 // should be in the system, and then tallys up the outputs to see if that is
 // the case.
 func (ct *ConsensusTester) CurrencyCheck() {
-	counter := ct.mu.RLock("state CurrencyCheck")
-	defer ct.mu.RUnlock("state CurrencyCheck", counter)
+	counter := ct.mu.RLock()
+	defer ct.mu.RUnlock(counter)
 
 	siafunds := NewCurrency64(0)
 	for _, siafundOutput := range ct.siafundOutputs {
@@ -168,7 +168,7 @@ func (s *State) consensusSetHash() crypto.Hash {
 
 // StateHash returns the markle root of the current state of consensus.
 func (s *State) StateHash() crypto.Hash {
-	counter := s.mu.RLock("state StateHash")
-	defer s.mu.RUnlock("state StateHash", counter)
+	counter := s.mu.RLock()
+	defer s.mu.RUnlock(counter)
 	return s.consensusSetHash()
 }

--- a/consensus/testenvironment.go
+++ b/consensus/testenvironment.go
@@ -97,8 +97,8 @@ func (ct *ConsensusTester) MineAndApplyValidBlock() (block Block) {
 
 // RewindABlock removes the most recent block from the consensus set.
 func (ct *ConsensusTester) RewindABlock() {
-	ct.mu.Lock()
-	defer ct.mu.Unlock()
+	counter := ct.mu.Lock("state RewindABlock")
+	defer ct.mu.Unlock("state RewindABlock", counter)
 
 	bn := ct.currentBlockNode()
 	ct.commitDiffSet(bn, DiffRevert)

--- a/consensus/testenvironment.go
+++ b/consensus/testenvironment.go
@@ -97,8 +97,8 @@ func (ct *ConsensusTester) MineAndApplyValidBlock() (block Block) {
 
 // RewindABlock removes the most recent block from the consensus set.
 func (ct *ConsensusTester) RewindABlock() {
-	counter := ct.mu.Lock("state RewindABlock")
-	defer ct.mu.Unlock("state RewindABlock", counter)
+	counter := ct.mu.Lock()
+	defer ct.mu.Unlock(counter)
 
 	bn := ct.currentBlockNode()
 	ct.commitDiffSet(bn, DiffRevert)

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -1,0 +1,115 @@
+package lock
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Lock provides locking functions, and an ability to detect and mitigate
+// deadlocks.
+type Lock struct {
+	openLocks        map[int]string
+	openLocksCounter int
+	openLocksMutex   sync.Mutex
+
+	maxLockTime time.Duration
+
+	mu sync.RWMutex
+}
+
+// New takes a maxLockTime and returns a lock. The lock will never stay locked
+// for more than maxLockTime, instead printing an error and unlocking after
+// maxLockTime has passed.
+func New(maxLockTime time.Duration) *Lock {
+	return &Lock{
+		openLocks:   make(map[int]string),
+		maxLockTime: maxLockTime,
+	}
+}
+
+// RLock will read lock the Lock. The id is so that if there is a problem, the
+// dev can easily figure out which caller caused the problem. The return value
+// is important for correctly managing unlocks.
+func (l *Lock) RLock(id string) int {
+	l.openLocksMutex.Lock()
+	counter := l.openLocksCounter
+	l.openLocks[counter] = id
+	l.openLocksCounter++
+	l.openLocksMutex.Unlock()
+
+	l.mu.RLock()
+
+	go func() {
+		time.Sleep(l.maxLockTime)
+
+		l.openLocksMutex.Lock()
+		_, exists := l.openLocks[counter]
+		if exists {
+			fmt.Printf("RLock held for too long, using id %v and counter %v\n", id, counter)
+			delete(l.openLocks, counter)
+			l.mu.RUnlock()
+		}
+		l.openLocksMutex.Unlock()
+	}()
+
+	return counter
+}
+
+// RUnlock will read unlock the lock. The id is so devs can easily figure out
+// which caller is causing problems. The counter is important for knowing which
+// instance was holding the lock.
+func (l *Lock) RUnlock(id string, counter int) {
+	l.openLocksMutex.Lock()
+	_, exists := l.openLocks[counter]
+	if !exists {
+		fmt.Printf("RUnlock called too late, using id %v and counter %v\n", id, counter)
+	} else {
+		delete(l.openLocks, counter)
+		l.mu.RUnlock()
+	}
+	l.openLocksMutex.Unlock()
+}
+
+// Lock will lock the Lock. The id is so that if there is a problem, the dev
+// can easily figure out which caller caused the problem. The return value is
+// important for correctly managing unlocks.
+func (l *Lock) Lock(id string) int {
+	l.openLocksMutex.Lock()
+	counter := l.openLocksCounter
+	l.openLocks[counter] = id
+	l.openLocksCounter++
+	l.openLocksMutex.Unlock()
+
+	l.mu.Lock()
+
+	go func() {
+		time.Sleep(l.maxLockTime)
+
+		l.openLocksMutex.Lock()
+		_, exists := l.openLocks[counter]
+		if exists {
+			fmt.Printf("Lock held for too long, using id %v and counter %v\n", id, counter)
+			delete(l.openLocks, counter)
+			l.mu.Unlock()
+		}
+		l.openLocksMutex.Unlock()
+	}()
+
+	return counter
+}
+
+// Unlock will unlock the lock. The id is so devs can easily figure out which
+// caller is causing problems. The counter is important for knowing which
+// instance was holding the lock.
+func (l *Lock) Unlock(id string, counter int) {
+	l.openLocksMutex.Lock()
+	_, exists := l.openLocks[counter]
+	if !exists {
+		fmt.Printf("RUnlock called too late, using id %v and counter %v\n", id, counter)
+	} else {
+		delete(l.openLocks, counter)
+		l.mu.Unlock()
+	}
+	l.openLocksMutex.Unlock()
+}

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -3,10 +3,11 @@ package gateway
 import (
 	"errors"
 	"net"
-	"sync"
+	"time"
 
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/sync"
 )
 
 const (
@@ -42,8 +43,8 @@ type Gateway struct {
 
 // Address returns the NetAddress of the Gateway.
 func (g *Gateway) Address() modules.NetAddress {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	counter := g.mu.RLock()
+	defer g.mu.RUnlock(counter)
 	return g.myAddr
 }
 
@@ -61,9 +62,9 @@ func (g *Gateway) Bootstrap(bootstrapPeer modules.NetAddress) (err error) {
 	if !g.Ping(bootstrapPeer) {
 		return errUnreachable
 	}
-	g.mu.Lock()
+	counter := g.mu.Lock()
 	g.addPeer(bootstrapPeer)
-	g.mu.Unlock()
+	g.mu.Unlock(counter)
 
 	// ask the bootstrap peer for our hostname
 	err = g.learnHostname(bootstrapPeer)
@@ -122,8 +123,8 @@ func (g *Gateway) RelayTransaction(t consensus.Transaction) (err error) {
 
 // Info returns metadata about the Gateway.
 func (g *Gateway) Info() (info modules.GatewayInfo) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	counter := g.mu.RLock()
+	defer g.mu.RUnlock(counter)
 	info.Address = g.myAddr
 	for peer := range g.peers {
 		info.Peers = append(info.Peers, peer)
@@ -143,6 +144,8 @@ func New(addr string, s *consensus.State) (g *Gateway, err error) {
 		myAddr:     modules.NetAddress(addr),
 		handlerMap: make(map[rpcID]modules.RPCFunc),
 		peers:      make(map[modules.NetAddress]int),
+
+		mu: sync.New(time.Second*2, 0),
 	}
 
 	g.RegisterRPC("Ping", writerRPC(pong))

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -38,7 +38,7 @@ type Gateway struct {
 	// removed.
 	peers map[modules.NetAddress]int
 
-	mu sync.RWMutex
+	mu *sync.RWMutex
 }
 
 // Address returns the NetAddress of the Gateway.

--- a/modules/gateway/helpers.go
+++ b/modules/gateway/helpers.go
@@ -36,8 +36,8 @@ func (g *Gateway) learnHostname(addr modules.NetAddress) error {
 
 // setHostname sets the hostname of the server.
 func (g *Gateway) setHostname(host string) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	counter := g.mu.Lock()
+	defer g.mu.Unlock(counter)
 	g.myAddr = modules.NetAddress(net.JoinHostPort(host, g.myAddr.Port()))
 }
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -55,15 +55,15 @@ func (g *Gateway) addStrike(peer modules.NetAddress) {
 
 // AddPeer adds a peer to the Gateway's peer list.
 func (g *Gateway) AddPeer(peer modules.NetAddress) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	counter := g.mu.Lock()
+	defer g.mu.Unlock(counter)
 	return g.addPeer(peer)
 }
 
 // RemovePeer removes a peer from the Gateway's peer list.
 func (g *Gateway) RemovePeer(peer modules.NetAddress) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+	counter := g.mu.Lock()
+	defer g.mu.Unlock(counter)
 	return g.removePeer(peer)
 }
 
@@ -84,8 +84,8 @@ func (g *Gateway) addMe(conn modules.NetConn) error {
 
 // sharePeers is an RPC that returns up to 10 randomly selected peers.
 func (g *Gateway) sharePeers(conn modules.NetConn) error {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	counter := g.mu.RLock()
+	defer g.mu.RUnlock(counter)
 
 	var peers []modules.NetAddress
 	for peer := range g.peers {

--- a/modules/gateway/synchronize.go
+++ b/modules/gateway/synchronize.go
@@ -28,8 +28,8 @@ func (g *Gateway) threadedResynchronize() {
 //
 // TODO: don't run two Synchronize threads at the same time
 func (g *Gateway) Synchronize() (err error) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	counter := g.mu.RLock()
+	defer g.mu.RUnlock(counter)
 
 	peer, err := g.randomPeer()
 	if err != nil {

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -106,8 +106,8 @@ func (m *Miner) updateBlockInfo() {
 // had actually changed, but this greatly increased the complexity of the code,
 // and I'm not even sure it made things run faster.
 func (m *Miner) update() {
-	counter := m.state.RLock("miner update")
-	defer m.state.RUnlock("miner update", counter)
+	counter := m.state.RLock()
+	defer m.state.RUnlock(counter)
 	m.updateTransactionSet()
 	m.updateBlockInfo()
 }

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -192,8 +192,8 @@ func (tp *TransactionPool) addTransactionToPool(t consensus.Transaction, directi
 // AcceptTransaction takes a new transaction from the network and puts it in
 // the transaction pool after checking it for legality and consistency.
 func (tp *TransactionPool) AcceptTransaction(t consensus.Transaction) (err error) {
-	tp.mu.Lock()
-	defer tp.mu.Unlock()
+	counter := tp.mu.Lock()
+	defer tp.mu.Unlock(counter)
 
 	// Check that the transaction is legal given the consensus set of the state
 	// and the unconfirmed set of the transaction pool.

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -196,10 +196,10 @@ func (tp *TransactionPool) AcceptTransaction(t consensus.Transaction) (err error
 	// and the unconfirmed set of the transaction pool.
 	counter := tp.mu.RLock()
 	err = tp.validUnconfirmedTransaction(t)
+	tp.mu.RUnlock(counter)
 	if err != nil {
 		return
 	}
-	tp.mu.RUnlock(counter)
 
 	// direction is set to true because a new transaction has been added and it
 	// may depend on existing unconfirmed transactions.

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -192,21 +192,22 @@ func (tp *TransactionPool) addTransactionToPool(t consensus.Transaction, directi
 // AcceptTransaction takes a new transaction from the network and puts it in
 // the transaction pool after checking it for legality and consistency.
 func (tp *TransactionPool) AcceptTransaction(t consensus.Transaction) (err error) {
-	counter := tp.mu.Lock()
-	defer tp.mu.Unlock(counter)
-
 	// Check that the transaction is legal given the consensus set of the state
 	// and the unconfirmed set of the transaction pool.
+	counter := tp.mu.RLock()
 	err = tp.validUnconfirmedTransaction(t)
 	if err != nil {
 		return
 	}
+	tp.mu.RUnlock(counter)
 
 	// direction is set to true because a new transaction has been added and it
 	// may depend on existing unconfirmed transactions.
+	counter = tp.mu.Lock()
 	direction := true
 	tp.addTransactionToPool(t, direction)
-	tp.gateway.RelayTransaction(t) // error is not checked
+	tp.mu.Unlock(counter)
 
+	tp.gateway.RelayTransaction(t) // error is not checked
 	return
 }

--- a/modules/transactionpool/dump.go
+++ b/modules/transactionpool/dump.go
@@ -11,8 +11,8 @@ import (
 // fork), and then treats remaining transactions in a first come first serve
 // manner.
 func (tp *TransactionPool) TransactionSet() (transactionSet []consensus.Transaction, err error) {
-	tp.mu.Lock()
-	defer tp.mu.Unlock()
+	counter := tp.mu.Lock()
+	defer tp.mu.Unlock(counter)
 	tp.update()
 
 	// Add transactions from the head of the linked list until there are no
@@ -44,8 +44,8 @@ func (tp *TransactionPool) TransactionSet() (transactionSet []consensus.Transact
 // would be created immediately if all of the unconfirmed transactions were
 // added to the blockchain.
 func (tp *TransactionPool) UnconfirmedSiacoinOutputDiffs() (scods []consensus.SiacoinOutputDiff) {
-	tp.mu.Lock()
-	defer tp.mu.Unlock()
+	counter := tp.mu.Lock()
+	defer tp.mu.Unlock(counter)
 	tp.update()
 
 	// For each transaction in the linked list, grab the siacoin output diffs

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -2,11 +2,12 @@ package transactionpool
 
 import (
 	"errors"
-	"sync"
+	"time"
 
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/sync"
 )
 
 // The current transaction pool code is blind to miner fees, and will not
@@ -89,6 +90,8 @@ func New(s *consensus.State, g modules.Gateway) (tp *TransactionPool, err error)
 		fileContractTerminations: make(map[consensus.FileContractID]*unconfirmedTransaction),
 		storageProofs:            make(map[consensus.BlockID]map[consensus.FileContractID]*unconfirmedTransaction),
 		usedSiafundOutputs:       make(map[consensus.SiafundOutputID]*unconfirmedTransaction),
+
+		mu: sync.New(3*time.Second, 0),
 	}
 
 	return

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -60,7 +60,7 @@ type TransactionPool struct {
 	storageProofs            map[consensus.BlockID]map[consensus.FileContractID]*unconfirmedTransaction
 	usedSiafundOutputs       map[consensus.SiafundOutputID]*unconfirmedTransaction
 
-	mu sync.RWMutex
+	mu *sync.RWMutex
 }
 
 // New creates a transaction pool that's ready to receive transactions.

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -123,8 +123,8 @@ func (tp *TransactionPool) removeConflictingTransactions(t consensus.Transaction
 // transactions that are in conflict with new transactions, and also removing
 // any transactions that have entered the blockchain.
 func (tp *TransactionPool) update() {
-	counter := tp.state.RLock("tpool update")
-	defer tp.state.RUnlock("tpool update", counter)
+	counter := tp.state.RLock()
+	defer tp.state.RUnlock(counter)
 
 	// Get the block diffs since the previous update.
 	var removedBlocks, addedBlocks []consensus.Block

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -92,14 +92,14 @@ func (w *Wallet) coinAddress() (coinAddress consensus.UnlockHash, unlockConditio
 // TimelockedCoinAddress returns an address that can only be spent after block
 // `unlockHeight`.
 func (w *Wallet) TimelockedCoinAddress(unlockHeight consensus.BlockHeight) (coinAddress consensus.UnlockHash, unlockConditions consensus.UnlockConditions, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet TimelockedCoinAddress")
+	defer w.mu.Unlock("wallet TimelockedCoinAddress", counter)
 	return w.timelockedCoinAddress(unlockHeight)
 }
 
 // CoinAddress implements the core.Wallet interface.
 func (w *Wallet) CoinAddress() (coinAddress consensus.UnlockHash, unlockConditions consensus.UnlockConditions, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet CoinAddress")
+	defer w.mu.Unlock("wallet CoinAddress", counter)
 	return w.coinAddress()
 }

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -92,14 +92,14 @@ func (w *Wallet) coinAddress() (coinAddress consensus.UnlockHash, unlockConditio
 // TimelockedCoinAddress returns an address that can only be spent after block
 // `unlockHeight`.
 func (w *Wallet) TimelockedCoinAddress(unlockHeight consensus.BlockHeight) (coinAddress consensus.UnlockHash, unlockConditions consensus.UnlockConditions, err error) {
-	counter := w.mu.Lock("wallet TimelockedCoinAddress")
-	defer w.mu.Unlock("wallet TimelockedCoinAddress", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 	return w.timelockedCoinAddress(unlockHeight)
 }
 
 // CoinAddress implements the core.Wallet interface.
 func (w *Wallet) CoinAddress() (coinAddress consensus.UnlockHash, unlockConditions consensus.UnlockConditions, err error) {
-	counter := w.mu.Lock("wallet CoinAddress")
-	defer w.mu.Unlock("wallet CoinAddress", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 	return w.coinAddress()
 }

--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -6,8 +6,8 @@ import (
 
 // Info fills out and returns a WalletInfo struct.
 func (w *Wallet) Info() modules.WalletInfo {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	counter := w.mu.RLock("wallet Info")
+	defer w.mu.RUnlock("wallet Info", counter)
 
 	return modules.WalletInfo{
 		Balance:      w.Balance(false),

--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -11,8 +11,8 @@ func (w *Wallet) Info() modules.WalletInfo {
 		FullBalance: w.Balance(true),
 	}
 
-	counter := w.mu.RLock("wallet Info")
+	counter := w.mu.RLock()
 	wi.NumAddresses = len(w.keys)
-	w.mu.RUnlock("wallet Info", counter)
+	w.mu.RUnlock(counter)
 	return wi
 }

--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -6,12 +6,13 @@ import (
 
 // Info fills out and returns a WalletInfo struct.
 func (w *Wallet) Info() modules.WalletInfo {
-	counter := w.mu.RLock("wallet Info")
-	defer w.mu.RUnlock("wallet Info", counter)
-
-	return modules.WalletInfo{
-		Balance:      w.Balance(false),
-		FullBalance:  w.Balance(true),
-		NumAddresses: len(w.keys),
+	wi := modules.WalletInfo{
+		Balance:     w.Balance(false),
+		FullBalance: w.Balance(true),
 	}
+
+	counter := w.mu.RLock("wallet Info")
+	wi.NumAddresses = len(w.keys)
+	w.mu.RUnlock("wallet Info", counter)
+	return wi
 }

--- a/modules/wallet/outputs.go
+++ b/modules/wallet/outputs.go
@@ -72,8 +72,8 @@ func (w *Wallet) findOutputs(amount consensus.Currency) (knownOutputs []*knownOu
 // have already been spent but the transactions haven't been added to the
 // transaction pool or blockchain)
 func (w *Wallet) Balance(full bool) (total consensus.Currency) {
-	counter := w.mu.Lock("wallet Balance")
-	defer w.mu.Unlock("wallet Balance", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 	w.update()
 
 	// Iterate through all outputs and tally them up.

--- a/modules/wallet/outputs.go
+++ b/modules/wallet/outputs.go
@@ -72,8 +72,8 @@ func (w *Wallet) findOutputs(amount consensus.Currency) (knownOutputs []*knownOu
 // have already been spent but the transactions haven't been added to the
 // transaction pool or blockchain)
 func (w *Wallet) Balance(full bool) (total consensus.Currency) {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	counter := w.mu.RLock("wallet Balance")
+	defer w.mu.RUnlock("wallet Balance", counter)
 	w.update()
 
 	// Iterate through all outputs and tally them up.

--- a/modules/wallet/outputs.go
+++ b/modules/wallet/outputs.go
@@ -72,8 +72,8 @@ func (w *Wallet) findOutputs(amount consensus.Currency) (knownOutputs []*knownOu
 // have already been spent but the transactions haven't been added to the
 // transaction pool or blockchain)
 func (w *Wallet) Balance(full bool) (total consensus.Currency) {
-	counter := w.mu.RLock("wallet Balance")
-	defer w.mu.RUnlock("wallet Balance", counter)
+	counter := w.mu.Lock("wallet Balance")
+	defer w.mu.Unlock("wallet Balance", counter)
 	w.update()
 
 	// Iterate through all outputs and tally them up.

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -26,8 +26,8 @@ type openTransaction struct {
 // then be used to modify and sign the transaction. An empty transaction is
 // legal input.
 func (w *Wallet) RegisterTransaction(t consensus.Transaction) (id string, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet RegisterTransaction")
+	defer w.mu.Unlock("wallet RegisterTransaction", counter)
 
 	id = strconv.Itoa(w.transactionCounter)
 	w.transactionCounter++
@@ -42,8 +42,8 @@ func (w *Wallet) RegisterTransaction(t consensus.Transaction) (id string, err er
 // of outputs that add up to at least the desired amount, and then creates a
 // single output of the exact amount and a second refund output.
 func (w *Wallet) FundTransaction(id string, amount consensus.Currency) (t consensus.Transaction, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet FundTransaction")
+	defer w.mu.Unlock("wallet FundTransaction", counter)
 
 	// Create a parent transaction and supply it with enough inputs to cover
 	// 'amount'.
@@ -147,8 +147,8 @@ func (w *Wallet) FundTransaction(id string, amount consensus.Currency) (t consen
 // index of the input within the transaction and the transaction itself. When
 // 'SignTransaction' is called, this input will not be signed.
 func (w *Wallet) AddSiacoinInput(id string, input consensus.SiacoinInput) (t consensus.Transaction, inputIndex uint64, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet AddSiacoinInput")
+	defer w.mu.Unlock("wallet AddSiacoinInput", counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -166,8 +166,8 @@ func (w *Wallet) AddSiacoinInput(id string, input consensus.SiacoinInput) (t con
 // inputs. The transaction and the index of the new miner fee within the
 // transaction are returned.
 func (w *Wallet) AddMinerFee(id string, fee consensus.Currency) (t consensus.Transaction, feeIndex uint64, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet AddMinerFee")
+	defer w.mu.Unlock("wallet AddMinerFee", counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -185,8 +185,8 @@ func (w *Wallet) AddMinerFee(id string, fee consensus.Currency) (t consensus.Tra
 // AddOutput returns the transaction and the index of the new output within the
 // transaction.
 func (w *Wallet) AddOutput(id string, output consensus.SiacoinOutput) (t consensus.Transaction, outputIndex uint64, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet AddOutput")
+	defer w.mu.Unlock("wallet AddOutput", counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -204,8 +204,8 @@ func (w *Wallet) AddOutput(id string, output consensus.SiacoinOutput) (t consens
 // the transaction and the index of the new file contract within the
 // transaction.
 func (w *Wallet) AddFileContract(id string, fc consensus.FileContract) (t consensus.Transaction, fcIndex uint64, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet AddFileContract")
+	defer w.mu.Unlock("wallet AddFileContract", counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -223,8 +223,8 @@ func (w *Wallet) AddFileContract(id string, fc consensus.FileContract) (t consen
 // the transaction and the index of the new storage proof within the
 // transaction.
 func (w *Wallet) AddStorageProof(id string, sp consensus.StorageProof) (t consensus.Transaction, spIndex uint64, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet AddStorageProof")
+	defer w.mu.Unlock("wallet AddStorageProof", counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -241,8 +241,8 @@ func (w *Wallet) AddStorageProof(id string, sp consensus.StorageProof) (t consen
 // AddArbitraryData adds arbitrary data to the transaction, returning a copy of
 // the transaction and the index of the new data within the transaction.
 func (w *Wallet) AddArbitraryData(id string, arb string) (t consensus.Transaction, adIndex uint64, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet AddArbitraryData")
+	defer w.mu.Unlock("wallet AddArbitraryData", counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -259,8 +259,8 @@ func (w *Wallet) AddArbitraryData(id string, arb string) (t consensus.Transactio
 // SignTransaction signs the transaction, then deletes the transaction from the
 // wallet's internal memory, then returns the transaction.
 func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensus.Transaction, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet SignTransaction")
+	defer w.mu.Unlock("wallet SignTransaction", counter)
 
 	// Fetch the transaction.
 	openTxn, exists := w.transactions[id]
@@ -334,8 +334,8 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensu
 // useful for dealing with multiparty signatures, or for staged negotiations
 // which involve sending the transaction first and the signature later.
 func (w *Wallet) AddSignature(id string, sig consensus.TransactionSignature) (t consensus.Transaction, sigIndex uint64, err error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	counter := w.mu.Lock("wallet AddSignature")
+	defer w.mu.Unlock("wallet AddSignature", counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -26,8 +26,8 @@ type openTransaction struct {
 // then be used to modify and sign the transaction. An empty transaction is
 // legal input.
 func (w *Wallet) RegisterTransaction(t consensus.Transaction) (id string, err error) {
-	counter := w.mu.Lock("wallet RegisterTransaction")
-	defer w.mu.Unlock("wallet RegisterTransaction", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	id = strconv.Itoa(w.transactionCounter)
 	w.transactionCounter++
@@ -42,8 +42,8 @@ func (w *Wallet) RegisterTransaction(t consensus.Transaction) (id string, err er
 // of outputs that add up to at least the desired amount, and then creates a
 // single output of the exact amount and a second refund output.
 func (w *Wallet) FundTransaction(id string, amount consensus.Currency) (t consensus.Transaction, err error) {
-	counter := w.mu.Lock("wallet FundTransaction")
-	defer w.mu.Unlock("wallet FundTransaction", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	// Create a parent transaction and supply it with enough inputs to cover
 	// 'amount'.
@@ -147,8 +147,8 @@ func (w *Wallet) FundTransaction(id string, amount consensus.Currency) (t consen
 // index of the input within the transaction and the transaction itself. When
 // 'SignTransaction' is called, this input will not be signed.
 func (w *Wallet) AddSiacoinInput(id string, input consensus.SiacoinInput) (t consensus.Transaction, inputIndex uint64, err error) {
-	counter := w.mu.Lock("wallet AddSiacoinInput")
-	defer w.mu.Unlock("wallet AddSiacoinInput", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -166,8 +166,8 @@ func (w *Wallet) AddSiacoinInput(id string, input consensus.SiacoinInput) (t con
 // inputs. The transaction and the index of the new miner fee within the
 // transaction are returned.
 func (w *Wallet) AddMinerFee(id string, fee consensus.Currency) (t consensus.Transaction, feeIndex uint64, err error) {
-	counter := w.mu.Lock("wallet AddMinerFee")
-	defer w.mu.Unlock("wallet AddMinerFee", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -185,8 +185,8 @@ func (w *Wallet) AddMinerFee(id string, fee consensus.Currency) (t consensus.Tra
 // AddOutput returns the transaction and the index of the new output within the
 // transaction.
 func (w *Wallet) AddOutput(id string, output consensus.SiacoinOutput) (t consensus.Transaction, outputIndex uint64, err error) {
-	counter := w.mu.Lock("wallet AddOutput")
-	defer w.mu.Unlock("wallet AddOutput", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -204,8 +204,8 @@ func (w *Wallet) AddOutput(id string, output consensus.SiacoinOutput) (t consens
 // the transaction and the index of the new file contract within the
 // transaction.
 func (w *Wallet) AddFileContract(id string, fc consensus.FileContract) (t consensus.Transaction, fcIndex uint64, err error) {
-	counter := w.mu.Lock("wallet AddFileContract")
-	defer w.mu.Unlock("wallet AddFileContract", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -223,8 +223,8 @@ func (w *Wallet) AddFileContract(id string, fc consensus.FileContract) (t consen
 // the transaction and the index of the new storage proof within the
 // transaction.
 func (w *Wallet) AddStorageProof(id string, sp consensus.StorageProof) (t consensus.Transaction, spIndex uint64, err error) {
-	counter := w.mu.Lock("wallet AddStorageProof")
-	defer w.mu.Unlock("wallet AddStorageProof", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -241,8 +241,8 @@ func (w *Wallet) AddStorageProof(id string, sp consensus.StorageProof) (t consen
 // AddArbitraryData adds arbitrary data to the transaction, returning a copy of
 // the transaction and the index of the new data within the transaction.
 func (w *Wallet) AddArbitraryData(id string, arb string) (t consensus.Transaction, adIndex uint64, err error) {
-	counter := w.mu.Lock("wallet AddArbitraryData")
-	defer w.mu.Unlock("wallet AddArbitraryData", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {
@@ -259,8 +259,8 @@ func (w *Wallet) AddArbitraryData(id string, arb string) (t consensus.Transactio
 // SignTransaction signs the transaction, then deletes the transaction from the
 // wallet's internal memory, then returns the transaction.
 func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensus.Transaction, err error) {
-	counter := w.mu.Lock("wallet SignTransaction")
-	defer w.mu.Unlock("wallet SignTransaction", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	// Fetch the transaction.
 	openTxn, exists := w.transactions[id]
@@ -334,8 +334,8 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn consensu
 // useful for dealing with multiparty signatures, or for staged negotiations
 // which involve sending the transaction first and the signature later.
 func (w *Wallet) AddSignature(id string, sig consensus.TransactionSignature) (t consensus.Transaction, sigIndex uint64, err error) {
-	counter := w.mu.Lock("wallet AddSignature")
-	defer w.mu.Unlock("wallet AddSignature", counter)
+	counter := w.mu.Lock()
+	defer w.mu.Unlock(counter)
 
 	openTxn, exists := w.transactions[id]
 	if !exists {

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -49,8 +49,16 @@ func (w *Wallet) applyDiff(scod consensus.SiacoinOutputDiff, dir consensus.DiffD
 // the transaction pool will update it's own understanding of the consensus
 // set. (This is currently true).
 func (w *Wallet) update() error {
+	// Because we were running into problems, the amount of time that the state
+	// lock is held has been minimized. Grab all of the necessary diffs under a
+	// lock before doing any computation.
 	counter := w.state.RLock("wallet update")
-	defer w.state.RUnlock("wallet update", counter)
+	newUnconfirmedDiffs := w.tpool.UnconfirmedSiacoinOutputDiffs()
+	removedBlocks, addedBlocks, err := w.state.BlocksSince(w.recentBlock)
+	w.state.RUnlock("wallet update", counter)
+	if err != nil {
+		return err
+	}
 
 	// Remove all of the diffs that have been applied by the unconfirmed set of
 	// transactions.
@@ -58,13 +66,9 @@ func (w *Wallet) update() error {
 		w.applyDiff(w.unconfirmedDiffs[i], consensus.DiffRevert)
 	}
 
-	// Apply the diffs in the state that have happened since the last update.
-	removedBlocks, addedBlocks, err := w.state.BlocksSince(w.recentBlock)
-	if err != nil {
-		return err
-	}
+	// Apply the diffs in the consensus set that have happened since the last
+	// update.
 	for _, id := range removedBlocks {
-		// Decrement the age of the wallet.
 		w.age--
 
 		scods, err := w.state.BlockOutputDiffs(id)
@@ -76,7 +80,6 @@ func (w *Wallet) update() error {
 		}
 	}
 	for _, id := range addedBlocks {
-		// Increment the age of the wallet.
 		w.age++
 
 		scods, err := w.state.BlockOutputDiffs(id)
@@ -91,8 +94,9 @@ func (w *Wallet) update() error {
 		}
 	}
 
-	// Get, apply, and store the unconfirmed diffs currently available in the transaction pool.
-	w.unconfirmedDiffs = w.tpool.UnconfirmedSiacoinOutputDiffs()
+	// Get, apply, and store the unconfirmed diffs currently available in the
+	// transaction pool.
+	w.unconfirmedDiffs = newUnconfirmedDiffs
 	for _, scod := range w.unconfirmedDiffs {
 		w.applyDiff(scod, consensus.DiffApply)
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -70,7 +70,7 @@ type Wallet struct {
 	transactionCounter int
 	transactions       map[string]*openTransaction
 
-	mu *sync.RWMutex
+	mu sync.RWMutex
 }
 
 // New creates a new wallet, loading any known addresses from the input file

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -105,7 +105,7 @@ func New(state *consensus.State, tpool modules.TransactionPool, filename string)
 
 		transactions: make(map[string]*openTransaction),
 
-		mu: sync.New(1 * time.Second),
+		mu: sync.New(5 * time.Second),
 	}
 
 	// If the wallet file already exists, try to load it.

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -105,7 +105,7 @@ func New(state *consensus.State, tpool modules.TransactionPool, filename string)
 
 		transactions: make(map[string]*openTransaction),
 
-		mu: sync.New(5 * time.Second),
+		mu: sync.New(5*time.Second, 0),
 	}
 
 	// If the wallet file already exists, try to load it.

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -70,7 +70,7 @@ type Wallet struct {
 	transactionCounter int
 	transactions       map[string]*openTransaction
 
-	mu sync.RWMutex
+	mu *sync.RWMutex
 }
 
 // New creates a new wallet, loading any known addresses from the input file

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -3,10 +3,11 @@ package wallet
 import (
 	"errors"
 	"fmt"
-	"sync"
+	"time"
 
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/sync"
 )
 
 const (
@@ -69,7 +70,7 @@ type Wallet struct {
 	transactionCounter int
 	transactions       map[string]*openTransaction
 
-	mu sync.RWMutex
+	mu *sync.RWMutex
 }
 
 // New creates a new wallet, loading any known addresses from the input file
@@ -103,6 +104,8 @@ func New(state *consensus.State, tpool modules.TransactionPool, filename string)
 		timelockedKeys: make(map[consensus.BlockHeight][]consensus.UnlockHash),
 
 		transactions: make(map[string]*openTransaction),
+
+		mu: sync.New(1 * time.Second),
 	}
 
 	// If the wallet file already exists, try to load it.

--- a/sync/lock.go
+++ b/sync/lock.go
@@ -112,7 +112,7 @@ func (rwm *RWMutex) safeUnlock(read bool, counter int) {
 		} else {
 			lockType = ""
 		}
-		fmt.Printf("A %v lock was held until deadlock, subsequent call to %v unlock failed. id '%v'. Call stack:\n", lockType, lockType, counter)
+		fmt.Printf("A%v lock was held until deadlock, subsequent call to%v unlock failed. id '%v'. Call stack:\n", lockType, lockType, counter)
 		for i := 0; i <= rwm.callDepth; i++ {
 			fmt.Printf("\tFile '%v', Line '%v'\n", callingFiles[i], callingLines[i])
 		}

--- a/sync/lock.go
+++ b/sync/lock.go
@@ -21,8 +21,8 @@ type RWMutex struct {
 // New takes a maxLockTime and returns a lock. The lock will never stay locked
 // for more than maxLockTime, instead printing an error and unlocking after
 // maxLockTime has passed.
-func New(maxLockTime time.Duration) *RWMutex {
-	return &RWMutex{
+func New(maxLockTime time.Duration) RWMutex {
+	return RWMutex{
 		openLocks:   make(map[int]string),
 		maxLockTime: maxLockTime,
 	}

--- a/sync/lock.go
+++ b/sync/lock.go
@@ -55,7 +55,7 @@ func (rwm *RWMutex) threadedDeadlockFinder() {
 			if time.Now().Sub(info.lockTime) > rwm.maxLockTime {
 				fmt.Printf("A lock was held for too long, id '%v'. Call stack:\n", id)
 				for i := 0; i <= rwm.callDepth; i++ {
-					fmt.Printf("\tFile '%v', Line '%v'\n", info.callingFiles[i], info.callingLines[i])
+					fmt.Printf("\tFile: '%v:%v'\n", info.callingFiles[i], info.callingLines[i])
 				}
 			}
 		}
@@ -110,15 +110,9 @@ func (rwm *RWMutex) safeUnlock(read bool, counter int) {
 	// Check if a deadlock has been detected and fixed manually.
 	_, exists := rwm.openLocks[counter]
 	if !exists {
-		var lockType string
-		if read {
-			lockType = "read "
-		} else {
-			lockType = ""
-		}
-		fmt.Printf("A%v lock was held until deadlock, subsequent call to%v unlock failed. id '%v'. Call stack:\n", lockType, lockType, counter)
+		fmt.Printf("A lock was held until deadlock, subsequent call to unlock failed. id '%v'. Call stack:\n", counter)
 		for i := 0; i <= rwm.callDepth; i++ {
-			fmt.Printf("\tFile '%v', Line '%v'\n", callingFiles[i], callingLines[i])
+			fmt.Printf("\tFile: '%v:%v'\n", callingFiles[i], callingLines[i])
 		}
 		return
 	}


### PR DESCRIPTION
This PR depends on the other one I have open. (#388)

I created a lock package, it records who locked it and it complains if there's a deadlock, and it also automatically fixes the deadlock. It also prints a call stack, so you can see who caused the deadlock.

The current implementation results in thousands of sleeping goroutines during standard Sia use. I think that we can implement a garbage collection style thread, so that instead of thousands of sleeping goroutines, you just have 1 that runs every 2 seconds or so and checks the timestamps on the lock calls to see if any of them have held a lock for too long. Then you'll only have 1 thread per unique lock, which should really only be one thread per module. This is much more manageable.

As best I can tell, using the lock package is impacting performance a noticeable amount, but not a significant amount. For now, I have no real desire to implement the garbage collection style manager. Probably best to leave it.

This PR also fixes a few deadlocks, which were discovered thanks to the new mutex type. Debugging was _substantially_ easier once you knew which call wasn't releasing in time. As best I can tell, there's still probably a deadlock somewhere in the transaction pool but I haven't been able to trigger it through testing.

I think that, until performance becomes absolutely necessary, we should leave all production binaries with the protected locking. In the event that a deadlock is triggered, it'll automatically fix itself instead of locking up the program and affecting user experience. I think that we should probably just keep it indefinitely, but then also provide 'performance' binaries that have a lot of the safeties removed.

Right now `I call fmt.Printf` to talk about any deadlocks that occur. It should probably instead go into a logging file somewhere. I'm not sure the best way to handle that. Also not worried about it for the time being. I'm more concerned about getting the final UX stuff ready. (files/directories, indications of failed uploads/downloads, auto-repair, and some indication for the host of how much money total has been made from offering storage).