### PR TITLE
Tpool polishing

### DIFF
--- a/consensus/info.go
+++ b/consensus/info.go
@@ -314,10 +314,3 @@ func (s *State) ValidTransactionComponents(t Transaction) (err error) {
 
 	return
 }
-
-// ValidUnlockConditions checks that the conditions of uc have been met.
-func (s *State) ValidUnlockConditions(uc UnlockConditions, uh UnlockHash) (err error) {
-	counter := s.mu.RLock()
-	defer s.mu.RUnlock(counter)
-	return s.validUnlockConditions(uc, uh)
-}

--- a/consensus/validtransaction.go
+++ b/consensus/validtransaction.go
@@ -63,17 +63,25 @@ func (t Transaction) SiacoinOutputSum() (sum Currency) {
 	return
 }
 
-// validUnlockConditions checks that the unlock conditions have been met
-// (signatures are checked elsewhere).
-func (s *State) validUnlockConditions(uc UnlockConditions, uh UnlockHash) (err error) {
+// ValidUnlockConditions checks that the conditions of uc have been met. The
+// height is taken as input so that modules who might be at a different height
+// can do the verification without needing to use their own function.
+// Additionally, it means that the function does not need to be a method of the
+// consensus set.
+func ValidUnlockConditions(uc UnlockConditions, uh UnlockHash, currentHeight BlockHeight) (err error) {
 	if uc.UnlockHash() != uh {
 		return errors.New("unlock conditions do not match unlock hash")
 	}
-	if uc.Timelock > s.height() {
+	if uc.Timelock > currentHeight {
 		return errors.New("unlock condition timelock has not been met")
 	}
-
 	return
+}
+
+// validUnlockConditions checks that the unlock conditions have been met
+// (signatures are checked elsewhere).
+func (s *State) validUnlockConditions(uc UnlockConditions, uh UnlockHash) (err error) {
+	return ValidUnlockConditions(uc, uh, s.height())
 }
 
 // validSiacoins iterates through the inputs of a transaction, summing the

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -15,17 +15,15 @@ var (
 // marking the consumed outputs and pointing to the transaction that consumed
 // them.
 func (tp *TransactionPool) applySiacoinInputs(t consensus.Transaction, ut *unconfirmedTransaction) {
-	for _, sci := range t.SiacoinInputs {
-		// Sanity check - this input should not already be in the usedOutputs
-		// list.
-		if consensus.DEBUG {
-			_, exists := tp.usedSiacoinOutputs[sci.ParentID]
-			if exists {
-				panic("addTransaction called on invalid transaction")
-			}
+	// Sanity check - check the validity of the siacoins in this transaction.
+	if consensus.DEBUG {
+		err := tp.validUnconfirmedSiacoins(t)
+		if err != nil {
+			panic("apply called on invalid transaction")
 		}
+	}
 
-		// Add this output to the list of spent outputs.
+	for _, sci := range t.SiacoinInputs {
 		tp.usedSiacoinOutputs[sci.ParentID] = ut
 	}
 }

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -7,6 +7,13 @@ import (
 	"github.com/NebulousLabs/Sia/crypto"
 )
 
+type TransactionDirection bool
+
+const (
+	NewTransaction   TransactionDirection = true
+	PriorTransaction TransactionDirection = false
+)
+
 var (
 	ErrDuplicate = errors.New("transaction is a duplicate")
 )
@@ -15,14 +22,6 @@ var (
 // marking the consumed outputs and pointing to the transaction that consumed
 // them.
 func (tp *TransactionPool) applySiacoinInputs(t consensus.Transaction, ut *unconfirmedTransaction) {
-	// Sanity check - check the validity of the siacoins in this transaction.
-	if consensus.DEBUG {
-		err := tp.validUnconfirmedSiacoins(t)
-		if err != nil {
-			panic("apply called on invalid transaction")
-		}
-	}
-
 	for _, sci := range t.SiacoinInputs {
 		tp.usedSiacoinOutputs[sci.ParentID] = ut
 	}
@@ -33,13 +32,18 @@ func (tp *TransactionPool) applySiacoinInputs(t consensus.Transaction, ut *uncon
 func (tp *TransactionPool) applySiacoinOutputs(t consensus.Transaction, ut *unconfirmedTransaction) {
 	// Add each new siacoin output to the list of siacoinOutputs and newSiacoinOutputs.
 	for i, sco := range t.SiacoinOutputs {
-		// Sanity check - this output should not already exist in
-		// siacoinOutputs.
+		// Sanity check - output should not exist in the unconfirmed or
+		// confirmed set.
 		scoid := t.SiacoinOutputID(i)
 		if consensus.DEBUG {
 			_, exists := tp.siacoinOutputs[scoid]
 			if exists {
 				panic("trying to add an output that already exists?")
+			} else {
+				_, exists = tp.state.SiacoinOutput(scoid)
+				if exists {
+					panic("adding a transaction that's already confirmed")
+				}
 			}
 		}
 
@@ -47,20 +51,22 @@ func (tp *TransactionPool) applySiacoinOutputs(t consensus.Transaction, ut *unco
 	}
 }
 
-// applyFileContracts scans a transaction for outputs and adds every new file
-// contract and adds the contracts to the unconfirmed consensus set. A log is
-// kept of the file contracts according to the start height. If the blockchain
-// reaches that height, the transaction is removed from the pool because it
-// will no longer be valid.
+// applyFileContracts adds every file contract in a transaction to the
+// unconfirmed set.
 func (tp *TransactionPool) applyFileContracts(t consensus.Transaction, ut *unconfirmedTransaction) {
 	for i, fc := range t.FileContracts {
-		// Sanity check - this file contract should not already be in the list
-		// of unconfirmed file contracts.
+		// Sanity check - file contract should not exist in the confirmed or
+		// unconfirmed set.
 		fcid := t.FileContractID(i)
 		if consensus.DEBUG {
 			_, exists := tp.fileContracts[fcid]
 			if exists {
 				panic("trying to add a file contract that's already in the unconfirmed set")
+			} else {
+				_, exists = tp.state.FileContract(fcid)
+				if exists {
+					panic("trying to add a file contract that's already in the confirmed set")
+				}
 			}
 		}
 
@@ -76,16 +82,16 @@ func (tp *TransactionPool) applyFileContracts(t consensus.Transaction, ut *uncon
 // applyFileContractTerminations deletes consumed file contracts from the
 // consensus set and pints to the transaction that consumed them.
 func (tp *TransactionPool) applyFileContractTerminations(t consensus.Transaction, ut *unconfirmedTransaction) {
-	for _, fct := range t.FileContractTerminations {
-		// Sanity check - this termination should not already be in the list of
-		// contract terminations.
-		if consensus.DEBUG {
-			_, exists := tp.fileContractTerminations[fct.ParentID]
-			if exists {
-				panic("trying to terminate a file contract that has already been terminated")
-			}
+	// Sanity check - check the validity of the file contracts in this
+	// transaction.
+	if consensus.DEBUG {
+		err := tp.validUnconfirmedFileContractTerminations(t)
+		if err != nil {
+			panic(err)
 		}
+	}
 
+	for _, fct := range t.FileContractTerminations {
 		delete(tp.fileContracts, fct.ParentID)
 		tp.fileContractTerminations[fct.ParentID] = ut
 	}
@@ -97,31 +103,39 @@ func (tp *TransactionPool) applyFileContractTerminations(t consensus.Transaction
 // removed from the transaction pool if the trigger block changes.
 func (tp *TransactionPool) applyStorageProofs(t consensus.Transaction, ut *unconfirmedTransaction) {
 	for _, sp := range t.StorageProofs {
-		// Grab the trigger block.
 		fc, _ := tp.state.FileContract(sp.ParentID)
-		triggerBlock, _ := tp.state.BlockAtHeight(fc.Start - 1)
 
 		// Sanity check - a storage proof for this file contract should not
 		// already exist.
 		if consensus.DEBUG {
-			_, exists := tp.storageProofs[triggerBlock.ID()]
+			_, exists := tp.storageProofsByStart[fc.Start]
 			if exists {
-				_, exists = tp.storageProofs[triggerBlock.ID()][sp.ParentID]
+				_, exists = tp.storageProofsByStart[fc.Start][sp.ParentID]
+				if exists {
+					panic("storage proof for this contract exists in the by-start map")
+				}
+			}
+			_, exists = tp.storageProofsByExpiration[fc.Expiration]
+			if exists {
+				_, exists = tp.storageProofsByExpiration[fc.Expiration][sp.ParentID]
 				if exists {
 					panic("storage proof for this file contract already exists in pool")
 				}
 			}
 		}
 
-		// Remove the file contract from the set and add the termination.
-		delete(tp.fileContracts, sp.ParentID)
-
 		// Add the storage proof to the set of storage proofs.
-		_, exists := tp.storageProofs[triggerBlock.ID()]
+		_, exists := tp.storageProofsByStart[fc.Start]
 		if !exists {
-			tp.storageProofs[triggerBlock.ID()] = make(map[consensus.FileContractID]*unconfirmedTransaction)
+			tp.storageProofsByStart[fc.Start] = make(map[consensus.FileContractID]*unconfirmedTransaction)
 		}
-		tp.storageProofs[triggerBlock.ID()][sp.ParentID] = ut
+		tp.storageProofsByStart[fc.Start][sp.ParentID] = ut
+
+		_, exists = tp.storageProofsByExpiration[fc.Expiration]
+		if !exists {
+			tp.storageProofsByExpiration[fc.Expiration] = make(map[consensus.FileContractID]*unconfirmedTransaction)
+		}
+		tp.storageProofsByExpiration[fc.Expiration][sp.ParentID] = ut
 	}
 }
 
@@ -168,7 +182,7 @@ func (tp *TransactionPool) applySiafundOutputs(t consensus.Transaction, ut *unco
 // unconfirmedTransaction is appended or prepended to the linked list of
 // transactions depending on the value of `direction`, false means prepend,
 // true means append.
-func (tp *TransactionPool) addTransactionToPool(t consensus.Transaction, direction bool) {
+func (tp *TransactionPool) addTransactionToPool(t consensus.Transaction, source TransactionDirection) {
 	ut := &unconfirmedTransaction{
 		transaction: t,
 	}
@@ -184,7 +198,7 @@ func (tp *TransactionPool) addTransactionToPool(t consensus.Transaction, directi
 
 	// Add the unconfirmed transaction to the end of the linked list of
 	// transactions.
-	if direction {
+	if source == NewTransaction {
 		tp.appendUnconfirmedTransaction(ut)
 	} else {
 		tp.prependUnconfirmedTransaction(ut)
@@ -215,8 +229,7 @@ func (tp *TransactionPool) AcceptTransaction(t consensus.Transaction) (err error
 
 	// direction is set to true because a new transaction has been added and it
 	// may depend on existing unconfirmed transactions.
-	direction := true
-	tp.addTransactionToPool(t, direction)
+	tp.addTransactionToPool(t, NewTransaction)
 	tp.updateSubscribers(nil, nil, nil, []consensus.Transaction{t})
 
 	tp.gateway.RelayTransaction(t) // error is not checked

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -49,16 +49,16 @@ type TransactionPool struct {
 	fileContracts  map[consensus.FileContractID]consensus.FileContract
 	siafundOutputs map[consensus.SiafundOutputID]consensus.SiafundOutput
 
-	// These maps point from objects to the unconfirmed transactions that
-	// resulted in the objects creation. This is a superset of the unconfirmed
-	// consensus set, for example a newFileContract will not necessarily be in
-	// the list of fileContracts if an unconfirmed termination has appeared for
-	// the unconfirmed file contract.
-	usedSiacoinOutputs       map[consensus.SiacoinOutputID]*unconfirmedTransaction
-	newFileContracts         map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction
-	fileContractTerminations map[consensus.FileContractID]*unconfirmedTransaction
-	storageProofs            map[consensus.BlockID]map[consensus.FileContractID]*unconfirmedTransaction
-	usedSiafundOutputs       map[consensus.SiafundOutputID]*unconfirmedTransaction
+	// There may be elements in this set that are not a part of the unconfirmed
+	// set. For example, a siacoin output can be created and spent by
+	// unconfirmed transactions, which would put it in this set, but not in the
+	// unconfirmed set.
+	usedSiacoinOutputs        map[consensus.SiacoinOutputID]*unconfirmedTransaction
+	newFileContracts          map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction
+	fileContractTerminations  map[consensus.FileContractID]*unconfirmedTransaction
+	storageProofsByStart      map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction
+	storageProofsByExpiration map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction
+	usedSiafundOutputs        map[consensus.SiafundOutputID]*unconfirmedTransaction
 
 	// Subscriber variables
 	revertBlocksUpdates [][]consensus.Block
@@ -91,11 +91,12 @@ func New(s *consensus.State, g modules.Gateway) (tp *TransactionPool, err error)
 		fileContracts:  make(map[consensus.FileContractID]consensus.FileContract),
 		siafundOutputs: make(map[consensus.SiafundOutputID]consensus.SiafundOutput),
 
-		usedSiacoinOutputs:       make(map[consensus.SiacoinOutputID]*unconfirmedTransaction),
-		newFileContracts:         make(map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction),
-		fileContractTerminations: make(map[consensus.FileContractID]*unconfirmedTransaction),
-		storageProofs:            make(map[consensus.BlockID]map[consensus.FileContractID]*unconfirmedTransaction),
-		usedSiafundOutputs:       make(map[consensus.SiafundOutputID]*unconfirmedTransaction),
+		usedSiacoinOutputs:        make(map[consensus.SiacoinOutputID]*unconfirmedTransaction),
+		newFileContracts:          make(map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction),
+		fileContractTerminations:  make(map[consensus.FileContractID]*unconfirmedTransaction),
+		storageProofsByStart:      make(map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction),
+		storageProofsByExpiration: make(map[consensus.BlockHeight]map[consensus.FileContractID]*unconfirmedTransaction),
+		usedSiafundOutputs:        make(map[consensus.SiafundOutputID]*unconfirmedTransaction),
 
 		mu: sync.New(1*time.Second, 0),
 	}

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -71,7 +71,10 @@ func (tpt *tpoolTester) testUpdateTransactionRemoval() {
 	if len(tpt.tpool.fileContractTerminations) != 0 {
 		tpt.t.Error("a field wasn't properly emptied out")
 	}
-	if len(tpt.tpool.storageProofs) != 0 {
+	if len(tpt.tpool.storageProofsByStart) != 0 {
+		tpt.t.Error("a field wasn't properly emptied out")
+	}
+	if len(tpt.tpool.storageProofsByExpiration) != 0 {
 		tpt.t.Error("a field wasn't properly emptied out")
 	}
 	if len(tpt.tpool.usedSiafundOutputs) != 0 {

--- a/modules/transactionpool/valid.go
+++ b/modules/transactionpool/valid.go
@@ -35,7 +35,7 @@ func (tp *TransactionPool) validUnconfirmedSiacoins(t consensus.Transaction) (er
 		}
 
 		// Check that the unlock conditions are reasonable.
-		err = tp.state.ValidUnlockConditions(sci.UnlockConditions, sco.UnlockHash)
+		err = consensus.ValidUnlockConditions(sci.UnlockConditions, sco.UnlockHash, tp.stateHeight)
 		if err != nil {
 			return
 		}
@@ -74,7 +74,7 @@ func (tp *TransactionPool) validUnconfirmedFileContractTerminations(t consensus.
 		}
 
 		// Check that the unlock conditions are resonable.
-		err = tp.state.ValidUnlockConditions(fct.TerminationConditions, fc.TerminationHash)
+		err = consensus.ValidUnlockConditions(fct.TerminationConditions, fc.TerminationHash, tp.stateHeight)
 		if err != nil {
 			return
 		}
@@ -116,7 +116,7 @@ func (tp *TransactionPool) validUnconfirmedSiafunds(t consensus.Transaction) (er
 		}
 
 		// Check that the unlock conditions are reasonable.
-		err = tp.state.ValidUnlockConditions(sfi.UnlockConditions, sfo.UnlockHash)
+		err = consensus.ValidUnlockConditions(sfi.UnlockConditions, sfo.UnlockHash, tp.stateHeight)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Among other issues, the transaction pool should now have a significantly reduced dependency on locking the state, now referred to as the consensus set in many places.

Additionally, there should be many fewer problems with regards to storage proofs that are invalid but make it into the transaction pool. I don't know if we've ever seen these problems in the wild, but it could explain some of the problems we've run into.