### PR TITLE
Renter sanity

### DIFF
--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -1,5 +1,11 @@
 package consensus
 
+// All changes to the consenuss set are made via diffs, specifically by calling
+// a commitDiff function. This means that future modifications (such as
+// replacing in-memory versions of the utxo set with on-disk versions of the
+// utxo set) should be relatively easy to verify for correctness. Modifying the
+// commitDiff functions will be sufficient.
+
 import (
 	"errors"
 	"os"

--- a/modules/hostdb.go
+++ b/modules/hostdb.go
@@ -53,9 +53,11 @@ type HostDB interface {
 	// InsertHost adds a host to the database.
 	InsertHost(HostSettings) error
 
-	// RandomHost pulls a host entry at random from the database, weighted
-	// according to whatever score is assigned the hosts.
-	RandomHost() (HostSettings, error)
+	// RandomHosts will pull up to 'num' random hosts from the hostdb. There
+	// will be no repeats, but the length of the slice returned may be less
+	// than 'num', and may even be 0. The hosts returned first have the higher
+	// priority.
+	RandomHosts(num int) []HostSettings
 
 	// Remove deletes the host with the input address from the database.
 	RemoveHost(NetAddress) error

--- a/modules/hostdb/weightedlist.go
+++ b/modules/hostdb/weightedlist.go
@@ -159,7 +159,7 @@ func (hdb *HostDB) RandomHosts(count int) (hosts []modules.HostSettings) {
 
 	var removedEntries []*hostEntry
 	for len(hosts) < count {
-		if hdb.hostTree.weight.IsZero() {
+		if hdb.hostTree == nil || hdb.hostTree.weight.IsZero() {
 			break
 		}
 		randWeight, err := rand.Int(rand.Reader, hdb.hostTree.weight.Big())

--- a/modules/renter/scan.go
+++ b/modules/renter/scan.go
@@ -6,7 +6,10 @@ func (r *Renter) scanAllFiles() {
 	for _, file := range r.files {
 		for i := range file.Pieces {
 			if !file.Pieces[i].Active && !file.Pieces[i].Repairing {
-				go r.threadedUploadPiece(file.UploadParams, &file.Pieces[i])
+				hosts := r.hostDB.RandomHosts(1)
+				if len(hosts) == 1 {
+					go r.threadedUploadPiece(hosts[0], file.UploadParams, &file.Pieces[i])
+				}
 			}
 		}
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -160,10 +160,8 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	errChan := make(chan error, len(f.Pieces))
 	for i := 0; i < parallelUploads; i++ {
 		go func() {
-			lockID := poolMutex.Lock()
 			pieceFinished := true
 			var piece *filePiece
-			poolMutex.Unlock(lockID)
 			for {
 				lockID := poolMutex.Lock()
 				if len(hostPool) == 0 || len(piecePool) == 0 {


### PR DESCRIPTION
The renter no longer chooses repeat hosts.

3 parallel uploads happen at a time. If a host is maliciously timing out or something, there are two backups. If all 3 are malicious, I guess that's a successful DoS vector right now.

If a host is just missing, the thread will be hogged for maybe ~100 seconds while it still does the exponential backoff thing, no more than that. If a host still isn't responsive, the next one is chosen.