### PR TITLE
Save node list on close

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -133,11 +133,23 @@ func (srv *Server) Serve() error {
 	// It can also be stopped manually by stopHandler.
 	err := srv.apiServer.ListenAndServe()
 	// despite its name, graceful still propogates this benign error
-	if err != nil && strings.HasSuffix(err.Error(), "use of closed network connection") {
-		err = nil
+	if err != nil && !strings.HasSuffix(err.Error(), "use of closed network connection") {
+		return err
 	}
+
+	// safely close each module
+	if srv.cs != nil {
+		srv.cs.Close()
+	}
+	if srv.gateway != nil {
+		srv.gateway.Close()
+	}
+	if srv.wallet != nil {
+		srv.wallet.Close()
+	}
+
 	fmt.Println("\rCaught stop signal, quitting.")
-	return err
+	return nil
 }
 
 // writeError an error to the API caller.

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -139,17 +139,6 @@ func applyUpdate(version string) (err error) {
 
 // daemonStopHandler handles the API call to stop the daemon cleanly.
 func (srv *Server) daemonStopHandler(w http.ResponseWriter, req *http.Request) {
-	// safely close each module
-	if srv.cs != nil {
-		srv.cs.Close()
-	}
-	if srv.gateway != nil {
-		srv.gateway.Close()
-	}
-	if srv.wallet != nil {
-		srv.wallet.Close()
-	}
-
 	// can't write after we stop the server, so lie a bit.
 	writeSuccess(w)
 

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -52,8 +52,14 @@ func (g *Gateway) Address() modules.NetAddress {
 	return g.myAddr
 }
 
-// Close stops the Gateway's listener process.
+// Close saves the state of the Gateway and stops the listener process.
 func (g *Gateway) Close() error {
+	id := g.mu.RLock()
+	defer g.mu.RUnlock(id)
+	err := g.save()
+	if err != nil {
+		return err
+	}
 	return g.listener.Close()
 }
 

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -2,10 +2,8 @@ package gateway
 
 import (
 	"errors"
-	"io"
 	"log"
 	"net"
-	"net/http"
 	"os"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -115,23 +113,6 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	go g.makeOutboundConnections()
 
 	return
-}
-
-// getExternalIP learns the server's hostname from a centralized service,
-// myexternalip.com.
-func getExternalIP() (string, error) {
-	resp, err := http.Get("http://myexternalip.com/raw")
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	buf := make([]byte, 64)
-	n, err := resp.Body.Read(buf)
-	if err != nil && err != io.EOF {
-		return "", err
-	}
-	hostname := string(buf[:n-1]) // trim newline
-	return hostname, nil
 }
 
 // enforce that Gateway satisfies the modules.Gateway interface

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -82,17 +82,3 @@ func TestNew(t *testing.T) {
 		t.Fatal("expected load error, got nil")
 	}
 }
-
-func TestExternalIP(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-
-	ip, err := getExternalIP()
-	if err != nil {
-		t.Fatal("couldn't determine external IP:", err)
-	}
-	if net.ParseIP(ip) == nil {
-		t.Fatal("getExternalIP returned bad IP:", ip)
-	}
-}


### PR DESCRIPTION
The node list wasn't being saved after removing nodes, so the gateway now calls `g.save` in `g.Close`. Saving inside `g.removeNode` is another option, but I wanted to avoid saving repeatedly when removing many nodes.

TODO: the gateway should ask for more nodes if its node list is getting too sparse.