### PR TITLE
friendlier price estimations

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -100,13 +100,13 @@ func newServerTester(name string, t *testing.T) *serverTester {
 	if err != nil {
 		t.Fatal("Failed to create miner:", err)
 	}
-	h, err := host.New(cs, tp, w, ":0", filepath.Join(testdir, "host"))
-	if err != nil {
-		t.Fatal("Failed to create host:", err)
-	}
 	hdb, err := hostdb.New(cs, g)
 	if err != nil {
 		t.Fatal("Failed to create hostdb:", err)
+	}
+	h, err := host.New(cs, hdb, tp, w, ":0", filepath.Join(testdir, "host"))
+	if err != nil {
+		t.Fatal("Failed to create host:", err)
 	}
 	r, err := renter.New(cs, hdb, w, filepath.Join(testdir, "renter"))
 	if err != nil {

--- a/modules/host.go
+++ b/modules/host.go
@@ -31,6 +31,8 @@ type HostInfo struct {
 	NumContracts     int
 	Profit           types.Currency
 	PotentialProfit  types.Currency
+
+	Competition types.Currency
 }
 
 type Host interface {

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -85,11 +85,11 @@ func New(cs *consensus.State, hdb modules.HostDB, tpool modules.TransactionPool,
 
 		// default host settings
 		HostSettings: modules.HostSettings{
-			TotalStorage: 10e9,                      // 10 GB
-			MaxFilesize:  1e9,                       // 1 GB
-			MaxDuration:  144 * 60,                  // 60 days
-			WindowSize:   288,                       // 48 hours
-			Price:        types.NewCurrency64(1e15), // 3 siacoin / mb / week
+			TotalStorage: 10e9,                        // 10 GB
+			MaxFilesize:  1e9,                         // 1 GB
+			MaxDuration:  144 * 60,                    // 60 days
+			WindowSize:   288,                         // 48 hours
+			Price:        types.NewCurrency64(100e12), // 0.1 siacoin / mb / week
 			Collateral:   types.NewCurrency64(0),
 			UnlockHash:   coinAddr,
 		},

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -31,6 +31,7 @@ type contractObligation struct {
 // performing the storage proofs on the received files.
 type Host struct {
 	cs          *consensus.State
+	hostdb      modules.HostDB
 	tpool       modules.TransactionPool
 	wallet      modules.Wallet
 	blockHeight types.BlockHeight
@@ -54,9 +55,13 @@ type Host struct {
 }
 
 // New returns an initialized Host.
-func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wallet, addr string, saveDir string) (h *Host, err error) {
+func New(cs *consensus.State, hdb modules.HostDB, tpool modules.TransactionPool, wallet modules.Wallet, addr string, saveDir string) (h *Host, err error) {
 	if cs == nil {
 		err = errors.New("host cannot use a nil state")
+		return
+	}
+	if hdb == nil {
+		err = errors.New("host cannot use a nil hostdb")
 		return
 	}
 	if tpool == nil {
@@ -74,6 +79,7 @@ func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wall
 	}
 	h = &Host{
 		cs:     cs,
+		hostdb: hdb,
 		tpool:  tpool,
 		wallet: wallet,
 
@@ -83,7 +89,7 @@ func New(cs *consensus.State, tpool modules.TransactionPool, wallet modules.Wall
 			MaxFilesize:  1e9,                       // 1 GB
 			MaxDuration:  144 * 60,                  // 60 days
 			WindowSize:   288,                       // 48 hours
-			Price:        types.NewCurrency64(3e15), // 3 siacoin / mb / week
+			Price:        types.NewCurrency64(1e15), // 3 siacoin / mb / week
 			Collateral:   types.NewCurrency64(0),
 			UnlockHash:   coinAddr,
 		},
@@ -157,6 +163,23 @@ func (h *Host) Info() modules.HostInfo {
 		fc := obligation.FileContract
 		info.PotentialProfit = info.PotentialProfit.Add(fc.Payout.Sub(fc.Tax()))
 	}
+
+	// Calculate estimated competition (reported in per GB per month). Price
+	// calculated by taking the average of 8 ranomly selected weighted hosts.
+	var averagePrice types.Currency
+	// TODO: 8 is the sample size - to be made a constant.
+	hosts := h.hostdb.RandomHosts(8)
+	for _, host := range hosts {
+		averagePrice = averagePrice.Add(host.Price)
+	}
+	if len(hosts) == 0 {
+		return info
+	}
+	averagePrice = averagePrice.Div(types.NewCurrency64(uint64(len(hosts))))
+	// HACK: 4320 is one month, and 1024^3 is a GB. Price is reported as per GB
+	// per month.
+	estimatedCost := averagePrice.Mul(types.NewCurrency64(4320)).Mul(types.NewCurrency64(1024 * 1024 * 1024))
+	info.Competition = estimatedCost
 
 	return info
 }

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/consensus"
 	"github.com/NebulousLabs/Sia/modules/gateway"
+	"github.com/NebulousLabs/Sia/modules/hostdb"
 	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	"github.com/NebulousLabs/Sia/modules/wallet"
@@ -53,38 +54,32 @@ func (ht *hostTester) tpUpdateWait() {
 func CreateHostTester(name string, t *testing.T) *hostTester {
 	testdir := build.TempDir(modules.HostDir, name)
 
-	// Create the gateway.
+	// Create the modules.
 	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Create the consensus set.
 	cs, err := consensus.New(g, filepath.Join(testdir, modules.ConsensusDir))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Create the transaction pool.
 	tp, err := transactionpool.New(cs, g)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Create the wallet.
 	w, err := wallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Create the miner.
 	m, err := miner.New(cs, tp, w)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// Create the host.
-	h, err := New(cs, tp, w, ":0", filepath.Join(testdir, modules.HostDir))
+	hdb, err := hostdb.New(cs, g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := New(cs, hdb, tp, w, ":0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/hostdb/hostdb_test.go
+++ b/modules/hostdb/hostdb_test.go
@@ -100,7 +100,7 @@ func newHDBTester(name string, t *testing.T) *hdbTester {
 	}
 
 	// Create the host.
-	h, err := host.New(cs, tp, w, ":0", filepath.Join(testdir, modules.HostDir))
+	h, err := host.New(cs, hdb, tp, w, ":0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/hostdb/scan.go
+++ b/modules/hostdb/scan.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	DefaultScanSleep = 15 * time.Hour
-	MaxScanSleep     = 20 * time.Hour
-	MinScanSleep     = 4 * time.Hour
+	DefaultScanSleep = 4 * time.Hour
+	MaxScanSleep     = 8 * time.Hour
+	MinScanSleep     = 1 * time.Hour
 
 	MaxActiveHosts              = 200
 	InactiveHostCheckupQuantity = 100

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -70,8 +70,9 @@ type DownloadInfo interface {
 
 // RentInfo contains a list of all files by nickname. (deprecated)
 type RentInfo struct {
-	Files []string
-	Price types.Currency
+	Files      []string
+	Price      types.Currency
+	KnownHosts int
 }
 
 // A Renter uploads, tracks, repairs, and downloads a set of files for the

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -89,20 +89,20 @@ func (r *Renter) Info() (ri modules.RentInfo) {
 	}
 
 	// Calculate the average cost of a file.
-	var averagePrice types.Currency
+	var totalPrice types.Currency
 	sampleSize := redundancy * 3 / 2
 	hosts := r.hostDB.RandomHosts(sampleSize)
 	for _, host := range hosts {
-		averagePrice = averagePrice.Add(host.Price)
+		totalPrice = totalPrice.Add(host.Price)
 	}
 	if len(hosts) == 0 {
 		return
 	}
-	averagePrice = averagePrice.Div(types.NewCurrency64(uint64(len(hosts))))
+	averagePrice := totalPrice.Mul(types.NewCurrency64(2)).Div(types.NewCurrency64(3))
 	// HACK: 6000 is the duration (set by the API), and 1024^3 is a GB. Price
 	// is reported as per GB, no timeframe is given.
 	estimatedCost := averagePrice.Mul(types.NewCurrency64(6000)).Mul(types.NewCurrency64(1024 * 1024 * 1024))
-	bufferedCost := estimatedCost.Mul(types.NewCurrency64(2))
+	bufferedCost := estimatedCost.Mul(types.NewCurrency64(4)).Div(types.NewCurrency64(3))
 	ri.Price = bufferedCost
 
 	// Report the number of known hosts.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -90,7 +90,7 @@ func (r *Renter) Info() (ri modules.RentInfo) {
 
 	// Calculate the average cost of a file.
 	var averagePrice types.Currency
-	sampleSize := redundancy * 2
+	sampleSize := redundancy * 3 / 2
 	hosts := r.hostDB.RandomHosts(sampleSize)
 	for _, host := range hosts {
 		averagePrice = averagePrice.Add(host.Price)
@@ -104,6 +104,9 @@ func (r *Renter) Info() (ri modules.RentInfo) {
 	estimatedCost := averagePrice.Mul(types.NewCurrency64(6000)).Mul(types.NewCurrency64(1024 * 1024 * 1024))
 	bufferedCost := estimatedCost.Mul(types.NewCurrency64(2))
 	ri.Price = bufferedCost
+
+	// Report the number of known hosts.
+	ri.KnownHosts = len(r.hostDB.ActiveHosts())
 
 	return
 }

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -19,7 +19,7 @@ const (
 var (
 	errUploadFailed = errors.New("failed to upload to the desired host")
 
-	redundancy = 15
+	redundancy = 8
 )
 
 // checkWalletBalance looks at an upload and determines if there is enough
@@ -34,7 +34,7 @@ func (r *Renter) checkWalletBalance(up modules.FileUploadParams) error {
 	curSize := types.NewCurrency64(uint64(fileInfo.Size()))
 
 	var averagePrice types.Currency
-	sampleSize := redundancy * 2
+	sampleSize := redundancy * 3 / 2
 	hosts := r.hostDB.RandomHosts(sampleSize)
 	for _, host := range hosts {
 		averagePrice = averagePrice.Add(host.Price)

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -45,11 +45,11 @@ func startDaemon() error {
 	if err != nil {
 		return err
 	}
-	host, err := host.New(state, tpool, wallet, config.Siad.HostAddr, filepath.Join(config.Siad.SiaDir, "host"))
+	hostdb, err := hostdb.New(state, gateway)
 	if err != nil {
 		return err
 	}
-	hostdb, err := hostdb.New(state, gateway)
+	host, err := host.New(state, hostdb, tpool, wallet, config.Siad.HostAddr, filepath.Join(config.Siad.SiaDir, "host"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Redundancy reduced to 8

Estimations use 12 hosts instead of 30.

Since there are only ~20 hosts on the network, the most expensive hosts will usually get excluded (but not always).