### PR TITLE
Debugging

### DIFF
--- a/modules/consensus/state.go
+++ b/modules/consensus/state.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/NebulousLabs/Sia/blockdb"
 	"github.com/NebulousLabs/Sia/build"
@@ -94,7 +93,7 @@ func New(gateway modules.Gateway, saveDir string) (*State, error) {
 
 		gateway: gateway,
 
-		mu: sync.New(1*time.Second, 1),
+		mu: sync.New(modules.SafeMutexDelay, 1),
 	}
 
 	// Create the genesis block and add it as the BlockRoot.

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -117,7 +116,7 @@ func New(addr string, saveDir string) (g *Gateway, err error) {
 		peers:      make(map[modules.NetAddress]*peer),
 		nodes:      make(map[modules.NetAddress]struct{}),
 		saveDir:    saveDir,
-		mu:         sync.New(time.Second*1, 0),
+		mu:         sync.New(modules.SafeMutexDelay, 0),
 		log:        logger,
 	}
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -97,7 +96,7 @@ func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wall
 		obligationsByID:     make(map[types.FileContractID]contractObligation),
 		obligationsByHeight: make(map[types.BlockHeight][]contractObligation),
 
-		mu: sync.New(1*time.Second, 0),
+		mu: sync.New(modules.SafeMutexDelay, 1),
 	}
 	block, exists := cs.BlockAtHeight(0)
 	if !exists {

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -280,6 +280,12 @@ func (h *Host) rpcContract(conn net.Conn) (err error) {
 	h.save()
 	h.mu.Unlock(lockID)
 
+	// Send an ack to the renter that all is well.
+	err = encoding.WriteObject(conn, true)
+	if err != nil {
+		return
+	}
+
 	// TODO: we don't currently watch the blockchain to make sure that the
 	// transaction actually gets into the blockchain.
 

--- a/modules/hostdb/hostdb.go
+++ b/modules/hostdb/hostdb.go
@@ -8,7 +8,6 @@ package hostdb
 
 import (
 	"errors"
-	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/consensus"
@@ -69,7 +68,7 @@ func New(cs *consensus.State, g modules.Gateway) (hdb *HostDB, err error) {
 		activeHosts: make(map[modules.NetAddress]*hostNode),
 		allHosts:    make(map[modules.NetAddress]*hostEntry),
 
-		mu: sync.New(1*time.Second, 0),
+		mu: sync.New(modules.SafeMutexDelay, 1),
 	}
 
 	cs.ConsensusSetSubscribe(hdb)

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -1,3 +1,25 @@
 package modules
 
-const NotifyBuffer = 3
+import (
+	"time"
+
+	"github.com/NebulousLabs/Sia/build"
+)
+
+const (
+	NotifyBuffer = 3
+)
+
+var (
+	SafeMutexDelay time.Duration
+)
+
+func init() {
+	if build.Release == "dev" {
+		SafeMutexDelay = 5 * time.Second
+	} else if build.Release == "standard" {
+		SafeMutexDelay = 8 * time.Second
+	} else if build.Release == "testing" {
+		SafeMutexDelay = 3 * time.Second
+	}
+}

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -193,6 +193,17 @@ func (r *Renter) negotiateContract(host modules.HostSettings, up modules.FileUpl
 	fcid = signedTxn.FileContractID(0)
 	contract = signedTxn.FileContracts[0]
 
+	// Read an ack from the host that all is well.
+	var ack bool
+	err = encoding.ReadObject(conn, &ack, 1)
+	if err != nil {
+		return
+	}
+	if !ack {
+		err = errors.New("host negotiation failed")
+		return
+	}
+
 	// TODO: We don't actually watch the blockchain to make sure that the
 	// file contract made it.
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -3,7 +3,6 @@ package renter
 import (
 	"errors"
 	"os"
-	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/consensus"
@@ -54,7 +53,7 @@ func New(cs *consensus.State, hdb modules.HostDB, wallet modules.Wallet, saveDir
 		files:   make(map[string]*file),
 		saveDir: saveDir,
 
-		mu: sync.New(1*time.Second, 0),
+		mu: sync.New(modules.SafeMutexDelay, 1),
 	}
 
 	err := os.MkdirAll(saveDir, 0700)

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -2,7 +2,6 @@ package transactionpool
 
 import (
 	"errors"
-	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
@@ -118,7 +117,7 @@ func New(cs *consensus.State, g modules.Gateway) (tp *TransactionPool, err error
 		referenceFileContracts:  make(map[types.FileContractID]types.FileContract),
 		referenceSiafundOutputs: make(map[types.SiafundOutputID]types.SiafundOutput),
 
-		mu: sync.New(3*time.Second, 0),
+		mu: sync.New(modules.SafeMutexDelay, 1),
 	}
 
 	// Register RPCs

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/consensus"
@@ -100,7 +99,7 @@ func New(state *consensus.State, tpool modules.TransactionPool, saveDir string) 
 
 		transactions: make(map[string]*openTransaction),
 
-		mu: sync.New(3*time.Second, 0),
+		mu: sync.New(modules.SafeMutexDelay, 1),
 	}
 
 	// Create the wallet folder.


### PR DESCRIPTION
1. Mutexes all now lock for the same amount of time, as specified by a module constant. In testing mode, they wait 3 seconds. In dev mode, they wait 5 seconds. In release mode, they wait 8 seconds. This should stop the mutexes from complaining when there are performance issues.
Performance issues will probably be addressed when I rehash the consensus testing.

2. If the host runs into problems during a negotiation, it'll complain to the renter so that the renter won't report a successful file.

NOTE: A host and a renter must be in the same peer graph for renting to work. (The renter broadcasts a transaction that must be seen by the host or the negotiation will fail. The host won't see it if there's no chain of broadcasts that lead from the renter to the host. This is the type of thing we will fix when we redo the negotiation)