### PR TITLE
Fix contract bug

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -1,15 +1,12 @@
 package modules
 
 import (
-	"io"
-
 	"github.com/NebulousLabs/Sia/consensus"
 )
 
-// UploadParams contains the information used by the Renter to upload a file,
-// including the file contents and the duration for which it is to be stored.
+// UploadParams contains the information used by the Renter to upload a file.
 type UploadParams struct {
-	Data     io.ReadSeeker
+	Filename string
 	Duration consensus.BlockHeight
 	Nickname string
 	Pieces   int

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -65,8 +65,8 @@ func hostannouncecmd() {
 }
 
 func hoststatuscmd() {
-	config := new(modules.HostInfo)
-	err := getAPI("/host/status", config)
+	info := new(modules.HostInfo)
+	err := getAPI("/host/status", info)
 	if err != nil {
 		fmt.Println("Could not fetch host settings:", err)
 		return
@@ -77,5 +77,6 @@ Price:        %v coins
 Collateral:   %v
 Max Filesize: %v
 Max Duration: %v
-`, config.TotalStorage, config.StorageRemaining, config.Price, config.Collateral, config.MaxFilesize, config.MaxDuration)
+Contracts:    %v
+`, info.TotalStorage, info.StorageRemaining, info.Price, info.Collateral, info.MaxFilesize, info.MaxDuration, info.NumContracts)
 }

--- a/siad/renter.go
+++ b/siad/renter.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/NebulousLabs/Sia/consensus"
 	"github.com/NebulousLabs/Sia/modules"
@@ -76,18 +75,10 @@ func (d *daemon) renterStatusHandler(w http.ResponseWriter, req *http.Request) {
 	writeJSON(w, d.renter.Info())
 }
 
-// renterUploadHandler handles the API call to upload a file using a
-// filepath.
+// renterUploadHandler handles the API call to upload a file.
 func (d *daemon) renterUploadHandler(w http.ResponseWriter, req *http.Request) {
-	// open the file
-	file, err := os.Open(req.FormValue("source"))
-	if err != nil {
-		writeError(w, "Couldn't open file: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	err = d.renter.Upload(modules.UploadParams{
-		Data:     file,
+	err := d.renter.Upload(modules.UploadParams{
+		Filename: req.FormValue("source"),
 		Duration: duration,
 		Nickname: req.FormValue("nickname"),
 		Pieces:   redundancy,


### PR DESCRIPTION
Found the bug!

Seems like it was actually caused by too *many* pieces, not too few. The problem was that each piece was being uploaded in parallel, but the actual data -- the `io.ReadSeeker` -- was shared between them. So their seeks, reads, merkle roots, etc. were being interleaved.

I changed the `UploadParams` back to just using a filename instead of a generic interface. I don't see a real need to support more than that. Maybe one day we will, but for now this is a lot easier. Each upload opens a separate file handle, so the reads don't conflict. We could potentially optimize this by writing to multiple connections at once, instead of having to read the entire file n times, but it'd be wasted effort since the pieces are eventually going to be erasure-coded anyway.

I also added a naive connection timeout; any time there's a read or write, the timeout is reset to 10 seconds. This should be more than enough time, even for very slow connections. (In case you're worried about large files: they call `Read` many times on a small buffer, so they shouldn't be in danger of timing out.)