### PR TITLE
Siag Header + Version checking

### DIFF
--- a/siag/main.go
+++ b/siag/main.go
@@ -11,8 +11,7 @@ import (
 
 const (
 	// Version of the siag program.
-	Version       = "1.0"
-	FileExtension = ".siakey"
+	Version = "1.0"
 
 	DefaultFolder       = ""
 	DefaultAddressName  = "SiafundAddress"


### PR DESCRIPTION
while modifying the persistence stuff for the renter I realized that siag doesn't check the header or version number on the files that it opens. I added checks for that with test coverage.