### PR TITLE
Siafund keygen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ test-wallet: clean fmt REBUILD
 # have been hit during testing and how many times each line has been hit.
 coverpackages = api crypto encoding modules/consensus modules/gateway           \
 	modules/host modules/hostdb modules/miner modules/renter                    \
-	modules/transactionpool modules/wallet types
+	modules/transactionpool modules/wallet siakg types
 cover: clean REBUILD
 	@mkdir -p cover/modules
 	@for package in $(coverpackages); do \

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -36,16 +36,14 @@ func GenerateSignatureKeys() (sk SecretKey, pk PublicKey, err error) {
 	return
 }
 
-// SignHash signs a message using a secret key. An error is returned if the
-// secret key is nil.
+// SignHash signs a message using a secret key.
 func SignHash(data Hash, sk SecretKey) (sig Signature, err error) {
 	skNorm := [SecretKeySize]byte(sk)
 	sig = *ed25519.Sign(&skNorm, data[:])
 	return
 }
 
-// VerifyHash uses a public key and input data to verify a signature. And error
-// is returned if the public key or signature is nil.
+// VerifyHash uses a public key and input data to verify a signature.
 func VerifyHash(data Hash, pk PublicKey, sig Signature) (err error) {
 	pkNorm := [PublicKeySize]byte(pk)
 	sigNorm := [SignatureSize]byte(sig)

--- a/modules/consensus/fork_test.go
+++ b/modules/consensus/fork_test.go
@@ -18,9 +18,9 @@ func (ct *ConsensusTester) MineInvalidSignatureBlockSet(depth int) (blocks []typ
 	txn.MinerFees = append(txn.MinerFees, value)
 
 	// Invalidate the signature.
-	byteSig := []byte(txn.Signatures[0].Signature)
+	byteSig := []byte(txn.TransactionSignatures[0].Signature)
 	byteSig[0]++
-	txn.Signatures[0].Signature = types.Signature(byteSig)
+	txn.TransactionSignatures[0].Signature = types.Signature(byteSig)
 
 	// Mine a block with this transcation.
 	block := ct.MineCurrentBlock([]types.Transaction{txn})

--- a/modules/consensus/testenvironment.go
+++ b/modules/consensus/testenvironment.go
@@ -114,7 +114,7 @@ func NewConsensusTester(t *testing.T, s *State) (ct *ConsensusTester) {
 		t.Fatal(err)
 	}
 	uc := types.UnlockConditions{
-		NumSignatures: 1,
+		RequiredSignatures: 1,
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,

--- a/modules/consensus/testenvironment.go
+++ b/modules/consensus/testenvironment.go
@@ -114,7 +114,7 @@ func NewConsensusTester(t *testing.T, s *State) (ct *ConsensusTester) {
 		t.Fatal(err)
 	}
 	uc := types.UnlockConditions{
-		RequiredSignatures: 1,
+		SignaturesRequired: 1,
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,

--- a/modules/consensus/testtransactions.go
+++ b/modules/consensus/testtransactions.go
@@ -56,14 +56,14 @@ func (ct *ConsensusTester) AddSiacoinInputToTransaction(inputT types.Transaction
 		CoveredFields:  types.CoveredFields{},
 		PublicKeyIndex: 0,
 	}
-	tsigIndex := len(t.Signatures)
-	t.Signatures = append(t.Signatures, tsig)
+	tsigIndex := len(t.TransactionSignatures)
+	t.TransactionSignatures = append(t.TransactionSignatures, tsig)
 	sigHash := t.SigHash(tsigIndex)
 	encodedSig, err := crypto.SignHash(sigHash, ct.SecretKey)
 	if err != nil {
 		ct.Fatal(err)
 	}
-	t.Signatures[tsigIndex].Signature = types.Signature(encodedSig[:])
+	t.TransactionSignatures[tsigIndex].Signature = types.Signature(encodedSig[:])
 
 	return
 }

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -248,7 +248,7 @@ func (h *Host) NegotiateContract(conn modules.NetConn) (err error) {
 
 	// Add the signatures from the renter signed transaction, and then sign the
 	// transaction, then submit the transaction.
-	for _, sig := range signedTxn.Signatures {
+	for _, sig := range signedTxn.TransactionSignatures {
 		_, _, err = h.wallet.AddSignature(txnID, sig)
 		if err != nil {
 			return

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -15,8 +15,8 @@ func (w *Wallet) timelockedCoinAddress(unlockHeight types.BlockHeight) (coinAddr
 		return
 	}
 	unlockConditions = types.UnlockConditions{
-		Timelock:      unlockHeight,
-		NumSignatures: 1,
+		Timelock:           unlockHeight,
+		RequiredSignatures: 1,
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,
@@ -60,7 +60,7 @@ func (w *Wallet) coinAddress() (coinAddress types.UnlockHash, unlockConditions t
 		return
 	}
 	unlockConditions = types.UnlockConditions{
-		NumSignatures: 1,
+		RequiredSignatures: 1,
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -16,7 +16,7 @@ func (w *Wallet) timelockedCoinAddress(unlockHeight types.BlockHeight) (coinAddr
 	}
 	unlockConditions = types.UnlockConditions{
 		Timelock:           unlockHeight,
-		RequiredSignatures: 1,
+		SignaturesRequired: 1,
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,
@@ -60,7 +60,7 @@ func (w *Wallet) coinAddress() (coinAddress types.UnlockHash, unlockConditions t
 		return
 	}
 	unlockConditions = types.UnlockConditions{
-		RequiredSignatures: 1,
+		SignaturesRequired: 1,
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -93,11 +93,11 @@ func (w *Wallet) FundTransaction(id string, amount types.Currency) (t types.Tran
 			CoveredFields:  coveredFields,
 			PublicKeyIndex: 0,
 		}
-		parentTxn.Signatures = append(parentTxn.Signatures, sig)
+		parentTxn.TransactionSignatures = append(parentTxn.TransactionSignatures, sig)
 
 		// Hash the transaction according to the covered fields.
 		coinAddress := input.UnlockConditions.UnlockHash()
-		sigIndex := len(parentTxn.Signatures) - 1
+		sigIndex := len(parentTxn.TransactionSignatures) - 1
 		secKey := w.keys[coinAddress].secretKey
 		sigHash := parentTxn.SigHash(sigIndex)
 
@@ -107,7 +107,7 @@ func (w *Wallet) FundTransaction(id string, amount types.Currency) (t types.Tran
 		if err != nil {
 			return
 		}
-		parentTxn.Signatures[sigIndex].Signature = types.Signature(encodedSig[:])
+		parentTxn.TransactionSignatures[sigIndex].Signature = types.Signature(encodedSig[:])
 	}
 
 	// Add the exact output to the wallet's knowledgebase before releasing the
@@ -296,8 +296,8 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn types.Tr
 		for i := range txn.ArbitraryData {
 			coveredFields.ArbitraryData = append(coveredFields.ArbitraryData, uint64(i))
 		}
-		for i := range txn.Signatures {
-			coveredFields.Signatures = append(coveredFields.Signatures, uint64(i))
+		for i := range txn.TransactionSignatures {
+			coveredFields.TransactionSignatures = append(coveredFields.TransactionSignatures, uint64(i))
 		}
 	}
 
@@ -309,11 +309,11 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn types.Tr
 			CoveredFields:  coveredFields,
 			PublicKeyIndex: 0,
 		}
-		txn.Signatures = append(txn.Signatures, sig)
+		txn.TransactionSignatures = append(txn.TransactionSignatures, sig)
 
 		// Hash the transaction according to the covered fields.
 		coinAddress := input.UnlockConditions.UnlockHash()
-		sigIndex := len(txn.Signatures) - 1
+		sigIndex := len(txn.TransactionSignatures) - 1
 		secKey := w.keys[coinAddress].secretKey
 		sigHash := txn.SigHash(sigIndex)
 
@@ -323,7 +323,7 @@ func (w *Wallet) SignTransaction(id string, wholeTransaction bool) (txn types.Tr
 		if err != nil {
 			return
 		}
-		txn.Signatures[sigIndex].Signature = types.Signature(encodedSig[:])
+		txn.TransactionSignatures[sigIndex].Signature = types.Signature(encodedSig[:])
 	}
 
 	// Delete the open transaction.
@@ -346,8 +346,8 @@ func (w *Wallet) AddSignature(id string, sig types.TransactionSignature) (t type
 		return
 	}
 
-	openTxn.transaction.Signatures = append(openTxn.transaction.Signatures, sig)
+	openTxn.transaction.TransactionSignatures = append(openTxn.transaction.TransactionSignatures, sig)
 	t = *openTxn.transaction
-	sigIndex = uint64(len(t.Signatures) - 1)
+	sigIndex = uint64(len(t.TransactionSignatures) - 1)
 	return
 }

--- a/siakg/keys.go
+++ b/siakg/keys.go
@@ -32,6 +32,13 @@ type KeyPair struct {
 
 // generateKeys will generate a set of keys and save the keyfiles to disk.
 func generateKeys(*cobra.Command, []string) {
+	// Check that the total number of keys is at least as large as the required
+	// number of keys.
+	if config.Siakg.TotalKeys < config.Siakg.RequiredKeys {
+		fmt.Printf("Total Keys (%v) must be greater than or equal to Required Keys (%v)\n", config.Siakg.TotalKeys, config.Siakg.RequiredKeys)
+		return
+	}
+
 	fmt.Printf("Creating key '%s' with %v total keys and %v required keys.\n", config.Siakg.KeyName, config.Siakg.TotalKeys, config.Siakg.RequiredKeys)
 
 	// Generate 'TotalKeys' keyparis and fill out the metadata.

--- a/siakg/keys.go
+++ b/siakg/keys.go
@@ -66,8 +66,8 @@ func generateKeys(*cobra.Command, []string) {
 
 	// Generate the unlock conditions and add them to each KeyPair object.
 	uc := types.UnlockConditions{
-		Timelock:      0,
-		NumSignatures: uint64(config.Siakg.RequiredKeys),
+		Timelock:           0,
+		RequiredSignatures: uint64(config.Siakg.RequiredKeys),
 	}
 	for i := range keys {
 		uc.PublicKeys = append(uc.PublicKeys, types.SiaPublicKey{
@@ -132,7 +132,7 @@ func generateKeys(*cobra.Command, []string) {
 		}
 		var j int
 		for j < config.Siakg.RequiredKeys {
-			txn.Signatures = append(txn.Signatures, types.TransactionSignature{
+			txn.TransactionSignatures = append(txn.TransactionSignatures, types.TransactionSignature{
 				PublicKeyIndex: uint64(i),
 				CoveredFields:  types.CoveredFields{WholeTransaction: true},
 			})
@@ -142,7 +142,7 @@ func generateKeys(*cobra.Command, []string) {
 				fmt.Println(err)
 				return
 			}
-			txn.Signatures[j].Signature = types.Signature(sig[:])
+			txn.TransactionSignatures[j].Signature = types.Signature(sig[:])
 			i++
 			j++
 		}
@@ -152,7 +152,7 @@ func generateKeys(*cobra.Command, []string) {
 			fmt.Println(err)
 		}
 		// Delete all of the signatures for the next iteration.
-		txn.Signatures = nil
+		txn.TransactionSignatures = nil
 	}
 
 	fmt.Printf("Success, the address for this set of keys is: %x\n", uc.UnlockHash())
@@ -167,6 +167,6 @@ func printKey(*cobra.Command, []string) {
 		return
 	}
 
-	fmt.Printf("Found a key for a %v of %v address.\n", kp.UnlockConditions.NumSignatures, len(kp.UnlockConditions.PublicKeys))
+	fmt.Printf("Found a key for a %v of %v address.\n", kp.UnlockConditions.RequiredSignatures, len(kp.UnlockConditions.PublicKeys))
 	fmt.Printf("The address is: %x\n", kp.UnlockConditions.UnlockHash())
 }

--- a/siakg/keys.go
+++ b/siakg/keys.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+type KeyPair struct {
+	Index            int
+	SecretKey        crypto.SecretKey
+	PublicKey        crypto.PublicKey
+	UnlockConditions types.UnlockConditions
+}
+
+func generateKeys(*cobra.Command, []string) {
+	fmt.Printf("Creating key '%s' with %v total keys and %v required keys.\n", config.Siakg.KeyName, config.Siakg.TotalKeys, config.Siakg.RequiredKeys)
+
+	// Generate 'TotalKeys' keyparis.
+	keys := make([]KeyPair, config.Siakg.TotalKeys)
+	for i := 0; i < config.Siakg.TotalKeys; i++ {
+		var err error
+		keys[i].SecretKey, keys[i].PublicKey, err = crypto.GenerateSignatureKeys()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		keys[i].Index = i
+	}
+
+	// Generate the 'UnlockConditions'.
+	uc := types.UnlockConditions{
+		Timelock:      0,
+		NumSignatures: uint64(config.Siakg.RequiredKeys),
+	}
+	for i := range keys {
+		uc.PublicKeys = append(uc.PublicKeys, types.SiaPublicKey{
+			Algorithm: types.SignatureEd25519,
+			Key:       string(keys[i].PublicKey[:]),
+		})
+	}
+	for i := range keys {
+		keys[i].UnlockConditions = uc
+	}
+
+	err := os.MkdirAll(config.Siakg.KeyName, 0700)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	for i, key := range keys {
+		err = encoding.WriteFile(filepath.Join(config.Siakg.KeyName, config.Siakg.KeyName+"_Key"+strconv.Itoa(i)), key)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+
+	fmt.Printf("Success, the address for this set of keys is: %x\n", uc.UnlockHash())
+}

--- a/siakg/keys.go
+++ b/siakg/keys.go
@@ -28,7 +28,6 @@ type KeyPair struct {
 	Version          string
 	Index            int
 	SecretKey        crypto.SecretKey
-	PublicKey        crypto.PublicKey
 	UnlockConditions types.UnlockConditions
 }
 
@@ -55,9 +54,10 @@ func generateKeys(*cobra.Command, []string) {
 	}
 
 	// Add the keys to each keypair.
+	pubKeys := make([]crypto.PublicKey, config.Siakg.TotalKeys)
 	for i := 0; i < config.Siakg.TotalKeys; i++ {
 		var err error
-		keys[i].SecretKey, keys[i].PublicKey, err = crypto.GenerateSignatureKeys()
+		keys[i].SecretKey, pubKeys[i], err = crypto.GenerateSignatureKeys()
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -72,7 +72,7 @@ func generateKeys(*cobra.Command, []string) {
 	for i := range keys {
 		uc.PublicKeys = append(uc.PublicKeys, types.SiaPublicKey{
 			Algorithm: types.SignatureEd25519,
-			Key:       string(keys[i].PublicKey[:]),
+			Key:       string(pubKeys[i][:]),
 		})
 	}
 	for i := range keys {

--- a/siakg/keys.go
+++ b/siakg/keys.go
@@ -176,7 +176,8 @@ func siakg(*cobra.Command, []string) {
 		return
 	}
 
-	fmt.Printf("Success, the address for this set of keys is: %x\n", unlockConditions.UnlockHash())
+	fmt.Printf("Keys created for address: %x\n", unlockConditions.UnlockHash())
+	fmt.Printf("%v files have been created. KEEP THESE FILES. To spend money from this address, you will need at least %v of the files.\n", config.Siakg.TotalKeys, config.Siakg.RequiredKeys)
 }
 
 // printKeyInfo opens a keyfile and prints the contents, returning an error if

--- a/siakg/keys_test.go
+++ b/siakg/keys_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules/tester"
+)
+
+// TestGenerateKeys probes the generateKeys function.
+func TestGenerateKeys(t *testing.T) {
+	testDir := tester.TempDir("siakg", "TestGenerateKeys")
+
+	// Try to create an anyone-can-spend set of keys.
+	_, err := generateKeys(0, 0, testDir, "anyoneCanSpend")
+	if err != ErrInsecureAddress {
+		t.Error("Expecting ErrInsecureAddress:", err)
+	}
+	// Try to create an unspendable address.
+	_, err = generateKeys(1, 0, testDir, "unspendable")
+	if err != ErrUnspendableAddress {
+		t.Error("Expecting ErrUnspendableAddress:", err)
+	}
+
+	// Create a legitimate set of keys.
+	_, err = generateKeys(1, 1, testDir, "genuine")
+	if err != nil {
+		t.Error(err)
+	}
+	// Check that the file was created.
+	_, err = os.Stat(filepath.Join(testDir, "genuine_Key0"+FileExtension))
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// TestVerifyKeys proves the verifyKeys function.
+func TestVerifyKeys(t *testing.T) {
+	testDir := tester.TempDir("siakg", "TestVerifyKeys")
+
+	// Create sets of keys that cover all boundaries from 0 of 1 to 5 of 9.
+	// This is to check for errors in the keycheck calculations.
+	for i := 1; i < 5; i++ {
+		for j := i; j < 9; j++ {
+			keyname := "genuine" + strconv.Itoa(i) + strconv.Itoa(j)
+			uc, err := generateKeys(i, j, testDir, keyname)
+			if err != nil {
+				t.Error(err)
+			}
+
+			// Check that the validate under standard conditions.
+			err = verifyKeys(uc, testDir, keyname)
+			if err != nil {
+				t.Error(err)
+			}
+
+			// Provide the wrong keyname to simulate a file does not exist error.
+			err = verifyKeys(uc, testDir, "wrongName")
+			if err == nil {
+				t.Error("Expecting an error")
+			}
+
+			// Corrupt the unlock conditions of the files 1 by 1, and see that each
+			// file is checked for validity.
+			for k := 0; k < j; k++ {
+				// Load, corrupt, and then save the keypair. This corruption
+				// alters the UnlockConditions.
+				var originalKP, badKP KeyPair
+				keyfile := filepath.Join(testDir, keyname+"_Key"+strconv.Itoa(k)+FileExtension)
+				err := encoding.ReadFile(keyfile, &originalKP)
+				if err != nil {
+					t.Fatal(err)
+				}
+				badKP = originalKP
+				badKP.UnlockConditions.PublicKeys = nil
+				err = encoding.WriteFile(keyfile, badKP)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Run verifyKeys with the corrupted file.
+				err = verifyKeys(uc, testDir, keyname)
+				if err == nil {
+					t.Error("Expecting error after corrupting unlock conditions")
+				}
+
+				// Restore the original keyfile.
+				err = encoding.WriteFile(keyfile, originalKP)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Verify that things work again.
+				err = verifyKeys(uc, testDir, keyname)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Corrupt the secret keys of the files 1 by 1, and see that each secret
+			// key is checked for validity.
+			for k := 0; k < j; k++ {
+				// Load, corrupt, and then save the keypair. This corruption
+				// alters the secret key.
+				var originalKP, badKP KeyPair
+				keyfile := filepath.Join(testDir, keyname+"_Key"+strconv.Itoa(k)+FileExtension)
+				err := encoding.ReadFile(keyfile, &originalKP)
+				if err != nil {
+					t.Fatal(err)
+				}
+				badKP = originalKP
+				badKP.SecretKey[0]++
+				err = encoding.WriteFile(keyfile, badKP)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Run verifyKeys with the corrupted file.
+				err = verifyKeys(uc, testDir, keyname)
+				if err == nil {
+					t.Error("Expecting error after corrupting unlock conditions")
+				}
+
+				// Restore the original keyfile.
+				err = encoding.WriteFile(keyfile, originalKP)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Verify that things work again.
+				err = verifyKeys(uc, testDir, keyname)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+	}
+}

--- a/siakg/keys_test.go
+++ b/siakg/keys_test.go
@@ -39,6 +39,10 @@ func TestGenerateKeys(t *testing.T) {
 
 // TestVerifyKeys proves the verifyKeys function.
 func TestVerifyKeys(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	testDir := tester.TempDir("siakg", "TestVerifyKeys")
 
 	// Create sets of keys that cover all boundaries from 0 of 1 to 5 of 9.

--- a/siakg/main.go
+++ b/siakg/main.go
@@ -14,7 +14,7 @@ const (
 	Version       = "1.0"
 	FileExtension = ".siakey"
 
-	DefaultFolder       = "SiafundKeys"
+	DefaultFolder       = ""
 	DefaultKeyname      = "SiafundKeys"
 	DefaultRequiredKeys = 2
 	DefaultTotalKeys    = 3
@@ -37,7 +37,7 @@ type Config struct {
 		TotalKeys    int
 	}
 
-	Address struct {
+	KeyInfo struct {
 		Filename string
 	}
 }
@@ -48,7 +48,7 @@ func main() {
 		Use:   os.Args[0],
 		Short: "Sia Keygen v" + Version,
 		Long:  "Sia Keygen v" + Version,
-		Run:   generateKeys,
+		Run:   siakg,
 	}
 	root.Flags().StringVarP(&config.Siakg.Folder, "folder", "f", DefaultFolder, "The folder where the keys will be created")
 	root.Flags().StringVarP(&config.Siakg.KeyName, "key-name", "n", DefaultKeyname, "The name for this set of keys")
@@ -59,9 +59,9 @@ func main() {
 		Use:   "keyinfo",
 		Short: "Print the address associated with a keyfile.",
 		Long:  "Load a keyfile and print the address that the keyfile is meant to spend on.",
-		Run:   printKey,
+		Run:   keyInfo,
 	}
-	address.Flags().StringVarP(&config.Address.Filename, "filename", "f", "SiafundKeys_Key0"+FileExtension, "Which file is being printed")
+	address.Flags().StringVarP(&config.KeyInfo.Filename, "filename", "f", "SiafundKeys_Key0"+FileExtension, "Which file is being printed")
 	root.AddCommand(address)
 
 	root.Execute()

--- a/siakg/main.go
+++ b/siakg/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	VERSION = "1.0"
+)
+
+var (
+	config Config
+)
+
+type Config struct {
+	Siakg struct {
+		KeyName      string
+		RequiredKeys int
+		TotalKeys    int
+	}
+}
+
+func main() {
+	root := &cobra.Command{
+		Use:   os.Args[0],
+		Short: "Sia Keygen v" + VERSION,
+		Long:  "Sia Keygen v" + VERSION,
+		Run:   generateKeys,
+	}
+
+	root.PersistentFlags().StringVarP(&config.Siakg.KeyName, "key-name", "n", "SiafundKeys", "The name for this set of keys")
+	root.PersistentFlags().IntVarP(&config.Siakg.RequiredKeys, "required-keys", "r", 2, "The number of keys required to use the address")
+	root.PersistentFlags().IntVarP(&config.Siakg.TotalKeys, "total-keys", "t", 3, "The total number of keys that can be used with the address")
+
+	root.Execute()
+}

--- a/siakg/main.go
+++ b/siakg/main.go
@@ -7,13 +7,19 @@ import (
 )
 
 const (
+	// Version of the siakg program.
 	VERSION = "1.0"
 )
 
 var (
+	// A global variable containing all of the configuration information,
+	// necessary for interacting with cobra.
 	config Config
 )
 
+// The Config struct holds all of the configuration variables. The format is
+// made to be compatible with gcfg. gcfg is not currently used in the siakg
+// project, however it helps maintain consistency with the design of siad.
 type Config struct {
 	Siakg struct {
 		KeyName      string
@@ -22,6 +28,7 @@ type Config struct {
 	}
 }
 
+// The main function initializes the cobra command scheme and program flags.
 func main() {
 	root := &cobra.Command{
 		Use:   os.Args[0],

--- a/siakg/main.go
+++ b/siakg/main.go
@@ -1,5 +1,8 @@
 package main
 
+// main.go defines the command structure using the cobra package. This includes
+// configuration variables and flags.
+
 import (
 	"os"
 
@@ -8,7 +11,13 @@ import (
 
 const (
 	// Version of the siakg program.
-	VERSION = "1.0"
+	Version       = "1.0"
+	FileExtension = ".siakey"
+
+	DefaultFolder       = "SiafundKeys"
+	DefaultKeyname      = "SiafundKeys"
+	DefaultRequiredKeys = 2
+	DefaultTotalKeys    = 3
 )
 
 var (
@@ -22,9 +31,14 @@ var (
 // project, however it helps maintain consistency with the design of siad.
 type Config struct {
 	Siakg struct {
+		Folder       string
 		KeyName      string
 		RequiredKeys int
 		TotalKeys    int
+	}
+
+	Address struct {
+		Filename string
 	}
 }
 
@@ -32,14 +46,23 @@ type Config struct {
 func main() {
 	root := &cobra.Command{
 		Use:   os.Args[0],
-		Short: "Sia Keygen v" + VERSION,
-		Long:  "Sia Keygen v" + VERSION,
+		Short: "Sia Keygen v" + Version,
+		Long:  "Sia Keygen v" + Version,
 		Run:   generateKeys,
 	}
+	root.Flags().StringVarP(&config.Siakg.Folder, "folder", "f", DefaultFolder, "The folder where the keys will be created")
+	root.Flags().StringVarP(&config.Siakg.KeyName, "key-name", "n", DefaultKeyname, "The name for this set of keys")
+	root.Flags().IntVarP(&config.Siakg.RequiredKeys, "required-keys", "r", DefaultRequiredKeys, "The number of keys required to use the address")
+	root.Flags().IntVarP(&config.Siakg.TotalKeys, "total-keys", "t", DefaultTotalKeys, "The total number of keys that can be used with the address")
 
-	root.PersistentFlags().StringVarP(&config.Siakg.KeyName, "key-name", "n", "SiafundKeys", "The name for this set of keys")
-	root.PersistentFlags().IntVarP(&config.Siakg.RequiredKeys, "required-keys", "r", 2, "The number of keys required to use the address")
-	root.PersistentFlags().IntVarP(&config.Siakg.TotalKeys, "total-keys", "t", 3, "The total number of keys that can be used with the address")
+	address := &cobra.Command{
+		Use:   "keyinfo",
+		Short: "Print the address associated with a keyfile.",
+		Long:  "Load a keyfile and print the address that the keyfile is meant to spend on.",
+		Run:   printKey,
+	}
+	address.Flags().StringVarP(&config.Address.Filename, "filename", "f", "SiafundKeys_Key0"+FileExtension, "Which file is being printed")
+	root.AddCommand(address)
 
 	root.Execute()
 }

--- a/siakg/main_test.go
+++ b/siakg/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules/tester"
+)
+
+// The tests in this file need to be checked manually, even if errors are
+// returned it will not be apparent to the test suite.
+//
+// CONTRIBUTE: Make these tests automatic.
+
+func TestMain(t *testing.T) {
+	// Get a test folder.
+	testDir := tester.TempDir("siakg", "TestMain")
+
+	// Create a default set of keys. The result should be 'DefaultTotalKeys'
+	// files being created.
+	defaultsDir := filepath.Join(testDir, "defaults")
+	os.Args = []string{
+		"siakg",
+		"-f",
+		defaultsDir,
+	}
+	main()
+
+	// Print out the value for one of those keys, the result should be a key
+	// that is 'DefaultRequiredKeys' of 'DefaultTotalKeys', and the same
+	// address printed by the above call should be printed now.
+	os.Args = []string{
+		"siakg",
+		"keyinfo",
+		"-f",
+		filepath.Join(defaultsDir, DefaultKeyname+"_Key0"+FileExtension),
+	}
+	main()
+
+	// Attempt to create an address with 0 required signatures. zeroRequiredDir
+	// should not be created because of an error.
+	zeroRequiredDir := filepath.Join(testDir, "zeroRequired")
+	os.Args = []string{
+		"siakg",
+		"-f",
+		zeroRequiredDir,
+		"-r",
+		"0",
+	}
+	main()
+
+	// Attempt to create an unspendable address. unspendableDir should not be
+	// created because of an error.
+	unspendableDir := filepath.Join(testDir, "zeroRequired")
+	os.Args = []string{
+		"siakg",
+		"-f",
+		unspendableDir,
+		"-t",
+		"1",
+	}
+	main()
+
+	// Attempt read a nonexistant file. The output should be a nonexistant file
+	// error.
+	os.Args = []string{
+		"siakg",
+		"keyinfo",
+		"-f",
+		"idontexist",
+	}
+	main()
+
+	// Attempt to read a corrupted file. The output should be something
+	// indicating corruption.
+	os.Args = []string{
+		"siakg",
+		"keyinfo",
+		"-f",
+		"main.go",
+	}
+	main()
+}

--- a/siakg/main_test.go
+++ b/siakg/main_test.go
@@ -10,8 +10,6 @@ import (
 
 // The tests in this file need to be checked manually, even if errors are
 // returned it will not be apparent to the test suite.
-//
-// CONTRIBUTE: Make these tests automatic.
 
 func TestMain(t *testing.T) {
 	// Get a test folder.
@@ -38,47 +36,23 @@ func TestMain(t *testing.T) {
 	}
 	main()
 
-	// Attempt to create an address with 0 required signatures. zeroRequiredDir
-	// should not be created because of an error.
-	zeroRequiredDir := filepath.Join(testDir, "zeroRequired")
+	// Try to create a set of keys that are invalid. An error should be printed.
+	errDir := filepath.Join(testDir, "err")
 	os.Args = []string{
 		"siakg",
 		"-f",
-		zeroRequiredDir,
-		"-r",
+		errDir,
+		"-t",
 		"0",
 	}
 	main()
 
-	// Attempt to create an unspendable address. unspendableDir should not be
-	// created because of an error.
-	unspendableDir := filepath.Join(testDir, "zeroRequired")
-	os.Args = []string{
-		"siakg",
-		"-f",
-		unspendableDir,
-		"-t",
-		"1",
-	}
-	main()
-
-	// Attempt read a nonexistant file. The output should be a nonexistant file
-	// error.
+	// Print the key info for keys that don't exist.
 	os.Args = []string{
 		"siakg",
 		"keyinfo",
 		"-f",
-		"idontexist",
-	}
-	main()
-
-	// Attempt to read a corrupted file. The output should be something
-	// indicating corruption.
-	os.Args = []string{
-		"siakg",
-		"keyinfo",
-		"-f",
-		"main.go",
+		"notExist",
 	}
 	main()
 }

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -23,6 +23,7 @@ var (
 
 	ErrEntropyKey                = errors.New("transaction tries to sign an entproy public key")
 	ErrFrivilousSignature        = errors.New("transaction contains a frivilous siganture")
+	ErrInvalidPubKeyIndex        = errors.New("transaction contains a signature that points to a nonexistent public key")
 	ErrMissingSignatures         = errors.New("transaction has inputs with missing signatures")
 	ErrPrematureSignature        = errors.New("timelock on signature has not expired")
 	ErrPublicKeyOveruse          = errors.New("public key was used multiple times while signing transaction")

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -57,7 +57,7 @@ type (
 		SiafundOutputs           []uint64
 		MinerFees                []uint64
 		ArbitraryData            []uint64
-		Signatures               []uint64
+		TransactionSignatures    []uint64
 	}
 
 	// A SiaPublicKey is a public key prefixed by a Specifier. The Specifier
@@ -96,17 +96,17 @@ type (
 	// must have a height >= 'Timelock'.
 	//
 	// 'PublicKeys' specifies the set of keys that can be used to satisfy the
-	// UnlockConditions; of these, at least 'NumSignatures' unique keys must sign
+	// UnlockConditions; of these, at least 'RequiredSignatures' unique keys must sign
 	// the transaction. The keys that do not need to use the same cryptographic
 	// algorithm.
 	//
-	// If 'NumSignatures' == 0, the UnlockConditions are effectively "anyone can
-	// unlock." If 'NumSignatures' > len('PublicKeys'), then the UnlockConditions
+	// If 'RequiredSignatures' == 0, the UnlockConditions are effectively "anyone can
+	// unlock." If 'RequiredSignatures' > len('PublicKeys'), then the UnlockConditions
 	// cannot be fulfilled under any circumstances.
 	UnlockConditions struct {
-		Timelock      BlockHeight
-		PublicKeys    []SiaPublicKey
-		NumSignatures uint64
+		Timelock           BlockHeight
+		PublicKeys         []SiaPublicKey
+		RequiredSignatures uint64
 	}
 
 	// Each input has a list of public keys and a required number of signatures.
@@ -124,7 +124,7 @@ type (
 // UnlockConditions object. The leaves of this tree are formed by taking the
 // hash of the timelock, the hash of the public keys (one leaf each), and the
 // hash of the number of signatures. The keys are put in the middle because
-// Timelock and NumSignatures are both low entropy fields; they can be
+// Timelock and RequiredSignatures are both low entropy fields; they can be
 // protected by having random public keys next to them.
 func (uc UnlockConditions) UnlockHash() UnlockHash {
 	tree := crypto.NewTree()
@@ -132,14 +132,14 @@ func (uc UnlockConditions) UnlockHash() UnlockHash {
 	for i := range uc.PublicKeys {
 		tree.PushObject(uc.PublicKeys[i])
 	}
-	tree.PushObject(uc.NumSignatures)
+	tree.PushObject(uc.RequiredSignatures)
 	return UnlockHash(tree.Root())
 }
 
 // SigHash returns the hash of the fields in a transaction covered by a given
 // signature. See CoveredFields for more details.
 func (t Transaction) SigHash(i int) crypto.Hash {
-	cf := t.Signatures[i].CoveredFields
+	cf := t.TransactionSignatures[i].CoveredFields
 	var signedData []byte
 	if cf.WholeTransaction {
 		signedData = encoding.MarshalAll(
@@ -152,9 +152,9 @@ func (t Transaction) SigHash(i int) crypto.Hash {
 			t.SiafundOutputs,
 			t.MinerFees,
 			t.ArbitraryData,
-			t.Signatures[i].ParentID,
-			t.Signatures[i].PublicKeyIndex,
-			t.Signatures[i].Timelock,
+			t.TransactionSignatures[i].ParentID,
+			t.TransactionSignatures[i].PublicKeyIndex,
+			t.TransactionSignatures[i].Timelock,
 		)
 	} else {
 		for _, input := range cf.SiacoinInputs {
@@ -186,8 +186,8 @@ func (t Transaction) SigHash(i int) crypto.Hash {
 		}
 	}
 
-	for _, sig := range cf.Signatures {
-		signedData = append(signedData, encoding.Marshal(t.Signatures[sig])...)
+	for _, sig := range cf.TransactionSignatures {
+		signedData = append(signedData, encoding.Marshal(t.TransactionSignatures[sig])...)
 	}
 
 	return crypto.HashBytes(signedData)
@@ -218,7 +218,7 @@ func sortedUnique(elems []uint64, max int) bool {
 // true, all fields except for 'Signatures' must be empty. All fields must be
 // sorted numerically, and there can be no repeats.
 func (t Transaction) validCoveredFields() error {
-	for _, sig := range t.Signatures {
+	for _, sig := range t.TransactionSignatures {
 		// convenience variables
 		cf := sig.CoveredFields
 		fieldMaxs := []struct {
@@ -234,7 +234,7 @@ func (t Transaction) validCoveredFields() error {
 			{cf.SiafundOutputs, len(t.SiafundOutputs)},
 			{cf.MinerFees, len(t.MinerFees)},
 			{cf.ArbitraryData, len(t.ArbitraryData)},
-			{cf.Signatures, len(t.Signatures)},
+			{cf.TransactionSignatures, len(t.TransactionSignatures)},
 		}
 
 		// Check that all fields are empty if 'WholeTransaction' is set, except
@@ -282,7 +282,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 		}
 
 		sigMap[id] = &inputSignatures{
-			remainingSignatures: input.UnlockConditions.NumSignatures,
+			remainingSignatures: input.UnlockConditions.RequiredSignatures,
 			possibleKeys:        input.UnlockConditions.PublicKeys,
 			usedKeys:            make(map[uint64]struct{}),
 			index:               i,
@@ -296,7 +296,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 		}
 
 		sigMap[id] = &inputSignatures{
-			remainingSignatures: termination.TerminationConditions.NumSignatures,
+			remainingSignatures: termination.TerminationConditions.RequiredSignatures,
 			possibleKeys:        termination.TerminationConditions.PublicKeys,
 			usedKeys:            make(map[uint64]struct{}),
 			index:               i,
@@ -310,7 +310,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 		}
 
 		sigMap[id] = &inputSignatures{
-			remainingSignatures: input.UnlockConditions.NumSignatures,
+			remainingSignatures: input.UnlockConditions.RequiredSignatures,
 			possibleKeys:        input.UnlockConditions.PublicKeys,
 			usedKeys:            make(map[uint64]struct{}),
 			index:               i,
@@ -318,7 +318,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 	}
 
 	// Check all of the signatures for validity.
-	for i, sig := range t.Signatures {
+	for i, sig := range t.TransactionSignatures {
 		// check that sig corresponds to an entry in sigMap
 		inSig, exists := sigMap[crypto.Hash(sig.ParentID)]
 		if !exists || inSig.remainingSignatures == 0 {

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -96,17 +96,17 @@ type (
 	// must have a height >= 'Timelock'.
 	//
 	// 'PublicKeys' specifies the set of keys that can be used to satisfy the
-	// UnlockConditions; of these, at least 'RequiredSignatures' unique keys must sign
+	// UnlockConditions; of these, at least 'SignaturesRequired' unique keys must sign
 	// the transaction. The keys that do not need to use the same cryptographic
 	// algorithm.
 	//
-	// If 'RequiredSignatures' == 0, the UnlockConditions are effectively "anyone can
-	// unlock." If 'RequiredSignatures' > len('PublicKeys'), then the UnlockConditions
+	// If 'SignaturesRequired' == 0, the UnlockConditions are effectively "anyone can
+	// unlock." If 'SignaturesRequired' > len('PublicKeys'), then the UnlockConditions
 	// cannot be fulfilled under any circumstances.
 	UnlockConditions struct {
 		Timelock           BlockHeight
 		PublicKeys         []SiaPublicKey
-		RequiredSignatures uint64
+		SignaturesRequired uint64
 	}
 
 	// Each input has a list of public keys and a required number of signatures.
@@ -124,7 +124,7 @@ type (
 // UnlockConditions object. The leaves of this tree are formed by taking the
 // hash of the timelock, the hash of the public keys (one leaf each), and the
 // hash of the number of signatures. The keys are put in the middle because
-// Timelock and RequiredSignatures are both low entropy fields; they can be
+// Timelock and SignaturesRequired are both low entropy fields; they can be
 // protected by having random public keys next to them.
 func (uc UnlockConditions) UnlockHash() UnlockHash {
 	tree := crypto.NewTree()
@@ -132,7 +132,7 @@ func (uc UnlockConditions) UnlockHash() UnlockHash {
 	for i := range uc.PublicKeys {
 		tree.PushObject(uc.PublicKeys[i])
 	}
-	tree.PushObject(uc.RequiredSignatures)
+	tree.PushObject(uc.SignaturesRequired)
 	return UnlockHash(tree.Root())
 }
 
@@ -282,7 +282,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 		}
 
 		sigMap[id] = &inputSignatures{
-			remainingSignatures: input.UnlockConditions.RequiredSignatures,
+			remainingSignatures: input.UnlockConditions.SignaturesRequired,
 			possibleKeys:        input.UnlockConditions.PublicKeys,
 			usedKeys:            make(map[uint64]struct{}),
 			index:               i,
@@ -296,7 +296,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 		}
 
 		sigMap[id] = &inputSignatures{
-			remainingSignatures: termination.TerminationConditions.RequiredSignatures,
+			remainingSignatures: termination.TerminationConditions.SignaturesRequired,
 			possibleKeys:        termination.TerminationConditions.PublicKeys,
 			usedKeys:            make(map[uint64]struct{}),
 			index:               i,
@@ -310,7 +310,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 		}
 
 		sigMap[id] = &inputSignatures{
-			remainingSignatures: input.UnlockConditions.RequiredSignatures,
+			remainingSignatures: input.UnlockConditions.SignaturesRequired,
 			possibleKeys:        input.UnlockConditions.PublicKeys,
 			usedKeys:            make(map[uint64]struct{}),
 			index:               i,
@@ -319,15 +319,19 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 
 	// Check all of the signatures for validity.
 	for i, sig := range t.TransactionSignatures {
-		// check that sig corresponds to an entry in sigMap
+		// Check that sig corresponds to an entry in sigMap.
 		inSig, exists := sigMap[crypto.Hash(sig.ParentID)]
 		if !exists || inSig.remainingSignatures == 0 {
 			return ErrFrivilousSignature
 		}
-		// check that sig's key hasn't already been used
+		// Check that sig's key hasn't already been used.
 		_, exists = inSig.usedKeys[sig.PublicKeyIndex]
 		if exists {
 			return ErrPublicKeyOveruse
+		}
+		// Check that the public key index refers to an existing public key.
+		if sig.PublicKeyIndex >= uint64(len(inSig.possibleKeys)) {
+			return ErrInvalidPubKeyIndex
 		}
 		// Check that the timelock has expired.
 		if sig.Timelock > currentHeight {

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -16,7 +16,7 @@ func TestUnlockHash(t *testing.T) {
 				Key:       "fake key",
 			},
 		},
-		RequiredSignatures: 3,
+		SignaturesRequired: 3,
 	}
 
 	_ = uc.UnlockHash()
@@ -184,7 +184,7 @@ func TestTransactionValidSignatures(t *testing.T) {
 				Algorithm: SignatureEntropy,
 			},
 		},
-		RequiredSignatures: 2,
+		SignaturesRequired: 2,
 	}
 
 	// Create a transaction with each type of spendable output.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -57,7 +57,7 @@ type (
 		SiafundOutputs           []SiafundOutput
 		MinerFees                []Currency
 		ArbitraryData            []string
-		Signatures               []TransactionSignature
+		TransactionSignatures    []TransactionSignature
 	}
 
 	// A SiacoinInput consumes a SiacoinOutput and adds the siacoins to the set of

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -418,10 +418,10 @@ func TestTransactionStandaloneValid(t *testing.T) {
 	txn.SiacoinInputs = nil
 
 	// Violate validSignatures
-	txn.Signatures = []TransactionSignature{TransactionSignature{}}
+	txn.TransactionSignatures = []TransactionSignature{TransactionSignature{}}
 	err = txn.StandaloneValid(0)
 	if err == nil {
 		t.Error("failed to trigger validSignatures error")
 	}
-	txn.Signatures = nil
+	txn.TransactionSignatures = nil
 }


### PR DESCRIPTION
This adds a cli tool for generating multisig keys and addresses. While there is no way to spend the results, support for that will be added before launch. At least this way people can get their keys.

The files created are a simple struct:
```go
type KeyPair struct {
    Header string
    Version string
    Index int
    SecretKey crypto.SecretKey
    UnlockConditions types.UnlockConditions
}
```

The header is for identifying the file without knowing the extension. The version is in case we need to change anything. Then there's an index, which allows you to find the public key associated with your secret key. Finally there's the unlock conditions, which is required for spending an address.

The keys generated can be used for siacoins or siafunds, but are mostly intended for helping people spend siafunds.