### PR TITLE
Upload progress

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -25,10 +25,11 @@ type DownloadInfo struct {
 
 // FileInfo is a helper struct for the files API call.
 type FileInfo struct {
-	Available     bool
-	Nickname      string
-	Repairing     bool
-	TimeRemaining types.BlockHeight
+	Available      bool
+	UploadProgress float32
+	Nickname       string
+	Repairing      bool
+	TimeRemaining  types.BlockHeight
 }
 
 // LoadedFiles lists files that were loaded into the renter.
@@ -72,10 +73,11 @@ func (srv *Server) renterFilesListHandler(w http.ResponseWriter, req *http.Reque
 	fileSet := make([]FileInfo, 0, len(files))
 	for _, file := range files {
 		fileSet = append(fileSet, FileInfo{
-			Available:     file.Available(),
-			Nickname:      file.Nickname(),
-			Repairing:     file.Repairing(),
-			TimeRemaining: file.TimeRemaining(),
+			Available:      file.Available(),
+			UploadProgress: file.UploadProgress(),
+			Nickname:       file.Nickname(),
+			Repairing:      file.Repairing(),
+			TimeRemaining:  file.TimeRemaining(),
 		})
 	}
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -25,6 +25,12 @@ type FileInfo interface {
 	// not.
 	Available() bool
 
+	// UploadProgress is a percentage indicating the progress of the file as
+	// it is being uploaded. This percentage is calculated internally (unlike
+	// DownloadInfo) because redundancy schemes complicate the definition of
+	// "progress." As a rule, Available == true IFF UploadProgress == 100.0.
+	UploadProgress() float32
+
 	// Nickname gives the nickname of the file.
 	Nickname() string
 

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -150,7 +150,7 @@ func renterfileslistcmd() {
 		if file.Available {
 			fmt.Println("\t", file.Nickname)
 		} else {
-			fmt.Println("\t", file.Nickname, "(uploading...)")
+			fmt.Printf("\t%s (uploading, %0.2f%%)\n", file.Nickname, file.UploadProgress)
 		}
 	}
 }
@@ -215,5 +215,5 @@ func renterfilesuploadcmd(source, nickname string) {
 		fmt.Println("Could not upload file:", err)
 		return
 	}
-	fmt.Println("Upload initiated.")
+	fmt.Printf("Uploaded '%s' as %s.\n", abs(source), nickname)
 }


### PR DESCRIPTION
Upload progress was a bit more of a pain to implement than download progress. Hopefully when we turn our full attention to the renter, we can refactor things into a more sane design.

You can now watch your files upload in real-time, which is pretty cool. I'm going to explore how difficult this would be to add to Sia-UI. If it seems easy I'll do it, otherwise I'll switch my focus to the persist package.

Fixes #527 