### PR TITLE
keep a loadable backup wallet in the home folder

### DIFF
--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"path/filepath"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -95,11 +96,12 @@ func (w *Wallet) loadKeys(savedKeys []savedKey) error {
 // load reads the contents of a wallet from a file.
 func (w *Wallet) load() error {
 	var savedKeys []savedKey
-	err := encoding.ReadFile(filepath.Join(w.saveDir, "wallet.backup"), &savedKeys)
-	if err != nil {
+	err := encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "wallet.dat"), &savedKeys)
+	// never load from the home folder during testing
+	if build.Release == "testing" || err != nil {
 		// try loading the backup
 		// TODO: display/log a warning?
-		err = encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "wallet.dat"), &savedKeys)
+		err = encoding.ReadFile(filepath.Join(w.saveDir, "wallet.backup"), &savedKeys)
 		if err != nil {
 			return err
 		}
@@ -112,7 +114,8 @@ func (w *Wallet) load() error {
 	// Load the siafunds file, which is intentionally called 'outputs.dat'.
 	var siafundAddresses []types.UnlockHash
 	err = encoding.ReadFile(filepath.Join(w.saveDir, "outputs.backup"), &siafundAddresses)
-	if err != nil {
+	// never load from the home folder during testing
+	if build.Release == "testing" || err != nil {
 		// try loading the backup
 		// TODO: display/log a warning?
 		err = encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "outputs.dat"), &siafundAddresses)

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -16,14 +16,6 @@ type savedKey struct {
 	Visible          bool
 }
 
-// legacySavedKey preserves compatibility with the other beta wallets. After
-// the full currency is launched, this struct and the related code can be
-// discarded.
-type legacySavedKey struct {
-	SecretKey        crypto.SecretKey
-	UnlockConditions types.UnlockConditions
-}
-
 // save writes the contents of a wallet to a file.
 func (w *Wallet) save() error {
 	// Convert the key map to a slice.

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -103,11 +103,11 @@ func (w *Wallet) loadKeys(savedKeys []savedKey) error {
 // load reads the contents of a wallet from a file.
 func (w *Wallet) load() error {
 	var savedKeys []savedKey
-	err := encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "wallet.dat"), &savedKeys)
+	err := encoding.ReadFile(filepath.Join(w.saveDir, "wallet.backup"), &savedKeys)
 	if err != nil {
 		// try loading the backup
 		// TODO: display/log a warning?
-		err = encoding.ReadFile(filepath.Join(w.saveDir, "wallet.backup"), &savedKeys)
+		err = encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "wallet.dat"), &savedKeys)
 		if err != nil {
 			return err
 		}
@@ -119,11 +119,11 @@ func (w *Wallet) load() error {
 
 	// Load the siafunds file, which is intentionally called 'outputs.dat'.
 	var siafundAddresses []types.UnlockHash
-	err = encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "outputs.dat"), &siafundAddresses)
+	err = encoding.ReadFile(filepath.Join(w.saveDir, "outputs.backup"), &siafundAddresses)
 	if err != nil {
 		// try loading the backup
 		// TODO: display/log a warning?
-		err = encoding.ReadFile(filepath.Join(w.saveDir, "outputs.backup"), &siafundAddresses)
+		err = encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "outputs.dat"), &siafundAddresses)
 		if err != nil {
 			return err
 		}

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -98,7 +98,7 @@ func (w *Wallet) load() error {
 	var savedKeys []savedKey
 	err := encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "wallet.dat"), &savedKeys)
 	// never load from the home folder during testing
-	if build.Release == "testing" || err != nil {
+	if build.Release != "release" || err != nil {
 		// try loading the backup
 		// TODO: display/log a warning?
 		err = encoding.ReadFile(filepath.Join(w.saveDir, "wallet.backup"), &savedKeys)
@@ -115,7 +115,7 @@ func (w *Wallet) load() error {
 	var siafundAddresses []types.UnlockHash
 	err = encoding.ReadFile(filepath.Join(w.saveDir, "outputs.backup"), &siafundAddresses)
 	// never load from the home folder during testing
-	if build.Release == "testing" || err != nil {
+	if build.Release != "release" || err != nil {
 		// try loading the backup
 		// TODO: display/log a warning?
 		err = encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "outputs.dat"), &siafundAddresses)

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -142,7 +142,6 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, saveDir string)
 	}
 	if err != nil {
 		err = fmt.Errorf("couldn't load wallet file %s: %v", saveDir, err)
-		// TODO: try to recover from wallet.backup?
 		return
 	}
 

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -119,6 +121,11 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, saveDir string)
 	err = os.MkdirAll(saveDir, 0700)
 	if err != nil {
 		return
+	}
+	homedir := filepath.Join(persist.HomeFolder, modules.WalletDir)
+	err = os.MkdirAll(homedir, 0700)
+	if err != nil {
+		return nil, err
 	}
 
 	// Try to load a previously saved wallet file. If it doesn't exist, assume

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -4,16 +4,20 @@ import (
 	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
+
+	"github.com/NebulousLabs/Sia/build"
 )
 
-var (
-	HomeFolder string
-)
+var HomeFolder = func() string {
+	// use a special folder during testing
+	if build.Release == "testing" {
+		return filepath.Join(build.SiaTestingDir, "home")
+	}
 
-func init() {
 	home, err := homedir.Dir()
 	if err != nil {
 		println("could not find homedir: " + err.Error()) // TODO: better error handling
+		return ""
 	}
-	HomeFolder = filepath.Join(home, ".config", "Sia")
-}
+	return filepath.Join(home, ".config", "Sia")
+}()

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -1,0 +1,19 @@
+package persist
+
+import (
+	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+var (
+	HomeFolder string
+)
+
+func init() {
+	home, err := homedir.Dir()
+	if err != nil {
+		println("could not find homedir: " + err.Error()) // TODO: better error handling
+	}
+	HomeFolder = filepath.Join(home, ".config", "Sia")
+}

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -9,15 +9,18 @@ import (
 )
 
 var HomeFolder = func() string {
-	// use a special folder during testing
-	if build.Release == "testing" {
-		return filepath.Join(build.SiaTestingDir, "home")
-	}
-
 	home, err := homedir.Dir()
 	if err != nil {
 		println("could not find homedir: " + err.Error()) // TODO: better error handling
 		return ""
 	}
-	return filepath.Join(home, ".config", "Sia")
+
+	switch build.Release {
+	case "testing":
+		return filepath.Join(build.SiaTestingDir, "home")
+	case "dev":
+		return filepath.Join(home, ".config", "SiaDev")
+	default:
+		return filepath.Join(home, ".config", "Sia")
+	}
 }()


### PR DESCRIPTION
wallet gets put in the homedir as backup.

If no wallet is found in the regular place, the homedir is checked.

fixes #594