### PR TITLE
Headerforwork + Submitheader

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -60,8 +60,10 @@ func (srv *Server) initAPI(addr string) {
 	handleHTTPRequest(mux, "/miner/start", srv.minerStartHandler)
 	handleHTTPRequest(mux, "/miner/status", srv.minerStatusHandler)
 	handleHTTPRequest(mux, "/miner/stop", srv.minerStopHandler)
-	handleHTTPRequest(mux, "/miner/blockforwork", srv.minerBlockforworkHandler)
-	handleHTTPRequest(mux, "/miner/submitblock", srv.minerSubmitBlockHandler)
+	handleHTTPRequest(mux, "/miner/blockforwork", srv.minerBlockforworkHandler) // Deprecated
+	handleHTTPRequest(mux, "/miner/submitblock", srv.minerSubmitblockHandler)   // Deprecated
+	handleHTTPRequest(mux, "/miner/headerforwork", srv.minerHeaderforworkHandler)
+	handleHTTPRequest(mux, "/miner/submitheader", srv.minerSubmitheaderHandler)
 
 	// Renter API Calls
 	handleHTTPRequest(mux, "/renter/downloadqueue", srv.renterDownloadqueueHandler)

--- a/api/miner.go
+++ b/api/miner.go
@@ -16,6 +16,13 @@ func (srv *Server) minerBlockforworkHandler(w http.ResponseWriter, req *http.Req
 	w.Write(encoding.MarshalAll(target, bfw.Header(), bfw))
 }
 
+// minerHeaderforworkHandler handles the API call that retrieves a block header
+// for work.
+func (srv *Server) minerHeaderforworkHandler(w http.ResponseWriter, req *http.Request) {
+	bhfw, target := srv.miner.HeaderForWork()
+	w.Write(encoding.MarshalAll(target, bhfw))
+}
+
 // minerStartHandler handles the API call that starts the miner.
 func (srv *Server) minerStartHandler(w http.ResponseWriter, req *http.Request) {
 	// Scan for the number of threads.
@@ -47,8 +54,8 @@ func (srv *Server) minerStopHandler(w http.ResponseWriter, req *http.Request) {
 	writeSuccess(w)
 }
 
-// minerSubmitBlockHandler handles the API call to submit a block to the miner.
-func (srv *Server) minerSubmitBlockHandler(w http.ResponseWriter, req *http.Request) {
+// minerSubmitblockHandler handles the API call to submit a block to the miner.
+func (srv *Server) minerSubmitblockHandler(w http.ResponseWriter, req *http.Request) {
 	var b types.Block
 	encodedBlock, err := ioutil.ReadAll(req.Body)
 	if err != nil {
@@ -62,6 +69,28 @@ func (srv *Server) minerSubmitBlockHandler(w http.ResponseWriter, req *http.Requ
 	}
 
 	err = srv.miner.SubmitBlock(b)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeSuccess(w)
+}
+
+// minerSubmitheaderHandler handles the API call to submit a block header to the
+// miner.
+func (srv *Server) minerSubmitheaderHandler(w http.ResponseWriter, req *http.Request) {
+	var bh types.BlockHeader
+	encodedHeader, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	err = encoding.Unmarshal(encodedHeader, &bh)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	err = srv.miner.SubmitHeader(bh)
 	if err != nil {
 		writeError(w, err.Error(), http.StatusBadRequest)
 		return

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -33,6 +33,11 @@ type Miner interface {
 	// set.
 	FindBlock() (types.Block, bool, error)
 
+	// HeaderForWork returns a block header that can be grinded on and
+	// resubmitted to the miner. HeaderForWork() will remember the block that
+	// corresponds to the header for 50 calls.
+	HeaderForWork() (types.BlockHeader, types.Target)
+
 	// MinerInfo returns a MinerInfo struct, containing information about the
 	// miner.
 	MinerInfo() MinerInfo
@@ -60,4 +65,8 @@ type Miner interface {
 	// SubmitBlock takes a block that has been worked on and has a valid
 	// target. Typically used with external miners.
 	SubmitBlock(types.Block) error
+
+	// SubmitHeader takes a block header that has been worked on and has a
+	// valid target. A superior choice to SubmitBlock.
+	SubmitHeader(types.BlockHeader) error
 }

--- a/modules/miner/externalmine.go
+++ b/modules/miner/externalmine.go
@@ -1,0 +1,104 @@
+package miner
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// BlockForWork returns a block that is ready for nonce grinding, along with
+// the root hash of the block.
+func (m *Miner) HeaderForWork() (types.BlockHeader, types.Target) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Determine the timestamp.
+	blockTimestamp := types.CurrentTimestamp()
+	if blockTimestamp < m.earliestTimestamp {
+		blockTimestamp = m.earliestTimestamp
+	}
+
+	// Create the miner payouts.
+	subsidy := types.CalculateCoinbase(m.height + 1)
+	for _, txn := range m.transactions {
+		for _, fee := range txn.MinerFees {
+			subsidy = subsidy.Add(fee)
+		}
+	}
+	blockPayouts := []types.SiacoinOutput{types.SiacoinOutput{Value: subsidy, UnlockHash: m.address}}
+
+	// Create the list of transacitons, including the randomized transaction.
+	// The transactions are assembled by calling append(singleElem,
+	// existingSlic) because doing it the reverse way has some side effects,
+	// creating a race condition and ultimately changing the block hash for
+	// other parts of the program. This is related to the fact that slices are
+	// pointers, and not immutable objects. Use of the builtin `copy` function
+	// when passing objects like blocks around may fix this problem.
+	randBytes := make([]byte, 16)
+	rand.Read(randBytes)
+	randTxn := types.Transaction{
+		ArbitraryData: []string{"NonSia" + string(randBytes)},
+	}
+	blockTransactions := append([]types.Transaction{randTxn}, m.transactions...)
+
+	// Assemble the block
+	b := types.Block{
+		ParentID:     m.parent,
+		Timestamp:    blockTimestamp,
+		MinerPayouts: blockPayouts,
+		Transactions: blockTransactions,
+	}
+
+	// Save a mapping between the block and its header, replacing the block
+	// that was stored 'headerForWorkMemory' requests ago.
+	delete(m.blockMem, m.headerMem[m.memProgress])
+	m.blockMem[b.Header()] = b
+	m.headerMem[m.memProgress] = b.Header()
+	m.memProgress++
+	if m.memProgress == headerForWorkMemory {
+		m.memProgress = 0
+	}
+
+	// Return the header and target.
+	return b.Header(), m.target
+}
+
+// submitBlock takes a solved block and submits it to the blockchain.
+// submitBlock should not be called with a lock.
+func (m *Miner) SubmitHeader(bh types.BlockHeader) error {
+	// Fetch the block from the blockMem.
+	var zeroNonce [8]byte
+	lookupBH := bh
+	lookupBH.Nonce = zeroNonce
+	m.mu.Lock()
+	b, exists := m.blockMem[lookupBH]
+	m.mu.Unlock()
+	if !exists {
+		fmt.Println("block returned too late - too many HeaderForWork().")
+		return errors.New("block returned too late - has already been cleared from memory")
+	}
+	b.Nonce = bh.Nonce
+
+	// Give the block to the consensus set.
+	err := m.cs.AcceptBlock(b)
+	if err != nil {
+		m.mu.Lock()
+		m.tpool.PurgeTransactionPool()
+		m.mu.Unlock()
+		fmt.Println("Error: an invalid block was submitted:", err)
+		return err
+	}
+
+	// Grab a new address for the miner.
+	m.mu.Lock()
+	m.blocksFound = append(m.blocksFound, b.ID())
+	var addr types.UnlockHash
+	addr, _, err = m.wallet.CoinAddress(false) // false indicates that the address should not be visible to the user.
+	if err == nil {                            // Special case: only update the address if there was no error.
+		m.address = addr
+	}
+	m.mu.Unlock()
+	return err
+}


### PR DESCRIPTION
I added 2 api calls, headerforwork and submitheader that reduce the amount of data you need to send when talking to an external miner. The payload is now 112 bytes for all calls.

A call is dumped after there have been 50 calls. This is because there's potentially a very large memory footprint that we need to worry about due to the way I'm storing blocks. With optimizations, this number could probably be raised to 10,000 or so. But I'm not sure how difficult those optimizations would be to implement.

Regardless, 50 is a pretty safe number for now.

I have also implemented the necessary changes in the miner.