### PR TITLE
stop using the home folder for saving the wallet

### DIFF
--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -6,8 +6,6 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
-	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -30,8 +28,8 @@ func (w *Wallet) save() error {
 	if err != nil {
 		return err
 	}
-	// Save to home.
-	err = encoding.WriteFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "wallet.dat"), keySlice)
+	// Save the primary copy.
+	err = encoding.WriteFile(filepath.Join(w.saveDir, "wallet.dat"), keySlice)
 	if err != nil {
 		// TODO: instruct user to recover wallet from the backup file
 		return err
@@ -51,8 +49,8 @@ func (w *Wallet) save() error {
 	if err != nil {
 		return err
 	}
-	// Save to home.
-	err = encoding.WriteFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "outputs.dat"), siafundSlice)
+	// Save the primary copy.
+	err = encoding.WriteFile(filepath.Join(w.saveDir, "outputs.dat"), siafundSlice)
 	if err != nil {
 		return err
 	}
@@ -96,11 +94,11 @@ func (w *Wallet) loadKeys(savedKeys []savedKey) error {
 // load reads the contents of a wallet from a file.
 func (w *Wallet) load() error {
 	var savedKeys []savedKey
-	err := encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "wallet.dat"), &savedKeys)
+	err := encoding.ReadFile(filepath.Join(w.saveDir, "wallet.dat"), &savedKeys)
 	// never load from the home folder during testing
-	if build.Release != "release" || err != nil {
+	if err != nil {
 		// try loading the backup
-		// TODO: display/log a warning?
+		// TODO: display/log a warning
 		err = encoding.ReadFile(filepath.Join(w.saveDir, "wallet.backup"), &savedKeys)
 		if err != nil {
 			return err
@@ -118,7 +116,7 @@ func (w *Wallet) load() error {
 	if build.Release != "release" || err != nil {
 		// try loading the backup
 		// TODO: display/log a warning?
-		err = encoding.ReadFile(filepath.Join(persist.HomeFolder, modules.WalletDir, "outputs.dat"), &siafundAddresses)
+		err = encoding.ReadFile(filepath.Join(w.saveDir, "outputs.dat"), &siafundAddresses)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When you have multiple versions, and multiple 'wallet.dat' files, it's
confusing. They both potentially load from the same place and then save
to the same place. And that means coins might get eaten, especially if
your refund addresses go into a wallet that later gets destroyed.