### PR TITLE
experimental logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,6 @@
 cover
-hostDir
-hostdir
 release
-renterDownload
 whitepaper.aux
 whitepaper.log
 whitepaper.pdf
-modules/*/*.dat
-modules/*/*.backup
-*_test
-testdir*
-*.wallet*
-walletDir*
 *.swp
-info.log

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,7 @@ xc: dependencies test test-long REBUILD
 # clean removes all directories that get automatically created during
 # development.
 clean:
-	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf         \
-		*.wallet* *_test testdir* */*_test hostdir* siad/walletDir*             \
-		siad/hostDir* info.log modules/*/*.dat modules/*/*.backup
+	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf
 
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ xc: dependencies test test-long REBUILD
 clean:
 	rm -rf hostdir release whitepaper.aux whitepaper.log whitepaper.pdf         \
 		*.wallet* *_test testdir* */*_test hostdir* siad/walletDir*             \
-		siad/hostDir* info.log modules/*/*.dat modules/*/*.backup               \
-		/tmp/SiaTesting
+		siad/hostDir* info.log modules/*/*.dat modules/*/*.backup
 
 # test runs the short tests for Sia, and aims to always take less than 2
 # seconds.

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -15,7 +15,7 @@ func (st *serverTester) announceHost() {
 // announcement that makes it into the blockchain.
 func TestHostAnnouncement(t *testing.T) {
 	// Create the server tester and check that the initial hostdb is empty.
-	st := newServerTester(t)
+	st := newServerTester("TestHostAnnouncement", t)
 	if st.hostdb.NumHosts() != 0 {
 		t.Fatal("hostdb needs to be empty after calling newServerTester")
 	}

--- a/api/miner_test.go
+++ b/api/miner_test.go
@@ -7,11 +7,14 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 )
 
-func (st *serverTester) testMining() {
+// TestMining starts the miner, mines a few blocks, and checks that the wallet
+// balance increased.
+func TestMining(t *testing.T) {
 	if testing.Short() {
-		st.Skip()
+		t.Skip()
 	}
 
+	st := newServerTester("TestMining", t)
 	// start miner
 	st.callAPI("/miner/start?threads=1")
 	// check that miner has started
@@ -28,11 +31,4 @@ func (st *serverTester) testMining() {
 	if walletstatus.FullBalance.IsZero() {
 		st.Fatalf("Mining did not increase wallet balance: %v", walletstatus.FullBalance.Big())
 	}
-}
-
-// TestMining starts the miner, mines a few blocks, and checks that the wallet
-// balance increased.
-func TestMining(t *testing.T) {
-	st := newServerTester(t)
-	st.testMining()
 }

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -41,7 +41,8 @@ func TestUploadAndDownload(t *testing.T) {
 	}
 
 	// Try to download the file.
-	st.callAPI("/renter/download?destination=renterTestDL_test&nickname=first")
+	downloadName := "renterTestDL_test"
+	st.callAPI("/renter/download?nickname=first&destination=" + downloadName)
 	time.Sleep(time.Second * 2)
 
 	// Check that the downloaded file is equal to the uploaded file.
@@ -50,7 +51,7 @@ func TestUploadAndDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer upFile.Close()
-	downFile, err := os.Open("renterTestDL_test")
+	downFile, err := os.Open(downloadName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,4 +67,5 @@ func TestUploadAndDownload(t *testing.T) {
 	if upRoot != downRoot {
 		t.Error("uploaded and downloaded file have a hash mismatch")
 	}
+	os.Remove(downloadName)
 }

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -17,7 +17,7 @@ func TestUploadAndDownload(t *testing.T) {
 	}
 
 	// Create a server and add a host to the network.
-	st := newServerTester(t)
+	st := newServerTester("TestUploadAndDownload", t)
 	st.announceHost()
 
 	for st.hostdb.NumHosts() == 0 {

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules/hostdb"
 	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/modules/renter"
+	"github.com/NebulousLabs/Sia/modules/tester"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	"github.com/NebulousLabs/Sia/modules/wallet"
 	"github.com/NebulousLabs/Sia/types"
@@ -30,13 +31,9 @@ type serverTester struct {
 	*testing.T
 }
 
-func newServerTester(t *testing.T) *serverTester {
+func newServerTester(name string, t *testing.T) *serverTester {
 	// create testing directory structure
-	testdir, err := ioutil.TempDir("..", "testdir")
-	if err != nil {
-		t.Fatal("Could not create testing dir:", err)
-	}
-
+	testdir := tester.TempDir(name)
 	APIAddr := ":" + strconv.Itoa(APIPort)
 	RPCAddr := ":" + strconv.Itoa(RPCPort)
 	APIPort++
@@ -172,5 +169,5 @@ func (st *serverTester) callAPI(call string) {
 
 // TestCreateServer creates a serverTester and immediately stops it.
 func TestCreateServer(t *testing.T) {
-	newServerTester(t).callAPI("/daemon/stop")
+	newServerTester("TestCreateServer", t).callAPI("/daemon/stop")
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -23,7 +23,6 @@ import (
 
 var (
 	APIPort int = 9020
-	RPCPort int = 9120
 )
 
 type serverTester struct {
@@ -35,13 +34,11 @@ func newServerTester(name string, t *testing.T) *serverTester {
 	// create testing directory structure
 	testdir := tester.TempDir("api", name)
 	APIAddr := ":" + strconv.Itoa(APIPort)
-	RPCAddr := ":" + strconv.Itoa(RPCPort)
 	APIPort++
-	RPCPort++
 
 	// create modules
 	state := consensus.CreateGenesisState()
-	gateway, err := gateway.New(RPCAddr, state, filepath.Join(testdir, "gateway"))
+	gateway, err := gateway.New(":0", state, filepath.Join(testdir, "gateway"))
 	if err != nil {
 		t.Fatal("Failed to create gateway:", err)
 	}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -33,7 +33,7 @@ type serverTester struct {
 
 func newServerTester(name string, t *testing.T) *serverTester {
 	// create testing directory structure
-	testdir := tester.TempDir(name)
+	testdir := tester.TempDir("api", name)
 	APIAddr := ":" + strconv.Itoa(APIPort)
 	RPCAddr := ":" + strconv.Itoa(RPCPort)
 	APIPort++

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -11,8 +11,8 @@ import (
 // The first balance should decrease, and the second balance should increase
 // proportionally.
 func TestSendCoins(t *testing.T) {
-	sender := newServerTester(t)
-	receiver := sender.addPeer()
+	sender := newServerTester("TestSendCoins1", t)
+	receiver := sender.addPeer("TestSendCoins2")
 
 	// get current balances
 	var oldSenderStatus modules.WalletInfo

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -14,9 +14,9 @@ var (
 )
 
 // newTestingGateway returns a gateway read to use in a testing environment.
-func newTestingGateway(directory string, t *testing.T) *Gateway {
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := New(":"+strconv.Itoa(rpcPort), consensus.CreateGenesisState(), gDir)
+func newTestingGateway(name string, t *testing.T) *Gateway {
+	testdir := tester.TempDir("gateway", name)
+	g, err := New(":"+strconv.Itoa(rpcPort), consensus.CreateGenesisState(), testdir)
 	rpcPort++
 	if err != nil {
 		t.Fatal(err)
@@ -87,11 +87,11 @@ func TestTimeout(t *testing.T) {
 		t.SkipNow()
 	}
 
-	g := newTestingGateway("TestTimeout - Good Peer", t)
+	g := newTestingGateway("TestTimeout1", t)
 	defer g.Close()
 
 	// create unresponsive peer
-	badpeer := newTestingGateway("TestTimeout - Bad Peer", t)
+	badpeer := newTestingGateway("TestTimeout2", t)
 	// overwrite badpeer's Ping RPC with an incorrect one
 	// since g is expecting 4 bytes, it will time out.
 	badpeer.RegisterRPC("Ping", func(conn modules.NetConn) error {

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -9,15 +8,10 @@ import (
 	"github.com/NebulousLabs/Sia/modules/tester"
 )
 
-var (
-	rpcPort = 10000
-)
-
 // newTestingGateway returns a gateway read to use in a testing environment.
 func newTestingGateway(name string, t *testing.T) *Gateway {
 	testdir := tester.TempDir("gateway", name)
-	g, err := New(":"+strconv.Itoa(rpcPort), consensus.CreateGenesisState(), testdir)
-	rpcPort++
+	g, err := New(":0", consensus.CreateGenesisState(), testdir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gateway/helpers.go
+++ b/modules/gateway/helpers.go
@@ -37,6 +37,7 @@ func (g *Gateway) setHostname(host string) {
 	counter := g.mu.Lock()
 	defer g.mu.Unlock(counter)
 	g.myAddr = modules.NetAddress(net.JoinHostPort(host, g.myAddr.Port()))
+	g.log.Println("INFO: set hostname to", g.myAddr)
 }
 
 // getExternalIP learns the server's hostname from a centralized service,

--- a/modules/gateway/peer_test.go
+++ b/modules/gateway/peer_test.go
@@ -70,11 +70,11 @@ func TestPeerSharing(t *testing.T) {
 
 // TestBadPeer tests that "bad" peers are correctly identified and removed.
 func TestBadPeer(t *testing.T) {
-	g := newTestingGateway("TestBadPeer - Good Peer", t)
+	g := newTestingGateway("TestBadPeer1", t)
 	defer g.Close()
 
 	// create bad peer
-	badpeer := newTestingGateway("TestBadPeer - Bad Peer", t)
+	badpeer := newTestingGateway("TestBadPeer2", t)
 	// overwrite badpeer's Ping RPC with an incorrect one
 	badpeer.RegisterRPC("Ping", writerRPC("lol"))
 
@@ -110,17 +110,17 @@ func TestBootstrap(t *testing.T) {
 	}
 
 	// create bootstrap peer
-	bootstrap := newTestingGateway("TestBootstrap", t)
+	bootstrap := newTestingGateway("TestBootstrap1", t)
 	ct := consensus.NewConsensusTester(t, bootstrap.state)
 	// give it some blocks
 	for i := 0; i < MaxCatchUpBlocks*2+1; i++ {
 		ct.MineAndApplyValidBlock()
 	}
 	// give it a peer
-	bootstrap.AddPeer(newTestingGateway("TestBootstrap - Peer 1", t).Address())
+	bootstrap.AddPeer(newTestingGateway("TestBootstrap2", t).Address())
 
 	// bootstrap a new peer
-	g := newTestingGateway("TestBootstrap - Peer 2", t)
+	g := newTestingGateway("TestBootstrap3", t)
 	err := g.Bootstrap(bootstrap.Address())
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +142,7 @@ func TestBootstrap(t *testing.T) {
 	}
 
 	// add another two peers to bootstrap: a real peer and a "dummy", which won't respond.
-	bootstrap.AddPeer(newTestingGateway("TestBootstrap - Peer 3", t).Address())
+	bootstrap.AddPeer(newTestingGateway("TestBootstrap4", t).Address())
 	bootstrap.AddPeer("dummy")
 
 	// have g request peers from bootstrap. g should add the real peer, but not the dummy.

--- a/modules/gateway/persist.go
+++ b/modules/gateway/persist.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"io/ioutil"
+	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/encoding"
@@ -16,7 +18,7 @@ func (g *Gateway) save() error {
 	return ioutil.WriteFile(filepath.Join(g.saveDir, "peers.dat"), encoding.Marshal(peers), 0666)
 }
 
-func (g *Gateway) load(filename string) (err error) {
+func (g *Gateway) load() (err error) {
 	contents, err := ioutil.ReadFile(filepath.Join(g.saveDir, "peers.dat"))
 	if err != nil {
 		return
@@ -30,4 +32,14 @@ func (g *Gateway) load(filename string) (err error) {
 		g.peers[peer] = 0 // TODO: support saving/loading strikes
 	}
 	return
+}
+
+// create logger
+// TODO: when is the logFile closed? Does it need to be closed?
+func makeLogger(saveDir string) (*log.Logger, error) {
+	logFile, err := os.OpenFile(filepath.Join(saveDir, "gateway.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
+	if err != nil {
+		return nil, err
+	}
+	return log.New(logFile, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile), nil
 }

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -9,11 +10,6 @@ import (
 	"github.com/NebulousLabs/Sia/modules/tester"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	"github.com/NebulousLabs/Sia/modules/wallet"
-)
-
-var (
-	walletNum int = 0
-	hostNum   int = 0
 )
 
 // A HostTester contains a consensus tester and a host, and provides a set of
@@ -25,10 +21,10 @@ type HostTester struct {
 }
 
 // CreateHostTester initializes a HostTester.
-func CreateHostTester(directory string, t *testing.T) (ht *HostTester) {
+func CreateHostTester(name string, t *testing.T) (ht *HostTester) {
 	ct := consensus.NewTestingEnvironment(t)
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := gateway.New(":0", ct.State, gDir)
+	testdir := tester.TempDir("host", name)
+	g, err := gateway.New(":0", ct.State, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,18 +34,15 @@ func CreateHostTester(directory string, t *testing.T) (ht *HostTester) {
 		t.Fatal(err)
 	}
 
-	wDir := tester.TempDir(directory, modules.WalletDir)
-	w, err := wallet.New(ct.State, tp, wDir)
+	w, err := wallet.New(ct.State, tp, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		t.Fatal(err)
 	}
-	walletNum++
 
-	h, err := New(ct.State, tp, w, modules.HostDir)
+	h, err := New(ct.State, tp, w, filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
-	hostNum++
 
 	ht = new(HostTester)
 	ht.ConsensusTester = ct

--- a/modules/hostdb/hostdb_test.go
+++ b/modules/hostdb/hostdb_test.go
@@ -1,6 +1,7 @@
 package hostdb
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -17,10 +18,10 @@ type HostDBTester struct {
 }
 
 // CreateHostDBTester initializes a hostdb tester.
-func CreateHostDBTester(directory string, t *testing.T) (hdbt *HostDBTester) {
+func CreateHostDBTester(name string, t *testing.T) (hdbt *HostDBTester) {
 	ct := consensus.NewTestingEnvironment(t)
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := gateway.New(":0", ct.State, gDir)
+	testdir := tester.TempDir("hostdb", name)
+	g, err := gateway.New(":0", ct.State, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -1,6 +1,7 @@
 package miner
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -12,16 +13,17 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// TODO: factor out newMinerTester
+
 // TestMiner creates a miner, mines a few blocks, and checks that the wallet
 // balance is updating as the blocks get mined.
 func TestMiner(t *testing.T) {
-	directory := "TestMiner"
+	testdir := tester.TempDir("miner", "TestMiner")
 
 	// Create the miner and all of it's dependencies.
 	s := consensus.CreateGenesisState()
 
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := gateway.New(":0", s, gDir)
+	g, err := gateway.New(":0", s, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,8 +31,7 @@ func TestMiner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wDir := tester.TempDir(directory, modules.WalletDir)
-	w, err := wallet.New(s, tpool, wDir)
+	w, err := wallet.New(s, tpool, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,12 +69,11 @@ func TestManyBlocks(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	directory := "TestManyBlocks"
+	testdir := tester.TempDir("miner", "TestMiner")
 
 	// Create the miner and all of it's dependencies.
 	s := consensus.CreateGenesisState()
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := gateway.New(":0", s, gDir)
+	g, err := gateway.New(":0", s, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,8 +81,7 @@ func TestManyBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wDir := tester.TempDir(directory, modules.WalletDir)
-	w, err := wallet.New(s, tpool, wDir)
+	w, err := wallet.New(s, tpool, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -1,6 +1,7 @@
 package renter
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -12,10 +13,6 @@ import (
 	"github.com/NebulousLabs/Sia/modules/wallet"
 )
 
-var (
-	walletNum int = 0
-)
-
 // A RenterTester contains a consensus tester and a renter, and provides a set
 // of helper functions for testing the renter without needing other modules
 // such as the host.
@@ -25,11 +22,11 @@ type RenterTester struct {
 }
 
 // CreateHostTester initializes a HostTester.
-func CreateRenterTester(directory string, t *testing.T) (rt *RenterTester) {
+func CreateRenterTester(name string, t *testing.T) (rt *RenterTester) {
 	ct := consensus.NewTestingEnvironment(t)
+	testdir := tester.TempDir("renter", name)
 
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := gateway.New(":0", ct.State, gDir)
+	g, err := gateway.New(":0", ct.State, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,14 +38,11 @@ func CreateRenterTester(directory string, t *testing.T) (rt *RenterTester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wDir := tester.TempDir(directory, modules.WalletDir)
-	w, err := wallet.New(ct.State, tp, wDir)
+	w, err := wallet.New(ct.State, tp, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		t.Fatal(err)
 	}
-	walletNum++
-	rDir := tester.TempDir(directory, modules.RenterDir)
-	r, err := New(ct.State, g, hdb, w, rDir)
+	r, err := New(ct.State, g, hdb, w, filepath.Join(testdir, modules.RenterDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +55,7 @@ func CreateRenterTester(directory string, t *testing.T) (rt *RenterTester) {
 
 // TestSaveLoad tests that saving and loading a Renter restores its data.
 func TestSaveLoad(t *testing.T) {
-	rt := CreateRenterTester("Renter - TestSaveLoad", t)
+	rt := CreateRenterTester("TestSaveLoad", t)
 	err := rt.save()
 	if err != nil {
 		rt.Fatal(err)

--- a/modules/tester/tester.go
+++ b/modules/tester/tester.go
@@ -5,14 +5,14 @@ import (
 	"path/filepath"
 )
 
-const (
-	SiaTestingDir = "SiaTesting"
+var (
+	SiaTestingDir = filepath.Join(os.TempDir(), "SiaTesting")
 )
 
-// TempDir takes a set of directory names and joins them to the sia temp
-// folder.
+// TempDir joins the provided directories and prefixes them with the Sia
+// testing directory.
 func TempDir(dirs ...string) string {
-	tmp := append([]string{os.TempDir()}, SiaTestingDir)
-	full := append(tmp, dirs...)
-	return filepath.Join(full...) // filepath.Join(tmp, testing, dirs...) returns 'too many arguments' error.
+	path := filepath.Join(SiaTestingDir, filepath.Join(dirs...))
+	os.RemoveAll(path) // remove old test data
+	return path
 }

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -53,14 +53,14 @@ func (tpt *tpoolTester) addDependentSiacoinTransactionToPool() (firstTxn, depend
 // TestAddSiacoinTransactionToPool creates a tpoolTester and uses it to call
 // addSiacoinTransactionToPool.
 func TestAddSiacoinTransactionToPool(t *testing.T) {
-	tpt := newTpoolTester("TransactionPool - TestAddSiacoinTransactionToPool", t)
+	tpt := newTpoolTester("TestAddSiacoinTransactionToPool", t)
 	tpt.addSiacoinTransactionToPool()
 }
 
 // TestAddDependentSiacoinTransactionToPool creates a tpoolTester and uses it
 // to cal addDependentSiacoinTransactionToPool.
 func TestAddDependentSiacoinTransactionToPool(t *testing.T) {
-	tpt := newTpoolTester("TransactionPool - TestAddDependentSiacoinTransactionToPool", t)
+	tpt := newTpoolTester("TestAddDependentSiacoinTransactionToPool", t)
 	tpt.addDependentSiacoinTransactionToPool()
 }
 
@@ -70,7 +70,7 @@ func TestAddDependentSiacoinTransactionToPool(t *testing.T) {
 // removed, and that will be removed after fees are required in all
 // transactions submitted to the pool.
 func TestDuplicateTransaction(t *testing.T) {
-	tpt := newTpoolTester("TransactionPool - TestDuplicateTransaction", t)
+	tpt := newTpoolTester("TestDuplicateTransaction", t)
 	txn := tpt.addSiacoinTransactionToPool()
 	err := tpt.tpool.AcceptTransaction(txn)
 	if err != ErrDuplicate {

--- a/modules/transactionpool/standard_test.go
+++ b/modules/transactionpool/standard_test.go
@@ -9,7 +9,7 @@ import (
 
 // Try to add a transaction that is too large to the transaction pool.
 func TestLargeTransaction(t *testing.T) {
-	tpt := newTpoolTester("TransactionPool - TestLargeTransaction", t)
+	tpt := newTpoolTester("TestLargeTransaction", t)
 
 	// Create a transaction that's larger than the size limit.
 	largeArbitraryData := make([]byte, TransactionSizeLimit)

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -1,6 +1,7 @@
 package transactionpool
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -98,13 +99,14 @@ func (tpt *tpoolTester) spendCoins(amount types.Currency, dest types.UnlockHash)
 }
 
 // CreatetpoolTester initializes a tpoolTester.
-func newTpoolTester(directory string, t *testing.T) (tpt *tpoolTester) {
+func newTpoolTester(name string, t *testing.T) (tpt *tpoolTester) {
 	// Create the consensus set.
 	cs := consensus.CreateGenesisState()
 
+	testdir := tester.TempDir("transactionpool", name)
+
 	// Create the gateway.
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := gateway.New(":0", cs, gDir)
+	g, err := gateway.New(":0", cs, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,8 +118,7 @@ func newTpoolTester(directory string, t *testing.T) (tpt *tpoolTester) {
 	}
 
 	// Create the wallet.
-	wDir := tester.TempDir(directory, modules.WalletDir)
-	w, err := wallet.New(cs, tp, wDir)
+	w, err := wallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +164,7 @@ func newTpoolTester(directory string, t *testing.T) (tpt *tpoolTester) {
 func TestNewNilInputs(t *testing.T) {
 	// Create a consensus set and gateway.
 	cs := consensus.CreateGenesisState()
-	gDir := tester.TempDir("Transaction Pool - TestNewNilInputs", modules.GatewayDir)
+	gDir := tester.TempDir("transactionpool", "TestNewNilInputs", modules.GatewayDir)
 	g, err := gateway.New(":0", cs, gDir)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/transactionpool/transactions_test.go
+++ b/modules/transactionpool/transactions_test.go
@@ -30,6 +30,6 @@ func (tpt *tpoolTester) testSiacoinTransactionDump() {
 // TestSiacoinTransactionDump creates a tpoolTester and uses it to call
 // testSiacoinTransactionDump.
 func TestSiacoinTransactionDump(t *testing.T) {
-	tpt := newTpoolTester("Transaction Pool - TetstSiacoinTransactionDump", t)
+	tpt := newTpoolTester("TestSiacoinTransactionDump", t)
 	tpt.testSiacoinTransactionDump()
 }

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -237,26 +237,26 @@ func (tpt *tpoolTester) testRewinding() {
 // TestUpdateTransactionRemoval creates a tpoolTester and uses it to call
 // tetsUpdateTransactionRemoval.
 func TestUpdateTransactionRemoval(t *testing.T) {
-	tpt := newTpoolTester("Transaction Pool - TestUpdateTransactionRemoval", t)
+	tpt := newTpoolTester("TestUpdateTransactionRemoval", t)
 	tpt.testUpdateTransactionRemoval()
 }
 
 // TestBlockConflicts creates a tpoolTester and uses it to call
 // testBlockConflicts.
 func TestBlockConflicts(t *testing.T) {
-	tpt := newTpoolTester("Transaction Pool - TestBlockConflicts", t)
+	tpt := newTpoolTester("TestBlockConflicts", t)
 	tpt.testBlockConflicts()
 }
 
 // TestDependentUpdates creates a tpoolTester and uses it to call
 // testDependentUpdates.
 func TestDependentUpdates(t *testing.T) {
-	tpt := newTpoolTester("Transaction Pool - TestDependentUpdates", t)
+	tpt := newTpoolTester("TestDependentUpdates", t)
 	tpt.testDependentUpdates()
 }
 
 // TestRewinding creates a tpoolTester and uses it to call testRewinding.
 func TestRewinding(t *testing.T) {
-	// tpt := newTpoolTester("Transaction Pool - TestRewinding", t)
+	// tpt := newTpoolTester("TestRewinding", t)
 	// tpt.testRewinding()
 }

--- a/modules/transactionpool/valid_test.go
+++ b/modules/transactionpool/valid_test.go
@@ -66,14 +66,14 @@ func (tpt *tpoolTester) testOverspend() {
 // TestAddConflictingSiacoinTransactionToPool creates a tpoolTester and uses it
 // to call addConflictingSiacoinTransactionToPool.
 func TestAddConflictingSiacoinTransaction(t *testing.T) {
-	tpt := newTpoolTester("Transaction Pool - TestAddConflictingSiacoinTransaction", t)
+	tpt := newTpoolTester("TestAddConflictingSiacoinTransaction", t)
 	tpt.addConflictingSiacoinTransaction()
 }
 
 // TestFalseSiacoinSpend creates a tpoolTester and uses it to call smaller
 // tests that probe the siacoin verification rules.
 func TestFalseSiacoinFeatures(t *testing.T) {
-	tpt := newTpoolTester("Transaction Pool - TestFalseSiacoinFeatures", t)
+	tpt := newTpoolTester("TestFalseSiacoinFeatures", t)
 	tpt.testFalseSiacoinSpend()
 	tpt.testBadSiacoinUnlock()
 	tpt.testOverspend()

--- a/modules/wallet/persist_test.go
+++ b/modules/wallet/persist_test.go
@@ -6,7 +6,7 @@ import (
 
 // TestSaveLoad tests that saving and loading a wallet restores its data.
 func TestSaveLoad(t *testing.T) {
-	wt := NewWalletTester("Wallet - TestSaveLoad", t)
+	wt := NewWalletTester("TestSaveLoad", t)
 
 	// save wallet data
 	err := wt.wallet.save()

--- a/modules/wallet/transactions_test.go
+++ b/modules/wallet/transactions_test.go
@@ -66,6 +66,6 @@ func (wt *walletTester) testFundTransaction() {
 // TestFundTransaction creates a wallet tester and uses it to call
 // testFundTransaction.
 func TestFundTransaction(t *testing.T) {
-	wt := NewWalletTester("Wallet - TestFundTransaction", t)
+	wt := NewWalletTester("TestFundTransaction", t)
 	wt.testFundTransaction()
 }

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -10,10 +11,6 @@ import (
 	"github.com/NebulousLabs/Sia/modules/tester"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	"github.com/NebulousLabs/Sia/types"
-)
-
-var (
-	walletNum int = 0
 )
 
 // A Wallet tester contains a ConsensusTester and has a bunch of helpful
@@ -69,13 +66,14 @@ func (wt *walletTester) updateWait() {
 }
 
 // NewWalletTester takes a testing.T and creates a WalletTester.
-func NewWalletTester(directory string, t *testing.T) (wt *walletTester) {
+func NewWalletTester(name string, t *testing.T) (wt *walletTester) {
+	testdir := tester.TempDir("wallet", name)
+
 	// Create the consensus set.
 	cs := consensus.CreateGenesisState()
 
 	// Create the gateway.
-	gDir := tester.TempDir(directory, modules.GatewayDir)
-	g, err := gateway.New(":0", cs, gDir)
+	g, err := gateway.New(":0", cs, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,8 +85,7 @@ func NewWalletTester(directory string, t *testing.T) (wt *walletTester) {
 	}
 
 	// Create the wallet.
-	wDir := tester.TempDir(directory, modules.WalletDir)
-	w, err := New(cs, tp, wDir)
+	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Exploring how we might do logging. The gateway now has fairly comprehensive logs. Eventually we may want to write a custom logger, but using the default one is okay for now. Some thoughts I had:

- Does it make sense to establish logging conventions (in the same style as our mutex conventions, that is)? e.g. "functions that return an error should not also log that error" or similar.
- If each module is writing to a separate log file, what's the best way to merge them so that we can see everything in chronological order? Or should all logs be written to the same file, and simply tagged by module? Should we write a "log viewer" tool to assist debugging?
- How can logs preserve context? That is, if there are two concurrent calls to the same function, their logs are going to be intertwined, so how do you tell how they're grouped?
- What's the best way to integrate logging with our `if DEBUG { panic() }` pattern? Maybe the logger could handle it implicitly, like:
```go
func (l *logger) Fatal(v ...interface{}) {
    msg := fmt.Sprint(v...)
    l.output(msg)
    if DEBUG {
        panic(msg)
    }
}
```

I also noticed that the tester package is apparently a module?? Is there some plan to expand its functionality? Because right now it's just the `TempDir` function. If it isn't clear how tester will be used, we could just move `TempDir` to the build package.
Speaking of which, `SiaTestingDir` is now organized by package, rather than throwing all the test folders into one directory. And all the tests use a random RPC port instead of incrementing a number. (This could be done with the API port too, but it'd be kind of a hassle.)