### PR TITLE
Force announce

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -57,7 +57,6 @@ func (srv *Server) initAPI(addr string) {
 	if srv.host != nil {
 		handleHTTPRequest(mux, "/host/announce", srv.hostAnnounceHandler)
 		handleHTTPRequest(mux, "/host/configure", srv.hostConfigureHandler)
-		handleHTTPRequest(mux, "/host/forceannounce", srv.hostForceAnnounceHandler)
 		handleHTTPRequest(mux, "/host/status", srv.hostStatusHandler)
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -57,6 +57,7 @@ func (srv *Server) initAPI(addr string) {
 	if srv.host != nil {
 		handleHTTPRequest(mux, "/host/announce", srv.hostAnnounceHandler)
 		handleHTTPRequest(mux, "/host/configure", srv.hostConfigureHandler)
+		handleHTTPRequest(mux, "/host/forceannounce", srv.hostForceAnnounceHandler)
 		handleHTTPRequest(mux, "/host/status", srv.hostStatusHandler)
 	}
 

--- a/api/host.go
+++ b/api/host.go
@@ -54,6 +54,17 @@ func (srv *Server) hostConfigureHandler(w http.ResponseWriter, req *http.Request
 	writeSuccess(w)
 }
 
+// hostForceAnnounceHandler handles the API call to get the host to announce
+// itself to the network. This call ignores connectivity checks.
+func (srv *Server) hostForceAnnounceHandler(w http.ResponseWriter, req *http.Request) {
+	err := srv.host.ForceAnnounce()
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeSuccess(w)
+}
+
 // hostStatusHandler handles the API call that queries the host status.
 func (srv *Server) hostStatusHandler(w http.ResponseWriter, req *http.Request) {
 	writeJSON(w, srv.host.Info())

--- a/api/host.go
+++ b/api/host.go
@@ -8,7 +8,14 @@ import (
 // hostAnnounceHandler handles the API call to get the host to announce itself
 // to the network.
 func (srv *Server) hostAnnounceHandler(w http.ResponseWriter, req *http.Request) {
-	err := srv.host.Announce()
+	// Announce checks that the host is connectible before proceeding. The
+	// user can override this check with the 'force' flag.
+	var err error
+	if req.FormValue("force") == "true" {
+		err = srv.host.ForceAnnounce()
+	} else {
+		err = srv.host.Announce()
+	}
 	if err != nil {
 		writeError(w, err.Error(), http.StatusBadRequest)
 		return
@@ -51,17 +58,6 @@ func (srv *Server) hostConfigureHandler(w http.ResponseWriter, req *http.Request
 	}
 
 	srv.host.SetSettings(config)
-	writeSuccess(w)
-}
-
-// hostForceAnnounceHandler handles the API call to get the host to announce
-// itself to the network. This call ignores connectivity checks.
-func (srv *Server) hostForceAnnounceHandler(w http.ResponseWriter, req *http.Request) {
-	err := srv.host.ForceAnnounce()
-	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
-		return
-	}
 	writeSuccess(w)
 }
 

--- a/modules/host.go
+++ b/modules/host.go
@@ -39,8 +39,13 @@ type Host interface {
 	// Address returns the host's network address
 	Address() NetAddress
 
-	// Announce announces the host on the blockchain.
+	// Announce announces the host on the blockchain, returning an error if the
+	// host cannot reach itself or if the external ip address is unknown.
 	Announce() error
+
+	// ForceAnnounce announces the host on the blockchain, regardless of
+	// connectivity.
+	ForceAnnounce() error
 
 	// HostNotify will push a struct down the channel every time that an update
 	// is received.

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -64,11 +64,10 @@ func (h *Host) announce(addr modules.NetAddress) error {
 // arbitrary data, signing the transaction, and submitting it to the
 // transaction pool.
 func (h *Host) Announce() error {
-	// check that our address is reachable
 	lockID := h.mu.RLock()
 	addr := h.myAddr
 	h.mu.RUnlock(lockID)
-	if addr.Host() == "" {
+	if addr.Host() == "::1" {
 		return errors.New("can't announce without knowing external IP")
 	} else if !ping(addr) {
 		return errors.New("host address not reachable; ensure you have forwarded port " + addr.Port())

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -14,7 +14,7 @@ func TestAnnouncement(t *testing.T) {
 	ht := CreateHostTester("TestAnnouncement", t)
 
 	// Place the announcement.
-	err := ht.host.Announce()
+	err := ht.host.ForceAnnounce()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -36,14 +36,9 @@ Available settings:
 	hostAnnounceCmd = &cobra.Command{
 		Use:   "announce",
 		Short: "Announce yourself as a host",
-		Long:  "Announce yourself as a host on the network.",
-		Run:   wrap(hostannouncecmd)}
-
-	hostForceAnnounceCmd = &cobra.Command{
-		Use:   "forceannounce",
-		Short: "Announce yourself as a host disregarding connectivity errors",
-		Long:  "Announce yourself as a host on the network, even if you are experiencing connectivity problems.",
-		Run:   wrap(hostannouncecmd)}
+		Long: `Announce yourself as a host on the network.
+The --force flag can be used to override connectivity checks.`,
+		Run: wrap(hostannouncecmd)}
 
 	hostStatusCmd = &cobra.Command{
 		Use:   "status",
@@ -73,16 +68,11 @@ func hostconfigcmd(param, value string) {
 }
 
 func hostannouncecmd() {
-	err := post("/host/announce", "")
-	if err != nil {
-		fmt.Println("Could not announce host:", err)
-		return
+	args := ""
+	if force {
+		args = "force=true"
 	}
-	fmt.Println("Host announcement submitted to network.")
-}
-
-func hostforceannouncecmd() {
-	err := post("/host/forceannounce", "")
+	err := post("/host/announce", args)
 	if err != nil {
 		fmt.Println("Could not announce host:", err)
 		return

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -39,6 +39,12 @@ Available settings:
 		Long:  "Announce yourself as a host on the network.",
 		Run:   wrap(hostannouncecmd)}
 
+	hostForceAnnounceCmd = &cobra.Command{
+		Use:   "forceannounce",
+		Short: "Announce yourself as a host disregarding connectivity errors",
+		Long:  "Announce yourself as a host on the network, even if you are experiencing connectivity problems.",
+		Run:   wrap(hostannouncecmd)}
+
 	hostStatusCmd = &cobra.Command{
 		Use:   "status",
 		Short: "View host settings",
@@ -68,6 +74,15 @@ func hostconfigcmd(param, value string) {
 
 func hostannouncecmd() {
 	err := post("/host/announce", "")
+	if err != nil {
+		fmt.Println("Could not announce host:", err)
+		return
+	}
+	fmt.Println("Host announcement submitted to network.")
+}
+
+func hostforceannouncecmd() {
+	err := post("/host/forceannounce", "")
 	if err != nil {
 		fmt.Println("Could not announce host:", err)
 		return

--- a/siac/main.go
+++ b/siac/main.go
@@ -158,7 +158,7 @@ func main() {
 	})
 
 	root.AddCommand(hostCmd)
-	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostStatusCmd)
+	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostForceAnnounceCmd, hostStatusCmd)
 
 	root.AddCommand(hostdbCmd)
 	hostCmd.AddCommand(hostdbCmd)

--- a/siac/main.go
+++ b/siac/main.go
@@ -16,7 +16,8 @@ import (
 )
 
 var (
-	port string
+	port  string
+	force bool
 )
 
 // apiGet wraps a GET request with a status code check, such that if the GET does
@@ -156,9 +157,11 @@ func main() {
 		Long:  "Print version information.",
 		Run:   version,
 	})
+	// certain commands accept a "force" flag
+	root.PersistentFlags().BoolVarP(&force, "force", "f", false, "force certain commands")
 
 	root.AddCommand(hostCmd)
-	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostForceAnnounceCmd, hostStatusCmd)
+	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostStatusCmd)
 
 	root.AddCommand(hostdbCmd)
 	hostCmd.AddCommand(hostdbCmd)

--- a/siac/main.go
+++ b/siac/main.go
@@ -157,7 +157,7 @@ func main() {
 		Long:  "Print version information.",
 		Run:   version,
 	})
-	// certain commands accept a "force" flag
+	// certain safety checks can be overrided with the "force" flag
 	root.PersistentFlags().BoolVarP(&force, "force", "f", false, "force certain commands")
 
 	root.AddCommand(hostCmd)

--- a/siae/main_test.go
+++ b/siae/main_test.go
@@ -24,7 +24,7 @@ func TestMain(t *testing.T) {
 		"-a",
 		"localhost:45350",
 		"-r",
-		"localhost:45351",
+		":0",
 		"-d",
 		testDir,
 	}


### PR DESCRIPTION
It probably didn't have to (sorry), but this PR builds on the other one I've got open.

This adds a force-announce api call, which is a response to the frustrated people whose ports are actually open but for some reason are failing our 'are your ports open?' internal test. Force-announce is only available directly in the api and in 'siac'.

I do believe that I implemented the siac command correctly.