### PR TITLE
Better Versioning

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -35,6 +35,7 @@ func (srv *Server) initAPI(addr string) {
 
 	// Daemon API Calls
 	handleHTTPRequest(mux, "/daemon/stop", srv.daemonStopHandler)
+	handleHTTPRequest(mux, "/daemon/version", srv.daemonVersionHandler)
 	handleHTTPRequest(mux, "/daemon/updates/apply", srv.daemonUpdatesApplyHandler)
 	handleHTTPRequest(mux, "/daemon/updates/check", srv.daemonUpdatesCheckHandler)
 

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -151,6 +151,11 @@ func (srv *Server) daemonStopHandler(w http.ResponseWriter, req *http.Request) {
 	srv.apiServer.Stop(time.Second)
 }
 
+// daemonVersionHandler handles the API call that requests the daemon's version.
+func (srv *Server) daemonVersionHandler(w http.ResponseWriter, req *http.Request) {
+	writeJSON(w, build.Version)
+}
+
 // daemonUpdatesCheckHandler handles the API call to check for daemon updates.
 func (srv *Server) daemonUpdatesCheckHandler(w http.ResponseWriter, req *http.Request) {
 	available, version, err := checkForUpdate()

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/inconshreveable/go-update"
 	"github.com/kardianos/osext"
+
+	"github.com/NebulousLabs/Sia/build"
 )
 
 type UpdateInfo struct {
@@ -20,8 +21,6 @@ type UpdateInfo struct {
 }
 
 const (
-	VERSION = "0.3.3"
-
 	developerKey = `-----BEGIN PUBLIC KEY-----
 MIIEIjANBgkqhkiG9w0BAQEFAAOCBA8AMIIECgKCBAEAsoQHOEU6s/EqMDtw5HvA
 YPTUaBgnviMFbG3bMsRqSCD8ug4XJYh+Ik6WP0xgq+OPDehPiaXK8ghAtBiW1EJK
@@ -57,23 +56,6 @@ bwIDAQAB
 // the version is newer, we download and apply the files listed in the update
 // manifest.
 var updateURL = "http://23.239.14.98/releases/" + runtime.GOOS + "_" + runtime.GOARCH
-
-// newerVersion returns true if version is "greater than" VERSION.
-func newerVersion(version string) bool {
-	remote := strings.Split(VERSION, ".")
-	local := strings.Split(version, ".")
-	for i := range remote {
-		ri, _ := strconv.Atoi(remote[i])
-		li, _ := strconv.Atoi(local[i])
-		if ri != li {
-			return ri < li
-		}
-		if len(local)-1 == i {
-			return false
-		}
-	}
-	return true
-}
 
 // getHTTP is a helper function that returns the full response of an HTTP call
 // to the update server.
@@ -113,7 +95,7 @@ func checkForUpdate() (bool, string, error) {
 		return false, "", err
 	}
 	version := manifest[0]
-	return newerVersion(version), version, nil
+	return build.VersionCmp(build.Version, version) < 0, version, nil
 }
 
 // applyUpdate downloads and applies an update.

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -4,33 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
 )
-
-// TestNewerVersion checks that in all cases, newerVesion returns the correct
-// result.
-func TestNewerVersion(t *testing.T) {
-	// If the VERSION is changed, these tests might no longer be valid.
-	if VERSION != "0.3.3" {
-		t.Fatal("Need to update version tests")
-	}
-
-	versionMap := map[string]bool{
-		VERSION:   false,
-		"0.1":     false,
-		"0.1.1":   false,
-		"1":       true,
-		"0.9":     true,
-		"0.3.2.9": false,
-		"0.3.3.0": true,
-		"0.3.3.1": true,
-	}
-
-	for version, expected := range versionMap {
-		if newerVersion(version) != expected {
-			t.Errorf("Comparing %v to %v should return %v", version, VERSION, expected)
-		}
-	}
-}
 
 type updateHandler struct {
 	version string
@@ -60,7 +36,7 @@ func TestSignedUpdate(t *testing.T) {
 	updateURL = "http://localhost:8080"
 
 	// same version
-	uh.version = VERSION
+	uh.version = build.Version
 	var info UpdateInfo
 	st.getAPI("/daemon/updates/check", &info)
 	if info.Available {
@@ -68,7 +44,7 @@ func TestSignedUpdate(t *testing.T) {
 	}
 
 	// newer version
-	uh.version = "0.4"
+	uh.version = "100.0"
 	st.getAPI("/daemon/updates/check", &info)
 	if !info.Available {
 		t.Error("new version should be available")

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -59,3 +59,12 @@ func TestSignedUpdate(t *testing.T) {
 		t.Error("expected internal server error, got", resp.StatusCode)
 	}
 }
+
+func TestVersion(t *testing.T) {
+	st := newServerTester("TestSignedUpdate", t)
+	var version string
+	st.getAPI("/daemon/version", &version)
+	if version != build.Version {
+		t.Fatalf("/daemon/version reporting bad version: expected %v, got %v", build.Version, version)
+	}
+}

--- a/build/version.go
+++ b/build/version.go
@@ -1,0 +1,59 @@
+package build
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Version is the current version of siad.
+const Version = "0.3.3.1"
+
+// IsVersion returns whether str is a valid version number.
+func IsVersion(str string) bool {
+	for _, n := range strings.Split(str, ".") {
+		if _, err := strconv.Atoi(n); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// min returns the smaller of two integers.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// VersionCmp returns an int indicating the difference between a and b. It
+// follows the convention of bytes.Compare and big.Cmp:
+//
+//   -1 if a <  b
+//    0 if a == b
+//   +1 if a >  b
+//
+// One important quirk is that "1.1.0" is considered newer than "1.1", despite
+// being numerically equal.
+func VersionCmp(a, b string) int {
+	aNums := strings.Split(a, ".")
+	bNums := strings.Split(b, ".")
+	for i := 0; i < min(len(aNums), len(bNums)); i++ {
+		// assume that both version strings are valid
+		aInt, _ := strconv.Atoi(aNums[i])
+		bInt, _ := strconv.Atoi(bNums[i])
+		if aInt < bInt {
+			return -1
+		} else if aInt > bInt {
+			return 1
+		}
+	}
+	// all shared digits are equal, but lengths may not be equal
+	if len(aNums) < len(bNums) {
+		return -1
+	} else if len(aNums) > len(bNums) {
+		return 1
+	}
+	// strings are identical
+	return 0
+}

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -1,0 +1,53 @@
+package build
+
+import (
+	"testing"
+)
+
+// TestVersionCmp checks that in all cases, VersionCmp returns the correct
+// result.
+func TestVersionCmp(t *testing.T) {
+	versionTests := []struct {
+		a, b string
+		exp  int
+	}{
+		{"0.1", "0.0.9", 1},
+		{"0.1", "0.1", 0},
+		{"0.1", "0.1.1", -1},
+		{"0.1", "0.1.0", -1},
+		{"0.1", "1.1", -1},
+		{"0.1.1.0", "0.1.1", 1},
+	}
+
+	for _, test := range versionTests {
+		if actual := VersionCmp(test.a, test.b); actual != test.exp {
+			t.Errorf("Comparing %v to %v should return %v (got %v)", test.a, test.b, test.exp, actual)
+		}
+	}
+}
+
+// TestIsVersion tests the IsVersion function.
+func TestIsVersion(t *testing.T) {
+	versionTests := []struct {
+		str string
+		exp bool
+	}{
+		{"1.0", true},
+		{"1", true},
+		{"0.1.2.3.4.5", true},
+
+		{"foo", false},
+		{".1", false},
+		{"1.", false},
+		{"a.b", false},
+		{"1.o", false},
+		{".", false},
+		{"", false},
+	}
+
+	for _, test := range versionTests {
+		if IsVersion(test.str) != test.exp {
+			t.Errorf("IsVersion(%v) should return %v", test.str, test.exp)
+		}
+	}
+}

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inconshreveable/muxado"
+
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/inconshreveable/muxado"
 )
 
 func TestAddPeer(t *testing.T) {
@@ -33,7 +35,7 @@ func TestListen(t *testing.T) {
 	}
 	addr := modules.NetAddress(conn.LocalAddr().String())
 	// send version
-	if err := encoding.WriteObject(conn, version); err != nil {
+	if err := encoding.WriteObject(conn, build.Version); err != nil {
 		t.Fatal("couldn't write version")
 	}
 	// read ack

--- a/siac/main.go
+++ b/siac/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/build"
 )
 
 var (
@@ -138,14 +138,14 @@ func wrap(fn interface{}) func(*cobra.Command, []string) {
 }
 
 func version(*cobra.Command, []string) {
-	println("Sia Client v" + api.VERSION)
+	println("Sia Client v" + build.Version)
 }
 
 func main() {
 	root := &cobra.Command{
 		Use:   os.Args[0],
-		Short: "Sia Client v" + api.VERSION,
-		Long:  "Sia Client v" + api.VERSION,
+		Short: "Sia Client v" + build.Version,
+		Long:  "Sia Client v" + build.Version,
 		Run:   version,
 	}
 

--- a/siad/main.go
+++ b/siad/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/build"
 )
 
 var (
@@ -42,15 +42,15 @@ func init() {
 
 // versionCmd is a cobra command that prints the version of siad.
 func versionCmd(*cobra.Command, []string) {
-	fmt.Println("Sia Daemon v" + api.VERSION)
+	fmt.Println("Sia Daemon v" + build.Version)
 }
 
 // main establishes a set of commands and flags using the cobra package.
 func main() {
 	root := &cobra.Command{
 		Use:   os.Args[0],
-		Short: "Sia Daemon v" + api.VERSION,
-		Long:  "Sia Daemon v" + api.VERSION,
+		Short: "Sia Daemon v" + build.Version,
+		Long:  "Sia Daemon v" + build.Version,
 		Run:   startDaemonCmd,
 	}
 


### PR DESCRIPTION
This change consolidates the various version numbers into one spot: `build.Version`. Well, mostly; the persist stuff is a work in progress. It also adds a `/daemon/version` API call.

The gateway is the test case for this new version management scheme. The idea is that in order to check that a version is compatible, you pass it to `build.VersionCmp`, along with a "minimum compatible version." As an example, when a connecting peer sends its version to the gateway, the gateway checks "is this version greater than v0.3.3?" by calling `build.VersionCmp(remoteVersion, "0.3.3") > 0`. If the check fails, the gateway refuses to connect.

This can be extended to the persist files in a similar fashion: they simply indicate the oldest version they are compatible with (i.e. the last version that changed the save format). This has not been implemented yet.

The downside of this is that we have to keep track of what is compatible with what. But that was sort of inevitable anyway. Basically, any time you alter a protocol -- consensus, peer negotiation, persist data -- you just have to remember to bump the "minimum acceptable version" to the current version.
(Of course, now that we're launched, we should also maintain compatibility tools that can read the old formats and update them to the new format.)

I also found a hackish way to ensure that we don't build releases with the wrong version number. You can pass a flag to the Go linker that sets the value of an unset string variable. So we could add a special test that compares such a string to `build.Version` and fails if they are not equal. Then, in the Makefile, we alter the `make xc` target to run a special test that sets the string to the same version passed to `goxc`.
This struck me as fairly ugly though, so I left it out of this PR.