### PR TITLE
add a wallet merge tool

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -100,6 +100,7 @@ func (srv *Server) initAPI(addr string) {
 	// Wallet API Calls
 	if srv.wallet != nil {
 		handleHTTPRequest(mux, "/wallet/address", srv.walletAddressHandler)
+		handleHTTPRequest(mux, "/wallet/merge", srv.walletMergeHandler)
 		handleHTTPRequest(mux, "/wallet/send", srv.walletSendHandler)
 		handleHTTPRequest(mux, "/wallet/status", srv.walletStatusHandler)
 		handleHTTPRequest(mux, "/wallet/siafunds/balance", srv.walletSiafundsBalanceHandler)

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -45,6 +45,18 @@ func (srv *Server) walletAddressHandler(w http.ResponseWriter, req *http.Request
 	writeJSON(w, struct{ Address types.UnlockHash }{coinAddress})
 }
 
+// walletMergeHandler handles the API call to merge a different wallet into the
+// current wallet.
+func (srv *Server) walletMergeHandler(w http.ResponseWriter, req *http.Request) {
+	// Scan the wallet file.
+	err := srv.wallet.MergeWallet(req.FormValue("walletfile"))
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeSuccess(w)
+}
+
 // walletSendHandler handles the API call to send coins to another address.
 func (srv *Server) walletSendHandler(w http.ResponseWriter, req *http.Request) {
 	// Scan the amount.

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -22,47 +22,6 @@ type WalletInfo struct {
 	NumAddresses     int
 }
 
-// Wallet is an interface that keeps track of addresses and balance. Using
-// TransactionBuilder it also streamlines sending coins.
-type Wallet interface {
-	TransactionBuilder
-	// Balance returns the total number of coins accessible to the wallet. If
-	// full == true, the number of coins returned will also include coins that
-	// have been spent in unconfirmed transactions.
-	Balance(full bool) types.Currency
-
-	// CoinAddress return an address into which coins can be paid. The bool
-	// indicates whether the address should be visible to the user.
-	CoinAddress(visible bool) (types.UnlockHash, types.UnlockConditions, error)
-
-	// TimelockedCoinAddress returns an address that can only be spent after
-	// block `unlockHeight`. The bool indicates whether the address should be
-	// visible to the user.
-	TimelockedCoinAddress(unlockHeight types.BlockHeight, visible bool) (types.UnlockHash, types.UnlockConditions, error)
-
-	Info() WalletInfo
-
-	SendCoins(amount types.Currency, dest types.UnlockHash) (types.Transaction, error)
-
-	// WalletNotify will push a struct down the channel any time that the
-	// wallet updates.
-	WalletNotify() <-chan struct{}
-
-	// SiafundBalance returns the number of siafunds owned by the wallet, and
-	// the number of siacoins available through siafund claims.
-	SiafundBalance() (siafundBalance types.Currency, siacoinClaimBalance types.Currency)
-
-	// SendSiagSiafunds sends siafunds to another address. The siacoins stored
-	// in the siafunds are sent to an address in the wallet.
-	SendSiagSiafunds(amount types.Currency, dest types.UnlockHash, keyfiles []string) (types.Transaction, error)
-
-	// WatchSiagSiafundAddress adds a siafund address pulled from a siag keyfile.
-	WatchSiagSiafundAddress(keyfile string) error
-
-	// Close safely closes the wallet file.
-	Close() error
-}
-
 // TransactionBuilder is an interface in which transactions are registered,
 // detailed, and signed. This gives other modules, and wallet itself, full
 // flexibility in creating dynamic transactions.
@@ -125,4 +84,50 @@ type TransactionBuilder interface {
 	// signature. After being signed, the transaction is deleted from the
 	// wallet and must be reregistered if more changes are to be made.
 	SignTransaction(id string, wholeTransaction bool) (types.Transaction, error)
+}
+
+// Wallet is an interface that keeps track of addresses and balance. Using
+// TransactionBuilder it also streamlines sending coins.
+type Wallet interface {
+	TransactionBuilder
+
+	// Balance returns the total number of coins accessible to the wallet. If
+	// full == true, the number of coins returned will also include coins that
+	// have been spent in unconfirmed transactions.
+	Balance(full bool) types.Currency
+
+	// Close safely closes the wallet file.
+	Close() error
+
+	// CoinAddress return an address into which coins can be paid. The bool
+	// indicates whether the address should be visible to the user.
+	CoinAddress(visible bool) (types.UnlockHash, types.UnlockConditions, error)
+
+	Info() WalletInfo
+
+	// MergeWallet takes a filepath to another wallet that should be merged
+	// with the current wallet. Repeat addresses will not be merged.
+	MergeWallet(string) error
+
+	// TimelockedCoinAddress returns an address that can only be spent after
+	// block `unlockHeight`. The bool indicates whether the address should be
+	// visible to the user.
+	TimelockedCoinAddress(unlockHeight types.BlockHeight, visible bool) (types.UnlockHash, types.UnlockConditions, error)
+
+	SendCoins(amount types.Currency, dest types.UnlockHash) (types.Transaction, error)
+
+	// WalletNotify will push a struct down the channel any time that the
+	// wallet updates.
+	WalletNotify() <-chan struct{}
+
+	// SiafundBalance returns the number of siafunds owned by the wallet, and
+	// the number of siacoins available through siafund claims.
+	SiafundBalance() (siafundBalance types.Currency, siacoinClaimBalance types.Currency)
+
+	// SendSiagSiafunds sends siafunds to another address. The siacoins stored
+	// in the siafunds are sent to an address in the wallet.
+	SendSiagSiafunds(amount types.Currency, dest types.UnlockHash, keyfiles []string) (types.Transaction, error)
+
+	// WatchSiagSiafundAddress adds a siafund address pulled from a siag keyfile.
+	WatchSiagSiafundAddress(keyfile string) error
 }

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -3,40 +3,33 @@ package wallet
 import (
 	"path/filepath"
 
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// a savedKey contains a single-signature key and all the tools needed to spend
+// outputs at its address.
 type savedKey struct {
 	SecretKey        crypto.SecretKey
 	UnlockConditions types.UnlockConditions
 	Visible          bool
 }
 
-// save writes the contents of a wallet to a file.
-func (w *Wallet) save() error {
-	// Convert the key map to a slice.
+// saveKeys saves the current set of keys known to the wallet to a file.
+func (w *Wallet) saveKeys(filepath string) error {
+	// Convert the key map to a slice and write to disk.
 	keySlice := make([]savedKey, 0, len(w.keys))
 	for _, key := range w.keys {
 		_, exists := w.visibleAddresses[key.unlockConditions.UnlockHash()]
 		keySlice = append(keySlice, savedKey{key.secretKey, key.unlockConditions, exists})
 	}
-	// Write the wallet data to a backup file, in case something goes wrong
-	err := encoding.WriteFile(filepath.Join(w.saveDir, "wallet.backup"), keySlice)
-	if err != nil {
-		return err
-	}
-	// Save the primary copy.
-	err = encoding.WriteFile(filepath.Join(w.saveDir, "wallet.dat"), keySlice)
-	if err != nil {
-		// TODO: instruct user to recover wallet from the backup file
-		return err
-	}
+	return encoding.WriteFile(filepath, keySlice)
+}
 
-	// Create a second file for the siafunds. This is another
-	// deprecated-on-arrival file.
+// saveSiafundTracking save the addresses that track siafunds.
+func (w *Wallet) saveSiafundTracking(filepath string) error {
+	// Put the siafund tracking addresses into a slice and write to disk.
 	siafundSlice := make([]types.UnlockHash, 0, len(w.siafundAddresses))
 	for sa, _ := range w.siafundAddresses {
 		siafundSlice = append(siafundSlice, sa)
@@ -45,12 +38,29 @@ func (w *Wallet) save() error {
 	// 'siafunds.dat' or something similar, people might think it's okay to
 	// delete their siafund keys, which is NOT okay. Instead of potentially
 	// having this confusion, I chose a less suggestive name.
-	err = encoding.WriteFile(filepath.Join(w.saveDir, "outputs.backup"), siafundSlice)
+	return encoding.WriteFile(filepath, siafundSlice)
+}
+
+// save writes the contents of a wallet to a file.
+func (w *Wallet) save() error {
+	// Save the siacoin keys to disk.
+	err := w.saveKeys(filepath.Join(w.saveDir, "wallet.backup"))
+	if err != nil {
+		return err
+	}
+	err = w.saveKeys(filepath.Join(w.saveDir, "wallet.dat"))
+	if err != nil {
+		return err
+	}
+
+	// Create a second file for the siafunds. This is another
+	// deprecated-on-arrival file.
+	err = w.saveSiafundTracking(filepath.Join(w.saveDir, "outputs.backup"))
 	if err != nil {
 		return err
 	}
 	// Save the primary copy.
-	err = encoding.WriteFile(filepath.Join(w.saveDir, "outputs.dat"), siafundSlice)
+	err = w.saveSiafundTracking(filepath.Join(w.saveDir, "outputs.dat"))
 	if err != nil {
 		return err
 	}
@@ -99,47 +109,10 @@ func (w *Wallet) loadKeys(savedKeys []savedKey) error {
 	return nil
 }
 
-// load reads the contents of a wallet from a file.
-func (w *Wallet) load() error {
-	var savedKeys []savedKey
-	err := encoding.ReadFile(filepath.Join(w.saveDir, "wallet.dat"), &savedKeys)
-	// never load from the home folder during testing
-	if err != nil {
-		// try loading the backup
-		// TODO: display/log a warning
-		err = encoding.ReadFile(filepath.Join(w.saveDir, "wallet.backup"), &savedKeys)
-		if err != nil {
-			return err
-		}
-	}
-	err = w.loadKeys(savedKeys)
-	if err != nil {
-		return err
-	}
-
-	// Load the siafunds file, which is intentionally called 'outputs.dat'.
-	var siafundAddresses []types.UnlockHash
-	err = encoding.ReadFile(filepath.Join(w.saveDir, "outputs.backup"), &siafundAddresses)
-	// never load from the home folder during testing
-	if build.Release != "release" || err != nil {
-		// try loading the backup
-		// TODO: display/log a warning?
-		err = encoding.ReadFile(filepath.Join(w.saveDir, "outputs.dat"), &siafundAddresses)
-		if err != nil {
-			return err
-		}
-	}
-	for _, sa := range siafundAddresses {
-		w.siafundAddresses[sa] = struct{}{}
-	}
-
-	return nil
-}
-
-// MergeWallet merges another wallet with the already-loaded wallet, creating a
-// new wallet that contains all of the addresses from each. This is useful for
-// loading backups.
-func (w *Wallet) MergeWallet(filepath string) error {
+// loadWallet pulls a wallet from disk into memory, merging it with whatever
+// wallet is already in memory. The result is a combined wallet that has all of
+// the addresses.
+func (w *Wallet) loadWallet(filepath string) error {
 	var savedKeys []savedKey
 	err := encoding.ReadFile(filepath, &savedKeys)
 	if err != nil {
@@ -150,4 +123,53 @@ func (w *Wallet) MergeWallet(filepath string) error {
 		return err
 	}
 	return nil
+}
+
+// loadSiafundTracking loads siafund addresses for tracking.
+func (w *Wallet) loadSiafundTracking(filepath string) error {
+	// Load the siafunds file, which is intentionally called 'outputs.dat'.
+	var siafundAddresses []types.UnlockHash
+	err := encoding.ReadFile(filepath, &siafundAddresses)
+	if err != nil {
+		return err
+	}
+
+	// Load the addresses into the wallet.
+	for _, sa := range siafundAddresses {
+		w.siafundAddresses[sa] = struct{}{}
+	}
+	return nil
+}
+
+// load reads the contents of a wallet from a file.
+func (w *Wallet) load() error {
+	err := w.loadWallet(filepath.Join(w.saveDir, "wallet.dat"))
+	if err != nil {
+		// try loading the backup
+		// TODO: display/log a warning
+		err = w.loadWallet(filepath.Join(w.saveDir, "wallet.backup"))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Load the siafunds file, which is intentionally called 'outputs.dat'.
+	err = w.loadSiafundTracking(filepath.Join(w.saveDir, "outputs.dat"))
+	if err != nil {
+		// try loading the backup
+		// TODO: display/log a warning?
+		err = w.loadSiafundTracking(filepath.Join(w.saveDir, "outputs.backup"))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MergeWallet merges another wallet with the already-loaded wallet, creating a
+// new wallet that contains all of the addresses from each. This is useful for
+// loading backups.
+func (w *Wallet) MergeWallet(filepath string) error {
+	return w.loadWallet(filepath)
 }

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -34,10 +34,6 @@ func (w *Wallet) saveSiafundTracking(filepath string) error {
 	for sa, _ := range w.siafundAddresses {
 		siafundSlice = append(siafundSlice, sa)
 	}
-	// outputs.dat is intentionally a bit of a misleading name. If I called it
-	// 'siafunds.dat' or something similar, people might think it's okay to
-	// delete their siafund keys, which is NOT okay. Instead of potentially
-	// having this confusion, I chose a less suggestive name.
 	return encoding.WriteFile(filepath, siafundSlice)
 }
 
@@ -53,8 +49,10 @@ func (w *Wallet) save() error {
 		return err
 	}
 
-	// Create a second file for the siafunds. This is another
-	// deprecated-on-arrival file.
+	// outputs.dat is intentionally a bit of a misleading name. If I called it
+	// 'siafunds.dat' or something similar, people might think it's okay to
+	// delete their siafund keys, which is NOT okay. Instead of potentially
+	// having this confusion, I chose a less suggestive name.
 	err = w.saveSiafundTracking(filepath.Join(w.saveDir, "outputs.backup"))
 	if err != nil {
 		return err

--- a/modules/wallet/siafunds.go
+++ b/modules/wallet/siafunds.go
@@ -40,7 +40,7 @@ func (w *Wallet) SiafundBalance() (siafundBalance types.Currency, siacoinClaimBa
 	csPool := w.state.SiafundPool()
 	for _, sfo := range w.siafundOutputs {
 		siafundBalance = siafundBalance.Add(sfo.Value)
-		siacoinsPerSiafund := csPool.Sub(sfo.ClaimStart)
+		siacoinsPerSiafund := csPool.Sub(sfo.ClaimStart).Div(types.NewCurrency64(types.SiafundCount))
 		siacoinClaim := siacoinsPerSiafund.Mul(sfo.Value)
 		siacoinClaimBalance = siacoinClaimBalance.Add(siacoinClaim)
 	}

--- a/siac/main.go
+++ b/siac/main.go
@@ -167,7 +167,7 @@ func main() {
 	minerCmd.AddCommand(minerStartCmd, minerStopCmd, minerStatusCmd)
 
 	root.AddCommand(walletCmd)
-	walletCmd.AddCommand(walletAddressCmd, walletSendCmd, walletSiafundsCmd, walletStatusCmd)
+	walletCmd.AddCommand(walletAddressCmd, walletMergeCmd, walletSendCmd, walletSiafundsCmd, walletStatusCmd)
 	walletSiafundsCmd.AddCommand(walletSiafundsTrackCmd)
 	walletSiafundsCmd.AddCommand(walletSiafundsSendCmd)
 

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -68,6 +68,13 @@ The smallest unit of siacoins is the hasting. One siacoin is 10^24 hastings. Oth
 		Run:   wrap(walletaddresscmd),
 	}
 
+	walletMergeCmd = &cobra.Command{
+		Use:   "merge [walletfile]",
+		Short: "Merge wallet",
+		Long:  "Merge another wallet with the existing wallet. The existing wallet will inherit all keys and addresses.",
+		Run:   wrap(walletmergecmd),
+	}
+
 	walletSendCmd = &cobra.Command{
 		Use:   "send [amount] [dest]",
 		Short: "Send coins to another wallet",
@@ -122,6 +129,18 @@ func walletaddresscmd() {
 		return
 	}
 	fmt.Printf("Created new address: %s\n", addr.Address)
+}
+
+func walletmergecmd(walletfile string) {
+	err := post("/wallet/merge", "walletfile="+abs(walletfile))
+	if err != nil {
+		fmt.Println("Could not merge wallet:", err)
+		return
+	}
+	fmt.Printf(`Added %s to the wallet.
+
+You must restart siad to update your wallet balance.
+`, walletfile)
 }
 
 func walletsendcmd(amount, dest string) {


### PR DESCRIPTION
There is now a command to help you merge wallets together, which means you're not at risk of losing coins when deleting or moving around other wallet files. This is also useful for people mining on many computers at the same time.

Thanks to this feature, I was able to recover 4m of the 6m I lost. I now am not sure whether I actually lost 6m or just 4m. Regardless, a significant chunk is back.