### PR TITLE
Hardfork

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -280,14 +280,14 @@ Layout:
 
 32-111: header
 
-111+: block
+112+: block
 
 32-39 of header: header nonce
 
 32-39 of block: block nonce
 
 When submitting the block, update the nonce and submit only the block (bytes
-111+).
+112+).
 
 #### /miner/start
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -256,29 +256,38 @@ Function: Provides a block that is ready for the blockchain except for having
 an invalid target. An external miner is expected to try nonces until a block
 with a valid target is found. Every block returned by this call will have a
 unique hash - miners can start at nonce 0 without worrying about trying the
-same block twice. The block id is calculated by appending Block.ParentID,
-Block.Nonce, and Block.MerkleRoot. The result is a 72 byte array that is fed
-into blake2b. See the miner package for a reference implementation.
+same block twice.
 
 Parameters: none
 
 Response:
 ```
-struct {
-	Block types.Block
-	MerkleRoot [32]byte
-	Target [32]byte
-}
+[]byte
 ```
-`Block` is a consensus block, and will have all fields such as transactions,
-miner payouts, etc. ready to go. The only thing that needs to be modified is
-the nonce.
+The response is a byte array containing a targe followed by a block header
+followed by a block. The target is the first 32 bytes. The block header is the
+following 80 bytes, and the nonce is bytes 32-39 (inclusive) of the header
+(bytes 64-71 of the whole array). The remaining bytes are the block. Hashing
+the header will result in the block id, which must be lower than the target.
+When submitting a solved block, you need to update the nonce in the block. The
+nonce is at bytes 32-39 (inclusive) of the block, or bytes 144-151 of the whole
+field. When submitting the block to /miner/submitblock, only submit the block
+and not the target or header.
 
-`MerkleRoot` is the Merkle root of the block structures. This can be computed
-from the block, but requires knowning how to encode a block. To keep external
-miners lightweight, this value is calculated for you.
+Layout:
 
-`Target` is the target that the block header hash needs to be less than. Once a nonce is found that produces a block id lower than the target, the block can be submitted to `/miner/submitblock`
+0-31: target
+
+32-111: header
+
+111+: block
+
+32-39 of header: header nonce
+
+32-39 of block: block nonce
+
+When submitting the block, update the nonce and submit only the block (bytes
+111+).
 
 #### /miner/start
 
@@ -327,13 +336,15 @@ Response: standard
 
 #### /miner/submitblock
 
-Function: Submits a block to the miner.
+Function: Submits a block to the miner. The block is submitted as an encoded
+byte slice. The block does not need to be modified from the block provided by
+/miner/blockforwork except that the nonce must be updated. The nonce can be
+found at bytes 32-39 (inclusive) of the block.
 
 Response Body:
 ```
-Block types.Block
+[]byte
 ```
