### PR TITLE
Ux tweaks

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -20,15 +20,17 @@ func (srv *Server) hostAnnounceHandler(w http.ResponseWriter, req *http.Request)
 func (srv *Server) hostConfigureHandler(w http.ResponseWriter, req *http.Request) {
 	// load current settings
 	config := srv.host.Info().HostSettings
+	fmt.Println(config)
+	fmt.Println(req.URL)
 
 	// map each query string to a field in the host announcement object
 	qsVars := map[string]interface{}{
-		"totalStorage": &config.TotalStorage,
-		"minFilesize":  &config.MinFilesize,
-		"maxFilesize":  &config.MaxFilesize,
-		"minDuration":  &config.MinDuration,
-		"maxDuration":  &config.MaxDuration,
-		"windowSize":   &config.WindowSize,
+		"totalstorage": &config.TotalStorage,
+		"minfilesize":  &config.MinFilesize,
+		"maxfilesize":  &config.MaxFilesize,
+		"minduration":  &config.MinDuration,
+		"maxduration":  &config.MaxDuration,
+		"windowsize":   &config.WindowSize,
 		"price":        &config.Price,
 		"collateral":   &config.Collateral,
 	}
@@ -50,6 +52,7 @@ func (srv *Server) hostConfigureHandler(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	fmt.Println(config)
 	srv.host.SetSettings(config)
 	writeSuccess(w)
 }

--- a/api/host.go
+++ b/api/host.go
@@ -20,8 +20,6 @@ func (srv *Server) hostAnnounceHandler(w http.ResponseWriter, req *http.Request)
 func (srv *Server) hostConfigureHandler(w http.ResponseWriter, req *http.Request) {
 	// load current settings
 	config := srv.host.Info().HostSettings
-	fmt.Println(config)
-	fmt.Println(req.URL)
 
 	// map each query string to a field in the host announcement object
 	qsVars := map[string]interface{}{
@@ -52,7 +50,6 @@ func (srv *Server) hostConfigureHandler(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	fmt.Println(config)
 	srv.host.SetSettings(config)
 	writeSuccess(w)
 }

--- a/api/host.go
+++ b/api/host.go
@@ -51,11 +51,6 @@ func (srv *Server) hostConfigureHandler(w http.ResponseWriter, req *http.Request
 	}
 
 	srv.host.SetSettings(config)
-	err := srv.host.Announce()
-	if err != nil {
-		writeError(w, "Could not announce host: "+err.Error(), http.StatusBadRequest)
-		return
-	}
 	writeSuccess(w)
 }
 

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -27,7 +27,7 @@ func TestUploadAndDownload(t *testing.T) {
 
 	// Upload to the host.
 	uploadName := "api.go"
-	st.callAPI("/renter/upload?pieces=1&nickname=first&source=" + uploadName)
+	st.callAPI("/renter/upload?pieces=1&nickname=api.go&source=" + uploadName)
 
 	// Wait for the upload to finish - this is necessary due to the
 	// fact that zero-conf transactions aren't actually propagated properly.
@@ -44,7 +44,7 @@ func TestUploadAndDownload(t *testing.T) {
 
 	// Try to download the file.
 	downloadName := build.TempDir("api", "TestUploadAndDownload", "downloadTestData")
-	st.callAPI("/renter/download?nickname=first&destination=" + downloadName)
+	st.callAPI("/renter/download?nickname=api.go&destination=" + downloadName)
 	time.Sleep(time.Second * 2)
 
 	// Check that the downloaded file is equal to the uploaded file.

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -202,7 +202,7 @@ func (s *State) RelayBlock(conn modules.PeerConn) error {
 		}
 		return errors.New("consensus set malfunction")
 	}
-	currentPathBlock, exists := s.BlockAtHeight(height)
+	currentPathBlock, exists := s.blockAtHeight(height)
 	if !exists || b.ID() != currentPathBlock.ID() {
 		return errors.New("block added, but it does not extend the consensus set height")
 	}

--- a/modules/consensus/info.go
+++ b/modules/consensus/info.go
@@ -47,6 +47,16 @@ func (s *State) height() types.BlockHeight {
 	return types.BlockHeight(len(s.currentPath) - 1)
 }
 
+// heightOfBlock returns the height of the block with the given ID.
+func (s *State) heightOfBlock(bid types.BlockID) (height types.BlockHeight, exists bool) {
+	bn, exists := s.blockMap[bid]
+	if !exists {
+		return
+	}
+	height = bn.height
+	return
+}
+
 // output returns the unspent SiacoinOutput associated with the given ID. If
 // the output is not in the UTXO set, 'exists' will be false.
 func (s *State) output(id types.SiacoinOutputID) (sco types.SiacoinOutput, exists bool) {
@@ -194,15 +204,9 @@ func (s *State) Height() types.BlockHeight {
 
 // HeightOfBlock returns the height of the block with the given ID.
 func (s *State) HeightOfBlock(bid types.BlockID) (height types.BlockHeight, exists bool) {
-	counter := s.mu.RLock()
-	defer s.mu.RUnlock(counter)
-
-	bn, exists := s.blockMap[bid]
-	if !exists {
-		return
-	}
-	height = bn.height
-	return
+	lockID := s.mu.RLock()
+	defer s.mu.RUnlock(lockID)
+	return s.heightOfBlock(bid)
 }
 
 // StorageProofSegment returns the segment to be used in the storage proof for

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -47,7 +47,7 @@ func (h *Host) Announce() error {
 	// create and encode the announcement and add it to the arbitrary data of
 	// the transaction.
 	lockID := h.mu.RLock()
-	if h.myAddr == "" {
+	if h.myAddr.Host() == "" {
 		h.mu.RUnlock(lockID)
 		return errors.New("can't announce without knowing external IP")
 	}
@@ -66,6 +66,9 @@ func (h *Host) Announce() error {
 
 	// Add the transaction to the transaction pool.
 	err = h.tpool.AcceptTransaction(t)
+	if err == modules.ErrTransactionPoolDuplicate {
+		return errors.New("You have already announced yourself.")
+	}
 	if err != nil {
 		return err
 	}

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -67,7 +67,7 @@ func (h *Host) Announce() error {
 	// Add the transaction to the transaction pool.
 	err = h.tpool.AcceptTransaction(t)
 	if err == modules.ErrTransactionPoolDuplicate {
-		return errors.New("You have already announced yourself.")
+		return errors.New("you have already announced yourself")
 	}
 	if err != nil {
 		return err

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -79,8 +79,8 @@ func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wall
 
 		// default host settings
 		HostSettings: modules.HostSettings{
-			TotalStorage: 2e9,                      // 2 GB
-			MaxFilesize:  300e6,                    // 300 MB
+			TotalStorage: 5e9,                      // 5 GB
+			MaxFilesize:  1e9,                      // 1 GB
 			MaxDuration:  5e3,                      // Just over a month.
 			WindowSize:   288,                      // 48 hours.
 			Price:        types.NewCurrency64(1e9), // 10^9

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -128,7 +128,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	// are in place. 512mib is chosen to prevent confusion - on anybody's
 	// machine any file appearing to be under 500mb will be below the hard
 	// limit.
-	if fileInfo.Size() > 512 * 1024 * 1024  {
+	if fileInfo.Size() > 512*1024*1024 {
 		return errors.New("cannot upload a file that's greater than 500mb")
 	}
 

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -101,6 +102,10 @@ func (r *Renter) threadedUploadPiece(up modules.FileUploadParams, piece *filePie
 func (r *Renter) Upload(up modules.FileUploadParams) error {
 	lockID := r.mu.Lock()
 	defer r.mu.Unlock(lockID)
+
+	if filepath.Ext(up.Filename) != filepath.Ext(up.Nickname) {
+		return errors.New("nickname and file name must have the same extension")
+	}
 
 	err := r.checkWalletBalance(up)
 	if err != nil {

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -103,6 +103,8 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	lockID := r.mu.Lock()
 	defer r.mu.Unlock(lockID)
 
+	// TODO: This type of restriction is something that should be handled by
+	// the frontend, not the backend.
 	if filepath.Ext(up.Filename) != filepath.Ext(up.Nickname) {
 		return errors.New("nickname and file name must have the same extension")
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -118,6 +118,20 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("file with that nickname already exists")
 	}
 
+	// Check that the file exists and is less than 500mb.
+	fileInfo, err := os.Stat(up.Filename)
+	if err != nil {
+		return err
+	}
+	// NOTE: The upload max of 500mb is temporary and therefore does not have a
+	// constant. This should be removed once micropayments + upload resuming
+	// are in place. 512mib is chosen to prevent confusion - on anybody's
+	// machine any file appearing to be under 500mb will be below the hard
+	// limit.
+	if fileInfo.Size() > 512 * 1024 * 1024  {
+		return errors.New("cannot upload a file that's greater than 500mb")
+	}
+
 	// Check that the hostdb is sufficiently large to support an upload. Right
 	// now that value is set to 3, but in the future the logic will be a bit
 	// more complex; once there is erasure coding we'll want to hit the minimum

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -1,7 +1,15 @@
 package modules
 
 import (
+	"errors"
+
 	"github.com/NebulousLabs/Sia/types"
+)
+
+var (
+	// ErrTransactionPoolDuplicate is returned when a duplicate transaction is
+	// submitted to the transaction pool.
+	ErrTransactionPoolDuplicate = errors.New("transaction is a duplicate")
 )
 
 // A TransactionPoolSubscriber receives updates about the confirmed and

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -1,8 +1,6 @@
 package transactionpool
 
 import (
-	"errors"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -15,10 +13,6 @@ import (
 // added to the unconfirmed consensus set piecemeal, and then the transaction
 // itself is appended to the linked list of transactions, such that any
 // dependecies will appear earlier in the list.
-
-var (
-	ErrDuplicate = errors.New("transaction is a duplicate")
-)
 
 // applySiacoinInputs incorporates all of the siacoin inputs of a transaction
 // into the unconfirmed set.
@@ -214,7 +208,7 @@ func (tp *TransactionPool) AcceptTransaction(t types.Transaction) (err error) {
 	txnHash := crypto.HashObject(t)
 	_, exists := tp.transactions[txnHash]
 	if exists {
-		return ErrDuplicate
+		return modules.ErrTransactionPoolDuplicate
 	}
 
 	// Check that the transaction is legal given the unconfirmed consensus set

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -3,6 +3,7 @@ package transactionpool
 import (
 	"testing"
 
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -73,7 +74,7 @@ func TestDuplicateTransaction(t *testing.T) {
 	tpt := newTpoolTester("TestDuplicateTransaction", t)
 	txn := tpt.addSiacoinTransactionToPool()
 	err := tpt.tpool.AcceptTransaction(txn)
-	if err != ErrDuplicate {
+	if err != modules.ErrTransactionPoolDuplicate {
 		t.Fatal("expecting ErrDuplicate got:", err)
 	}
 }


### PR DESCRIPTION
Renter returns an error if you upload something more than 500mb.
Host returns more reasonable error if you try to announce multiple times.
Changing your host settings works now (it didn't before).
File nicknames must have an extension matching the original extension.
Host defaults changed to 1gb max filesize and 5gb starting storage.