### PR TITLE
switch from cbc to gcm

### DIFF
--- a/crypto/encrypt.go
+++ b/crypto/encrypt.go
@@ -47,7 +47,7 @@ func (key TwofishKey) EncryptBytes(plaintext []byte) (ct Ciphertext, err error) 
 
 	// Encrypt the data. No authenticated data is provided, as EncryptBytes is
 	// meant for file encryption.
-	ct = append(nonce, aead.Seal(nil, nonce, plaintext, nil)...)
+	ct = aead.Seal(nonce, nonce, plaintext, nil)
 	return ct, nil
 }
 

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -5,8 +5,6 @@ import (
 	"compress/gzip"
 	"crypto/rand"
 	"testing"
-
-	"golang.org/x/crypto/twofish"
 )
 
 // TestTwofishEncryption checks that encryption and decryption works correctly.
@@ -17,24 +15,35 @@ func TestTwofishEncryption(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Encrypt the zero plaintext.
-	plaintext := make([]byte, 128)
+	// Encrypt and decrypt a zero plaintext, and compare the decrypted to the
+	// original.
+	plaintext := make([]byte, 600)
+	ciphertext, err := key.EncryptBytes(plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decryptedPlaintext, err := key.DecryptBytes(ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(plaintext, decryptedPlaintext) != 0 {
+		t.Fatal("Encrypted and decrypted zero plaintext do not match")
+	}
+
+	// Try again with a nonzero plaintext.
+	plaintext = make([]byte, 600)
 	_, err = rand.Read(plaintext)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ciphertext, iv, padding, err := key.EncryptBytes(plaintext)
+	ciphertext, err = key.EncryptBytes(plaintext)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Get the decrypted plaintext.
-	decryptedPlaintext, err := key.DecryptBytes(ciphertext, iv, padding)
+	decryptedPlaintext, err = key.DecryptBytes(ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Compare the original to the decrypted.
 	if bytes.Compare(plaintext, decryptedPlaintext) != 0 {
 		t.Fatal("Encrypted and decrypted zero plaintext do not match")
 	}
@@ -44,69 +53,45 @@ func TestTwofishEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	badtext, err := key2.DecryptBytes(ciphertext, iv, padding)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare(plaintext, badtext) == 0 {
-		t.Fatal("When using the wrong key, plaintext was still decrypted!")
+	_, err = key2.DecryptBytes(ciphertext)
+	if err == nil {
+		t.Fatal("Expecting failed authentication err", err)
 	}
 
-	// Try to decrypt using a different iv.
-	badIV := iv
-	badIV[0]++
-	badtext, err = key.DecryptBytes(ciphertext, badIV, padding)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare(plaintext, badtext) == 0 {
-		t.Fatal("When using the wrong key, plaintext was still decrypted!")
-	}
-
-	// Try to decrypt using incorrectly sized ivs, ciphertext, and padding.
-	_, err = key.DecryptBytes(ciphertext, iv[1:], padding)
+	// Try to decrypt using bad ciphertexts.
+	ciphertext[0]++
+	_, err = key.DecryptBytes(ciphertext)
 	if err == nil {
-		t.Fatal("Was able to decrypt with a bad iv.")
+		t.Fatal("Expecting failed authentication err", err)
 	}
-	_, err = key.DecryptBytes(ciphertext[1:], iv, padding)
-	if err == nil {
-		t.Fatal("Was able to decrypt with a bad ciphertext")
-	}
-	_, err = key.DecryptBytes(ciphertext, iv, 1+len(ciphertext))
-	if err == nil {
-		t.Fatal("Was able to decrypt using bad padding")
-	}
-	_, err = key.DecryptBytes(ciphertext, iv, -1)
-	if err == nil {
-		t.Fatal("Was able to decrypt using bad padding")
+	_, err = key.DecryptBytes(ciphertext[:10])
+	if err != ErrInsufficientLen {
+		t.Error("Expecting ErrInsufficientLen:", err)
 	}
 
 	// Try to trigger a panic with nil values.
 	key.EncryptBytes(nil)
-	key.DecryptBytes(nil, iv, padding)
-	key.DecryptBytes(ciphertext, nil, padding)
+	key.DecryptBytes(nil)
 
 }
 
 // TestTwofishEntropy encrypts and then decrypts a zero plaintext, checking
-// that the ciphertext is high entropy. This is simply to check for obvious
-// mistakes and not to guarantee security of the ciphertext.
+// that the ciphertext is high entropy.
 func TestTwofishEntropy(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
 
 	// Encrypt a larger zero plaintext and make sure that the outcome is high
-	// entropy. We measure entropy by seeing how much gzip can compress the
-	// ciphertext. 10 * 1000 bytes was chosen because gzip overhead will exceed
-	// compression rate for smaller files, even low entropy files.
-	cipherSize := int(10e3) // default is a float? - caused an error in `make([]byte, cipherSize)`
+	// entropy. Entropy is measured by compressing the ciphertext with gzip.
+	// 10 * 1000 bytes was chosen to minimize the impact of gzip overhead.
+	cipherSize := int(10e3)
 	key, err := GenerateTwofishKey()
 	if err != nil {
 		t.Fatal(err)
 	}
 	plaintext := make([]byte, cipherSize)
-	ciphertext, _, _, err := key.EncryptBytes(plaintext)
+	ciphertext, err := key.EncryptBytes(plaintext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,35 +103,5 @@ func TestTwofishEntropy(t *testing.T) {
 	zip.Close()
 	if b.Len() < cipherSize {
 		t.Error("supposedly high entropy ciphertext has been compressed!")
-	}
-}
-
-// TestTwofishPadding encrypts and decrypts a byte slice that invokes every
-// possible padding length.
-func TestTwofishPadding(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-
-	// Encrypt and decrypt for all of the potential padded values and see that
-	// padding is handled correctly.
-	for i := 256; i < 256+twofish.BlockSize; i++ {
-		key, err := GenerateTwofishKey()
-		if err != nil {
-			t.Fatal(err)
-		}
-		plaintext := make([]byte, i)
-		rand.Read(plaintext)
-		ciphertext, iv, padding, err := key.EncryptBytes(plaintext)
-		if err != nil {
-			t.Fatal(err)
-		}
-		decryptedPlaintext, err := key.DecryptBytes(ciphertext, iv, padding)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if bytes.Compare(plaintext, decryptedPlaintext) != 0 {
-			t.Fatal("Encrypted and decrypted zero plaintext do not match for i = ", i)
-		}
 	}
 }


### PR DESCRIPTION
I also changed the way nonces and padding works. Padding is taken care of automatically by the AEAD interface from what I can tell. The nonce now gets prepended to the ciphertext. To create type safety, I made a new type 'Ciphertext'. (Since a ciphertext is not just a byte slice, it's a byte slice with a specific format, IE a nonce prepended at the beginning).

I was going to include functions for readers and writers but I actually wanted to work more on the renter first before doing that. One concern is that if we're encrypting a 1TB file, we have to find someway to encrypt it and then upload it. I'm not sure what the best design there is but I want to make sure we're not using the disk too much.