### PR TITLE
Visible addresses

### DIFF
--- a/api/debug.go
+++ b/api/debug.go
@@ -118,7 +118,7 @@ func (srv *Server) mutexTestHandler(w http.ResponseWriter, req *http.Request) {
 		mds.TransactionPool = true
 	}()
 	go func() {
-		srv.wallet.CoinAddress()
+		srv.wallet.CoinAddress(false) // false indicates that the address should not be visible to the user.
 		mds.Wallet = true
 	}()
 	time.Sleep(time.Second * 3)

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -11,7 +11,7 @@ import (
 
 // walletAddressHandler handles the API request for a new address.
 func (srv *Server) walletAddressHandler(w http.ResponseWriter, req *http.Request) {
-	coinAddress, _, err := srv.wallet.CoinAddress()
+	coinAddress, _, err := srv.wallet.CoinAddress(true) // true indicates that the address should be visible to the user
 	if err != nil {
 		writeError(w, "Failed to get a coin address", http.StatusInternalServerError)
 		return

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -20,9 +20,7 @@ func (srv *Server) walletAddressHandler(w http.ResponseWriter, req *http.Request
 	// Since coinAddress is not a struct, we define one here so that writeJSON
 	// writes an object instead of a bare value. In addition, we transmit the
 	// coinAddress as a hex-encoded string rather than a byte array.
-	writeJSON(w, struct {
-		Address string
-	}{fmt.Sprintf("%x", coinAddress)})
+	writeJSON(w, struct{ Address types.UnlockHash }{coinAddress})
 }
 
 // walletSendHandler handles the API call to send coins to another address.

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -67,7 +67,7 @@ func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wall
 		return
 	}
 
-	coinAddr, _, err := wallet.CoinAddress()
+	coinAddr, _, err := wallet.CoinAddress(false) // false indicates that the address should not be visible to the user.
 	if err != nil {
 		return
 	}
@@ -78,11 +78,11 @@ func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wall
 
 		// default host settings
 		HostSettings: modules.HostSettings{
-			TotalStorage: 5e9,                      // 5 GB
-			MaxFilesize:  1e9,                      // 1 GB
-			MaxDuration:  144 * 30,                 // 30 days
-			WindowSize:   288,                      // 48 hours
-			Price:        types.NewCurrency64(1e9), // 10^9
+			TotalStorage: 5e9,                       // 5 GB
+			MaxFilesize:  1e9,                       // 1 GB
+			MaxDuration:  144 * 30,                  // 30 days
+			WindowSize:   288,                       // 48 hours
+			Price:        types.NewCurrency64(1e15), // 1 siacoin / mb / week
 			Collateral:   types.NewCurrency64(0),
 			UnlockHash:   coinAddr,
 		},

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -64,6 +64,7 @@ func (h *Host) ReceiveConsensusSetUpdate(revertedBlocks []types.Block, appliedBl
 
 	// Check the applied blocks and see if any of the contracts we have are
 	// ready for storage proofs.
+	var shouldSave bool
 	for _ = range appliedBlocks {
 		h.blockHeight++
 
@@ -83,10 +84,13 @@ func (h *Host) ReceiveConsensusSetUpdate(revertedBlocks []types.Block, appliedBl
 				return
 			}
 			h.deallocate(uint64(stat.Size()), obligation.Path) // TODO: file might actually be the wrong size.
-
 			delete(h.obligationsByID, obligation.ID)
+			shouldSave = true
 		}
 		delete(h.obligationsByHeight, h.blockHeight)
+	}
+	if shouldSave {
+		_ = h.save() // TODO: Some way to communicate that the save failed.
 	}
 
 	h.updateSubscribers()

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -13,7 +13,7 @@ type MinerInfo struct {
 	Threads        int
 	RunningThreads int
 	HashRate       int64
-	BlocksPerMonth float64
+	BlocksPerWeek  float64
 	BlocksMined    int
 	OrphansMined   int
 	Address        types.UnlockHash

--- a/modules/miner/info.go
+++ b/modules/miner/info.go
@@ -25,10 +25,12 @@ func (m *Miner) MinerInfo() modules.MinerInfo {
 
 	// Using the hashrate and target, determine the number of blocks per month
 	// that could be mined.
-	hashesRequired, _ := big.NewRat(0, 1).SetFrac(types.RootDepth.Int(), m.target.Int()).Float64()
-	hashesPerWeek := big.NewInt(0).Mul(big.NewInt(60*60*24*7), big.NewInt(m.hashRate))
-	floatHPW, _ := big.NewRat(0, 1).SetInt(hashesPerWeek).Float64()
-	blocksPerWeek := floatHPW / hashesRequired
+	blocksPerWeek := float64(0)
+	if m.target.Int().Sign() > 0 {
+		hashesPerWeek := new(big.Int).Mul(big.NewInt(60*60*24*7), big.NewInt(m.hashRate))
+		hashesPerBlock := new(big.Int).Div(types.RootDepth.Int(), m.target.Int())
+		blocksPerWeek, _ = new(big.Rat).SetFrac(hashesPerWeek, hashesPerBlock).Float64()
+	}
 
 	info := modules.MinerInfo{
 		Threads:        m.threads,

--- a/modules/miner/info.go
+++ b/modules/miner/info.go
@@ -1,7 +1,6 @@
 package miner
 
 import (
-	"math"
 	"math/big"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -26,19 +25,17 @@ func (m *Miner) MinerInfo() modules.MinerInfo {
 
 	// Using the hashrate and target, determine the number of blocks per month
 	// that could be mined.
-	floatMaxTarget, _ := big.NewRat(0, 1).SetInt(types.RootDepth.Int()).Float64()
-	floatCurTarget, _ := big.NewRat(0, 1).SetInt(m.target.Int()).Float64()
-	hashesRequired := math.Exp2(math.Log2(floatMaxTarget) - math.Log2(floatCurTarget))
-	hashesPerMonth := big.NewInt(0).Mul(big.NewInt(60*60*24*30), big.NewInt(m.hashRate))
-	floatHPM, _ := big.NewRat(0, 1).SetInt(hashesPerMonth).Float64()
-	blocksPerMonth := floatHPM / hashesRequired
+	hashesRequired, _ := big.NewRat(0, 1).SetFrac(types.RootDepth.Int(), m.target.Int()).Float64()
+	hashesPerWeek := big.NewInt(0).Mul(big.NewInt(60*60*24*7), big.NewInt(m.hashRate))
+	floatHPW, _ := big.NewRat(0, 1).SetInt(hashesPerWeek).Float64()
+	blocksPerWeek := floatHPW / hashesRequired
 
 	info := modules.MinerInfo{
 		Threads:        m.threads,
 		RunningThreads: m.runningThreads,
 		Address:        m.address,
 		HashRate:       m.hashRate,
-		BlocksPerMonth: blocksPerMonth,
+		BlocksPerWeek:  blocksPerWeek,
 	}
 
 	// Using the reference of all blocks that have been mined, determine how

--- a/modules/miner/mine.go
+++ b/modules/miner/mine.go
@@ -60,11 +60,6 @@ func (m *Miner) submitBlock(b types.Block) error {
 	err := m.cs.AcceptBlock(b)
 	if err != nil {
 		m.mu.Lock()
-		fmt.Println("Mined a bad block:", err)
-		fmt.Println(b.ID())
-		childtarget, _ := m.cs.ChildTarget(b.ParentID)
-		fmt.Println(childtarget)
-		fmt.Println(b.Nonce)
 		m.tpool.PurgeTransactionPool()
 		m.mu.Unlock()
 		return err

--- a/modules/miner/mine.go
+++ b/modules/miner/mine.go
@@ -77,8 +77,8 @@ func (m *Miner) submitBlock(b types.Block) error {
 	m.mu.Lock()
 	m.blocksFound = append(m.blocksFound, b.ID())
 	var addr types.UnlockHash
-	addr, _, err = m.wallet.CoinAddress()
-	if err == nil { // Special case: only update the address if there was no error.
+	addr, _, err = m.wallet.CoinAddress(false) // false indicates that the address should not be visible to the user.
+	if err == nil {                            // Special case: only update the address if there was no error.
 		m.address = addr
 	}
 	m.mu.Unlock()

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -80,7 +80,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 	}
 
 	// Get an address for the miner payout.
-	addr, _, err := m.wallet.CoinAddress()
+	addr, _, err := m.wallet.CoinAddress(false) // false indicates that the address should not be visible to the user.
 	if err != nil {
 		return
 	}

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -25,7 +25,7 @@ func (tpt *tpoolTester) addSiacoinTransactionToPool() (txn types.Transaction) {
 // the unconfirmed siacoin output.
 func (tpt *tpoolTester) addDependentSiacoinTransactionToPool() (firstTxn, dependentTxn types.Transaction) {
 	// Get an address to receive coins.
-	addr, _, err := tpt.wallet.CoinAddress()
+	addr, _, err := tpt.wallet.CoinAddress(false) // false means hide the address from the user; doesn't matter for test.
 	if err != nil {
 		tpt.t.Fatal(err)
 	}

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -16,9 +16,10 @@ var (
 
 // WalletInfo contains basic information about the wallet.
 type WalletInfo struct {
-	Balance      types.Currency
-	FullBalance  types.Currency
-	NumAddresses int
+	Balance          types.Currency
+	FullBalance      types.Currency
+	VisibleAddresses []types.UnlockHash
+	NumAddresses     int
 }
 
 // Wallet in an interface that helps to build and sign transactions. The user
@@ -31,11 +32,14 @@ type Wallet interface {
 	// have been spent in unconfirmed transactions.
 	Balance(full bool) types.Currency
 
-	// CoinAddress return an address into which coins can be paid.
-	CoinAddress() (types.UnlockHash, types.UnlockConditions, error)
+	// CoinAddress return an address into which coins can be paid. The bool
+	// indicates whether the address should be visible to the user.
+	CoinAddress(visible bool) (types.UnlockHash, types.UnlockConditions, error)
 
-	// TimelockedCoinAddress returns an address that can only be spent after block `unlockHeight`.
-	TimelockedCoinAddress(unlockHeight types.BlockHeight) (types.UnlockHash, types.UnlockConditions, error)
+	// TimelockedCoinAddress returns an address that can only be spent after
+	// block `unlockHeight`. The bool indicates whether the address should be
+	// visible to the user.
+	TimelockedCoinAddress(unlockHeight types.BlockHeight, visible bool) (types.UnlockHash, types.UnlockConditions, error)
 
 	// RegisterTransaction creates a transaction out of an existing transaction
 	// which can be modified by the wallet, returning an id that can be used to

--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -14,5 +14,9 @@ func (w *Wallet) Info() modules.WalletInfo {
 	counter := w.mu.RLock()
 	wi.NumAddresses = len(w.keys)
 	w.mu.RUnlock(counter)
+
+	for va := range w.visibleAddresses {
+		wi.VisibleAddresses = append(wi.VisibleAddresses, va)
+	}
 	return wi
 }

--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -1,7 +1,11 @@
 package wallet
 
 import (
+	"sort"
+
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // Info fills out and returns a WalletInfo struct.
@@ -15,8 +19,13 @@ func (w *Wallet) Info() modules.WalletInfo {
 	wi.NumAddresses = len(w.keys)
 	w.mu.RUnlock(counter)
 
+	var sortingSpace crypto.HashSlice
 	for va := range w.visibleAddresses {
-		wi.VisibleAddresses = append(wi.VisibleAddresses, va)
+		sortingSpace = append(sortingSpace, crypto.Hash(va))
+	}
+	sort.Sort(sortingSpace)
+	for _, va := range sortingSpace {
+		wi.VisibleAddresses = append(wi.VisibleAddresses, types.UnlockHash(va))
 	}
 	return wi
 }

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -11,6 +11,15 @@ import (
 type savedKey struct {
 	SecretKey        crypto.SecretKey
 	UnlockConditions types.UnlockConditions
+	Visible          bool
+}
+
+// legacySavedKey preserves compatibility with the other beta wallets. After
+// the full currency is launched, this struct and the related code can be
+// discarded.
+type legacySavedKey struct {
+	SecretKey        crypto.SecretKey
+	UnlockConditions types.UnlockConditions
 }
 
 // save writes the contents of a wallet to a file.
@@ -18,7 +27,8 @@ func (w *Wallet) save() error {
 	// Convert the key map to a slice.
 	keySlice := make([]savedKey, 0, len(w.keys))
 	for _, key := range w.keys {
-		keySlice = append(keySlice, savedKey{key.secretKey, key.unlockConditions})
+		_, exists := w.visibleAddresses[key.unlockConditions.UnlockHash()]
+		keySlice = append(keySlice, savedKey{key.secretKey, key.unlockConditions, exists})
 	}
 
 	// Write the wallet data to a backup file, in case something goes wrong
@@ -39,9 +49,17 @@ func (w *Wallet) save() error {
 // load reads the contents of a wallet from a file.
 func (w *Wallet) load() error {
 	var savedKeys []savedKey
+	var legacyKeys []legacySavedKey
 	err := encoding.ReadFile(filepath.Join(w.saveDir, "wallet.dat"), &savedKeys)
 	if err != nil {
-		return err
+		err = encoding.ReadFile(filepath.Join(w.saveDir, "wallet.dat"), &legacyKeys)
+		if err != nil {
+			return err
+		}
+
+		for _, key := range legacyKeys {
+			savedKeys = append(savedKeys, savedKey{key.SecretKey, key.UnlockConditions, false})
+		}
 	}
 
 	height := w.state.Height()
@@ -58,9 +76,19 @@ func (w *Wallet) load() error {
 		if tl := skey.UnlockConditions.Timelock; tl != 0 {
 			w.timelockedKeys[tl] = append(w.timelockedKeys[tl], skey.UnlockConditions.UnlockHash())
 		}
+
+		if skey.Visible {
+			w.visibleAddresses[skey.UnlockConditions.UnlockHash()] = struct{}{}
+		}
 	}
 
-	// TODO TODO TODO: Need a scan or 're-scan' function.
+	// If there are no visible addresses, create one.
+	if len(w.visibleAddresses) == 0 {
+		_, _, err := w.coinAddress(true)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -64,7 +64,7 @@ func (w *Wallet) FundTransaction(id string, amount types.Currency) (t types.Tran
 
 	// Create and add the output that will be used to fund the standard
 	// transaction.
-	parentDest, parentSpendConds, err := w.coinAddress()
+	parentDest, parentSpendConds, err := w.coinAddress(false) // false indicates that the address should not be visible to the user
 	exactOutput := types.SiacoinOutput{
 		Value:      amount,
 		UnlockHash: parentDest,
@@ -74,7 +74,7 @@ func (w *Wallet) FundTransaction(id string, amount types.Currency) (t types.Tran
 	// Create a refund output if needed.
 	if amount.Cmp(fundingTotal) != 0 {
 		var refundDest types.UnlockHash
-		refundDest, _, err = w.coinAddress()
+		refundDest, _, err = w.coinAddress(false) // false indicates that the address should not be visible to the user
 		if err != nil {
 			return
 		}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -60,9 +60,12 @@ type Wallet struct {
 	// Timelocked keys is a list of addresses found in `keys` that can't be
 	// spent until a certain height. The wallet will use `timelockedKeys` to
 	// mark keys as unspendable until the timelock has lifted.
-	age            int
-	keys           map[types.UnlockHash]*key
-	timelockedKeys map[types.BlockHeight][]types.UnlockHash
+	//
+	// Visible keys will be displayed to the user.
+	age              int
+	keys             map[types.UnlockHash]*key
+	timelockedKeys   map[types.BlockHeight][]types.UnlockHash
+	visibleAddresses map[types.UnlockHash]struct{}
 
 	// transactions is a list of transactions that are currently being built by
 	// the wallet. Each transaction has a unique id, which is enforced by the
@@ -93,9 +96,10 @@ func New(state *consensus.State, tpool modules.TransactionPool, saveDir string) 
 
 		saveDir: saveDir,
 
-		age:            AgeDelay + 100,
-		keys:           make(map[types.UnlockHash]*key),
-		timelockedKeys: make(map[types.BlockHeight][]types.UnlockHash),
+		age:              AgeDelay + 100,
+		keys:             make(map[types.UnlockHash]*key),
+		timelockedKeys:   make(map[types.BlockHeight][]types.UnlockHash),
+		visibleAddresses: make(map[types.UnlockHash]struct{}),
 
 		transactions: make(map[string]*openTransaction),
 

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -6,6 +6,9 @@ package types
 // it is cryptographically unlikely that any two objects would share an id.
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/NebulousLabs/Sia/crypto"
 )
 
@@ -223,4 +226,11 @@ func (t Transaction) SiacoinOutputSum() (sum Currency) {
 	}
 
 	return
+}
+
+// MarshalJSON is implemented on the unlock hash to always produce a hex string
+// upon marshalling.
+func (uh *UnlockHash) MarshalJSON() ([]byte, error) {
+	str := fmt.Sprintf("%x", *uh)
+	return json.Marshal(str)
 }

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -6,9 +6,6 @@ package types
 // it is cryptographically unlikely that any two objects would share an id.
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/NebulousLabs/Sia/crypto"
 )
 
@@ -34,12 +31,6 @@ type (
 	SiacoinOutputID crypto.Hash
 	SiafundOutputID crypto.Hash
 	FileContractID  crypto.Hash
-
-	// An UnlockHash is a specially constructed hash of the UnlockConditions
-	// type. "Locked" values can be unlocked by providing the UnlockConditions
-	// that hash to a given UnlockHash. See SpendConditions.UnlockHash for
-	// details on how the UnlockHash is constructed.
-	UnlockHash crypto.Hash
 
 	// A Transaction is an atomic component of a block. Transactions can contain
 	// inputs and outputs, file contracts, storage proofs, and even arbitrary
@@ -226,11 +217,4 @@ func (t Transaction) SiacoinOutputSum() (sum Currency) {
 	}
 
 	return
-}
-
-// MarshalJSON is implemented on the unlock hash to always produce a hex string
-// upon marshalling.
-func (uh *UnlockHash) MarshalJSON() ([]byte, error) {
-	str := fmt.Sprintf("%x", *uh)
-	return json.Marshal(str)
 }


### PR DESCRIPTION
3 things (commits sum it up nicely):

1. I added visible addresses, which are addresses that get displayed to the user. Right now, that's only addresses that the user created manually and not addresses created by the miner, wallet, or host. Visible addresses are saved and reloaded.

2. UnlockHash type is now encoded as hex by JSON. There's no decoder at the moment.

3. Switch from 'blocks per month' to 'blocks per week', and reduce 2^(log(x) - log(y)) to x/y...