### PR TITLE
v0.3.3.3 gateway tweaks

### DIFF
--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 )
@@ -94,7 +95,9 @@ var ExternalIP = func() string {
 		return "::1"
 	}
 
-	resp, err := http.Get("http://myexternalip.com/raw")
+	// timeout after 3 seconds
+	client := http.Client{Timeout: time.Duration(3 * time.Second)}
+	resp, err := client.Get("http://myexternalip.com/raw")
 	if err != nil {
 		return "::1"
 	}

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -101,9 +101,6 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 
 	g.log.Println("INFO: our address is", g.myAddr)
 
-	// Add ourselves as a node.
-	g.addNode(g.myAddr)
-
 	// Spawn the primary listener.
 	go g.listen()
 

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -105,5 +105,9 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 
 // sendAddress is the calling end of the RelayNode RPC.
 func (g *Gateway) sendAddress(conn modules.PeerConn) error {
+	// don't send if we aren't connectible
+	if g.Address().Host() == "::1" {
+		return errors.New("can't send address without knowing external IP")
+	}
 	return encoding.WriteObject(conn, g.Address())
 }

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -25,7 +25,6 @@ func (g *Gateway) addNode(addr modules.NetAddress) error {
 		return errors.New("cannot add loopback address")
 	}
 	g.nodes[addr] = struct{}{}
-	g.log.Println("INFO: added node", addr)
 	return nil
 }
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -239,8 +239,9 @@ func (g *Gateway) makeOutboundConnections() {
 			if err != nil || numPeers >= wellConnectedThreshold {
 				break
 			}
-			if g.Connect(addr) != nil {
-				// aggressively remove unresponsive nodes
+			err = g.Connect(addr)
+			// aggressively remove unresponsive nodes
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				id = g.mu.Lock()
 				g.removeNode(addr)
 				g.mu.Unlock(id)

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -122,7 +122,7 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 	}
 
 	// respond with our version
-	if err := encoding.WriteObject(conn, build.Version); err != nil {
+	if err := encoding.WriteObject(conn, "0.3.3"); err != nil {
 		conn.Close()
 		g.log.Printf("INFO: could not write version ack to %v: %v", addr, err)
 		return
@@ -168,7 +168,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 		return err
 	}
 	// send our version
-	if err := encoding.WriteObject(conn, build.Version); err != nil {
+	if err := encoding.WriteObject(conn, "0.3.3"); err != nil {
 		return err
 	}
 	// read version ack

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -239,7 +239,12 @@ func (g *Gateway) makeOutboundConnections() {
 			if err != nil || numPeers >= wellConnectedThreshold {
 				break
 			}
-			g.Connect(addr)
+			if g.Connect(addr) != nil {
+				// aggressively remove unresponsive nodes
+				id = g.mu.Lock()
+				g.removeNode(addr)
+				g.mu.Unlock(id)
+			}
 		}
 		time.Sleep(5 * time.Second)
 	}


### PR DESCRIPTION
The gateway now advertises itself as v0.3.3. Otherwise, v0.3.3 nodes will refuse to connect to it. This is a temporary measure to alleviate network splitting.

Nodes are pruned by `makeOutboundConnections` if they aren't reachable. If the connection fails for a different reason, the node is not pruned.

The `ExternalIP` function now times out after 3 seconds. This is the easiest way to prevent clients without Internet access from hanging. I'll implement a more robust solution when I tackle UPnP, which gives us an alternative way of discovering the external IP.