-`Block` is a json encoded block that is put into the resonse body.
 
 Response: standard
 

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -214,8 +214,8 @@ func TestMissedTarget(t *testing.T) {
 
 	// Mine a block that doesn't meet the target.
 	block, _, target := cst.miner.BlockForWork()
-	for block.CheckTarget(target) {
-		block.Nonce++
+	for block.CheckTarget(target) && block.Nonce[0] != 255 {
+		block.Nonce[0]++
 	}
 	if block.CheckTarget(target) {
 		t.Fatal("unable to find a failing target (lol)")

--- a/modules/consensus/applytransaction_frest_test.go
+++ b/modules/consensus/applytransaction_frest_test.go
@@ -19,21 +19,33 @@ func (cst *consensusSetTester) checkRevertApplyNode(initialSum crypto.Hash, bn *
 	for _, diff := range bn.siacoinOutputDiffs {
 		cst.cs.commitSiacoinOutputDiff(diff, modules.DiffRevert)
 	}
+	for _, diff := range bn.fileContractDiffs {
+		cst.cs.commitFileContractDiff(diff, modules.DiffRevert)
+	}
+	for _, diff := range bn.siafundOutputDiffs {
+		cst.cs.commitSiafundOutputDiff(diff, modules.DiffRevert)
+	}
 	if initialSum != cst.cs.consensusSetHash() {
 		return errors.New("inconsistency after rewinding a diff set")
 	}
 	for _, diff := range bn.siacoinOutputDiffs {
 		cst.cs.commitSiacoinOutputDiff(diff, modules.DiffApply)
 	}
+	for _, diff := range bn.fileContractDiffs {
+		cst.cs.commitFileContractDiff(diff, modules.DiffApply)
+	}
+	for _, diff := range bn.siafundOutputDiffs {
+		cst.cs.commitSiafundOutputDiff(diff, modules.DiffApply)
+	}
 	if resultingSum != cst.cs.consensusSetHash() {
-		return errors.New("inconsistency after rewinding a diff set")
+		return errors.New("inconsistency after reapplying a diff set")
 	}
 	return nil
 }
 
-// TestApplySiacoinInput probes the applySiacoinInput method of the consensus
+// TestApplySiacoinInputs probes the applySiacoinInputs method of the consensus
 // set.
-func TestApplySiacoinInput(t *testing.T) {
+func TestApplySiacoinInputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -107,9 +119,9 @@ func TestApplySiacoinInput(t *testing.T) {
 	}
 }
 
-// TestMisuseApplySiacoinInput misuses applySiacoinInput and checks that a
+// TestMisuseApplySiacoinInputs misuses applySiacoinInput and checks that a
 // panic was triggered.
-func TestMisuseApplySiacoinInput(t *testing.T) {
+func TestMisuseApplySiacoinInputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -146,15 +158,12 @@ func TestMisuseApplySiacoinInput(t *testing.T) {
 	cst.cs.applySiacoinInputs(bn, txn)
 }
 
-// TestApplySiacoinOutput probes the applySiacoinOutput method of the consensus
-// set.
-func TestApplySiacoinOutput(t *testing.T) {
+// TestApplySiacoinOutputs probes the applySiacoinOutput method of the
+// consensus set.
+func TestApplySiacoinOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
-	// Create a consensus set and get it to 3 siacoin outputs. The consensus
-	// set starts with 2 siacoin outputs, mining a block will add another.
 	cst, err := createConsensusSetTester("TestApplySiacoinInput")
 	if err != nil {
 		t.Fatal(err)
@@ -183,7 +192,7 @@ func TestApplySiacoinOutput(t *testing.T) {
 		t.Error("block node was not updated for single element transaction")
 	}
 	if bn.siacoinOutputDiffs[0].Direction != modules.DiffApply {
-		t.Error("wrong diff direction applied when consuming a siacoin output")
+		t.Error("wrong diff direction applied when creating a siacoin output")
 	}
 	if bn.siacoinOutputDiffs[0].ID != scoid {
 		t.Error("wrong id used when creating a siacoin output")
@@ -211,7 +220,7 @@ func TestApplySiacoinOutput(t *testing.T) {
 		t.Error("siacoin outputs not correctly updated")
 	}
 	if len(bn.siacoinOutputDiffs) != 3 {
-		t.Error("block node was not updated for single element transaction")
+		t.Error("block node was not updated correctly")
 	}
 
 	err = cst.checkRevertApplyNode(initialSum, bn)
@@ -220,9 +229,9 @@ func TestApplySiacoinOutput(t *testing.T) {
 	}
 }
 
-// TestMisuseApplySiacoinOutput misuses applySiacoinOutput and checks that a
+// TestMisuseApplySiacoinOutputs misuses applySiacoinOutputs and checks that a
 // panic was triggered.
-func TestMisuseApplySiacoinOutput(t *testing.T) {
+func TestMisuseApplySiacoinOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -249,4 +258,460 @@ func TestMisuseApplySiacoinOutput(t *testing.T) {
 		}
 	}()
 	cst.cs.applySiacoinOutputs(bn, txn)
+}
+
+// TestApplyFileContracts probes the appliyFileContracts method of the
+// consensus set.
+func TestApplyFileContracts(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplyFileContracts")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Grab the inital hash of the consensus set.
+	initialSum := cst.cs.consensusSetHash()
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Apply a transaction with a single file contract.
+	txn := types.Transaction{
+		FileContracts: []types.FileContract{{}},
+	}
+	cst.cs.applyFileContracts(bn, txn)
+	fcid := txn.FileContractID(0)
+	_, exists := cst.cs.fileContracts[fcid]
+	if !exists {
+		t.Error("Failed to create file contract")
+	}
+	if len(cst.cs.fileContracts) != 1 {
+		t.Error("file contracts not correctly updated")
+	}
+	if len(bn.fileContractDiffs) != 1 {
+		t.Error("block node was not updated for single element transaction")
+	}
+	if bn.fileContractDiffs[0].Direction != modules.DiffApply {
+		t.Error("wrong diff direction applied when creating a file contract")
+	}
+	if bn.fileContractDiffs[0].ID != fcid {
+		t.Error("wrong id used when creating a file contract")
+	}
+
+	// Apply a transaction with 2 file contracts.
+	txn = types.Transaction{
+		FileContracts: []types.FileContract{
+			{Payout: types.NewCurrency64(1)},
+			{Payout: types.NewCurrency64(2)},
+		},
+	}
+	cst.cs.applyFileContracts(bn, txn)
+	fcid0 := txn.FileContractID(0)
+	fcid1 := txn.FileContractID(1)
+	_, exists = cst.cs.fileContracts[fcid0]
+	if !exists {
+		t.Error("Failed to create file contract")
+	}
+	_, exists = cst.cs.fileContracts[fcid1]
+	if !exists {
+		t.Error("Failed to create file contract")
+	}
+	if len(cst.cs.fileContracts) != 3 {
+		t.Error("file contracts not correctly updated")
+	}
+	if len(bn.fileContractDiffs) != 3 {
+		t.Error("block node was not updated correctly")
+	}
+
+	err = cst.checkRevertApplyNode(initialSum, bn)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// TestMisuseApplyFileContracts misuses applyFileContracts and checks that a
+// panic was triggered.
+func TestMisuseApplyFileContracts(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Apply a transaction with a single file contract.
+	txn := types.Transaction{
+		FileContracts: []types.FileContract{{}},
+	}
+	cst.cs.applyFileContracts(bn, txn)
+
+	// Trigger the panic that occurs when an output is applied incorrectly, and
+	// perform a catch to read the error that is created.
+	defer func() {
+		r := recover()
+		if r != ErrMisuseApplyFileContracts {
+			t.Error("no panic occured when misusing applySiacoinInput")
+		}
+	}()
+	cst.cs.applyFileContracts(bn, txn)
+}
+
+// TestApplyFileContractRevisions probes the appliyFileContractRevisions method
+// of the consensus set.
+func TestApplyFileContractRevisions(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplyFileContracts")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Grab the inital hash of the consensus set.
+	initialSum := cst.cs.consensusSetHash()
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Apply a transaction with two file contracts - that way there is
+	// something to revise.
+	txn := types.Transaction{
+		FileContracts: []types.FileContract{
+			{},
+			{Payout: types.NewCurrency64(1)},
+		},
+	}
+	cst.cs.applyFileContracts(bn, txn)
+	fcid0 := txn.FileContractID(0)
+	fcid1 := txn.FileContractID(1)
+
+	// Apply a single file contract revision.
+	txn = types.Transaction{
+		FileContractRevisions: []types.FileContractRevision{
+			{
+				ParentID:    fcid0,
+				NewFileSize: 1,
+			},
+		},
+	}
+	cst.cs.applyFileContractRevisions(bn, txn)
+	fc, exists := cst.cs.fileContracts[fcid0]
+	if !exists {
+		t.Error("Revision killed a file contract")
+	}
+	if fc.FileSize != 1 {
+		t.Error("file contract filesize not properly updated")
+	}
+	if len(cst.cs.fileContracts) != 2 {
+		t.Error("file contracts not correctly updated")
+	}
+	if len(bn.fileContractDiffs) != 4 { // 2 creating the initial contracts, 1 to remove the old, 1 to add the revision.
+		t.Error("block node was not updated for single element transaction")
+	}
+	if bn.fileContractDiffs[2].Direction != modules.DiffRevert {
+		t.Error("wrong diff direction applied when revising a file contract")
+	}
+	if bn.fileContractDiffs[3].Direction != modules.DiffApply {
+		t.Error("wrong diff direction applied when revising a file contract")
+	}
+	if bn.fileContractDiffs[2].ID != fcid0 {
+		t.Error("wrong id used when revising a file contract")
+	}
+	if bn.fileContractDiffs[3].ID != fcid0 {
+		t.Error("wrong id used when revising a file contract")
+	}
+
+	// Apply a transaction with 2 file contract revisions.
+	txn = types.Transaction{
+		FileContractRevisions: []types.FileContractRevision{
+			{
+				ParentID:    fcid0,
+				NewFileSize: 2,
+			},
+			{
+				ParentID:    fcid1,
+				NewFileSize: 3,
+			},
+		},
+	}
+	cst.cs.applyFileContractRevisions(bn, txn)
+	fc0, exists := cst.cs.fileContracts[fcid0]
+	if !exists {
+		t.Error("Revision ate file contract")
+	}
+	fc1, exists := cst.cs.fileContracts[fcid1]
+	if !exists {
+		t.Error("Revision ate file contract")
+	}
+	if fc0.FileSize != 2 {
+		t.Error("Revision not correctly applied")
+	}
+	if fc1.FileSize != 3 {
+		t.Error("Revision not correctly applied")
+	}
+	if len(cst.cs.fileContracts) != 2 {
+		t.Error("file contracts not correctly updated")
+	}
+	if len(bn.fileContractDiffs) != 8 {
+		t.Error("block node was not updated correctly")
+	}
+
+	err = cst.checkRevertApplyNode(initialSum, bn)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// TestMisuseApplyFileContractRevisions misuses applyFileContractRevisions and
+// checks that a panic was triggered.
+func TestMisuseApplyFileContractRevisions(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Trigger a panic from revising a nonexistent file contract.
+	defer func() {
+		r := recover()
+		if r != ErrMisuseApplyFileContractRevisions {
+			t.Error("no panic occured when misusing applySiacoinInput")
+		}
+	}()
+	txn := types.Transaction{
+		FileContractRevisions: []types.FileContractRevision{{}},
+	}
+	cst.cs.applyFileContractRevisions(bn, txn)
+}
+
+/*
+// TestApplySiafundInputs probes the applySiafundInputs method of the consensus
+// set.
+func TestApplySiafundInputs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = cst.miner.FindBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cst.csUpdateWait()
+
+	// Grab the inital hash of the consensus set.
+	initialSum := cst.cs.consensusSetHash()
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Fetch the output id's of each siacoin output in the consensus set.
+	var ids []types.SiacoinOutputID
+	for id, _ := range cst.cs.siacoinOutputs {
+		ids = append(ids, id)
+	}
+
+	// Apply a transaction with a single siacoin input.
+	txn := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{
+			{ParentID: ids[0]},
+		},
+	}
+	cst.cs.applySiacoinInputs(bn, txn)
+	_, exists := cst.cs.siacoinOutputs[ids[0]]
+	if exists {
+		t.Error("Failed to conusme a siacoin output")
+	}
+	if len(cst.cs.siacoinOutputs) != 2 {
+		t.Error("siacoin outputs not correctly updated")
+	}
+	if len(bn.siacoinOutputDiffs) != 1 {
+		t.Error("block node was not updated for single transaction")
+	}
+	if bn.siacoinOutputDiffs[0].Direction != modules.DiffRevert {
+		t.Error("wrong diff direction applied when consuming a siacoin output")
+	}
+	if bn.siacoinOutputDiffs[0].ID != ids[0] {
+		t.Error("wrong id used when consuming a siacoin output")
+	}
+
+	// Apply a transaction with two siacoin inputs.
+	txn = types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{
+			{ParentID: ids[1]},
+			{ParentID: ids[2]},
+		},
+	}
+	cst.cs.applySiacoinInputs(bn, txn)
+	if len(cst.cs.siacoinOutputs) != 0 {
+		t.Error("failed to consume all siacoin outputs in the consensus set")
+	}
+	if len(bn.siacoinOutputDiffs) != 3 {
+		t.Error("block node was not updated for single transaction")
+	}
+
+	err = cst.checkRevertApplyNode(initialSum, bn)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// TestMisuseApplySiacoinInputs misuses applySiacoinInput and checks that a
+// panic was triggered.
+func TestMisuseApplySiacoinInputs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Fetch the output id's of each siacoin output in the consensus set.
+	var ids []types.SiacoinOutputID
+	for id, _ := range cst.cs.siacoinOutputs {
+		ids = append(ids, id)
+	}
+
+	// Apply a transaction with a single siacoin input.
+	txn := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{
+			{ParentID: ids[0]},
+		},
+	}
+	cst.cs.applySiacoinInputs(bn, txn)
+
+	// Trigger the panic that occurs when an output is applied incorrectly, and
+	// perform a catch to read the error that is created.
+	defer func() {
+		r := recover()
+		if r != ErrMisuseApplySiacoinInput {
+			t.Error("no panic occured when misusing applySiacoinInput")
+		}
+	}()
+	cst.cs.applySiacoinInputs(bn, txn)
+}
+*/
+
+// TestApplySiafundOutputs probes the applySiafundOutputs method of the
+// consensus set.
+func TestApplySiafundOutputs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cst.cs.siafundPool = types.NewCurrency64(101)
+
+	// Grab the inital hash of the consensus set.
+	initialSum := cst.cs.consensusSetHash()
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Apply a transaction with a single siafund output.
+	txn := types.Transaction{
+		SiafundOutputs: []types.SiafundOutput{{}},
+	}
+	cst.cs.applySiafundOutputs(bn, txn)
+	sfoid := txn.SiafundOutputID(0)
+	_, exists := cst.cs.siafundOutputs[sfoid]
+	if !exists {
+		t.Error("Failed to create siafund output")
+	}
+	if len(cst.cs.siafundOutputs) != 2 { // TODO: This value needs to be updated when siafunds are added.
+		t.Error("siafund outputs not correctly updated")
+	}
+	if len(bn.siafundOutputDiffs) != 1 {
+		t.Error("block node was not updated for single element transaction")
+	}
+	if bn.siafundOutputDiffs[0].Direction != modules.DiffApply {
+		t.Error("wrong diff direction applied when creating a siafund output")
+	}
+	if bn.siafundOutputDiffs[0].ID != sfoid {
+		t.Error("wrong id used when creating a siafund output")
+	}
+	if bn.siafundOutputDiffs[0].SiafundOutput.ClaimStart.Cmp(types.NewCurrency64(101)) != 0 {
+		t.Error("claim start set incorrectly when creating a siafund output")
+	}
+
+	// Apply a transaction with 2 siacoin outputs.
+	txn = types.Transaction{
+		SiafundOutputs: []types.SiafundOutput{
+			{Value: types.NewCurrency64(1)},
+			{Value: types.NewCurrency64(2)},
+		},
+	}
+	cst.cs.applySiafundOutputs(bn, txn)
+	sfoid0 := txn.SiafundOutputID(0)
+	sfoid1 := txn.SiafundOutputID(1)
+	_, exists = cst.cs.siafundOutputs[sfoid0]
+	if !exists {
+		t.Error("Failed to create siafund output")
+	}
+	_, exists = cst.cs.siafundOutputs[sfoid1]
+	if !exists {
+		t.Error("Failed to create siafund output")
+	}
+	if len(cst.cs.siafundOutputs) != 4 { // TODO: This value needs to be added when genesis siafunds are added.
+		t.Error("siafund outputs not correctly updated")
+	}
+	if len(bn.siafundOutputDiffs) != 3 {
+		t.Error("block node was not updated for single element transaction")
+	}
+
+	err = cst.checkRevertApplyNode(initialSum, bn)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// TestMisuseApplySiafundOutputs misuses applySiafundOutputs and checks that a
+// panic was triggered.
+func TestMisuseApplySiafundOutputs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a block node to use with application.
+	bn := new(blockNode)
+
+	// Apply a transaction with a single siacoin output.
+	txn := types.Transaction{
+		SiafundOutputs: []types.SiafundOutput{{}},
+	}
+	cst.cs.applySiafundOutputs(bn, txn)
+
+	// Trigger the panic that occurs when an output is applied incorrectly, and
+	// perform a catch to read the error that is created.
+	defer func() {
+		r := recover()
+		if r != ErrMisuseApplySiafundOutput {
+			t.Error("no panic occured when misusing applySiafundInput")
+		}
+	}()
+	cst.cs.applySiafundOutputs(bn, txn)
 }

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -9,25 +9,6 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// testApplyFileContract gets a transaction with file contract creation and
-// puts it into the blockchain, then checks that the file contract has appeared
-// in the consensus set.
-func (ct *ConsensusTester) testApplyFileContract() {
-	// Grab a transction with a file contract and put it into the blockchain.
-	txn, _ := ct.FileContractTransaction(ct.Height()+2, ct.Height()+3)
-	block := ct.MineCurrentBlock([]types.Transaction{txn})
-	err := ct.AcceptBlock(block)
-	if err != nil {
-		ct.Fatal(err)
-	}
-
-	// Check for the file contract in the consensus set.
-	_, exists := ct.fileContracts[txn.FileContractID(0)]
-	if !exists {
-		ct.Fatal("file contract did not make it into the consensus set.")
-	}
-}
-
 // testApplyStorageProof gets a transaction with file contract creation and
 // puts it into the blockchain, then submits a storage proof for the file and
 // checks that the payout was properly distributed.
@@ -85,13 +66,6 @@ func (ct *ConsensusTester) testApplyStorageProof() {
 	if !exists {
 		ct.Fatal("delayed outputs don't seem to exist, but height map does")
 	}
-}
-
-// TestApplyFileContract creates a new testing environment and uses it to call
-// testApplyFileContract.
-func TestApplyFileContract(t *testing.T) {
-	ct := NewTestingEnvironment("TestApplyFileContract", t)
-	ct.testApplyFileContract()
 }
 
 // TestApplyStorageProof creates a new testing environment and uses it to call

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -64,6 +64,9 @@ func (s *State) applyMissedProof(bn *blockNode, fcid types.FileContractID) {
 		return
 	}
 
+	// Add the siafund tax to the siafund pool.
+	s.siafundPool = s.siafundPool.Add(fc.Tax())
+
 	// Add all of the outputs in the missed proof outputs to the consensus set.
 	for i, output := range fc.MissedProofOutputs {
 		// Sanity check - output should not already exist.

--- a/modules/miner/mine.go
+++ b/modules/miner/mine.go
@@ -54,7 +54,7 @@ func (m *Miner) blockForWork() (types.Block, crypto.Hash, types.Target) {
 
 // submitBlock takes a solved block and submits it to the blockchain.
 // submitBlock should not be called with a lock.
-func (m *Miner) submitBlock(b types.Block) error {
+func (m *Miner) SubmitBlock(b types.Block) error {
 	// Give the block to the consensus set.
 	err := m.cs.AcceptBlock(b)
 	if err != nil {
@@ -97,7 +97,7 @@ func (m *Miner) solveBlock(blockForWork types.Block, blockMerkleRoot crypto.Hash
 			id := crypto.HashBytes(hashbytes)
 			if bytes.Compare(target[:], id[:]) >= 0 {
 				copy(b.Nonce[:], nonce)
-				err = m.submitBlock(b)
+				err = m.SubmitBlock(b)
 				if err != nil {
 					return
 				}
@@ -197,12 +197,4 @@ func (m *Miner) SolveBlock(blockForWork types.Block, target types.Target) (b typ
 		}
 	}
 	return b, false
-}
-
-// SubmitBlock accepts a block with a valid target and presents it to the
-// consensus set.
-func (m *Miner) SubmitBlock(b types.Block) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.submitBlock(b)
 }

--- a/modules/miner/mine.go
+++ b/modules/miner/mine.go
@@ -3,6 +3,7 @@ package miner
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -83,9 +84,10 @@ func (m *Miner) submitBlock(b types.Block) error {
 // time to complete, and should not be called with a lock.
 func (m *Miner) solveBlock(blockForWork types.Block, blockMerkleRoot crypto.Hash, target types.Target) (b types.Block, solved bool, err error) {
 	b = blockForWork
-	hashbytes := make([]byte, 72)
+	hashbytes := make([]byte, 80)
 	copy(hashbytes, b.ParentID[:])
-	copy(hashbytes[40:], blockMerkleRoot[:])
+	binary.LittleEndian.PutUint64(hashbytes[40:48], uint64(b.Timestamp))
+	copy(hashbytes[48:], blockMerkleRoot[:])
 
 	nonce := hashbytes[32:40]
 	for i := 0; i < 255; i++ {

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -23,15 +23,11 @@ const (
 // signed.
 func (r *Renter) createContractTransaction(terms modules.ContractTerms, merkleRoot crypto.Hash) (txn types.Transaction, id string, err error) {
 	// Get the payout as set by the missed proofs, and the client fund as determined by the terms.
-	var payout types.Currency
-	for _, output := range terms.MissedProofOutputs {
-		payout = payout.Add(output.Value)
-	}
-
-	// Get the cost to the client as per the terms in the contract.
 	sizeCurrency := types.NewCurrency64(terms.FileSize)
 	durationCurrency := types.NewCurrency64(uint64(terms.Duration))
 	clientCost := terms.Price.Mul(sizeCurrency).Mul(durationCurrency)
+	hostCollateral := terms.Collateral.Mul(sizeCurrency).Mul(durationCurrency)
+	payout := clientCost.Add(hostCollateral)
 
 	// Fill out the contract.
 	contract := types.FileContract{
@@ -122,7 +118,7 @@ func (r *Renter) negotiateContract(host modules.HostSettings, up modules.FileUpl
 		},
 
 		MissedProofOutputs: []types.SiacoinOutput{
-			{Value: payout, UnlockHash: types.ZeroUnlockHash},
+			{Value: validOutputValue, UnlockHash: types.ZeroUnlockHash},
 		},
 	}
 

--- a/types/block.go
+++ b/types/block.go
@@ -19,7 +19,7 @@ type (
 	// given Target.
 	Block struct {
 		ParentID     BlockID
-		Nonce        uint64
+		Nonce        BlockNonce
 		Timestamp    Timestamp
 		MinerPayouts []SiacoinOutput
 		Transactions []Transaction
@@ -27,6 +27,7 @@ type (
 
 	BlockHeight uint64
 	BlockID     crypto.Hash
+	BlockNonce  [8]byte
 )
 
 // CalculateCoinbase calculates the coinbase for a given height. The coinbase

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -42,7 +42,7 @@ func TestBlockID(t *testing.T) {
 	ids = append(ids, b.ID())
 	b.ParentID[0] = 1
 	ids = append(ids, b.ID())
-	b.Nonce = 45
+	b.Nonce[0] = 45
 	ids = append(ids, b.ID())
 	b.Timestamp = CurrentTimestamp()
 	ids = append(ids, b.ID())

--- a/types/timestamp.go
+++ b/types/timestamp.go
@@ -12,6 +12,11 @@ type (
 	TimestampSlice []Timestamp
 )
 
+// CurrentTimestamp returns the current time as a Timestamp.
+func CurrentTimestamp() Timestamp {
+	return Timestamp(time.Now().Unix())
+}
+
 // Len is part of sort.Interface
 func (ts TimestampSlice) Len() int {
 	return len(ts)
@@ -25,9 +30,4 @@ func (ts TimestampSlice) Less(i, j int) bool {
 // Swap is part of sort.Interface
 func (ts TimestampSlice) Swap(i, j int) {
 	ts[i], ts[j] = ts[j], ts[i]
-}
-
-// CurrentTimestamp returns the current time as a Timestamp.
-func CurrentTimestamp() Timestamp {
-	return Timestamp(time.Now().Unix())
 }

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -39,9 +39,8 @@ func (t Transaction) correctFileContracts(currentHeight BlockHeight) error {
 			return ErrFileContractWindowEndViolation
 		}
 
-		// Check that the valid proof outputs sum to the payout after the
-		// siafund fee has been applied, and check that the missed proof
-		// outputs sum to the full payout.
+		// Check that the proof outputs sum to the payout after the
+		// siafund fee has been applied.
 		var validProofOutputSum, missedProofOutputSum Currency
 		for _, output := range fc.ValidProofOutputs {
 			validProofOutputSum = validProofOutputSum.Add(output.Value)
@@ -53,7 +52,7 @@ func (t Transaction) correctFileContracts(currentHeight BlockHeight) error {
 		if validProofOutputSum.Cmp(outputPortion) != 0 {
 			return ErrFileContractOutputSumViolation
 		}
-		if missedProofOutputSum.Cmp(fc.Payout) != 0 {
+		if missedProofOutputSum.Cmp(outputPortion) != 0 {
 			return ErrFileContractOutputSumViolation
 		}
 	}

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -21,6 +21,7 @@ var (
 	ErrStorageProofWithOutputs          = errors.New("transaction has both a storage proof and other outputs")
 	ErrTimelockNotSatisfied             = errors.New("timelock has not been met")
 	ErrTransactionTooLarge              = errors.New("transaction is too large to fit in a block")
+	ErrZeroMinerFee                     = errors.New("transaction has a zero value miner fee")
 	ErrZeroOutput                       = errors.New("transaction cannot have an output or payout that has zero value")
 	ErrZeroRevision                     = errors.New("transaction has a file contract revision with RevisionNumber=0")
 )
@@ -127,6 +128,11 @@ func (t Transaction) followsMinimumValues() error {
 		}
 		if sfo.Value.IsZero() {
 			return ErrZeroOutput
+		}
+	}
+	for _, fee := range t.MinerFees {
+		if fee.IsZero() {
+			return ErrZeroMinerFee
 		}
 	}
 	return nil

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -19,7 +19,7 @@ func TestTransactionCorrectFileContracts(t *testing.T) {
 					{Value: NewCurrency64(900e3)},
 				},
 				MissedProofOutputs: []SiacoinOutput{
-					{Value: NewCurrency64(100e3)},
+					{Value: NewCurrency64(70e3)},
 					{Value: NewCurrency64(900e3)},
 				},
 			},
@@ -66,17 +66,17 @@ func TestTransactionCorrectFileContracts(t *testing.T) {
 	}
 	txn.FileContracts[0].ValidProofOutputs[0].Value = NewCurrency64(70e3)
 
-	txn.FileContracts[0].MissedProofOutputs[0].Value = NewCurrency64(99e3)
+	txn.FileContracts[0].MissedProofOutputs[0].Value = NewCurrency64(69e3)
 	err = txn.correctFileContracts(30)
 	if err != ErrFileContractOutputSumViolation {
 		t.Error(err)
 	}
-	txn.FileContracts[0].MissedProofOutputs[0].Value = NewCurrency64(101e3)
+	txn.FileContracts[0].MissedProofOutputs[0].Value = NewCurrency64(71e3)
 	err = txn.correctFileContracts(30)
 	if err != ErrFileContractOutputSumViolation {
 		t.Error(err)
 	}
-	txn.FileContracts[0].MissedProofOutputs[0].Value = NewCurrency64(100e3)
+	txn.FileContracts[0].MissedProofOutputs[0].Value = NewCurrency64(70e3)
 
 	// Try the payouts when the value of the contract is too low to incur a
 	// fee.

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -162,6 +162,7 @@ func TestTransactionFollowsMinimumValues(t *testing.T) {
 		SiacoinOutputs: []SiacoinOutput{{Value: NewCurrency64(1)}},
 		FileContracts:  []FileContract{{Payout: NewCurrency64(1)}},
 		SiafundOutputs: []SiafundOutput{{Value: NewCurrency64(1)}},
+		MinerFees:      []Currency{NewCurrency64(1)},
 	}
 	err := txn.followsMinimumValues()
 	if err != nil {
@@ -187,6 +188,12 @@ func TestTransactionFollowsMinimumValues(t *testing.T) {
 		t.Error(err)
 	}
 	txn.SiafundOutputs[0].Value = NewCurrency64(1)
+	txn.MinerFees[0] = ZeroCurrency
+	err = txn.followsMinimumValues()
+	if err != ErrZeroMinerFee {
+		t.Error(err)
+	}
+	txn.MinerFees[0] = NewCurrency64(1)
 
 	// Try a non-zero value for the ClaimStart field of a siafund output.
 	txn.SiafundOutputs[0].ClaimStart = NewCurrency64(1)


### PR DESCRIPTION
This should be merged after consensus-testing.

This package does expand further on the testing, but the primary purpose is to introduce a few hardforking changes. Primarily:

+ a vulnerability in the fee structure has been closed
+ block nonce is now [8]byte
+ timestamp is in the block header

I've updated the miner api calls and documentation for /miner/blockforwork and /miner/submitblock. Josh was testing them with the gpu miner and they were not working as expected. It did seem as though the first block was getting through, but then everything just froze?

Maybe the program deadlocked. I mentioned a few other ideas in the slack.

Thanks to the thorough testing, I've been finding ways to clean up the code and have squashed a small number of bugs. There's a lot more ground to cover. I've yet to find any of the problems that have been appearing at random, but I haven't gotten to the suspected problem points either.