### PR TITLE
Synchronous uploads + downloads

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -14,6 +15,7 @@ const (
 
 // DownloadInfo is a helper struct for the downloadqueue API call.
 type DownloadInfo struct {
+	StartTime   time.Time
 	Complete    bool
 	Filesize    uint64
 	Received    uint64
@@ -52,6 +54,7 @@ func (srv *Server) renterDownloadqueueHandler(w http.ResponseWriter, req *http.R
 	downloadSet := make([]DownloadInfo, 0, len(downloads))
 	for _, dl := range downloads {
 		downloadSet = append(downloadSet, DownloadInfo{
+			StartTime:   dl.StartTime(),
 			Complete:    dl.Complete(),
 			Filesize:    dl.Filesize(),
 			Received:    dl.Received(),

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -42,8 +42,11 @@ func (h *Host) deallocate(filesize uint64, path string) {
 // within acceptable bounds, as defined by the host.
 func (h *Host) considerTerms(terms modules.ContractTerms) error {
 	switch {
-	case terms.FileSize < h.MinFilesize || terms.FileSize > h.MaxFilesize:
-		return errors.New("file is of incorrect size")
+	case terms.FileSize < h.MinFilesize:
+		return errors.New("file is too small")
+
+	case terms.FileSize > h.MaxFilesize:
+		return errors.New("file is too large")
 
 	case terms.FileSize > uint64(h.spaceRemaining):
 		return HostCapacityErr

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -1,6 +1,8 @@
 package modules
 
 import (
+	"time"
+
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -38,6 +40,9 @@ type FileInfo interface {
 // DownloadInfo is an interface providing information about a file that has
 // been requested for download.
 type DownloadInfo interface {
+	// StartTime is when the download was initiated.
+	StartTime() time.Time
+
 	// Complete returns whether the file is ready to be used. Note that
 	// Received == Filesize does not imply Complete, because the file may
 	// require additional processing (e.g. decryption) after all of the raw

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -26,6 +26,7 @@ type Download struct {
 	// correctly on ARM and x86-32.
 	received uint64
 
+	startTime   time.Time
 	complete    bool
 	filesize    uint64
 	destination string
@@ -33,6 +34,11 @@ type Download struct {
 
 	pieces []filePiece
 	file   *os.File
+}
+
+// StartTime returns when the download was initiated.
+func (d *Download) StartTime() time.Time {
+	return d.startTime
 }
 
 // Complete returns whether the file is ready to be used.
@@ -126,7 +132,8 @@ func newDownload(file *file, destination string) (*Download, error) {
 	}
 
 	return &Download{
-		complete: false,
+		startTime: time.Now(),
+		complete:  false,
 		// for now, all the pieces are equivalent
 		filesize:    file.Pieces[0].Contract.FileSize,
 		received:    0,

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -142,8 +142,6 @@ func newDownload(file *file, destination string) (*Download, error) {
 // specified.
 func (r *Renter) Download(nickname, destination string) error {
 	lockID := r.mu.Lock()
-	defer r.mu.Unlock(lockID)
-
 	// Lookup the file associated with the nickname.
 	file, exists := r.files[nickname]
 	if !exists {
@@ -158,6 +156,7 @@ func (r *Renter) Download(nickname, destination string) error {
 
 	// Add the download to the download queue.
 	r.downloadQueue = append(r.downloadQueue, d)
+	r.mu.Unlock(lockID)
 
 	// Download the file. We only need one piece, so iterate through the hosts
 	// until a download succeeds.

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -201,9 +201,10 @@ func (r *Renter) DownloadQueue() []modules.DownloadInfo {
 	lockID := r.mu.RLock()
 	defer r.mu.RUnlock(lockID)
 
+	// order from most recent to least recent
 	downloads := make([]modules.DownloadInfo, len(r.downloadQueue))
 	for i := range r.downloadQueue {
-		downloads[i] = r.downloadQueue[i]
+		downloads[i] = r.downloadQueue[len(r.downloadQueue)-i-1]
 	}
 	return downloads
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -68,7 +68,9 @@ func New(cs *consensus.State, hdb modules.HostDB, wallet modules.Wallet, saveDir
 	// need to make sure that scanAllFiles() didn't get called until the entire
 	// balance had loaded, which would require loading the entire blockchain.
 	// This also won't be a problem once we're also saving the addresses.
-	r.scanAllFiles()
+	//
+	// TODO: bring back this functionality when we have resumable uploads.
+	//r.scanAllFiles()
 
 	r.cs.ConsensusSetSubscribe(r)
 

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -120,18 +120,18 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("file with that nickname already exists")
 	}
 
-	// Check that the file exists and is less than 500mb.
+	// Check that the file exists and is less than 500 MiB.
 	fileInfo, err := os.Stat(up.Filename)
 	if err != nil {
 		return err
 	}
-	// NOTE: The upload max of 500mb is temporary and therefore does not have a
+	// NOTE: The upload max of 500 MiB is temporary and therefore does not have a
 	// constant. This should be removed once micropayments + upload resuming
-	// are in place. 512mib is chosen to prevent confusion - on anybody's
-	// machine any file appearing to be under 500mb will be below the hard
+	// are in place. 500 MiB is chosen to prevent confusion - on anybody's
+	// machine any file appearing to be under 500 MB will be below the hard
 	// limit.
-	if fileInfo.Size() > 512*1024*1024 {
-		return errors.New("cannot upload a file that's greater than 500mb")
+	if fileInfo.Size() > 500*1024*1024 {
+		return errors.New("cannot upload a file larger than 500 MB")
 	}
 
 	// Check that the hostdb is sufficiently large to support an upload. Right
@@ -140,7 +140,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	// number of pieces plus some buffer before we decide that an upload is
 	// okay.
 	if len(r.hostDB.ActiveHosts()) < 1 {
-		return errors.New("not enough hosts on the network to upload a file :( - maybe you need to upgrade your software")
+		return errors.New("not enough hosts on the network to upload a file")
 	}
 
 	// Upload a piece to every host on the network.

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -51,7 +51,7 @@ func (r *Renter) checkWalletBalance(up modules.FileUploadParams) error {
 // uploadPiece will give up. The file uploading can be continued using a repair
 // tool. Upon completion, the memory containg the piece's information is
 // updated.
-func (r *Renter) threadedUploadPiece(up modules.FileUploadParams, piece *filePiece) {
+func (r *Renter) threadedUploadPiece(up modules.FileUploadParams, piece *filePiece) error {
 	// Set 'Repairing' for the piece to true.
 	lockID := r.mu.Lock()
 	piece.Repairing = true
@@ -62,47 +62,46 @@ func (r *Renter) threadedUploadPiece(up modules.FileUploadParams, piece *filePie
 		// Select a host. An error here is unrecoverable.
 		host, err := r.hostDB.RandomHost()
 		if err != nil {
-			return
+			return err
 		}
 
 		// Negotiate the contract with the host. If the negotiation is
-		// unsuccessful, we need to try again with a new host. Otherwise, the
-		// file will be uploaded and we'll be done.
+		// unsuccessful, we need to try again with a new host.
 		contract, contractID, key, err := r.negotiateContract(host, up)
-		if err != nil {
-			// The previous attempt didn't work. We will try again after
-			// sleeping for a randomized amount of time to increase our chances
-			// of success. This will help spread things out if there are
-			// problems with network congestion or other randomized issues.
-			randSource := make([]byte, 1)
-			rand.Read(randSource)
-			time.Sleep(time.Duration(attempts) * time.Duration(attempts) * 250 * time.Millisecond * time.Duration(randSource[0]))
-			continue
+		if err == nil {
+			// Negotiation was successful; update the filePiece.
+			lockID := r.mu.Lock()
+			*piece = filePiece{
+				Active:     true,
+				Repairing:  false,
+				Contract:   contract,
+				ContractID: contractID,
+
+				HostIP: host.IPAddress,
+
+				EncryptionKey: key,
+			}
+			r.save()
+			r.mu.Unlock(lockID)
+			return nil
 		}
 
-		lockID := r.mu.Lock()
-		*piece = filePiece{
-			Active:     true,
-			Repairing:  false,
-			Contract:   contract,
-			ContractID: contractID,
-
-			HostIP: host.IPAddress,
-
-			EncryptionKey: key,
-		}
-		r.save()
-		r.mu.Unlock(lockID)
-		return
+		// The previous attempt didn't work. We will try again after
+		// sleeping for a randomized amount of time to increase our chances
+		// of success. This will help spread things out if there are
+		// problems with network congestion or other randomized issues.
+		randSource := make([]byte, 1)
+		rand.Read(randSource)
+		time.Sleep(time.Duration(attempts) * time.Duration(attempts) * 250 * time.Millisecond * time.Duration(randSource[0]))
 	}
+
+	// All attempts failed.
+	return errors.New("failed to upload filePiece")
 }
 
 // Upload takes an upload parameters, which contain a file to upload, and then
 // creates a redundant copy of the file on the Sia network.
 func (r *Renter) Upload(up modules.FileUploadParams) error {
-	lockID := r.mu.Lock()
-	defer r.mu.Unlock(lockID)
-
 	// TODO: This type of restriction is something that should be handled by
 	// the frontend, not the backend.
 	if filepath.Ext(up.Filename) != filepath.Ext(up.Nickname) {
@@ -115,10 +114,12 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	}
 
 	// Check for a nickname conflict.
+	lockID := r.mu.RLock()
 	_, exists := r.files[up.Nickname]
 	if exists {
 		return errors.New("file with that nickname already exists")
 	}
+	r.mu.RUnlock(lockID)
 
 	// Check that the file exists and is less than 500 MiB.
 	fileInfo, err := os.Stat(up.Filename)
@@ -143,7 +144,8 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("not enough hosts on the network to upload a file")
 	}
 
-	// Upload a piece to every host on the network.
+	// Create file object.
+	lockID = r.mu.Lock()
 	r.files[up.Nickname] = &file{
 		Name: up.Nickname,
 
@@ -152,13 +154,36 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		UploadParams:   up,
 		renter:         r,
 	}
-	for i := range r.files[up.Nickname].Pieces {
-		// threadedUploadPiece will change the memory that the piece points to,
-		// which is useful because it means the file itself can be renamed but
-		// will still point to the same underlying pieces.
-		go r.threadedUploadPiece(up, &r.files[up.Nickname].Pieces[i])
-	}
 	r.save()
 
-	return nil
+	// Upload a piece to every host on the network.
+	errChan := make(chan error, len(r.files[up.Nickname].Pieces))
+	for i := range r.files[up.Nickname].Pieces {
+		// threadedUploadPiece will change the memory that the piece points
+		// to, which is useful because it means the file can be renamed
+		// without disrupting the upload process.
+		go func(piece *filePiece) {
+			errChan <- r.threadedUploadPiece(up, piece)
+		}(&r.files[up.Nickname].Pieces[i])
+	}
+	r.mu.Unlock(lockID)
+
+	// Wait for success or failure. Since we are (currently) using full
+	// replication, success means "one piece was uploaded," while failure
+	// means "zero pieces were uploaded."
+	for i := 0; i < up.Pieces; i++ {
+		if <-errChan == nil {
+			return nil
+		}
+	}
+
+	// All uploads failed. Remove the file object.
+	lockID = r.mu.Lock()
+	delete(r.files, up.Nickname)
+	r.save()
+	r.mu.Unlock(lockID)
+
+	close(errChan)
+
+	return errors.New("failed to upload any file pieces")
 }

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -21,12 +21,12 @@ var (
 		Short: "Modify host settings",
 		Long: `Modify host settings.
 Available settings:
-	totalStorage
-	minFilesize
-	maxFilesize
-	minDuration
-	maxDuration
-	windowSize
+	totalstorage
+	minfilesize
+	maxfilesize
+	minduration
+	maxduration
+	windowsize
 	price
 	collateral`,
 		Run: wrap(hostconfigcmd),

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -112,7 +112,7 @@ func renterdownloadqueuecmd() {
 	}
 	fmt.Println("Download Queue:")
 	for _, file := range queue {
-		fmt.Printf("%5.1f%% %s -> %s\n", 100*float32(file.Received)/float32(file.Filesize), file.Nickname, file.Destination)
+		fmt.Printf("%s: %5.1f%% %s -> %s\n", file.StartTime.Format("Jan 2 3:04 PM"), 100*float32(file.Received)/float32(file.Filesize), file.Nickname, file.Destination)
 	}
 }
 
@@ -131,7 +131,7 @@ func renterfilesdownloadcmd(nickname, destination string) {
 		fmt.Println("Could not download file:", err)
 		return
 	}
-	fmt.Printf("Started downloading '%s' to %s.\n", nickname, abs(destination))
+	fmt.Printf("Downloaded '%s' to %s.\n", nickname, abs(destination))
 }
 
 func renterfileslistcmd() {


### PR DESCRIPTION
`Upload` and `Download` now block until finished instead of returning immediately. For `Download`, this means waiting for the file to be completely transferred, decrypted, and (eventually) rebuilt. For `Upload`, this just means waiting until the file is available, i.e. ready to be downloaded. Since we are currently using full replication, this means `Upload` returns as soon as one `filePiece` is uploaded.

The advantage to making these functions synchronous is that the error handling is simplified. Previously, upload and download errors were completely invisible to the user. Now, they will be reported like any other error.
Error handling is tricky for `Upload`, because it may fail for a combination of different reasons, i.e. hosts rejecting file contracts for different reasons. For now we simply return a generic "no pieces could be uploaded" error. It would be fairly easy to return the most common error though (e.g. "file is too large/small"), which would be much more helpful to the user.

Next step is to implement upload progress, probably modeled after download progress (i.e. adding methods to the `File` interface and polling it from the UI). Again, though, `Upload` is tricky because you are uploading to multiple sources. So how do you report a percentage? For now we can get away with using the largest percentage among the file pieces, but eventually we'll need something more sophisticated.
Once upload progress is implemented on the backend, it should be added to the frontend. Hopefully we can adopt the existing download bar code to this purpose.