### PR TITLE
Peering

### DIFF
--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -84,7 +84,7 @@ func TestRPC(t *testing.T) {
 // TestTimeout tests that connections time out properly.
 func TestTimeout(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 	}
 
 	g := newTestingGateway("TestTimeout - Good Peer", t)

--- a/modules/gateway/peer_test.go
+++ b/modules/gateway/peer_test.go
@@ -106,7 +106,7 @@ func TestBadPeer(t *testing.T) {
 // TestBootstrap tests the bootstrapping process, including synchronization.
 func TestBootstrap(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 	}
 
 	// create bootstrap peer

--- a/modules/gateway/peer_test.go
+++ b/modules/gateway/peer_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/consensus"
@@ -84,9 +85,21 @@ func TestBadPeer(t *testing.T) {
 		g.Ping(badpeer.Address())
 	}
 
-	// badpeer should no longer be in our peer list
-	if len(g.peers) != 0 {
-		t.Fatal("gateway did not remove bad peer:", g.Info().Peers)
+	// since we are poorly-connected, badpeer should still be in our peer list
+	if len(g.peers) != 1 {
+		t.Fatal("gateway removed peer when poorly-connected:", g.Info().Peers)
+	}
+
+	// add minPeers more peers
+	for i := 0; i < minPeers; i++ {
+		g.AddPeer(modules.NetAddress("foo" + strconv.Itoa(i)))
+	}
+
+	// once we exceed minPeers, badpeer should be kicked out
+	if len(g.peers) != minPeers {
+		t.Fatal("gateway did not remove bad peer after becoming well-connected:", g.Info().Peers)
+	} else if _, ok := g.peers[badpeer.Address()]; ok {
+		t.Fatal("gateway removed wrong peer:", g.Info().Peers)
 	}
 }
 


### PR DESCRIPTION
This PR address #421. I'm not certain was the best approach is. Here, the gateway will simply stop automatically removing peers when it drops below 3 (they can still be manually removed, though perhaps this should cause a warning). Another way would be to not throw any peers away, but just keep them in a "bad peers" map. Then if we fall below 3 peers, we add the best of the bad peers. Finally, if we fall below 3 peers, we could query the remaining ones for their peers. But this won't help if those peers aren't well-connected themselves.

btw, we should be using SkipNow instead of Skip. Skip produces a log entry, while SkipNow does not.