### PR TITLE
Miner hashrate

### DIFF
--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -87,6 +87,16 @@ type ConsensusSet interface {
 	// This is a thread-safe way of managing updates.
 	ConsensusSetSubscribe(ConsensusSetSubscriber)
 
+	// CurrentBlock returns the most recent block on the heaviest fork known to
+	// the consensus set.
+	CurrentBlock() types.Block
+
+	// EarliestChildTimestamp returns the earliest timestamp that is acceptable
+	// on the current longest fork according to the consensus set. This is a
+	// required piece of information for the miner, who could otherwise be at
+	// risk of mining invalid blocks.
+	EarliestChildTimestamp(types.BlockID) (types.Timestamp, bool)
+
 	// Synchronize will try to synchronize to a specific peer. During general
 	// use, this call should never be necessary.
 	Synchronize(NetAddress) error

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -12,7 +12,7 @@ type MinerInfo struct {
 	Threads        int
 	RunningThreads int
 	HashRate       int64
-	BlocksPerMonth int
+	BlocksPerMonth float64
 	Address        types.UnlockHash
 }
 

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -11,6 +11,8 @@ type MinerInfo struct {
 	Mining         bool
 	Threads        int
 	RunningThreads int
+	HashRate       int64
+	BlocksPerMonth int
 	Address        types.UnlockHash
 }
 

--- a/modules/miner/info.go
+++ b/modules/miner/info.go
@@ -24,6 +24,8 @@ func (m *Miner) MinerInfo() modules.MinerInfo {
 		Threads:        m.threads,
 		RunningThreads: m.runningThreads,
 		Address:        m.address,
+		HashRate:       m.hashRate,
+		// Blocks per month left empty: not sure how to convert 'target' to 'hashes required'
 	}
 	if info.RunningThreads != 0 {
 		info.Mining = true

--- a/modules/miner/info.go
+++ b/modules/miner/info.go
@@ -17,8 +17,8 @@ import (
 //
 // Address is the current address that is receiving block payouts.
 func (m *Miner) MinerInfo() modules.MinerInfo {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	info := modules.MinerInfo{
 		Threads:        m.threads,
@@ -49,7 +49,7 @@ func (m *Miner) MinerInfo() modules.MinerInfo {
 
 // Threads returns the number of threads being used by the miner.
 func (m *Miner) Threads() int {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.threads
 }

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -2,9 +2,7 @@ package miner
 
 import (
 	"errors"
-	"fmt"
 	"sync"
-	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/consensus"
@@ -33,7 +31,7 @@ type Miner struct {
 
 	subscribers []chan struct{}
 
-	mu sync.RWMutex
+	mu sync.Mutex
 }
 
 // New returns a ready-to-go miner that is not mining.
@@ -72,23 +70,7 @@ func New(s *consensus.State, tpool modules.TransactionPool, w modules.Wallet) (m
 
 	m.tpool.TransactionPoolSubscribe(m)
 
-	go m.threadedPrintHashRate()
-
 	return
-}
-
-func (m *Miner) threadedPrintHashRate() {
-	for {
-		m.mu.Lock()
-		attempts := m.attempts
-		m.attempts = 0
-		m.mu.Unlock()
-
-		// Prints the number of kilohashes that second.
-		iterations := attempts * 16
-		fmt.Println(iterations)
-		time.Sleep(4 * time.Second)
-	}
 }
 
 // SetThreads establishes how many threads the miner will use when mining.

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -3,14 +3,15 @@ package miner
 import (
 	"errors"
 	"sync"
+	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/modules/consensus"
 	"github.com/NebulousLabs/Sia/types"
 )
 
 type Miner struct {
-	state  *consensus.State
+	cs     modules.ConsensusSet
 	tpool  modules.TransactionPool
 	wallet modules.Wallet
 
@@ -22,7 +23,9 @@ type Miner struct {
 	earliestTimestamp types.Timestamp
 	address           types.UnlockHash
 
-	attempts int
+	startTime int64
+	attempts  uint64
+	hashRate  int64
 
 	threads              int // how many threads the miner uses, shouldn't ever be 0.
 	desiredThreads       int // 0 if not mining.
@@ -35,8 +38,9 @@ type Miner struct {
 }
 
 // New returns a ready-to-go miner that is not mining.
-func New(s *consensus.State, tpool modules.TransactionPool, w modules.Wallet) (m *Miner, err error) {
-	if s == nil {
+func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Wallet) (m *Miner, err error) {
+	// Create the miner and its dependencies.
+	if cs == nil {
 		err = errors.New("miner cannot use a nil state")
 		return
 	}
@@ -48,26 +52,38 @@ func New(s *consensus.State, tpool modules.TransactionPool, w modules.Wallet) (m
 		err = errors.New("miner cannot use a nil wallet")
 		return
 	}
-
+	currentBlock := cs.CurrentBlock().ID()
+	currentTarget, exists1 := cs.ChildTarget(currentBlock)
+	earliestTimestamp, exists2 := cs.EarliestChildTimestamp(currentBlock)
+	if build.DEBUG {
+		if !exists1 {
+			panic("could not get child target")
+		}
+		if !exists2 {
+			panic("could not get child earliest timestamp")
+		}
+	}
 	m = &Miner{
-		state:  s,
+		cs:     cs,
 		tpool:  tpool,
 		wallet: w,
 
-		parent:            s.CurrentBlock().ID(),
-		target:            s.CurrentTarget(),
-		earliestTimestamp: s.EarliestTimestamp(),
+		parent:            currentBlock,
+		target:            currentTarget,
+		earliestTimestamp: earliestTimestamp,
 
 		threads:              1,
-		iterationsPerAttempt: 64 * 1024,
+		iterationsPerAttempt: 32 * 1024,
 	}
 
+	// Get an address for the miner payout.
 	addr, _, err := m.wallet.CoinAddress()
 	if err != nil {
 		return
 	}
 	m.address = addr
 
+	// Subscribe to the transaction pool to get transactions to put in blocks.
 	m.tpool.TransactionPoolSubscribe(m)
 
 	return
@@ -82,6 +98,35 @@ func (m *Miner) SetThreads(threads int) error {
 		return errors.New("cannot have a miner with 0 threads.")
 	}
 	m.threads = threads
+	m.attempts = 0
+	m.startTime = time.Now().UnixNano()
 
+	return nil
+}
+
+// StartMining spawns a bunch of mining threads which will mine until stop is
+// called.
+func (m *Miner) StartMining() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Increase the number of threads to m.desiredThreads.
+	m.desiredThreads = m.threads
+	for i := m.runningThreads; i < m.desiredThreads; i++ {
+		go m.threadedMine()
+	}
+
+	return nil
+}
+
+// StopMining sets desiredThreads to 0, a value which is polled by mining
+// threads. When set to 0, the mining threads will all cease mining.
+func (m *Miner) StopMining() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Set desiredThreads to 0. The miners will shut down automatically.
+	m.desiredThreads = 0
+	m.hashRate = 0
 	return nil
 }

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -47,8 +47,8 @@ func (m *Miner) ReceiveTransactionPoolUpdate(revertedBlocks, appliedBlocks []typ
 
 	// Update the parent, target, and earliest timestamp fields for the miner.
 	m.parent = appliedBlocks[len(appliedBlocks)-1].ID()
-	target, exists1 := m.state.ChildTarget(m.parent)
-	timestamp, exists2 := m.state.EarliestChildTimestamp(m.parent)
+	target, exists1 := m.cs.ChildTarget(m.parent)
+	timestamp, exists2 := m.cs.EarliestChildTimestamp(m.parent)
 	if build.DEBUG {
 		if !exists1 {
 			panic("could not get child target")

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -15,6 +15,9 @@ func (m *Miner) ReceiveTransactionPoolUpdate(revertedBlocks, appliedBlocks []typ
 	defer m.mu.Unlock()
 	defer m.notifySubscribers()
 
+	m.height -= types.BlockHeight(len(revertedBlocks))
+	m.height += types.BlockHeight(len(appliedBlocks))
+
 	// The total encoded size of the transactions cannot exceed the block size.
 	m.transactions = nil
 	remainingSize := int(types.BlockSizeLimit - 5e3)


### PR DESCRIPTION
This should be merged after the ux pr.

I reorganized the miner a bit. Now it uses the consensus package as a module instead of importing the state directly. Other smaller organizations were made, mostly that reduce dependency on locking.

Though it probably wasn't the best use of my time, I ran the miner through a profiler and optimized it. As it happens, the call `crypto.HashAll(b.ID, b.Nonce, blockRoot)` was taking the vast majority of the time, as one might expect, except that the hashing portion was only active 20% of the time. Garbage collection was taking up something like 70% of the time??? So I rewrote it, bypassing the HashAll function and the encoding package and instead encoding it manually. The result was a 3x speedup to our miner. My desktop is running this code and it's working very much to my favor.

Then I added some code to give the miner awareness of how fast it's hashing. The old code would get all the way up to about 1.1 Mhash/s on 7+ threads. To my surprise, 20 threads were just as efficient as 7, there didn't seem to be overhead with having too many threads. The new code runs at about 3.1 Mhash/s on my desktop, which is comparable to Forest's single 100mhz fpga core.

Finally, I added a tool to convert hashrate to blocks per month. The math took me a while but that's probably a calculation we're going to want to keep. It would probably be nice to have some api call that allows external miners to report their hashrate.

I plan on integrating these 2 new statistics with the UI. The only thing that's missing now is some indicator of how many blocks total you've found, (this indicator should probably also have an orphan count), and additional information about how long it will be until you get your payments.