### PR TITLE
Host Scanning

### DIFF
--- a/modules/hostdb/hostentry.go
+++ b/modules/hostdb/hostentry.go
@@ -46,12 +46,7 @@ func (hdb *HostDB) insertHost(host modules.HostSettings) {
 	_, exists := hdb.allHosts[entry.IPAddress]
 	if !exists {
 		hdb.allHosts[entry.IPAddress] = entry
-
-		// Add the host to the scanPool, but in a goroutine so that if the
-		// scanPool is full, the hostdb does not deadlock.
-		go func() {
-			hdb.scanPool <- entry
-		}()
+		hdb.scanHostEntry(entry)
 	}
 }
 

--- a/modules/hostdb/hostentry.go
+++ b/modules/hostdb/hostentry.go
@@ -14,6 +14,7 @@ var (
 	baseWeight = types.NewCurrency(new(big.Int).Exp(big.NewInt(10), big.NewInt(120), nil))
 )
 
+// A hostEntry represents a host on the network.
 type hostEntry struct {
 	modules.HostSettings
 	weight      types.Currency
@@ -40,12 +41,17 @@ func (hdb *HostDB) insertHost(host modules.HostSettings) {
 	// Add the host to allHosts.
 	entry := &hostEntry{
 		HostSettings: host,
-		reliability:  InactiveReliability,
+		reliability:  DefaultReliability,
 	}
 	_, exists := hdb.allHosts[entry.IPAddress]
 	if !exists {
 		hdb.allHosts[entry.IPAddress] = entry
-		go hdb.threadedProbeHost(entry)
+
+		// Add the host to the scanPool, but in a goroutine so that if the
+		// scanPool is full, the hostdb does not deadlock.
+		go func() {
+			hdb.scanPool <- entry
+		}()
 	}
 }
 

--- a/modules/hostdb/scan.go
+++ b/modules/hostdb/scan.go
@@ -26,11 +26,11 @@ const (
 
 	maxSettingsLen = 1024
 
-	hostRequestTimeout = 15 * time.Second
+	hostRequestTimeout = 5 * time.Second
 
 	// scanningThreads is the number of threads that will be probing hosts for
 	// their settings and checking for reliability.
-	scanningThreads = 4
+	scanningThreads = 25
 )
 
 var (

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -110,7 +110,7 @@ func (r *Renter) negotiateContract(host modules.HostSettings, up modules.FileUpl
 	terms := modules.ContractTerms{
 		FileSize:      filesize,
 		Duration:      up.Duration,
-		DurationStart: height - 1,
+		DurationStart: height - 3,
 		WindowSize:    defaultWindowSize,
 		Price:         host.Price,
 		Collateral:    host.Collateral,

--- a/siae/main_test.go
+++ b/siae/main_test.go
@@ -22,9 +22,9 @@ func TestMain(t *testing.T) {
 		"siad",
 		"-n",
 		"-a",
-		"localhost:45150",
+		"localhost:45350",
 		"-r",
-		"localhost:45151",
+		"localhost:45351",
 		"-d",
 		testDir,
 	}
@@ -34,7 +34,7 @@ func TestMain(t *testing.T) {
 	// daemon.
 	<-started
 	time.Sleep(250 * time.Millisecond)
-	resp, err := http.Get("http://localhost:45150/daemon/stop")
+	resp, err := http.Get("http://localhost:45350/daemon/stop")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Host scanning is now done by a thread pool, instead of all being done at once. The timeout for host response has been reduced from 10 seconds to 5 seconds, to facilitate speed during startup.

There are 25 threads that pull hosts out of channels. At startup, the hosts are added to the channels. Then, over time, hosts are selected randomly (though to the tune of 250-750 at a time) and placed into the channels. This happens every 3.5 hours on average.

If a host fails to respond 25 times in a row, the host is kicked from the database. This is different from before where the host would just get kicked immediately. It does mean that there is some pollution for bad hostnames (which do exist in the database) and that those names will take a few days to get cleared out.

After responding positively, the host can fail to respond up to 50 times in a row before getting kicked.

After failing to respond once, the host is removed from the set of active hosts. This is different from previously, where a host was allowed to not respond up to 10 times before being pulled from the set of active hosts.

Overall, I think this represents significant improvements to our host finding algorithm.