### PR TITLE
Orphan synchronization

### DIFF
--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -84,13 +84,11 @@ type Gateway interface {
 	// given peer.
 	Synchronize(NetAddress) error
 
-	// RelayBlock accepts a block and submits it to the state, broadcasting it
-	// to the network if it's valid and on the current longest fork.
-	RelayBlock(consensus.Block) error
+	// RelayBlock broadcasts a block to the Gateway's peers.
+	RelayBlock(consensus.Block)
 
-	// RelayTransaction announces a transaction to all of the Gateway's
-	// known peers.
-	RelayTransaction(consensus.Transaction) error
+	// RelayTransaction broadcasts a transaction to the Gateway's peers.
+	RelayTransaction(consensus.Transaction)
 
 	// Info reports metadata about the Gateway.
 	Info() GatewayInfo

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -77,9 +77,9 @@ type Gateway interface {
 	// supply the given RPC ID.
 	RegisterRPC(string, RPCFunc)
 
-	// Synchronize synchronizes the local consensus set with the sets of known
-	// peers.
-	Synchronize() error
+	// Synchronize synchronizes the local consensus set with the set of the
+	// given peer.
+	Synchronize(NetAddress) error
 
 	// RelayBlock accepts a block and submits it to the state, broadcasting it
 	// to the network if it's valid and on the current longest fork.

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -68,6 +68,9 @@ type Gateway interface {
 	// RemovePeer removes a peer from the Gateway's peer list.
 	RemovePeer(NetAddress) error
 
+	// RandomPeer returns a random peer from the Gateway's peer list.
+	RandomPeer() (NetAddress, error)
+
 	// RPC establishes a connection to the supplied address and writes the RPC
 	// header, indicating which function will handle the connection. The
 	// supplied function takes over from there.

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -89,8 +89,8 @@ func (g *Gateway) Bootstrap(bootstrapPeer modules.NetAddress) (err error) {
 	// announce ourselves to the new peers
 	go g.threadedBroadcast("AddMe", writerRPC(g.myAddr))
 
-	// synchronize to a random peer
-	g.Synchronize()
+	// spawn synchronizer
+	go g.threadedResynchronize()
 
 	return
 }

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -95,35 +95,14 @@ func (g *Gateway) Bootstrap(bootstrapPeer modules.NetAddress) (err error) {
 	return
 }
 
-// RelayBlock relays a block, both locally and to the network.
-func (g *Gateway) RelayBlock(b consensus.Block) (err error) {
-	err = g.state.AcceptBlock(b)
-	if err != nil {
-		return
-	}
-
-	// Check if b is in the current path.
-	height, exists := g.state.HeightOfBlock(b.ID())
-	if !exists {
-		if consensus.DEBUG {
-			panic("could not get the height of a block that did not return an error when being accepted into the state")
-		}
-		return errors.New("state malfunction")
-	}
-	currentPathBlock, exists := g.state.BlockAtHeight(height)
-	if !exists || b.ID() != currentPathBlock.ID() {
-		return errors.New("block added, but it does not extend the state height")
-	}
-
-	go g.threadedBroadcast("RelayBlock", writerRPC(b))
-	return
+// RelayBlock relays a block to the network.
+func (g *Gateway) RelayBlock(b consensus.Block) {
+	go g.threadedBroadcast("AcceptBlock", writerRPC(b))
 }
 
-// RelayTransaction relays a transaction, both locally and to the network.
-func (g *Gateway) RelayTransaction(t consensus.Transaction) (err error) {
-	// no locking necessary
+// RelayTransaction relays a transaction to the network.
+func (g *Gateway) RelayTransaction(t consensus.Transaction) {
 	go g.threadedBroadcast("AcceptTransaction", writerRPC(t))
-	return
 }
 
 // Info returns metadata about the Gateway.

--- a/modules/gateway/peer_test.go
+++ b/modules/gateway/peer_test.go
@@ -117,7 +117,7 @@ func TestBootstrap(t *testing.T) {
 	if g.state.Height() != bootstrap.state.Height() {
 		// g may have tried to synchronize to the other peer, so try manually
 		// synchronizing to the bootstrap
-		g.synchronize(bootstrap.Address())
+		g.Synchronize(bootstrap.Address())
 		if g.state.Height() != bootstrap.state.Height() {
 			t.Fatalf("gateway height %v does not match bootstrap height %v", g.state.Height(), bootstrap.state.Height())
 		}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -69,6 +69,13 @@ func (g *Gateway) RemovePeer(peer modules.NetAddress) error {
 	return g.removePeer(peer)
 }
 
+// RandomPeer returns a random peer from the Gateway's peer list.
+func (g *Gateway) RandomPeer() (modules.NetAddress, error) {
+	counter := g.mu.RLock()
+	defer g.mu.RUnlock(counter)
+	return g.randomPeer()
+}
+
 // addMe is an RPC that requests that the Gateway add a peer to its peer
 // list. The supplied peer is assumed to be the peer making the RPC.
 func (g *Gateway) addMe(conn modules.NetConn) error {

--- a/modules/miner/mine.go
+++ b/modules/miner/mine.go
@@ -109,12 +109,13 @@ func (m *Miner) solveBlock(blockForWork consensus.Block, target consensus.Target
 	// to find a winnning solution.
 	for maxNonce := b.Nonce + iterations; b.Nonce != maxNonce; b.Nonce++ {
 		if b.CheckTarget(target) {
-			err = m.gateway.RelayBlock(b)
+			err = m.state.AcceptBlock(b)
 			if consensus.DEBUG {
 				if err != nil {
 					// Log Error
 				}
 			}
+			m.gateway.RelayBlock(b)
 
 			solved = true
 

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -118,6 +118,7 @@ func (d *daemon) acceptBlock(conn modules.NetConn) error {
 	err = d.state.AcceptBlock(b)
 	if err == consensus.ErrOrphan {
 		go d.gateway.Synchronize(conn.Addr())
+		return err
 	} else if err != nil {
 		return err
 	}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -84,7 +85,7 @@ func newDaemon(config DaemonConfig) (d *daemon, err error) {
 	}
 
 	// Register RPCs for each module
-	d.gateway.RegisterRPC("RelayBlock", d.relayBlock)
+	d.gateway.RegisterRPC("AcceptBlock", d.acceptBlock)
 	d.gateway.RegisterRPC("AcceptTransaction", d.acceptTransaction)
 	d.gateway.RegisterRPC("HostSettings", d.host.Settings)
 	d.gateway.RegisterRPC("NegotiateContract", d.host.NegotiateContract)
@@ -107,13 +108,35 @@ func createSubdirs(rootDir string) error {
 }
 
 // TODO: move this to the state module?
-func (d *daemon) relayBlock(conn modules.NetConn) error {
+func (d *daemon) acceptBlock(conn modules.NetConn) error {
 	var b consensus.Block
 	err := conn.ReadObject(&b, consensus.BlockSizeLimit)
 	if err != nil {
 		return err
 	}
-	return d.gateway.RelayBlock(b)
+
+	err = d.state.AcceptBlock(b)
+	if err == consensus.ErrOrphan {
+		go d.gateway.Synchronize(conn.Addr())
+	} else if err != nil {
+		return err
+	}
+
+	// Check if b is in the current path.
+	height, exists := d.state.HeightOfBlock(b.ID())
+	if !exists {
+		if consensus.DEBUG {
+			panic("could not get the height of a block that did not return an error when being accepted into the state")
+		}
+		return errors.New("state malfunction")
+	}
+	currentPathBlock, exists := d.state.BlockAtHeight(height)
+	if !exists || b.ID() != currentPathBlock.ID() {
+		return errors.New("block added, but it does not extend the state height")
+	}
+
+	d.gateway.RelayBlock(b)
+	return nil
 }
 
 // TODO: move this to the tpool module?

--- a/siad/gateway.go
+++ b/siad/gateway.go
@@ -14,11 +14,12 @@ func (d *daemon) gatewayStatusHandler(w http.ResponseWriter, req *http.Request) 
 // gatewaySynchronizeHandler handles the API call asking for the gateway to
 // synchronize with other peers.
 func (d *daemon) gatewaySynchronizeHandler(w http.ResponseWriter, req *http.Request) {
-	err := d.gateway.Synchronize()
+	peer, err := d.gateway.RandomPeer()
 	if err != nil {
 		writeError(w, "No peers available for syncing", http.StatusInternalServerError)
 		return
 	}
+	go d.gateway.Synchronize(peer)
 
 	writeSuccess(w)
 }

--- a/siad/gateway_test.go
+++ b/siad/gateway_test.go
@@ -31,8 +31,7 @@ func (dt *daemonTester) addPeer() *daemonTester {
 	// force synchronization to dt, in case newPeer tried to synchronize to
 	// one of dt's peers.
 	for dt.state.Height() != newPeer.state.Height() {
-		newPeer.gateway.Synchronize()
-		time.Sleep(10 * time.Millisecond)
+		newPeer.gateway.Synchronize(dt.netAddress())
 	}
 	return newPeer
 }


### PR DESCRIPTION
The gateway will now synchronize to peers who send it orphan blocks.
This required changing the function signatures of `Synchronize` to take a peer.

I feel that the current relayblock/transaction design is pretty ugly. It would be much cleaner if the State had a Gateway and just announced blocks as they were accepted. It's not really possible to accomplish this with subscription because there's no way to synchronize to a peer who sent an orphan block.