### PR TITLE
More node sharing

### DIFF
--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -18,7 +18,7 @@ func (st *serverTester) addPeer(name string) *serverTester {
 
 	// Create a new peer and bootstrap it to st.
 	newPeer := newServerTester(name, st.t)
-	err := newPeer.server.gateway.Bootstrap(st.netAddress())
+	err := newPeer.server.gateway.Connect(st.netAddress())
 	if err != nil {
 		st.t.Fatal("bootstrap failed:", err)
 	}

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -50,9 +50,6 @@ func (na NetAddress) Port() string {
 // it is responsible for ensuring that the local consensus set is consistent
 // with the "network" consensus set.
 type Gateway interface {
-	// Bootstrap joins the Sia network and establishes an initial peer list.
-	Bootstrap(NetAddress) error
-
 	// Connect establishes a persistent connection to a peer.
 	Connect(NetAddress) error
 

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -73,31 +73,6 @@ func (g *Gateway) Close() error {
 	return g.listener.Close()
 }
 
-// Bootstrap joins the Sia network and establishes an initial peer list.
-func (g *Gateway) Bootstrap(addr modules.NetAddress) error {
-	g.log.Println("INFO: initiated bootstrapping to", addr)
-
-	// contact the bootstrap peer
-	err := g.Connect(addr)
-	if err != nil {
-		return err
-	}
-
-	// initial peer discovery
-	nodes, err := g.requestNodes(addr)
-	g.log.Printf("INFO: %v sent us %v peers", addr, len(nodes))
-	id := g.mu.Lock()
-	for _, node := range nodes {
-		g.addNode(node)
-	}
-	g.save()
-	g.mu.Unlock(id)
-
-	g.log.Printf("INFO: successfully bootstrapped to %v", addr)
-
-	return nil
-}
-
 // New returns an initialized Gateway.
 func New(addr string, saveDir string) (g *Gateway, err error) {
 	// Create the directory if it doesn't exist.

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -97,6 +97,7 @@ func New(addr string, saveDir string) (g *Gateway, err error) {
 	}
 
 	g.RegisterRPC("ShareNodes", g.shareNodes)
+	g.RegisterRPC("RelayNode", g.relayNode)
 
 	g.log.Println("INFO: gateway created, started logging")
 

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -56,38 +56,6 @@ func TestPeers(t *testing.T) {
 	}
 }
 
-func TestBootstrap(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-
-	// create bootstrap peer
-	bootstrap := newTestingGateway("TestBootstrap1", t)
-
-	// give it a peer
-	err := bootstrap.Connect(newTestingGateway("TestBootstrap2", t).Address())
-	if err != nil {
-		t.Fatal("couldn't connect:", err)
-	}
-
-	// bootstrap a new peer
-	g := newTestingGateway("TestBootstrap3", t)
-	err = g.Bootstrap(bootstrap.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// node lists should be the same
-	if len(g.nodes) != len(bootstrap.nodes) {
-		t.Fatalf("gateway peer list %v does not match bootstrap peer list %v", g.nodes, bootstrap.nodes)
-	}
-
-	err = g.Disconnect(bootstrap.Address())
-	if err != nil {
-		t.Fatal("failed to disconnect:", err)
-	}
-}
-
 func TestNew(t *testing.T) {
 	if _, err := New("", ""); err == nil {
 		t.Fatal("expecting saveDir error, got nil")

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -96,11 +96,11 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	}
 	// TODO: exchange version messages
 
+	g.log.Println("INFO: connected to new peer", addr)
+
 	id = g.mu.Lock()
 	g.addPeer(&peer{addr: addr, sess: muxado.Client(conn)})
 	g.mu.Unlock(id)
-
-	g.log.Println("INFO: connected to new peer", addr)
 
 	// request nodes
 	nodes, err := g.requestNodes(addr)

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -2,6 +2,9 @@ package gateway
 
 import (
 	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 func TestLoad(t *testing.T) {
@@ -18,5 +21,28 @@ func TestLoad(t *testing.T) {
 	}
 	if _, ok := g2.nodes["foo"]; !ok {
 		t.Fatal("gateway did not load old peer list:", g2.nodes)
+	}
+}
+
+func TestLoadPeer(t *testing.T) {
+	g1 := newTestingGateway("TestLoadPeer1", t)
+	g2 := newTestingGateway("TestLoadPeer2", t)
+
+	err := g1.Connect(g2.Address())
+	if err != nil {
+		t.Fatal("couldn't connect")
+	}
+	// g2 is now in g1's node and peer list
+	g1.Close()
+
+	// g1 should reconnect to g2 upon load
+	g1, err = New(":0", g1.saveDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	peers := g1.Peers()
+	if len(peers) != 1 || peers[0] != g2.Address() {
+		t.Fatalf("gateway did not reconnect to loaded peer: expected %v, got %v", []modules.NetAddress{g2.Address()}, peers)
 	}
 }

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -72,13 +72,13 @@ func (g *Gateway) listenPeer(p *peer) {
 	for {
 		conn, err := p.accept()
 		if err != nil {
+			g.log.Println("WARN: lost connection to peer", p.addr)
 			break
 		}
 
 		// it is the handler's responsibility to close the connection
 		go g.threadedHandleConn(conn)
 	}
-	g.log.Println("WARN: lost connection to peer", p.addr)
 	g.Disconnect(p.addr)
 }
 

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -111,7 +111,8 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 // which simply write an object and disconnect. This is why Broadcast takes an
 // interface{} instead of an RPCFunc.
 func (g *Gateway) Broadcast(name string, obj interface{}) {
-	g.log.Printf("INFO: broadcasting RPC \"%v\" to %v peers", name, len(g.peers))
+	peers := g.Peers()
+	g.log.Printf("INFO: broadcasting RPC \"%v\" to %v peers", name, len(peers))
 
 	// only encode obj once, instead of using WriteObject
 	enc := encoding.Marshal(obj)
@@ -120,8 +121,8 @@ func (g *Gateway) Broadcast(name string, obj interface{}) {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(len(g.peers))
-	for _, addr := range g.Peers() {
+	wg.Add(len(peers))
+	for _, addr := range peers {
 		go func(addr modules.NetAddress) {
 			err := g.RPC(addr, name, fn)
 			if err != nil {

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -130,6 +131,9 @@ func (g *Gateway) Broadcast(name string, obj interface{}) {
 			err := g.RPC(addr, name, fn)
 			if err != nil {
 				g.log.Printf("WARN: broadcast: calling RPC \"%v\" on peer %v returned error: %v", name, addr, err)
+				// try one more time before giving up
+				time.Sleep(10 * time.Second)
+				g.RPC(addr, name, fn)
 			}
 			wg.Done()
 		}(addr)

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -50,6 +50,7 @@ func (g *Gateway) RPC(addr modules.NetAddress, name string, fn modules.RPCFunc) 
 	// call fn
 	err = fn(conn)
 	if err != nil {
+		// TODO: log error here?
 		// give peer a strike
 		atomic.AddUint32(&peer.strikes, 1)
 	}

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -32,7 +32,9 @@ func handlerName(name string) (id rpcID) {
 // that the Gateway is not connected to.
 func (g *Gateway) RPC(addr modules.NetAddress, name string, fn modules.RPCFunc) error {
 	g.log.Printf("INFO: calling RPC \"%v\" on %v", name, addr)
+	id := g.mu.RLock()
 	peer, ok := g.peers[addr]
+	g.mu.RUnlock(id)
 	if !ok {
 		return errors.New("can't call RPC on unconnected peer " + string(addr))
 	}

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -2,7 +2,6 @@ package gateway
 
 import (
 	"testing"
-	"time"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -143,7 +142,6 @@ func TestThreadedHandleConn(t *testing.T) {
 			return err
 		}
 		defer conn.Close()
-		time.Sleep(10 * time.Millisecond)
 		return fn(conn)
 	}
 

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -64,7 +64,7 @@ func startDaemon() error {
 
 	// Bootstrap to the network.
 	if !config.Siad.NoBootstrap {
-		go gateway.Bootstrap(modules.BootstrapPeers[0])
+		go gateway.Connect(modules.BootstrapPeers[0])
 	}
 
 	// Send a struct down the started channel, so the testing package knows


### PR DESCRIPTION
Nodes are now requested whenever you connect to a peer, and that peer will also broadcast your address to its peers when you connect to it.
This should mean that at any given point, your node list will be the union of the node lists of all of your peers. Ideally, this implies that every node knows about every other node, and that when a node joins the network, its address is quickly relayed to the entire network. Whether or not these ideals will hold in reality remains to be seen.