### PR TITLE
Download progress

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -33,14 +33,16 @@ type FileInfo interface {
 // DownloadInfo is an interface providing information about a file that has
 // been requested for download.
 type DownloadInfo interface {
-	// Completed indicates whether the download has finished or not.
-	Completed() bool
+	// Filesize is the size of the file being downloaded.
+	Filesize() uint64
+
+	// Received is the number of bytes downloaded so far.
+	Received() uint64
 
 	// Destination is the filepath that the file was downloaded into.
 	Destination() string
 
-	// Nickname gives the name of the file according to the renter. Nickname
-	// may be different from Destination.
+	// Nickname is the identifier assigned to the file when it was uploaded.
 	Nickname() string
 }
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -33,6 +33,12 @@ type FileInfo interface {
 // DownloadInfo is an interface providing information about a file that has
 // been requested for download.
 type DownloadInfo interface {
+	// Complete returns whether the file is ready to be used. Note that
+	// Received == Filesize does not imply Complete, because the file may
+	// require additional processing (e.g. decryption) after all of the raw
+	// bytes have been downloaded.
+	Complete() bool
+
 	// Filesize is the size of the file being downloaded.
 	Filesize() uint64
 

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -17,6 +17,7 @@ var (
 
 // A Download is a file download that has been queued by the renter.
 type Download struct {
+	complete    bool
 	filesize    uint64
 	received    uint64
 	destination string
@@ -25,6 +26,11 @@ type Download struct {
 	pieces  []FilePiece
 	file    *os.File
 	gateway modules.Gateway
+}
+
+// Complete returns whether the file is ready to be used.
+func (d *Download) Complete() bool {
+	return d.complete
 }
 
 // Filesize returns the size of the file.
@@ -91,6 +97,7 @@ func (d *Download) start() {
 		for _, piece := range d.pieces {
 			downloadErr := d.downloadPiece(piece)
 			if downloadErr == nil {
+				d.complete = true
 				d.file.Close()
 				return
 			}
@@ -133,6 +140,7 @@ func newDownload(file File, destination string) (*Download, error) {
 	}
 
 	return &Download{
+		complete: false,
 		// for now, all the pieces are equivalent
 		filesize:    file.pieces[0].Contract.FileSize,
 		received:    0,

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -17,7 +17,7 @@ type Renter struct {
 	wallet  modules.Wallet
 
 	files         map[string]File
-	downloadQueue []Download
+	downloadQueue []*Download
 	saveDir       string
 
 	mu sync.RWMutex

--- a/siac/daemoncmd.go
+++ b/siac/daemoncmd.go
@@ -107,7 +107,7 @@ Target: %v
 }
 
 func stopcmd() {
-	err := callAPI("/stop/stop")
+	err := callAPI("/daemon/stop")
 	if err != nil {
 		fmt.Println("Could not stop daemon:", err)
 		return

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -17,9 +17,9 @@ var (
 	}
 
 	renterUploadCmd = &cobra.Command{
-		Use:   "upload [filename] [nickname] [pieces]",
+		Use:   "upload [filename] [nickname]",
 		Short: "Upload a file",
-		Long:  "Upload a file using a given nickname and split across 'pieces' hosts.",
+		Long:  "Upload a file using a given nickname.",
 		Run:   wrap(renteruploadcmd),
 	}
 
@@ -45,8 +45,8 @@ var (
 	}
 )
 
-func renteruploadcmd(source, nickname, pieces string) {
-	err := callAPI(fmt.Sprintf("/renter/upload?source=%s&nickname=%s&pieces=%s", source, nickname, pieces))
+func renteruploadcmd(source, nickname string) {
+	err := callAPI(fmt.Sprintf("/renter/upload?source=%s&nickname=%s", source, nickname))
 	if err != nil {
 		fmt.Println("Could not upload file:", err)
 		return

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -51,7 +51,7 @@ func renteruploadcmd(source, nickname string) {
 		fmt.Println("Could not upload file:", err)
 		return
 	}
-	fmt.Printf("Uploaded %s as '%s'.\n", source, nickname)
+	fmt.Println("Upload initiated.")
 }
 
 func renterdownloadcmd(nickname, destination string) {

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -64,30 +64,27 @@ func renterdownloadcmd(nickname, destination string) {
 }
 
 // TODO: this should be defined elsewhere
-type downloadInfo struct {
-	Completed   bool
+type queue []struct {
+	Filesize    uint64
+	Received    uint64
 	Destination string
 	Nickname    string
 }
 
 func renterdownloadqueuecmd() {
-	var queue []downloadInfo
-	err := getAPI("/renter/downloadqueue", &queue)
+	var q queue
+	err := getAPI("/renter/downloadqueue", &q)
 	if err != nil {
 		fmt.Println("Could not get download queue:", err)
 		return
 	}
-	if len(queue) == 0 {
+	if len(q) == 0 {
 		fmt.Println("No downloads to show.")
 		return
 	}
 	fmt.Println("Download Queue:")
-	for _, file := range queue {
-		done := "Done"
-		if !file.Completed {
-			done = "... "
-		}
-		fmt.Printf("%s %s -> %s\n", done, file.Nickname, file.Destination)
+	for _, file := range q {
+		fmt.Printf("%5.1f %s -> %s\n", 100*float32(file.Received)/float32(file.Filesize), file.Nickname, file.Destination)
 	}
 }
 

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -65,6 +65,7 @@ func renterdownloadcmd(nickname, destination string) {
 
 // TODO: this should be defined elsewhere
 type queue []struct {
+	Complete    bool
 	Filesize    uint64
 	Received    uint64
 	Destination string
@@ -84,7 +85,7 @@ func renterdownloadqueuecmd() {
 	}
 	fmt.Println("Download Queue:")
 	for _, file := range q {
-		fmt.Printf("%5.1f %s -> %s\n", 100*float32(file.Received)/float32(file.Filesize), file.Nickname, file.Destination)
+		fmt.Printf("%5.1f%% %s -> %s\n", 100*float32(file.Received)/float32(file.Filesize), file.Nickname, file.Destination)
 	}
 }
 

--- a/siad/API.md
+++ b/siad/API.md
@@ -310,18 +310,27 @@ Parameters: none
 Response:
 ```
 []struct{
-	Completed   bool
+	Complete    bool
+	Filesize    uint64
+	Received    uint64
 	Destination string
 	Nickname    string
 }
 ```
 Each file in the queue is represented by the above struct.
 
+`Complete` indicates whether the file is ready to be used. Note that `Received
+== Filesize` does not imply `Complete`, because the file may require
+additional processing (e.g. decryption) after all of the raw bytes have been
+downloaded.
+
+`Filesize` is the size of the file being download.
+
+`Received` is the number of bytes downloaded thus far.
+
 `Destination` is the path that the file was downloaded to.
 
 `Nickname` is the nickname given to the file when it was uploaded.
-
-`Completed` indicates whether the download has finished.
 
 #### /renter/files
 

--- a/siad/renter.go
+++ b/siad/renter.go
@@ -14,7 +14,8 @@ const (
 
 // DownloadInfo is a helper struct for the downloadqueue API call.
 type DownloadInfo struct {
-	Completed   bool
+	Filesize    uint64
+	Received    uint64
 	Destination string
 	Nickname    string
 }
@@ -45,7 +46,8 @@ func (d *daemon) renterDownloadqueueHandler(w http.ResponseWriter, req *http.Req
 	downloadSet := make([]DownloadInfo, 0, len(downloads))
 	for _, dl := range downloads {
 		downloadSet = append(downloadSet, DownloadInfo{
-			Completed:   dl.Completed(),
+			Filesize:    dl.Filesize(),
+			Received:    dl.Received(),
 			Destination: dl.Destination(),
 			Nickname:    dl.Nickname(),
 		})

--- a/siad/renter.go
+++ b/siad/renter.go
@@ -14,6 +14,7 @@ const (
 
 // DownloadInfo is a helper struct for the downloadqueue API call.
 type DownloadInfo struct {
+	Complete    bool
 	Filesize    uint64
 	Received    uint64
 	Destination string
@@ -46,6 +47,7 @@ func (d *daemon) renterDownloadqueueHandler(w http.ResponseWriter, req *http.Req
 	downloadSet := make([]DownloadInfo, 0, len(downloads))
 	for _, dl := range downloads {
 		downloadSet = append(downloadSet, DownloadInfo{
+			Complete:    dl.Complete(),
 			Filesize:    dl.Filesize(),
 			Received:    dl.Received(),
 			Destination: dl.Destination(),


### PR DESCRIPTION
The `DownloadInfo` interface now exposes `Filesize() uint64` and `Received() uint64` methods. The value returned by `Received()` changes in real-time as the file downloads. These are included in the `/renter/downloadqueue` response, so the client can implement a "download progress bar" by calculating the received/total ratio.
This functionality has been added to siac; to watch a file download in real-time, start a download with `siac renter download [nickname] [destination]` and then run `watch -n0.1 siac renter queue`.