### PR TITLE
fix a few uploading race conditions

### DIFF
--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
@@ -68,7 +69,7 @@ type uploadWriter struct {
 // Transferred field. This allows upload progress to be monitored in real-time.
 func (uw *uploadWriter) Write(b []byte) (int, error) {
 	n, err := uw.w.Write(b)
-	uw.piece.Transferred += uint64(n)
+	atomic.AddUint64(&uw.piece.Transferred, uint64(n))
 	return n, err
 }
 


### PR DESCRIPTION
There is still a race condition remaining when we save file pieces, because there we actually copy the whole file when passing it to save, and this happens even mid-upload.

The solution is either to add a lock to the uploading updater, or to exclude in-progress uploads from being saved. I'm in favor of the latter given our current design (uploads can't be resumed anyway), but neither can be easily implemented.

I'm just going to leave it for now, since the renter is going to be getting a pretty big facelift anyway.