### PR TITLE
add 32bit and arm to 'make xc'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ release: REBUILD
 # xc builds and packages release binaries for all systems by using goxc.
 # Cross Compile - makes binaries for windows, linux, and mac, 32 and 64 bit.
 xc: dependencies test test-long REBUILD
-	goxc -arch="amd64" -bc="linux windows darwin" -d=release -pv=0.3.1          \
+	goxc -arch="386 amd64 arm" -bc="linux windows darwin" -d=release -pv=0.3.1  \
 		-br=release -pr=beta -include=LICENSE,README.md,doc/API.md              \
 		-main-dirs-exclude=siag	-tasks-=deb,deb-dev,deb-source,go-test
 


### PR DESCRIPTION
Enough people have asked for alternate architectures on the forums that I've added everything back in. I'm still in doubt that we'll ever need 32bit mac, but people have explicitly asked for everything else.