### PR TITLE
Renter upgrades

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -33,6 +33,20 @@ type FileInfo interface {
 	TimeRemaining() consensus.BlockHeight
 }
 
+// DownloadInfo is an interface providing information about a file that has
+// been requested for download.
+type DownloadInfo interface {
+	// Completed indicates whether the download has finished or not.
+	Completed() bool
+
+	// Destination is the filepath that the file was downloaded into.
+	Destination() string
+
+	// Nickname gives the name of the file according to the renter. Nickname
+	// may be different from Destination.
+	Nickname() string
+}
+
 // RentInfo contains a list of all files by nickname. (deprecated)
 type RentInfo struct {
 	Files []string
@@ -43,6 +57,9 @@ type RentInfo struct {
 type Renter interface {
 	// Download downloads a file to the given filepath.
 	Download(nickname, filepath string) error
+
+	// DownloadQueue lists all the files that have been scheduled for download.
+	DownloadQueue() []DownloadInfo
 
 	// FileList returns information on all of the files stored by the renter.
 	FileList() []FileInfo

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -1,0 +1,79 @@
+package renter
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// downloadPiece attempts to retrieve a file from a host.
+func (r *Renter) downloadPiece(piece FilePiece, path string) error {
+	return r.gateway.RPC(piece.HostIP, "RetrieveFile", func(conn modules.NetConn) (err error) {
+		// Send the id of the contract for the file piece we're requesting. The
+		// response will be the file piece contents.
+		if err = conn.WriteObject(piece.ContractID); err != nil {
+			return
+		}
+
+		// Create the file on disk.
+		file, err := os.Create(path)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+
+		// Simultaneously download file and calculate its Merkle root.
+		tee := io.TeeReader(
+			// use a LimitedReader to ensure we don't read indefinitely
+			io.LimitReader(conn, int64(piece.Contract.FileSize)),
+			// each byte we read from tee will also be written to file
+			file,
+		)
+		merkleRoot, err := crypto.ReaderMerkleRoot(tee)
+		if err != nil {
+			return
+		}
+
+		if merkleRoot != piece.Contract.FileMerkleRoot {
+			return errors.New("host provided a file that's invalid")
+		}
+
+		return
+	})
+}
+
+// Download downloads a file. Mutex conventions are broken to prevent doing
+// network communication with io in place.
+func (r *Renter) Download(nickname, filename string) error {
+	// Grab the set of pieces we're downloading.
+	r.mu.RLock()
+	var pieces []FilePiece
+	_, exists := r.files[nickname]
+	if !exists {
+		r.mu.RUnlock()
+		return errors.New("no file of that nickname")
+	}
+	for _, piece := range r.files[nickname].pieces {
+		if piece.Active {
+			pieces = append(pieces, piece)
+		}
+	}
+	r.mu.RUnlock()
+
+	// We only need one piece, so iterate through the hosts until a download
+	// succeeds.
+	for _, piece := range pieces {
+		downloadErr := r.downloadPiece(piece, filename)
+		if downloadErr == nil {
+			return nil
+		} else {
+			// log error
+		}
+		// r.hostDB.FlagHost(piece.Host.IPAddress)
+	}
+
+	return errors.New("Too many hosts returned errors - could not recover the file")
+}

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -109,7 +109,7 @@ func (r *Renter) Download(nickname, filename string) error {
 			// after waiting a random amount of time.
 			randSource := make([]byte, 1)
 			rand.Read(randSource)
-			time.Sleep(time.Second * time.Duration(i) * time.Duration(i) * time.Duration(randSource[0]))
+			time.Sleep(time.Second * time.Duration(i*i) * time.Duration(randSource[0]))
 		}
 	}()
 
@@ -122,7 +122,7 @@ func (r *Renter) DownloadQueue() []modules.DownloadInfo {
 	defer r.mu.RUnlock()
 
 	downloads := make([]modules.DownloadInfo, len(r.downloadQueue))
-	for i := 0; i < len(r.downloadQueue); i++ {
+	for i := range r.downloadQueue {
 		downloads[i] = &r.downloadQueue[i]
 	}
 	return downloads

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -16,8 +16,9 @@ type Renter struct {
 	hostDB  modules.HostDB
 	wallet  modules.Wallet
 
-	files   map[string]File
-	saveDir string
+	files          map[string]File
+	downloadQueue  []Download
+	saveDir        string
 
 	mu sync.RWMutex
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -16,9 +16,9 @@ type Renter struct {
 	hostDB  modules.HostDB
 	wallet  modules.Wallet
 
-	files          map[string]File
-	downloadQueue  []Download
-	saveDir        string
+	files         map[string]File
+	downloadQueue []Download
+	saveDir       string
 
 	mu sync.RWMutex
 }

--- a/siad/API.md
+++ b/siad/API.md
@@ -259,6 +259,7 @@ Renter
 Queries:
 
 * /renter/download
+* /renter/downloadqueue
 * /renter/files
 * /renter/upload
 
@@ -277,6 +278,26 @@ destination is the filepath that the file should be downloaded to.
 
 Response: standard
 
+#### /renter/downloadqueue
+
+Function: Lists all files in the download queue.
+
+Parameters: none
+
+Response:
+```
+[]struct{
+	Completed   bool
+	Destination string
+	Nickname    string
+}
+```
+Destination is the filepath that the file was downloaded to.
+
+Nickname is the name of the file that was downloaded according to the renter.
+
+Completed is true when the download has finished.
+
 #### /renter/files
 
 Function: Lists the status of all files.
@@ -286,9 +307,9 @@ Parameters: none
 Response:
 ```
 []struct {
-	Available bool
-	Nickname  string
-	Repairing bool
+	Available     bool
+	Nickname      string
+	Repairing     bool
 	TimeRemaining int
 }
 ```

--- a/siad/API.md
+++ b/siad/API.md
@@ -260,7 +260,6 @@ Queries:
 
 * /renter/download
 * /renter/files
-* /renter/status
 * /renter/upload
 
 #### /renter/download
@@ -305,20 +304,6 @@ Repairing indicates whether the file is currently being repaired. It is
 typically best not to shut down siad until files are no longer being repaired.
 
 TimeRemaining indicates how many blocks the file will be available for.
-
-#### /renter/status
-
-Function: Returns the status of the renter.
-
-Parameters: none
-
-Response:
-```
-struct {
-	Files []string
-}
-```
-Files is a list of all the files by their nickname.
 
 #### /renter/upload
 

--- a/siad/API.md
+++ b/siad/API.md
@@ -285,15 +285,15 @@ Parameters: none
 
 Response:
 ```
-struct {
-	FileInfo []struct {
-		Available bool
-		Nickname  string
-		Repairing bool
-		TimeRemaining int
-	}
+[]struct {
+	Available bool
+	Nickname  string
+	Repairing bool
+	TimeRemaining int
 }
 ```
+The above is an array of objects, where each object represents a singe file.
+
 Available indicates whether or not the file can be downloaded immediately.
 
 Files is a type.

--- a/siad/api.go
+++ b/siad/api.go
@@ -59,6 +59,7 @@ func (d *daemon) initAPI(addr string) {
 
 	// Renter API Calls
 	handleHTTPRequest(mux, "/renter/download", d.renterDownloadHandler)
+	handleHTTPRequest(mux, "/renter/downloadqueue", d.renterDownloadqueueHandler)
 	handleHTTPRequest(mux, "/renter/files", d.renterFilesHandler)
 	handleHTTPRequest(mux, "/renter/status", d.renterStatusHandler)
 	handleHTTPRequest(mux, "/renter/upload", d.renterUploadHandler)

--- a/siad/renter.go
+++ b/siad/renter.go
@@ -13,6 +13,14 @@ const (
 	redundancy = 15   // Redundancy of files uploaded to the network.
 )
 
+// DownloadInfo is a helper struct for the downloadqueue API call.
+type DownloadInfo struct {
+	Completed   bool
+	Destination string
+	Nickname    string
+}
+
+// FileInfo is a helper struct for the files API call.
 type FileInfo struct {
 	Available     bool
 	Nickname      string
@@ -29,6 +37,22 @@ func (d *daemon) renterDownloadHandler(w http.ResponseWriter, req *http.Request)
 	}
 
 	writeSuccess(w)
+}
+
+// renterDownloadqueueHandler handles the API call to request the download
+// queue.
+func (d *daemon) renterDownloadqueueHandler(w http.ResponseWriter, req *http.Request) {
+	downloads := d.renter.DownloadQueue()
+	downloadSet := make([]DownloadInfo, 0, len(downloads))
+	for _, dl := range downloads {
+		downloadSet = append(downloadSet, DownloadInfo{
+			Completed:   dl.Completed(),
+			Destination: dl.Destination(),
+			Nickname:    dl.Nickname(),
+		})
+	}
+
+	writeJSON(w, downloadSet)
 }
 
 // renterFilesHandler handles the API call to list all of the files.


### PR DESCRIPTION
The download call is no longer blocking.

The /renter/status call is no longer documented (it's deprecated)

There's a new API call /renter/downloadqueue which returns the list of downloads that the renter has made, including information about whether or not they've completed.

Finally, downloading does the same try-wait strategy as uploading now. If a download fails, it'll wait some arbitrary amount of time before trying again.

The download queue is not saved to disk. There's no way to remove items from the download queue except by restarting the renter.

The renter still does not remove files that have expired. For the time being, I consider this sufficient.