### PR TITLE
Encoding safety

### DIFF
--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -220,7 +220,7 @@ func (d *Decoder) readN(n int) []byte {
 // readPrefix reads a length-prefixed byte slice and panics if the read fails.
 func (d *Decoder) readPrefix() []byte {
 	// TODO: what should maxlen be?
-	b, err := ReadPrefix(d.r, 1<<32)
+	b, err := ReadPrefix(d.r, maxSliceLen)
 	if err != nil {
 		panic(err)
 	}

--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -187,6 +187,9 @@ type Decoder struct {
 	n int
 }
 
+// Read implements the io.Reader interface. It also keeps track of the total
+// number of bytes decoded, and panics if that number exceeds a global
+// maximum.
 func (d *Decoder) Read(p []byte) (int, error) {
 	n, err := d.r.Read(p)
 	// enforce an absolute maximum size limit

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -146,6 +147,13 @@ func TestDecode(t *testing.T) {
 	// massive slice (larger than MaxInt32)
 	err = Unmarshal(EncUint64(1<<32), new([]byte))
 	if err == nil || err.Error() != "could not decode type []uint8: slice is too large" {
+		t.Error("expected large slice error, got", err)
+	}
+
+	// many small slices (total larger than maxDecodeLen)
+	bigSlice := strings.Split(strings.Repeat("0123456789abcdefghijklmnopqrstuvwxyz", (maxSliceLen/16)-1), "0")
+	err = Unmarshal(Marshal(bigSlice), new([]string))
+	if err == nil || err.Error() != "could not decode type []string: encoded type exceeds size limit" {
 		t.Error("expected large slice error, got", err)
 	}
 

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -121,8 +121,8 @@ func TestDecode(t *testing.T) {
 
 	// bad boolean
 	err := Unmarshal([]byte{3}, new(bool))
-	if err == nil {
-		t.Error("expected error, got nil")
+	if err == nil || err.Error() != "could not decode type bool: boolean value was not 0 or 1" {
+		t.Error("expected bool error, got", err)
 	}
 
 	// non-pointer
@@ -133,20 +133,20 @@ func TestDecode(t *testing.T) {
 
 	// unknown type
 	err = Unmarshal([]byte{1, 2, 3}, new(map[int]int))
-	if err == nil {
-		t.Error("expected error, got nil")
+	if err == nil || err.Error() != "could not decode type map[int]int: unknown type" {
+		t.Error("expected unknown type error, got", err)
 	}
 
 	// big slice (larger than maxSliceLen)
 	err = Unmarshal(EncUint64(maxSliceLen+1), new([]byte))
 	if err == nil || err.Error() != "could not decode type []uint8: slice is too large" {
-		t.Error("expected error, got", err)
+		t.Error("expected large slice error, got", err)
 	}
 
 	// massive slice (larger than MaxInt32)
 	err = Unmarshal(EncUint64(1<<32), new([]byte))
 	if err == nil || err.Error() != "could not decode type []uint8: slice is too large" {
-		t.Error("expected error, got", err)
+		t.Error("expected large slice error, got", err)
 	}
 
 	// badReader should fail on every decode
@@ -159,8 +159,8 @@ func TestDecode(t *testing.T) {
 	}
 	// special case, not covered by testStructs
 	err = dec.Decode(new([3]byte))
-	if err == nil {
-		t.Error("expected error, got nil")
+	if err == nil || err.Error() != "could not decode type [3]uint8: EOF" {
+		t.Error("expected EOF error, got", err)
 	}
 
 }

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -154,7 +154,7 @@ func TestDecode(t *testing.T) {
 	bigSlice := strings.Split(strings.Repeat("0123456789abcdefghijklmnopqrstuvwxyz", (maxSliceLen/16)-1), "0")
 	err = Unmarshal(Marshal(bigSlice), new([]string))
 	if err == nil || err.Error() != "could not decode type []string: encoded type exceeds size limit" {
-		t.Error("expected large slice error, got", err)
+		t.Error("expected size limit error, got", err)
 	}
 
 	// badReader should fail on every decode

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -137,6 +137,18 @@ func TestDecode(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 
+	// big slice (larger than maxSliceLen)
+	err = Unmarshal(EncUint64(maxSliceLen+1), new([]byte))
+	if err == nil || err.Error() != "could not decode type []uint8: slice is too large" {
+		t.Error("expected error, got", err)
+	}
+
+	// massive slice (larger than MaxInt32)
+	err = Unmarshal(EncUint64(1<<32), new([]byte))
+	if err == nil || err.Error() != "could not decode type []uint8: slice is too large" {
+		t.Error("expected error, got", err)
+	}
+
 	// badReader should fail on every decode
 	dec := NewDecoder(new(badReader))
 	for i := range testEncodings {

--- a/persist/json_test.go
+++ b/persist/json_test.go
@@ -2,6 +2,7 @@ package persist
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -61,7 +62,8 @@ func TestSaveLoadFile(t *testing.T) {
 	var meta = Metadata{"TestSaveLoadFile", "0.1"}
 	var saveData int = 3
 
-	filename := build.TempDir("TestSaveLoadFile")
+	os.MkdirAll(build.TempDir("persist"), 0777)
+	filename := build.TempDir("persist", "TestSaveLoadFile")
 	err := SaveFile(meta, saveData, filename)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Patch vulnerabilities in the decoding functions. Variable length types will no longer be allocated if they exceed 4MB. In addition, if the decoder will not decode more than 10MB while decoding a single type.