### PR TITLE
renter changed to 6 weeks, host price increased

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	duration   = 20 // Duration that hosts will hold onto the file.
-	redundancy = 12 // Redundancy of files uploaded to the network.
+	duration   = 6000 // Duration that hosts will hold onto the file.
+	redundancy = 15   // Redundancy of files uploaded to the network.
 )
 
 // DownloadInfo is a helper struct for the downloadqueue API call.

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -79,11 +79,11 @@ func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wall
 
 		// default host settings
 		HostSettings: modules.HostSettings{
-			TotalStorage: 5e9,                       // 5 GB
+			TotalStorage: 10e9,                      // 10 GB
 			MaxFilesize:  1e9,                       // 1 GB
-			MaxDuration:  144 * 30,                  // 30 days
+			MaxDuration:  144 * 60,                  // 60 days
 			WindowSize:   288,                       // 48 hours
-			Price:        types.NewCurrency64(1e15), // 1 siacoin / mb / week
+			Price:        types.NewCurrency64(3e15), // 3 siacoin / mb / week
 			Collateral:   types.NewCurrency64(0),
 			UnlockHash:   coinAddr,
 		},

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -19,7 +19,7 @@ const (
 var (
 	errUploadFailed = errors.New("failed to upload to the desired host")
 
-	redundancy = 12
+	redundancy = 15
 )
 
 // checkWalletBalance looks at an upload and determines if there is enough


### PR DESCRIPTION
Renter and host now do storage for 6 weeks instead of 200 minutes.

Redundancy upped to 15.

Default price upped to 3 siacoins per mb per week. That's ~270 siacoins per mb per upload, or about 135,000 for a 500mb upload. It's pretty steep, but hosts can change the price if they want.