### PR TITLE
Contract revisions

### DIFF
--- a/modules/consensus/applytransaction.go
+++ b/modules/consensus/applytransaction.go
@@ -101,8 +101,8 @@ func (s *State) applyFileContractRevisions(bn *blockNode, t types.Transaction) {
 		nfc := types.FileContract{
 			FileSize:           fcr.NewFileSize,
 			FileMerkleRoot:     fcr.NewFileMerkleRoot,
-			Start:              fcr.NewStart,
-			Expiration:         fcr.NewExpiration,
+			WindowStart:        fcr.NewWindowStart,
+			WindowEnd:          fcr.NewWindowEnd,
 			Payout:             fc.Payout,
 			ValidProofOutputs:  fcr.NewValidProofOutputs,
 			MissedProofOutputs: fcr.NewMissedProofOutputs,

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -60,7 +60,7 @@ func (ct *ConsensusTester) testApplyStorageProof() {
 	}
 
 	// Mine blocks until the file contract is active.
-	for ct.Height() < fcTxn.FileContracts[0].Start {
+	for ct.Height() < fcTxn.FileContracts[0].WindowStart {
 		block := ct.MineCurrentBlock(nil)
 		err := ct.AcceptBlock(block)
 		if err != nil {

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -86,7 +86,7 @@ func (ct *ConsensusTester) testApplyStorageProof() {
 	block = ct.MineCurrentBlock([]types.Transaction{proofTxn})
 	err = ct.AcceptBlock(block)
 	if err != nil {
-		ct.Fatal(err)
+		ct.Fatal(err) // TODO: Occasionally fails, not sure why.
 	}
 
 	// Check that the file contract was deleted from the consensus set, and

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -104,7 +104,7 @@ func (s *State) applyContractMaintenance(bn *blockNode) {
 	currentHeight := s.height()
 	var expiredFileContracts []types.FileContractID
 	for id, fc := range s.fileContracts {
-		if fc.Expiration == currentHeight {
+		if fc.WindowEnd == currentHeight {
 			expiredFileContracts = append(expiredFileContracts, id)
 		}
 	}

--- a/modules/consensus/testtransactions.go
+++ b/modules/consensus/testtransactions.go
@@ -101,9 +101,9 @@ func (ct *ConsensusTester) FileContractTransaction(start types.BlockHeight, expi
 	txn.FileContracts = append(txn.FileContracts, types.FileContract{
 		FileSize:       4e3,
 		FileMerkleRoot: mRoot,
-		Start:          start,
+		WindowStart:    start,
 		Payout:         value,
-		Expiration:     expiration,
+		WindowEnd:      expiration,
 		MissedProofOutputs: []types.SiacoinOutput{
 			types.SiacoinOutput{
 				Value: value,

--- a/modules/consensus/testtransactions.go
+++ b/modules/consensus/testtransactions.go
@@ -109,7 +109,7 @@ func (ct *ConsensusTester) FileContractTransaction(start types.BlockHeight, expi
 				Value: value,
 			},
 		},
-		TerminationHash: ct.UnlockHash,
+		UnlockHash: ct.UnlockHash,
 	})
 	txn.FileContracts[0].ValidProofOutputs = []types.SiacoinOutput{types.SiacoinOutput{Value: value.Sub(txn.FileContracts[0].Tax())}}
 

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -49,7 +49,7 @@ func (s *State) storageProofSegment(fcid types.FileContractID) (index uint64, er
 	}
 
 	// Get the ID of the trigger block.
-	triggerHeight := fc.Start - 1
+	triggerHeight := fc.WindowStart - 1
 	if triggerHeight > s.height() {
 		err = errors.New("no block found at contract trigger block height")
 		return
@@ -111,10 +111,10 @@ func (s *State) validFileContractRevisions(t types.Transaction) (err error) {
 			return ErrMissingFileContract
 		}
 
-		// Check that the height is less than fc.Start - revisions are not
-		// allowed to be submitted once the storage proof window has opened.
-		// This reduces complexity for unconfirmed transactions.
-		if s.height() > fc.Start {
+		// Check that the height is less than fc.WindowStart - revisions are
+		// not allowed to be submitted once the storage proof window has
+		// opened.  This reduces complexity for unconfirmed transactions.
+		if s.height() > fc.WindowStart {
 			return errors.New("contract revision submitted too late")
 		}
 

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -101,37 +101,45 @@ func (s *State) validStorageProofs(t types.Transaction) error {
 	return nil
 }
 
-// validFileContractTerminations checks that each file contract termination is
-// valid in the context of the current consensus set.
-func (s *State) validFileContractTerminations(t types.Transaction) (err error) {
-	for _, fct := range t.FileContractTerminations {
-		// Check that the FileContractTermination terminates an existing
-		// FileContract.
-		fc, exists := s.fileContracts[fct.ParentID]
+// validFileContractRevision checks that each file contract revision is valid
+// in the context of the current consensus set.
+func (s *State) validFileContractRevisions(t types.Transaction) (err error) {
+	for _, fcr := range t.FileContractRevisions {
+		// Check that the revision revises an existing contract.
+		fc, exists := s.fileContracts[fcr.ParentID]
 		if !exists {
 			return ErrMissingFileContract
 		}
 
-		// Check that the height is less than fc.Start - terminations are not
+		// Check that the height is less than fc.Start - revisions are not
 		// allowed to be submitted once the storage proof window has opened.
 		// This reduces complexity for unconfirmed transactions.
-		if fc.Start < s.height() {
-			return errors.New("contract termination submitted too late")
+		if s.height() > fc.Start {
+			return errors.New("contract revision submitted too late")
+		}
+
+		// Check that the revision number of the revision is greater than the
+		// revision number of the existing file contract.
+		if fc.RevisionNumber >= fcr.NewRevisionNumber {
+			return errors.New("contract revision has an outdated revision number")
 		}
 
 		// Check that the unlock conditions match the unlock hash.
-		if fct.TerminationConditions.UnlockHash() != fc.TerminationHash {
-			return errors.New("termination conditions don't match required termination hash")
+		if fcr.UnlockConditions.UnlockHash() != fc.UnlockHash {
+			return errors.New("unlock conditions don't match unlock hash")
 		}
 
-		// Check that the payouts in the termination add up to the payout of the
-		// contract.
-		var payoutSum types.Currency
-		for _, payout := range fct.Payouts {
-			payoutSum = payoutSum.Add(payout.Value)
+		// Check that the payout of the revision matches the payout of the
+		// original.
+		//
+		// txn.StandaloneValid checks for the validity of the
+		// ValidProofOutputs.
+		var payout types.Currency
+		for _, output := range fcr.NewMissedProofOutputs {
+			payout = payout.Add(output.Value)
 		}
-		if payoutSum.Cmp(fc.Payout) != 0 {
-			return errors.New("contract termination has incorrect payouts")
+		if payout.Cmp(fc.Payout) != 0 {
+			return errors.New("contract revision has incorrect payouts")
 		}
 	}
 
@@ -182,7 +190,7 @@ func (s *State) validTransaction(t types.Transaction) (err error) {
 	if err != nil {
 		return
 	}
-	err = s.validFileContractTerminations(t)
+	err = s.validFileContractRevisions(t)
 	if err != nil {
 		return
 	}

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -101,10 +101,10 @@ func verifyTransaction(txn types.Transaction, terms modules.ContractTerms, merkl
 	case fc.FileMerkleRoot != merkleRoot:
 		return errors.New("bad file contract Merkle root")
 
-	case fc.Start != terms.DurationStart+terms.Duration:
+	case fc.WindowStart != terms.DurationStart+terms.Duration:
 		return errors.New("bad file contract start height")
 
-	case fc.Expiration != terms.DurationStart+terms.Duration+terms.WindowSize:
+	case fc.WindowEnd != terms.DurationStart+terms.Duration+terms.WindowSize:
 		return errors.New("bad file contract expiration")
 
 	case fc.Payout.Cmp(expectedPayout) != 0:
@@ -266,7 +266,7 @@ func (h *Host) NegotiateContract(conn modules.NetConn) (err error) {
 	// Add this contract to the host's list of obligations.
 	fcid := signedTxn.FileContractID(0)
 	fc := signedTxn.FileContracts[0]
-	proofHeight := fc.Expiration + StorageProofReorgDepth
+	proofHeight := fc.WindowEnd + StorageProofReorgDepth
 	co := contractObligation{
 		ID:           fcid,
 		FileContract: fc,

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -122,7 +122,7 @@ func verifyTransaction(txn types.Transaction, terms modules.ContractTerms, merkl
 	case fc.MissedProofOutputs[0].UnlockHash != terms.MissedProofOutputs[0].UnlockHash:
 		return errors.New("bad file contract missed proof outputs")
 
-	case fc.TerminationHash != types.ZeroUnlockHash:
+	case fc.UnlockHash != types.ZeroUnlockHash:
 		return errors.New("bad file contract termination hash")
 	}
 	return nil

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -40,7 +40,7 @@ func (h *Host) load() error {
 	h.HostSettings = sHost.HostSettings
 	// recreate maps
 	for _, obligation := range sHost.Obligations {
-		height := obligation.FileContract.Start + StorageProofReorgDepth
+		height := obligation.FileContract.WindowStart + StorageProofReorgDepth
 		h.obligationsByHeight[height] = append(h.obligationsByHeight[height], obligation)
 		h.obligationsByID[obligation.ID] = obligation
 	}

--- a/modules/host/update_test.go
+++ b/modules/host/update_test.go
@@ -39,8 +39,8 @@ func (ht *HostTester) testObligation() {
 	fc := types.FileContract{
 		FileSize:       filesize,
 		FileMerkleRoot: merkleRoot,
-		Start:          ht.State.Height() + 2,
-		Expiration:     ht.State.Height() + 3,
+		WindowStart:    ht.State.Height() + 2,
+		WindowEnd:      ht.State.Height() + 3,
 		Payout:         value,
 		ValidProofOutputs: []types.SiacoinOutput{
 			types.SiacoinOutput{Value: value, UnlockHash: ht.Host.UnlockHash},

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -35,8 +35,8 @@ func (r *Renter) createContractTransaction(terms modules.ContractTerms, merkleRo
 	contract := types.FileContract{
 		FileMerkleRoot:     merkleRoot,
 		FileSize:           terms.FileSize,
-		Start:              terms.DurationStart + terms.Duration,
-		Expiration:         terms.DurationStart + terms.Duration + terms.WindowSize,
+		WindowStart:        terms.DurationStart + terms.Duration,
+		WindowEnd:          terms.DurationStart + terms.Duration + terms.WindowSize,
 		Payout:             payout,
 		ValidProofOutputs:  terms.ValidProofOutputs,
 		MissedProofOutputs: terms.MissedProofOutputs,

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -105,8 +105,8 @@ func (tp *TransactionPool) applyFileContractRevisions(t types.Transaction) {
 		nfc := types.FileContract{
 			FileSize:           fcr.NewFileSize,
 			FileMerkleRoot:     fcr.NewFileMerkleRoot,
-			Start:              fcr.NewStart,
-			Expiration:         fcr.NewExpiration,
+			WindowStart:        fcr.NewWindowStart,
+			WindowEnd:          fcr.NewWindowEnd,
 			Payout:             fc.Payout,
 			ValidProofOutputs:  fcr.NewValidProofOutputs,
 			MissedProofOutputs: fcr.NewMissedProofOutputs,

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -78,27 +78,42 @@ func (tp *TransactionPool) applyFileContracts(t types.Transaction) {
 	}
 }
 
-// applyFileContractTerminations incorporates all of the file contract
-// terminations of a transaction into the unconfirmed set.
-func (tp *TransactionPool) applyFileContractTerminations(t types.Transaction) {
-	// For each file contract termination, delete the corresponding file
-	// contract from the unconfirmed set and add it to the reference set.
-	for _, fct := range t.FileContractTerminations {
+// applyFileContractRevisions incorporates all of the file contract revisions
+// of a transaction into the unconfirmed set.
+func (tp *TransactionPool) applyFileContractRevisions(t types.Transaction) {
+	for _, fcr := range t.FileContractRevisions {
 		// Sanity check - file contract should be in the unconfirmed set and
 		// absent from the reference set.
-		fc, exists := tp.fileContracts[fct.ParentID]
+		revisionID := crypto.HashAll(fcr.ParentID, fcr.NewRevisionNumber)
+		fc, exists := tp.fileContracts[fcr.ParentID]
 		if build.DEBUG {
 			if !exists {
 				panic("could not find file contract")
 			}
-			_, exists = tp.referenceFileContracts[fct.ParentID]
+			_, exists = tp.referenceFileContractRevisions[revisionID]
 			if exists {
 				panic("reference contract already exists")
 			}
 		}
 
-		delete(tp.fileContracts, fct.ParentID)
-		tp.referenceFileContracts[fct.ParentID] = fc
+		// Delete the old file contract from the unconfirmed set and add it to
+		// the reference set.
+		delete(tp.fileContracts, fcr.ParentID)
+		tp.referenceFileContractRevisions[revisionID] = fc
+
+		// Add the new file contract to the reference set.
+		nfc := types.FileContract{
+			FileSize:           fcr.NewFileSize,
+			FileMerkleRoot:     fcr.NewFileMerkleRoot,
+			Start:              fcr.NewStart,
+			Expiration:         fcr.NewExpiration,
+			Payout:             fc.Payout,
+			ValidProofOutputs:  fcr.NewValidProofOutputs,
+			MissedProofOutputs: fcr.NewMissedProofOutputs,
+			UnlockHash:         fcr.NewUnlockHash,
+			RevisionNumber:     fcr.NewRevisionNumber,
+		}
+		tp.fileContracts[fcr.ParentID] = nfc
 	}
 }
 
@@ -176,7 +191,7 @@ func (tp *TransactionPool) addTransactionToPool(t types.Transaction) {
 	tp.applySiacoinInputs(t)
 	tp.applySiacoinOutputs(t)
 	tp.applyFileContracts(t)
-	tp.applyFileContractTerminations(t)
+	tp.applyFileContractRevisions(t)
 	tp.applyStorageProofs(t)
 	tp.applySiafundInputs(t)
 	tp.applySiafundOutputs(t)

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -67,8 +67,8 @@ func (tp *TransactionPool) IsStandardTransaction(t types.Transaction) (err error
 			return
 		}
 	}
-	for _, fct := range t.FileContractTerminations {
-		err = tp.checkUnlockConditions(fct.TerminationConditions)
+	for _, fcr := range t.FileContractRevisions {
+		err = tp.checkUnlockConditions(fcr.UnlockConditions)
 		if err != nil {
 			return
 		}

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -71,9 +71,10 @@ type TransactionPool struct {
 	// The reference set contains any objects that are not in the unconfirmed
 	// set, but may still need to be referenced when creating diffs or
 	// reverting unconfirmed transactions (due to conflicts).
-	referenceSiacoinOutputs map[types.SiacoinOutputID]types.SiacoinOutput
-	referenceFileContracts  map[types.FileContractID]types.FileContract
-	referenceSiafundOutputs map[types.SiafundOutputID]types.SiafundOutput
+	referenceSiacoinOutputs        map[types.SiacoinOutputID]types.SiacoinOutput
+	referenceFileContracts         map[types.FileContractID]types.FileContract
+	referenceFileContractRevisions map[crypto.Hash]types.FileContract
+	referenceSiafundOutputs        map[types.SiafundOutputID]types.SiafundOutput
 
 	// The entire history of the transaction pool is kept. Each element
 	// represents an atomic change to the transaction pool. When a new

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -74,21 +74,22 @@ func (tp *TransactionPool) removeFileContracts(t types.Transaction) {
 	}
 }
 
-// removeFileContractTerminations removes all of the file contract terminations
-// of a transaction from the unconfirmed consensus set.
-func (tp *TransactionPool) removeFileContractTerminations(t types.Transaction) {
-	for _, fct := range t.FileContractTerminations {
+// removeFileContractRevisions removes all of the file contract revisions of a
+// transaction from the unconfirmed consensus set.
+func (tp *TransactionPool) removeFileContractRevisions(t types.Transaction) {
+	for _, fcr := range t.FileContractRevisions {
 		// Sanity check - the corresponding file contract should be in the
 		// reference set.
+		referenceID := crypto.HashAll(fcr.ParentID, fcr.NewRevisionNumber)
 		if build.DEBUG {
-			_, exists := tp.referenceFileContracts[fct.ParentID]
+			_, exists := tp.referenceFileContractRevisions[referenceID]
 			if !exists {
 				panic("cannot locate file contract to delete storage proof transaction")
 			}
 		}
 
-		tp.fileContracts[fct.ParentID] = tp.referenceFileContracts[fct.ParentID]
-		delete(tp.referenceFileContracts, fct.ParentID)
+		tp.fileContracts[fcr.ParentID] = tp.referenceFileContractRevisions[referenceID]
+		delete(tp.referenceFileContractRevisions, referenceID)
 	}
 }
 
@@ -169,7 +170,7 @@ func (tp *TransactionPool) removeTailTransaction() {
 	tp.removeSiacoinInputs(t)
 	tp.removeSiacoinOutputs(t)
 	tp.removeFileContracts(t)
-	tp.removeFileContractTerminations(t)
+	tp.removeFileContractRevisions(t)
 	tp.removeStorageProofs(t)
 	tp.removeSiafundInputs(t)
 	tp.removeSiafundOutputs(t)

--- a/modules/transactionpool/valid.go
+++ b/modules/transactionpool/valid.go
@@ -78,7 +78,7 @@ func (tp *TransactionPool) validUnconfirmedFileContractRevisions(t types.Transac
 
 		// Check that the revision was submitted before the storage proof
 		// window opened.
-		if tp.consensusSetHeight > fc.Start {
+		if tp.consensusSetHeight > fc.WindowStart {
 			return errors.New("revision submitted too late")
 		}
 

--- a/types/constants.go
+++ b/types/constants.go
@@ -2,6 +2,9 @@ package types
 
 // constants.go contains the Sia constants. Depending on which build tags are
 // used, the constants will be initialized to different values.
+//
+// CONTRIBUTE: We don't have way to check that the non-test constants are all
+// sane, plus we have no coverage for them.
 
 import (
 	"math/big"
@@ -92,7 +95,11 @@ func init() {
 		RootTarget = Target{64} // Takes an expected 4 hashes; very fast for testing but still probes 'bad hash' code.
 		RootDepth = Target{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
 
-		MaxAdjustmentUp = big.NewRat(10001, 10000) // Small to prevent the difficulty from increasing during testing.
+		// A really restrictive difficulty clamp prevents the difficulty from
+		// climbing during testing, as the resolution on the difficulty
+		// adjustment is only 1 second and testing mining should be happening
+		// substantially faster than that.
+		MaxAdjustmentUp = big.NewRat(10001, 10000)
 		MaxAdjustmentDown = big.NewRat(9999, 10000)
 
 		CoinbaseAugment = new(big.Int).Exp(big.NewInt(10), big.NewInt(24), nil)
@@ -114,11 +121,7 @@ func init() {
 
 		RenterZeroConfDelay = 60 * time.Second
 
-		// Some types of siacoin outputs cannot be collected for 50 blocks, or
-		// about 8 hours. This makes it difficult to spend money that may not exist
-		// in the future. Reorganizations 50 deep would be required, which takes a
-		// lot of resources.
-		MaturityDelay = 50
+		MaturityDelay = 50 // 8 hours.
 
 		RootTarget = Target{0, 0, 0, 64}
 		RootDepth = Target{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -1,0 +1,107 @@
+package types
+
+// filecontracts.go contains the basic structs and helper functions for file
+// contracts.
+
+import (
+	"github.com/NebulousLabs/Sia/crypto"
+)
+
+type (
+	// A FileContract is a public record of a storage agreement between a "host"
+	// and a "renter." It mandates that a host must submit a storage proof to the
+	// network, proving that they still possess the file they have agreed to
+	// store.
+	//
+	// The party must submit the storage proof in a block that is between 'Start'
+	// and 'Expiration'. Upon submitting the proof, the outputs for
+	// 'ValidProofOutputs' are created. If the party does not submit a storage
+	// proof by 'Expiration', then the outputs for 'MissedProofOutputs' are
+	// created instead. The sum of 'MissedProofOutputs' must equal 'Payout', and
+	// the sum of 'ValidProofOutputs' must equal 'Payout' plus the siafund fee.
+	// This fee is sent to the siafund pool, which is a set of siacoins only
+	// spendable by siafund owners.
+	//
+	// Under normal circumstances, the payout will be funded by both the host and
+	// the renter, which gives the host incentive not to lose the file. The
+	// 'ValidProofUnlockHash' will typically be spendable by host, and the
+	// 'MissedProofUnlockHash' will either by spendable by the renter or by
+	// nobody (the ZeroUnlockHash).
+	//
+	// A contract can be terminated early by submitting a FileContractTermination
+	// whose UnlockConditions hash to 'TerminationHash'.
+	FileContract struct {
+		FileSize           uint64
+		FileMerkleRoot     crypto.Hash
+		Start              BlockHeight
+		Expiration         BlockHeight
+		Payout             Currency
+		ValidProofOutputs  []SiacoinOutput
+		MissedProofOutputs []SiacoinOutput
+		TerminationHash    UnlockHash
+	}
+
+	// A FileContractTermination terminates a file contract. The ParentID
+	// specifies the contract being terminated, and the TerminationConditions are
+	// the conditions under which termination will be treated as valid. The hash
+	// of the TerminationConditions must match the TerminationHash in the
+	// contract. 'Payouts' is a set of SiacoinOutputs describing how the payout of
+	// the contract is redistributed. It follows that the sum of these outputs
+	// must equal the original payout. The outputs can have any Value and
+	// UnlockHash, and do not need to match the ValidProofUnlockHash or
+	// MissedProofUnlockHash of the original FileContract.
+	FileContractTermination struct {
+		ParentID              FileContractID
+		TerminationConditions UnlockConditions
+		Payouts               []SiacoinOutput
+	}
+
+	// A StorageProof fulfills a FileContract. The proof contains a specific
+	// segment of the file, along with a set of hashes from the file's Merkle
+	// tree. In combination, these can be used to prove that the segment came from
+	// the file. To prevent abuse, the segment must be chosen randomly, so the ID
+	// of block 'Start' - 1 is used as a seed value; see StorageProofSegment for
+	// the exact implementation.
+	//
+	// A transaction with a StorageProof cannot have any SiacoinOutputs,
+	// SiafundOutputs, or FileContracts. This is because a mundane reorg can
+	// invalidate the proof, and with it the rest of the transaction.
+	StorageProof struct {
+		ParentID FileContractID
+		Segment  [crypto.SegmentSize]byte
+		HashSet  []crypto.Hash
+	}
+)
+
+// FileContractTerminationPayoutID returns the ID of a file contract
+// termination payout, given the index of the payout in the termination. The
+// ID is calculated by hashing the concatenation of the
+// FileContractTerminationPayout Specifier, the ID of the file contract being
+// terminated, and the payout index.
+func (fcid FileContractID) FileContractTerminationPayoutID(i int) SiacoinOutputID {
+	return SiacoinOutputID(crypto.HashAll(
+		SpecifierFileContractTerminationPayout,
+		fcid,
+		i,
+	))
+}
+
+// StorageProofOutputID returns the ID of an output created by a file
+// contract, given the status of the storage proof. The ID is calculating by
+// hashing the concatenation of the StorageProofOutput Specifier, the ID of
+// the file contract that the proof is for, a boolean indicating whether the
+// proof was valid (true) or missed (false), and the index of the output
+// within the file contract.
+func (fcid FileContractID) StorageProofOutputID(proofValid bool, i int) SiacoinOutputID {
+	return SiacoinOutputID(crypto.HashAll(
+		SpecifierStorageProofOutput,
+		fcid,
+		proofValid,
+		i,
+	))
+}
+
+// Tax returns the amount of Currency that will be taxed from fc.
+func (fc FileContract) Tax() Currency {
+	return fc.Payout.MulFloat(SiafundPortion).RoundDown(SiafundCount)
+}

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -38,22 +38,33 @@ type (
 		Payout             Currency
 		ValidProofOutputs  []SiacoinOutput
 		MissedProofOutputs []SiacoinOutput
-		TerminationHash    UnlockHash
+		UnlockHash         UnlockHash
 	}
 
-	// A FileContractTermination terminates a file contract. The ParentID
-	// specifies the contract being terminated, and the TerminationConditions are
-	// the conditions under which termination will be treated as valid. The hash
-	// of the TerminationConditions must match the TerminationHash in the
-	// contract. 'Payouts' is a set of SiacoinOutputs describing how the payout of
-	// the contract is redistributed. It follows that the sum of these outputs
-	// must equal the original payout. The outputs can have any Value and
-	// UnlockHash, and do not need to match the ValidProofUnlockHash or
-	// MissedProofUnlockHash of the original FileContract.
-	FileContractTermination struct {
-		ParentID              FileContractID
-		TerminationConditions UnlockConditions
-		Payouts               []SiacoinOutput
+	// A FileContractRevision revises an existing file contract. The ParentID
+	// points to the file contract that is being revised. The UnlockConditions
+	// are the conditions under which the revision is valid, and must match the
+	// UnlockHash of the parent file contract. The Payout of the file contract
+	// cannot be changed, but all other fields are allowed to be changed. The
+	// sum of the outputs must match the original payout (taking into account
+	// the fee for valid proof payouts.) A revision number is included. When
+	// getting accepted, the revision number of the revision must be higher
+	// than any previously seen revision number for that file contract.
+	//
+	// FileContractRevisions enable trust-free modifications to existing file
+	// contracts.
+	FileContractRevision struct {
+		ParentID         FileContractID
+		UnlockConditions UnlockConditions
+		RevisionNumber   uint64
+
+		NewFileSize           uint64
+		NewFileMerkleRoot     crypto.Hash
+		NewStart              BlockHeight
+		NewExpiration         BlockHeight
+		NewValidProofOutputs  []SiacoinOutput
+		NewMissedProofOutputs []SiacoinOutput
+		NewUnlockHash         UnlockHash
 	}
 
 	// A StorageProof fulfills a FileContract. The proof contains a specific

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -13,14 +13,14 @@ type (
 	// network, proving that they still possess the file they have agreed to
 	// store.
 	//
-	// The party must submit the storage proof in a block that is between 'Start'
-	// and 'Expiration'. Upon submitting the proof, the outputs for
-	// 'ValidProofOutputs' are created. If the party does not submit a storage
-	// proof by 'Expiration', then the outputs for 'MissedProofOutputs' are
-	// created instead. The sum of 'MissedProofOutputs' must equal 'Payout', and
-	// the sum of 'ValidProofOutputs' must equal 'Payout' plus the siafund fee.
-	// This fee is sent to the siafund pool, which is a set of siacoins only
-	// spendable by siafund owners.
+	// The party must submit the storage proof in a block that is between
+	// 'WindowStart' and 'WindowEnd'. Upon submitting the proof, the outputs
+	// for 'ValidProofOutputs' are created. If the party does not submit a
+	// storage proof by 'WindowEnd', then the outputs for 'MissedProofOutputs'
+	// are created instead. The sum of 'MissedProofOutputs' must equal
+	// 'Payout', and the sum of 'ValidProofOutputs' must equal 'Payout' plus
+	// the siafund fee.  This fee is sent to the siafund pool, which is a set
+	// of siacoins only spendable by siafund owners.
 	//
 	// Under normal circumstances, the payout will be funded by both the host and
 	// the renter, which gives the host incentive not to lose the file. The
@@ -70,10 +70,10 @@ type (
 
 	// A StorageProof fulfills a FileContract. The proof contains a specific
 	// segment of the file, along with a set of hashes from the file's Merkle
-	// tree. In combination, these can be used to prove that the segment came from
-	// the file. To prevent abuse, the segment must be chosen randomly, so the ID
-	// of block 'Start' - 1 is used as a seed value; see StorageProofSegment for
-	// the exact implementation.
+	// tree. In combination, these can be used to prove that the segment came
+	// from the file. To prevent abuse, the segment must be chosen randomly, so
+	// the ID of block 'WindowStart' - 1 is used as a seed value; see
+	// StorageProofSegment for the exact implementation.
 	//
 	// A transaction with a StorageProof cannot have any SiacoinOutputs,
 	// SiafundOutputs, or FileContracts. This is because a mundane reorg can

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -39,6 +39,7 @@ type (
 		ValidProofOutputs  []SiacoinOutput
 		MissedProofOutputs []SiacoinOutput
 		UnlockHash         UnlockHash
+		RevisionNumber     uint64
 	}
 
 	// A FileContractRevision revises an existing file contract. The ParentID
@@ -54,9 +55,9 @@ type (
 	// FileContractRevisions enable trust-free modifications to existing file
 	// contracts.
 	FileContractRevision struct {
-		ParentID         FileContractID
-		UnlockConditions UnlockConditions
-		RevisionNumber   uint64
+		ParentID          FileContractID
+		UnlockConditions  UnlockConditions
+		NewRevisionNumber uint64
 
 		NewFileSize           uint64
 		NewFileMerkleRoot     crypto.Hash

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -33,8 +33,8 @@ type (
 	FileContract struct {
 		FileSize           uint64
 		FileMerkleRoot     crypto.Hash
-		Start              BlockHeight
-		Expiration         BlockHeight
+		WindowStart        BlockHeight
+		WindowEnd          BlockHeight
 		Payout             Currency
 		ValidProofOutputs  []SiacoinOutput
 		MissedProofOutputs []SiacoinOutput
@@ -61,8 +61,8 @@ type (
 
 		NewFileSize           uint64
 		NewFileMerkleRoot     crypto.Hash
-		NewStart              BlockHeight
-		NewExpiration         BlockHeight
+		NewWindowStart        BlockHeight
+		NewWindowEnd          BlockHeight
 		NewValidProofOutputs  []SiacoinOutput
 		NewMissedProofOutputs []SiacoinOutput
 		NewUnlockHash         UnlockHash

--- a/types/filecontracts_test.go
+++ b/types/filecontracts_test.go
@@ -1,0 +1,30 @@
+package types
+
+import (
+	"testing"
+)
+
+// TestFileContractTax probes the Tax function.
+func TestTax(t *testing.T) {
+	if SiafundPortion != 0.039 {
+		t.Error("SiafundPortion does not match expected value, Tax testing may be off")
+	}
+	if SiafundCount != 10000 {
+		t.Error("SiafundCount does not match expected value, Tax testing may be off")
+	}
+
+	fc := FileContract{
+		Payout: NewCurrency64(435000),
+	}
+	if fc.Tax().Cmp(NewCurrency64(10000)) != 0 {
+		t.Error("Tax producing unexpected result")
+	}
+	fc.Payout = NewCurrency64(150000)
+	if fc.Tax().Cmp(NewCurrency64(0)) != 0 {
+		t.Error("Tax producing unexpected result")
+	}
+	fc.Payout = NewCurrency64(123456789)
+	if fc.Tax().Cmp(NewCurrency64(4810000)) != 0 {
+		t.Error("Tax producing unexpected result")
+	}
+}

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -25,15 +25,15 @@ func TestUnlockHash(t *testing.T) {
 // TestSigHash runs the SigHash function of the transaction type.
 func TestSigHash(t *testing.T) {
 	txn := Transaction{
-		SiacoinInputs:            []SiacoinInput{SiacoinInput{}},
-		SiacoinOutputs:           []SiacoinOutput{SiacoinOutput{}},
-		FileContracts:            []FileContract{FileContract{}},
-		FileContractTerminations: []FileContractTermination{FileContractTermination{}},
-		StorageProofs:            []StorageProof{StorageProof{}},
-		SiafundInputs:            []SiafundInput{SiafundInput{}},
-		SiafundOutputs:           []SiafundOutput{SiafundOutput{}},
-		MinerFees:                []Currency{Currency{}},
-		ArbitraryData:            []string{"one", "two"},
+		SiacoinInputs:         []SiacoinInput{SiacoinInput{}},
+		SiacoinOutputs:        []SiacoinOutput{SiacoinOutput{}},
+		FileContracts:         []FileContract{FileContract{}},
+		FileContractRevisions: []FileContractRevision{FileContractRevision{}},
+		StorageProofs:         []StorageProof{StorageProof{}},
+		SiafundInputs:         []SiafundInput{SiafundInput{}},
+		SiafundOutputs:        []SiafundOutput{SiafundOutput{}},
+		MinerFees:             []Currency{Currency{}},
+		ArbitraryData:         []string{"one", "two"},
 		TransactionSignatures: []TransactionSignature{
 			TransactionSignature{
 				CoveredFields: CoveredFields{
@@ -42,16 +42,16 @@ func TestSigHash(t *testing.T) {
 			},
 			TransactionSignature{
 				CoveredFields: CoveredFields{
-					SiacoinInputs:            []uint64{0},
-					SiacoinOutputs:           []uint64{0},
-					FileContracts:            []uint64{0},
-					FileContractTerminations: []uint64{0},
-					StorageProofs:            []uint64{0},
-					SiafundInputs:            []uint64{0},
-					SiafundOutputs:           []uint64{0},
-					MinerFees:                []uint64{0},
-					ArbitraryData:            []uint64{0},
-					TransactionSignatures:    []uint64{0},
+					SiacoinInputs:         []uint64{0},
+					SiacoinOutputs:        []uint64{0},
+					FileContracts:         []uint64{0},
+					FileContractRevisions: []uint64{0},
+					StorageProofs:         []uint64{0},
+					SiafundInputs:         []uint64{0},
+					SiafundOutputs:        []uint64{0},
+					MinerFees:             []uint64{0},
+					ArbitraryData:         []uint64{0},
+					TransactionSignatures: []uint64{0},
 				},
 			},
 		},
@@ -97,15 +97,15 @@ func TestTransactionValidCoveredFields(t *testing.T) {
 	// Create a transaction with all fields filled in minimally. The first
 	// check has a legal CoveredFields object with 'WholeTransaction' set.
 	txn := Transaction{
-		SiacoinInputs:            []SiacoinInput{SiacoinInput{}},
-		SiacoinOutputs:           []SiacoinOutput{SiacoinOutput{}},
-		FileContracts:            []FileContract{FileContract{}},
-		FileContractTerminations: []FileContractTermination{FileContractTermination{}},
-		StorageProofs:            []StorageProof{StorageProof{}},
-		SiafundInputs:            []SiafundInput{SiafundInput{}},
-		SiafundOutputs:           []SiafundOutput{SiafundOutput{}},
-		MinerFees:                []Currency{Currency{}},
-		ArbitraryData:            []string{"one", "two"},
+		SiacoinInputs:         []SiacoinInput{SiacoinInput{}},
+		SiacoinOutputs:        []SiacoinOutput{SiacoinOutput{}},
+		FileContracts:         []FileContract{FileContract{}},
+		FileContractRevisions: []FileContractRevision{FileContractRevision{}},
+		StorageProofs:         []StorageProof{StorageProof{}},
+		SiafundInputs:         []SiafundInput{SiafundInput{}},
+		SiafundOutputs:        []SiafundOutput{SiafundOutput{}},
+		MinerFees:             []Currency{Currency{}},
+		ArbitraryData:         []string{"one", "two"},
 		TransactionSignatures: []TransactionSignature{
 			TransactionSignature{
 				CoveredFields: CoveredFields{
@@ -123,10 +123,10 @@ func TestTransactionValidCoveredFields(t *testing.T) {
 	// set.
 	txn.TransactionSignatures = append(txn.TransactionSignatures, TransactionSignature{
 		CoveredFields: CoveredFields{
-			SiacoinOutputs:           []uint64{0},
-			MinerFees:                []uint64{0},
-			ArbitraryData:            []uint64{0},
-			FileContractTerminations: []uint64{0},
+			SiacoinOutputs:        []uint64{0},
+			MinerFees:             []uint64{0},
+			ArbitraryData:         []uint64{0},
+			FileContractRevisions: []uint64{0},
 		},
 	})
 	err = txn.validCoveredFields()
@@ -187,20 +187,20 @@ func TestTransactionValidSignatures(t *testing.T) {
 		SignaturesRequired: 2,
 	}
 
-	// Create a transaction with each type of spendable output.
+	// Create a transaction with each type of unlock condition.
 	txn := Transaction{
 		SiacoinInputs: []SiacoinInput{
 			SiacoinInput{UnlockConditions: uc},
 		},
-		FileContractTerminations: []FileContractTermination{
-			FileContractTermination{TerminationConditions: uc},
+		FileContractRevisions: []FileContractRevision{
+			FileContractRevision{UnlockConditions: uc},
 		},
 		SiafundInputs: []SiafundInput{
 			SiafundInput{UnlockConditions: uc},
 		},
 	}
-	txn.FileContractTerminations[0].ParentID[0] = 1 // can't overlap with other objects
-	txn.SiafundInputs[0].ParentID[0] = 2            // can't overlap with other objects
+	txn.FileContractRevisions[0].ParentID[0] = 1 // can't overlap with other objects
+	txn.SiafundInputs[0].ParentID[0] = 2         // can't overlap with other objects
 
 	// Create the signatures that spend the output.
 	txn.TransactionSignatures = []TransactionSignature{
@@ -276,12 +276,12 @@ func TestTransactionValidSignatures(t *testing.T) {
 		t.Error("failed to double spend a siacoin input")
 	}
 	txn.SiacoinInputs = txn.SiacoinInputs[:len(txn.SiacoinInputs)-1]
-	txn.FileContractTerminations = append(txn.FileContractTerminations, FileContractTermination{TerminationConditions: UnlockConditions{}})
+	txn.FileContractRevisions = append(txn.FileContractRevisions, FileContractRevision{UnlockConditions: UnlockConditions{}})
 	err = txn.validSignatures(10)
 	if err == nil {
 		t.Error("failed to double spend a file contract termination")
 	}
-	txn.FileContractTerminations = txn.FileContractTerminations[:len(txn.FileContractTerminations)-1]
+	txn.FileContractRevisions = txn.FileContractRevisions[:len(txn.FileContractRevisions)-1]
 	txn.SiafundInputs = append(txn.SiafundInputs, SiafundInput{UnlockConditions: UnlockConditions{}})
 	err = txn.validSignatures(10)
 	if err == nil {

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -322,6 +322,14 @@ func TestTransactionValidSignatures(t *testing.T) {
 	}
 	txn.TransactionSignatures[0] = tmpTxn0
 
+	// Try to point to a nonexistant public key.
+	txn.TransactionSignatures[0] = TransactionSignature{PublicKeyIndex: 5}
+	err = txn.validSignatures(10)
+	if err != ErrInvalidPubKeyIndex {
+		t.Error(err)
+	}
+	txn.TransactionSignatures[0] = tmpTxn0
+
 	// Insert a malformed public key into the transaction.
 	txn.SiacoinInputs[0].UnlockConditions.PublicKeys[0].Key = "malformed"
 	err = txn.validSignatures(10)

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -48,16 +48,16 @@ type (
 	// but transactions cannot spend outputs that they create or otherwise be
 	// self-dependent.
 	Transaction struct {
-		SiacoinInputs            []SiacoinInput
-		SiacoinOutputs           []SiacoinOutput
-		FileContracts            []FileContract
-		FileContractTerminations []FileContractTermination
-		StorageProofs            []StorageProof
-		SiafundInputs            []SiafundInput
-		SiafundOutputs           []SiafundOutput
-		MinerFees                []Currency
-		ArbitraryData            []string
-		TransactionSignatures    []TransactionSignature
+		SiacoinInputs         []SiacoinInput
+		SiacoinOutputs        []SiacoinOutput
+		FileContracts         []FileContract
+		FileContractRevisions []FileContractRevision
+		StorageProofs         []StorageProof
+		SiafundInputs         []SiafundInput
+		SiafundOutputs        []SiafundOutput
+		MinerFees             []Currency
+		ArbitraryData         []string
+		TransactionSignatures []TransactionSignature
 	}
 
 	// A SiacoinInput consumes a SiacoinOutput and adds the siacoins to the set of
@@ -127,7 +127,7 @@ func (t Transaction) ID() crypto.Hash {
 		t.SiacoinInputs,
 		t.SiacoinOutputs,
 		t.FileContracts,
-		t.FileContractTerminations,
+		t.FileContractRevisions,
 		t.StorageProofs,
 		t.SiafundInputs,
 		t.SiafundOutputs,
@@ -148,7 +148,7 @@ func (t Transaction) SiacoinOutputID(i int) SiacoinOutputID {
 		t.SiacoinInputs,
 		t.SiacoinOutputs,
 		t.FileContracts,
-		t.FileContractTerminations,
+		t.FileContractRevisions,
 		t.StorageProofs,
 		t.SiafundInputs,
 		t.SiafundOutputs,
@@ -168,7 +168,7 @@ func (t Transaction) SiafundOutputID(i int) SiafundOutputID {
 		t.SiacoinInputs,
 		t.SiacoinOutputs,
 		t.FileContracts,
-		t.FileContractTerminations,
+		t.FileContractRevisions,
 		t.StorageProofs,
 		t.SiafundInputs,
 		t.SiafundOutputs,
@@ -188,7 +188,7 @@ func (t Transaction) FileContractID(i int) FileContractID {
 		t.SiacoinInputs,
 		t.SiacoinOutputs,
 		t.FileContracts,
-		t.FileContractTerminations,
+		t.FileContractRevisions,
 		t.StorageProofs,
 		t.SiafundInputs,
 		t.SiafundOutputs,

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -79,70 +79,6 @@ type (
 		UnlockHash UnlockHash
 	}
 
-	// A FileContract is a public record of a storage agreement between a "host"
-	// and a "renter." It mandates that a host must submit a storage proof to the
-	// network, proving that they still possess the file they have agreed to
-	// store.
-	//
-	// The party must submit the storage proof in a block that is between 'Start'
-	// and 'Expiration'. Upon submitting the proof, the outputs for
-	// 'ValidProofOutputs' are created. If the party does not submit a storage
-	// proof by 'Expiration', then the outputs for 'MissedProofOutputs' are
-	// created instead. The sum of 'MissedProofOutputs' must equal 'Payout', and
-	// the sum of 'ValidProofOutputs' must equal 'Payout' plus the siafund fee.
-	// This fee is sent to the siafund pool, which is a set of siacoins only
-	// spendable by siafund owners.
-	//
-	// Under normal circumstances, the payout will be funded by both the host and
-	// the renter, which gives the host incentive not to lose the file. The
-	// 'ValidProofUnlockHash' will typically be spendable by host, and the
-	// 'MissedProofUnlockHash' will either by spendable by the renter or by
-	// nobody (the ZeroUnlockHash).
-	//
-	// A contract can be terminated early by submitting a FileContractTermination
-	// whose UnlockConditions hash to 'TerminationHash'.
-	FileContract struct {
-		FileSize           uint64
-		FileMerkleRoot     crypto.Hash
-		Start              BlockHeight
-		Expiration         BlockHeight
-		Payout             Currency
-		ValidProofOutputs  []SiacoinOutput
-		MissedProofOutputs []SiacoinOutput
-		TerminationHash    UnlockHash
-	}
-
-	// A FileContractTermination terminates a file contract. The ParentID
-	// specifies the contract being terminated, and the TerminationConditions are
-	// the conditions under which termination will be treated as valid. The hash
-	// of the TerminationConditions must match the TerminationHash in the
-	// contract. 'Payouts' is a set of SiacoinOutputs describing how the payout of
-	// the contract is redistributed. It follows that the sum of these outputs
-	// must equal the original payout. The outputs can have any Value and
-	// UnlockHash, and do not need to match the ValidProofUnlockHash or
-	// MissedProofUnlockHash of the original FileContract.
-	FileContractTermination struct {
-		ParentID              FileContractID
-		TerminationConditions UnlockConditions
-		Payouts               []SiacoinOutput
-	}
-
-	// A StorageProof fulfills a FileContract. The proof contains a specific
-	// segment of the file, along with a set of hashes from the file's Merkle
-	// tree. In combination, these can be used to prove that the segment came from
-	// the file. To prevent abuse, the segment must be chosen randomly, so the ID
-	// of block 'Start' - 1 is used as a seed value; see StorageProofSegment for
-	// the exact implementation.
-	//
-	// A transaction with a StorageProof cannot have any SiacoinOutputs,
-	// SiafundOutputs, or FileContracts. This is because a mundane reorg can
-	// invalidate the proof, and with it the rest of the transaction.
-	StorageProof struct {
-		ParentID FileContractID
-		Segment  [crypto.SegmentSize]byte
-		HashSet  []crypto.Hash
-	}
-
 	// A SiafundInput consumes a SiafundOutput and adds the siafunds to the set of
 	// siafunds that can be spent in the transaction. The ParentID points to the
 	// output that is getting consumed, and the UnlockConditions contain the rules
@@ -222,26 +158,6 @@ func (t Transaction) SiacoinOutputID(i int) SiacoinOutputID {
 	))
 }
 
-// FileContractID returns the ID of a file contract at the given index, which
-// is calculated by hashing the concatenation of the FileContract Specifier,
-// all of the fields in the transaction (except the signatures), and the
-// contract index.
-func (t Transaction) FileContractID(i int) FileContractID {
-	return FileContractID(crypto.HashAll(
-		SpecifierFileContract,
-		t.SiacoinInputs,
-		t.SiacoinOutputs,
-		t.FileContracts,
-		t.FileContractTerminations,
-		t.StorageProofs,
-		t.SiafundInputs,
-		t.SiafundOutputs,
-		t.MinerFees,
-		t.ArbitraryData,
-		i,
-	))
-}
-
 // SiafundOutputID returns the ID of a SiafundOutput at the given index, which
 // is calculated by hashing the concatenation of the SiafundOutput Specifier,
 // all of the fields in the transaction (except the signatures), and output
@@ -262,30 +178,22 @@ func (t Transaction) SiafundOutputID(i int) SiafundOutputID {
 	))
 }
 
-// FileContractTerminationPayoutID returns the ID of a file contract
-// termination payout, given the index of the payout in the termination. The
-// ID is calculated by hashing the concatenation of the
-// FileContractTerminationPayout Specifier, the ID of the file contract being
-// terminated, and the payout index.
-func (fcid FileContractID) FileContractTerminationPayoutID(i int) SiacoinOutputID {
-	return SiacoinOutputID(crypto.HashAll(
-		SpecifierFileContractTerminationPayout,
-		fcid,
-		i,
-	))
-}
-
-// StorageProofOutputID returns the ID of an output created by a file
-// contract, given the status of the storage proof. The ID is calculating by
-// hashing the concatenation of the StorageProofOutput Specifier, the ID of
-// the file contract that the proof is for, a boolean indicating whether the
-// proof was valid (true) or missed (false), and the index of the output
-// within the file contract.
-func (fcid FileContractID) StorageProofOutputID(proofValid bool, i int) SiacoinOutputID {
-	return SiacoinOutputID(crypto.HashAll(
-		SpecifierStorageProofOutput,
-		fcid,
-		proofValid,
+// FileContractID returns the ID of a file contract at the given index, which
+// is calculated by hashing the concatenation of the FileContract Specifier,
+// all of the fields in the transaction (except the signatures), and the
+// contract index.
+func (t Transaction) FileContractID(i int) FileContractID {
+	return FileContractID(crypto.HashAll(
+		SpecifierFileContract,
+		t.SiacoinInputs,
+		t.SiacoinOutputs,
+		t.FileContracts,
+		t.FileContractTerminations,
+		t.StorageProofs,
+		t.SiafundInputs,
+		t.SiafundOutputs,
+		t.MinerFees,
+		t.ArbitraryData,
 		i,
 	))
 }
@@ -318,9 +226,4 @@ func (t Transaction) SiacoinOutputSum() (sum Currency) {
 	}
 
 	return
-}
-
-// Tax returns the amount of Currency that will be taxed from fc.
-func (fc FileContract) Tax() Currency {
-	return fc.Payout.MulFloat(SiafundPortion).RoundDown(SiafundCount)
 }

--- a/types/transactions_test.go
+++ b/types/transactions_test.go
@@ -75,28 +75,3 @@ func TestTransactionSiacoinOutputSum(t *testing.T) {
 		t.Error("wrong siacoin output sum was calculated, got:", txn.SiacoinOutputSum())
 	}
 }
-
-// TestFileContractTax probes the Tax function.
-func TestTax(t *testing.T) {
-	if SiafundPortion != 0.039 {
-		t.Error("SiafundPortion does not match expected value, Tax testing may be off")
-	}
-	if SiafundCount != 10000 {
-		t.Error("SiafundCount does not match expected value, Tax testing may be off")
-	}
-
-	fc := FileContract{
-		Payout: NewCurrency64(435000),
-	}
-	if fc.Tax().Cmp(NewCurrency64(10000)) != 0 {
-		t.Error("Tax producing unexpected result")
-	}
-	fc.Payout = NewCurrency64(150000)
-	if fc.Tax().Cmp(NewCurrency64(0)) != 0 {
-		t.Error("Tax producing unexpected result")
-	}
-	fc.Payout = NewCurrency64(123456789)
-	if fc.Tax().Cmp(NewCurrency64(4810000)) != 0 {
-		t.Error("Tax producing unexpected result")
-	}
-}

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -13,8 +13,8 @@ import (
 
 var (
 	ErrDoubleSpend                      = errors.New("transaction uses a parent object twice")
-	ErrFileContractExpirationViolation  = errors.New("file contract must expire at least one block after it starts")
-	ErrFileContractWindowStartViolation = errors.New("file contract must start in the future")
+	ErrFileContractWindowEndViolation   = errors.New("file contract window must end at least one block after it starts")
+	ErrFileContractWindowStartViolation = errors.New("file contract window must start in the future")
 	ErrFileContractOutputSumViolation   = errors.New("file contract has invalid output sums")
 	ErrNonZeroClaimStart                = errors.New("transaction has a siafund output with a non-zero siafund claim")
 	ErrNonZeroRevision                  = errors.New("new file contract has a nonzero revision number")
@@ -35,7 +35,7 @@ func (t Transaction) correctFileContracts(currentHeight BlockHeight) error {
 			return ErrFileContractWindowStartViolation
 		}
 		if fc.WindowEnd <= fc.WindowStart {
-			return ErrFileContractExpirationViolation
+			return ErrFileContractWindowEndViolation
 		}
 
 		// Check that the valid proof outputs sum to the payout after the

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -12,17 +12,17 @@ import (
 )
 
 var (
-	ErrDoubleSpend                     = errors.New("transaction uses a parent object twice")
-	ErrFileContractExpirationViolation = errors.New("file contract must expire at least one block after it starts")
-	ErrFileContractStartViolation      = errors.New("file contract must start in the future")
-	ErrFileContractOutputSumViolation  = errors.New("file contract has invalid output sums")
-	ErrNonZeroClaimStart               = errors.New("transaction has a siafund output with a non-zero siafund claim")
-	ErrNonZeroRevision                 = errors.New("new file contract has a nonzero revision number")
-	ErrStorageProofWithOutputs         = errors.New("transaction has both a storage proof and other outputs")
-	ErrTimelockNotSatisfied            = errors.New("timelock has not been met")
-	ErrTransactionTooLarge             = errors.New("transaction is too large to fit in a block")
-	ErrZeroOutput                      = errors.New("transaction cannot have an output or payout that has zero value")
-	ErrZeroRevision                    = errors.New("transaction has a file contract revision with RevisionNumber=0")
+	ErrDoubleSpend                      = errors.New("transaction uses a parent object twice")
+	ErrFileContractExpirationViolation  = errors.New("file contract must expire at least one block after it starts")
+	ErrFileContractWindowStartViolation = errors.New("file contract must start in the future")
+	ErrFileContractOutputSumViolation   = errors.New("file contract has invalid output sums")
+	ErrNonZeroClaimStart                = errors.New("transaction has a siafund output with a non-zero siafund claim")
+	ErrNonZeroRevision                  = errors.New("new file contract has a nonzero revision number")
+	ErrStorageProofWithOutputs          = errors.New("transaction has both a storage proof and other outputs")
+	ErrTimelockNotSatisfied             = errors.New("timelock has not been met")
+	ErrTransactionTooLarge              = errors.New("transaction is too large to fit in a block")
+	ErrZeroOutput                       = errors.New("transaction cannot have an output or payout that has zero value")
+	ErrZeroRevision                     = errors.New("transaction has a file contract revision with RevisionNumber=0")
 )
 
 // correctFileContracts checks that the file contracts adhere to the file
@@ -31,10 +31,10 @@ func (t Transaction) correctFileContracts(currentHeight BlockHeight) error {
 	// Check that FileContract rules are being followed.
 	for _, fc := range t.FileContracts {
 		// Check that start and expiration are reasonable values.
-		if fc.Start <= currentHeight {
-			return ErrFileContractStartViolation
+		if fc.WindowStart <= currentHeight {
+			return ErrFileContractWindowStartViolation
 		}
-		if fc.Expiration <= fc.Start {
+		if fc.WindowEnd <= fc.WindowStart {
 			return ErrFileContractExpirationViolation
 		}
 
@@ -75,8 +75,8 @@ func (t Transaction) correctFileContractRevisions(currentHeight BlockHeight) err
 				FileContract{
 					FileSize:           fcr.NewFileSize,
 					FileMerkleRoot:     fcr.NewFileMerkleRoot,
-					Start:              fcr.NewStart,
-					Expiration:         fcr.NewExpiration,
+					WindowStart:        fcr.NewWindowStart,
+					WindowEnd:          fcr.NewWindowEnd,
 					Payout:             payout,
 					ValidProofOutputs:  fcr.NewValidProofOutputs,
 					MissedProofOutputs: fcr.NewMissedProofOutputs,

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -17,6 +17,7 @@ var (
 	ErrFileContractStartViolation      = errors.New("file contract must start in the future")
 	ErrFileContractOutputSumViolation  = errors.New("file contract has invalid output sums")
 	ErrNonZeroClaimStart               = errors.New("transaction has a siafund output with a non-zero siafund claim")
+	ErrNonZeroRevision                 = errors.New("new file contract has a nonzero revision number")
 	ErrStorageProofWithOutputs         = errors.New("transaction has both a storage proof and other outputs")
 	ErrTimelockNotSatisfied            = errors.New("timelock has not been met")
 	ErrTransactionTooLarge             = errors.New("transaction is too large to fit in a block")
@@ -62,12 +63,6 @@ func (t Transaction) correctFileContracts(currentHeight BlockHeight) error {
 // to the revision rules.
 func (t Transaction) correctFileContractRevisions(currentHeight BlockHeight) error {
 	for _, fcr := range t.FileContractRevisions {
-		// The revision number cannot be zero, that revision number is reserved
-		// for original file contracts.
-		if fcr.RevisionNumber == 0 {
-			return ErrZeroRevision
-		}
-
 		// To ensure consistency with the file contract rules, a temporary txn
 		// is created containing only the file contract that would result from
 		// this revision.
@@ -86,6 +81,7 @@ func (t Transaction) correctFileContractRevisions(currentHeight BlockHeight) err
 					ValidProofOutputs:  fcr.NewValidProofOutputs,
 					MissedProofOutputs: fcr.NewMissedProofOutputs,
 					UnlockHash:         fcr.NewUnlockHash,
+					RevisionNumber:     fcr.NewRevisionNumber,
 				},
 			},
 		}

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -11,9 +11,9 @@ func TestTransactionCorrectFileContracts(t *testing.T) {
 	txn := Transaction{
 		FileContracts: []FileContract{
 			FileContract{
-				Start:      35,
-				Expiration: 40,
-				Payout:     NewCurrency64(1e6),
+				WindowStart: 35,
+				WindowEnd:   40,
+				Payout:      NewCurrency64(1e6),
 				ValidProofOutputs: []SiacoinOutput{
 					SiacoinOutput{
 						Value: NewCurrency64(70e3),
@@ -40,26 +40,26 @@ func TestTransactionCorrectFileContracts(t *testing.T) {
 
 	// Try when the start height was missed.
 	err = txn.correctFileContracts(35)
-	if err != ErrFileContractStartViolation {
+	if err != ErrFileContractWindowStartViolation {
 		t.Error(err)
 	}
 	err = txn.correctFileContracts(135)
-	if err != ErrFileContractStartViolation {
+	if err != ErrFileContractWindowStartViolation {
 		t.Error(err)
 	}
 
 	// Try when the expiration equal to and less than the start.
-	txn.FileContracts[0].Expiration = 35
+	txn.FileContracts[0].WindowEnd = 35
 	err = txn.correctFileContracts(30)
 	if err != ErrFileContractExpirationViolation {
 		t.Error(err)
 	}
-	txn.FileContracts[0].Expiration = 35
+	txn.FileContracts[0].WindowEnd = 35
 	err = txn.correctFileContracts(30)
 	if err != ErrFileContractExpirationViolation {
 		t.Error(err)
 	}
-	txn.FileContracts[0].Expiration = 40
+	txn.FileContracts[0].WindowEnd = 40
 
 	// Attempt under and over output sums.
 	txn.FileContracts[0].ValidProofOutputs[0].Value = NewCurrency64(69e3)
@@ -89,9 +89,9 @@ func TestTransactionCorrectFileContracts(t *testing.T) {
 	// Try the payouts when the value of the contract is too low to incur a
 	// fee.
 	txn.FileContracts = append(txn.FileContracts, FileContract{
-		Start:      35,
-		Expiration: 40,
-		Payout:     NewCurrency64(1e3),
+		WindowStart: 35,
+		WindowEnd:   40,
+		Payout:      NewCurrency64(1e3),
 		ValidProofOutputs: []SiacoinOutput{
 			SiacoinOutput{
 				Value: NewCurrency64(1e3),
@@ -397,9 +397,9 @@ func TestTransactionStandaloneValid(t *testing.T) {
 	// Violate correctFileContracts
 	txn.FileContracts = []FileContract{
 		FileContract{
-			Payout:     NewCurrency64(1),
-			Start:      5,
-			Expiration: 5,
+			Payout:      NewCurrency64(1),
+			WindowStart: 5,
+			WindowEnd:   5,
 		},
 	}
 	err = txn.StandaloneValid(0)

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -204,12 +204,12 @@ func TestTransactionFollowsStorageProofRules(t *testing.T) {
 	txn.FileContracts = nil
 
 	// Try a transaction with a storage proof and a FileContractTermination.
-	txn.FileContractTerminations = append(txn.FileContractTerminations, FileContractTermination{})
+	txn.FileContractRevisions = append(txn.FileContractRevisions, FileContractRevision{})
 	err = txn.followsStorageProofRules()
 	if err != ErrStorageProofWithOutputs {
 		t.Error(err)
 	}
-	txn.FileContractTerminations = nil
+	txn.FileContractRevisions = nil
 
 	// Try a transaction with a storage proof and a FileContractTermination.
 	txn.SiafundOutputs = append(txn.SiafundOutputs, SiafundOutput{})
@@ -225,12 +225,12 @@ func TestTransactionFollowsStorageProofRules(t *testing.T) {
 func TestTransactionNoRepeats(t *testing.T) {
 	// Try a transaction all the repeatable types but no conflicts.
 	txn := Transaction{
-		SiacoinInputs:            []SiacoinInput{SiacoinInput{}},
-		StorageProofs:            []StorageProof{StorageProof{}},
-		FileContractTerminations: []FileContractTermination{FileContractTermination{}},
-		SiafundInputs:            []SiafundInput{SiafundInput{}},
+		SiacoinInputs:         []SiacoinInput{SiacoinInput{}},
+		StorageProofs:         []StorageProof{StorageProof{}},
+		FileContractRevisions: []FileContractRevision{FileContractRevision{}},
+		SiafundInputs:         []SiafundInput{SiafundInput{}},
 	}
-	txn.FileContractTerminations[0].ParentID[0] = 1 // Otherwise it will conflict with the storage proof.
+	txn.FileContractRevisions[0].ParentID[0] = 1 // Otherwise it will conflict with the storage proof.
 	err := txn.noRepeats()
 	if err != nil {
 		t.Error(err)
@@ -262,13 +262,13 @@ func TestTransactionNoRepeats(t *testing.T) {
 	txn.StorageProofs[0].ParentID[0] = 0
 
 	// Have the file contract termination conflict with itself.
-	txn.FileContractTerminations = append(txn.FileContractTerminations, FileContractTermination{})
-	txn.FileContractTerminations[1].ParentID[0] = 1
+	txn.FileContractRevisions = append(txn.FileContractRevisions, FileContractRevision{})
+	txn.FileContractRevisions[1].ParentID[0] = 1
 	err = txn.noRepeats()
 	if err != ErrDoubleSpend {
 		t.Error(err)
 	}
-	txn.FileContractTerminations = txn.FileContractTerminations[:1]
+	txn.FileContractRevisions = txn.FileContractRevisions[:1]
 
 	// Try a transaction double spending a siafund output.
 	txn.SiafundInputs = append(txn.SiafundInputs, SiafundInput{})
@@ -307,9 +307,9 @@ func TestTransactionValidUnlockConditions(t *testing.T) {
 				UnlockConditions: UnlockConditions{Timelock: 3},
 			},
 		},
-		FileContractTerminations: []FileContractTermination{
-			FileContractTermination{
-				TerminationConditions: UnlockConditions{Timelock: 3},
+		FileContractRevisions: []FileContractRevision{
+			FileContractRevision{
+				UnlockConditions: UnlockConditions{Timelock: 3},
 			},
 		},
 		SiafundInputs: []SiafundInput{
@@ -332,12 +332,12 @@ func TestTransactionValidUnlockConditions(t *testing.T) {
 	txn.SiacoinInputs[0].UnlockConditions.Timelock = 3
 
 	// Try with illegal conditions in the siafund inputs.
-	txn.FileContractTerminations[0].TerminationConditions.Timelock = 5
+	txn.FileContractRevisions[0].UnlockConditions.Timelock = 5
 	err = txn.validUnlockConditions(4)
 	if err == nil {
 		t.Error(err)
 	}
-	txn.FileContractTerminations[0].TerminationConditions.Timelock = 3
+	txn.FileContractRevisions[0].UnlockConditions.Timelock = 3
 
 	// Try with illegal conditions in the siafund inputs.
 	txn.SiafundInputs[0].UnlockConditions.Timelock = 5


### PR DESCRIPTION
This pull request exchanges contract terminations for contract revisions. After careful analysis of the situation, I realized that contract terminations weren't sufficient to make fully functional microdiff channels. I have replaced them with contract revisions, which are extremely close to being a superset of functionality. At the very least, you can make microdiff channels now, which are a superset of micropayment channels. Yay.

I also changed the 'Start' and 'Expiration' variable names in the FileContract type to 'WindowStart' and 'WindowEnd', because I felt that these names more accurately reflected their function.