### PR TITLE
add compatibility for non-checksummed addresses - temporary

### DIFF
--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -61,7 +61,10 @@ func New(cs *consensus.State, hdb modules.HostDB, wallet modules.Wallet, saveDir
 		return nil, err
 	}
 
-	r.load()
+	err = r.load()
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
 
 	// TODO: I'm worried about balances here. Because of the way that the
 	// re-try algorithm works, it won't be a problem, but without that we would


### PR DESCRIPTION
The renter and host persistence files couldn't be loaded because the addresses inside of them did not have checksums.

So, when loading, the checksum can be ignored but only if there are enough characters. This is temporary and only for compatibility reasons. This will be removed after a few versions.