### PR TITLE
No strings

### DIFF
--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -242,9 +242,9 @@ func TestLargeBlock(t *testing.T) {
 	}
 
 	// Create a transaction that puts the block over the size limit.
-	bigData := string(make([]byte, types.BlockSizeLimit))
+	bigData := make([]byte, types.BlockSizeLimit)
 	txn := types.Transaction{
-		ArbitraryData: []string{bigData},
+		ArbitraryData: [][]byte{bigData},
 	}
 
 	// Fetch a block and add the transaction, then submit the block.

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -39,7 +39,7 @@ func (h *Host) announce(addr modules.NetAddress) error {
 	announcement := encoding.Marshal(modules.HostAnnouncement{
 		IPAddress: addr,
 	})
-	_, _, err = h.wallet.AddArbitraryData(id, modules.PrefixHostAnnouncement+string(announcement))
+	_, _, err = h.wallet.AddArbitraryData(id, append(modules.PrefixHostAnnouncement[:], announcement...))
 	if err != nil {
 		return err
 	}

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -1,11 +1,11 @@
 package host
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // TestAnnouncement has a host announce itself to the blockchain and then
@@ -25,7 +25,7 @@ func TestAnnouncement(t *testing.T) {
 	if len(txns) != 1 {
 		t.Error("Expecting 1 transaction in transaction pool, instead there was", len(txns))
 	}
-	encodedAnnouncement := strings.TrimPrefix(txns[0].ArbitraryData[0], modules.PrefixHostAnnouncement)
+	encodedAnnouncement := txns[0].ArbitraryData[0][types.SpecifierLen:]
 	var ha modules.HostAnnouncement
 	err = encoding.Unmarshal([]byte(encodedAnnouncement), &ha)
 	if err != nil {

--- a/modules/hostdb.go
+++ b/modules/hostdb.go
@@ -6,7 +6,11 @@ import (
 
 const (
 	// Denotes a host announcement in the Arbitrary Data section.
-	PrefixHostAnnouncement = "HostAnnouncement"
+	PrefixStrHostAnnouncement = "HostAnnouncement" // preserved for compatibility with 0.3.3.3
+)
+
+var (
+	PrefixHostAnnouncement = types.Specifier{'H', 'o', 's', 't', 'A', 'n', 'n', 'o', 'u', 'n', 'c', 'e', 'm', 'e', 'n', 't'}
 )
 
 // HostAnnouncements are stored in the Arbitrary Data section of transactions

--- a/modules/hostdb/update.go
+++ b/modules/hostdb/update.go
@@ -23,16 +23,19 @@ import (
 // announcement is actually a valid ip address.
 func findHostAnnouncements(b types.Block) (announcements []modules.HostSettings) {
 	for _, t := range b.Transactions {
-		for _, data := range t.ArbitraryData {
-			// the HostAnnouncement must be prefaced by the standard host announcement string
-			if !strings.HasPrefix(data, modules.PrefixHostAnnouncement) {
+		// the HostAnnouncement must be prefaced by the standard host
+		// announcement string
+		var prefix types.Specifier
+		for _, arb := range t.ArbitraryData {
+			copy(prefix[:], arb)
+			if !strings.HasPrefix(string(arb), modules.PrefixStrHostAnnouncement) && // preserved for compatibility with 0.3.3.3
+				prefix != modules.PrefixHostAnnouncement {
 				continue
 			}
 
 			// decode the HostAnnouncement
 			var ha modules.HostAnnouncement
-			encAnnouncement := []byte(strings.TrimPrefix(data, modules.PrefixHostAnnouncement))
-			err := encoding.Unmarshal(encAnnouncement, &ha)
+			err := encoding.Unmarshal(arb[types.SpecifierLen:], &ha)
 			if err != nil {
 				continue
 			}

--- a/modules/hostdb/update_test.go
+++ b/modules/hostdb/update_test.go
@@ -11,11 +11,11 @@ import (
 // TestFindHostAnnouncements probes the findHostAnnouncements function
 func TestFindHostAnnouncements(t *testing.T) {
 	// Create a block with a host announcement.
-	announcement := modules.PrefixHostAnnouncement + string(encoding.Marshal(modules.HostAnnouncement{}))
+	announcement := append(modules.PrefixHostAnnouncement[:], encoding.Marshal(modules.HostAnnouncement{})...)
 	b := types.Block{
 		Transactions: []types.Transaction{
 			types.Transaction{
-				ArbitraryData: []string{announcement},
+				ArbitraryData: [][]byte{announcement},
 			},
 		},
 	}
@@ -25,14 +25,15 @@ func TestFindHostAnnouncements(t *testing.T) {
 	}
 
 	// Try with an altered prefix
-	b.Transactions[0].ArbitraryData[0] = "bad" + b.Transactions[0].ArbitraryData[0]
+	b.Transactions[0].ArbitraryData[0][0]++
 	announcements = findHostAnnouncements(b)
 	if len(announcements) != 0 {
 		t.Error("host announcement found when there was an invalid prefix")
 	}
+	b.Transactions[0].ArbitraryData[0][0]--
 
 	// Try with an invalid host encoding.
-	b.Transactions[0].ArbitraryData[0] = modules.PrefixHostAnnouncement + "bad"
+	b.Transactions[0].ArbitraryData[0][17]++
 	announcements = findHostAnnouncements(b)
 	if len(announcements) != 0 {
 		t.Error("host announcement found when there was an invalid encoding of a host announcement")
@@ -52,7 +53,7 @@ func TestReceiveConsensusSetUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = hdbt.wallet.AddArbitraryData(id, modules.PrefixHostAnnouncement+string(announcement))
+	_, _, err = hdbt.wallet.AddArbitraryData(id, append(modules.PrefixHostAnnouncement[:], announcement...))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -36,10 +37,10 @@ func (m *Miner) blockForWork() (types.Block, types.Target) {
 	// other parts of the program. This is related to the fact that slices are
 	// pointers, and not immutable objects. Use of the builtin `copy` function
 	// when passing objects like blocks around may fix this problem.
-	randBytes := make([]byte, 16)
+	randBytes := make([]byte, types.SpecifierLen)
 	rand.Read(randBytes)
 	randTxn := types.Transaction{
-		ArbitraryData: []string{"NonSia" + string(randBytes)},
+		ArbitraryData: [][]byte{append(modules.PrefixNonSia[:], randBytes...)},
 	}
 	blockTransactions := append([]types.Transaction{randTxn}, m.transactions...)
 

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -6,10 +6,16 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+const (
+	TransactionSizeLimit = 16 * 1024
+)
+
 var (
 	// ErrTransactionPoolDuplicate is returned when a duplicate transaction is
 	// submitted to the transaction pool.
 	ErrTransactionPoolDuplicate = errors.New("transaction is a duplicate")
+	PrefixNonSia                = types.Specifier{'N', 'o', 'n', 'S', 'i', 'a'}
+	PrefixStrNonSia             = "NonSia" // preserved for compatibility with 0.3.3.3
 )
 
 // A TransactionPoolSubscriber receives updates about the confirmed and

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -109,7 +109,7 @@ func TestLowFeeTransaction(t *testing.T) {
 	emptyData := make([]byte, 15e3-16)
 	randData := make([]byte, 16) // not yet random
 	emptyTxn := types.Transaction{
-		ArbitraryData: []string{"NonSia" + string(append(emptyData, randData...))},
+		ArbitraryData: [][]byte{append(modules.PrefixNonSia[:], (append(emptyData, randData...))...)},
 	}
 	transSize := len(encoding.Marshal(emptyTxn))
 
@@ -118,7 +118,7 @@ func TestLowFeeTransaction(t *testing.T) {
 		// Make a unique transaction to accept
 		rand.Read(randData)
 		uniqueTxn := types.Transaction{
-			ArbitraryData: []string{"NonSia" + string(append(emptyData, randData...))},
+			ArbitraryData: [][]byte{append(modules.PrefixNonSia[:], append(emptyData, randData...)...)},
 		}
 
 		// Accept said transaction

--- a/modules/transactionpool/standard_test.go
+++ b/modules/transactionpool/standard_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"testing"
 
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -12,11 +13,11 @@ func TestLargeTransaction(t *testing.T) {
 	tpt := newTpoolTester("TestLargeTransaction", t)
 
 	// Create a transaction that's larger than the size limit.
-	largeArbitraryData := make([]byte, TransactionSizeLimit)
+	largeArbitraryData := make([]byte, modules.TransactionSizeLimit)
 	rand.Read(largeArbitraryData)
-	acceptableData := "NonSia" + string(largeArbitraryData)
+	acceptableData := append(modules.PrefixNonSia[:], largeArbitraryData...)
 	txn := types.Transaction{
-		ArbitraryData: []string{acceptableData},
+		ArbitraryData: [][]byte{acceptableData},
 	}
 
 	// Check IsStandard.

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -37,7 +37,7 @@ func (tpt *tpoolTester) testUpdateTransactionRemoval() {
 func (tpt *tpoolTester) testDataTransactions() {
 	// Make a data transaction and put it into the blockchain.
 	txn := types.Transaction{
-		ArbitraryData: []string{"NonSiadata"},
+		ArbitraryData: [][]byte{append(modules.PrefixNonSia[:], 'd')},
 	}
 	err := tpt.tpool.AcceptTransaction(txn)
 	if err != nil {

--- a/modules/transactionpool/valid_test.go
+++ b/modules/transactionpool/valid_test.go
@@ -3,6 +3,7 @@ package transactionpool
 import (
 	"testing"
 
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -17,7 +18,7 @@ func (tpt *tpoolTester) addConflictingSiacoinTransaction() {
 	if err != nil {
 		tpt.t.Error(err)
 	}
-	txn.ArbitraryData = append(txn.ArbitraryData, "NonSia: this stops the transaction from being a duplicate")
+	txn.ArbitraryData = append(txn.ArbitraryData, modules.PrefixNonSia[:]) // Prevent the txn from being a duplicate.
 	err = tpt.tpool.AcceptTransaction(txn)
 	if err != ErrUnrecognizedSiacoinInput {
 		tpt.t.Error(err)

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -70,7 +70,7 @@ type TransactionBuilder interface {
 	// AddArbitraryData adds a byte slice to the arbitrary data section of the
 	// transaction, returning the transaction and the index of the new
 	// arbitrary data.
-	AddArbitraryData(id string, arb string) (types.Transaction, uint64, error)
+	AddArbitraryData(id string, arb []byte) (types.Transaction, uint64, error)
 
 	// AddTransactionSignature adds a signature to the transaction, the
 	// signature should already be valid, and shouldn't sign any of the inputs

--- a/modules/wallet/addresses.go
+++ b/modules/wallet/addresses.go
@@ -20,7 +20,7 @@ func (w *Wallet) timelockedCoinAddress(unlockHeight types.BlockHeight, visible b
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,
-				Key:       string(encoding.Marshal(pk)),
+				Key:       encoding.Marshal(pk),
 			},
 		},
 	}
@@ -69,7 +69,7 @@ func (w *Wallet) coinAddress(visible bool) (coinAddress types.UnlockHash, unlock
 		PublicKeys: []types.SiaPublicKey{
 			types.SiaPublicKey{
 				Algorithm: types.SignatureEd25519,
-				Key:       string(encoding.Marshal(pk)),
+				Key:       encoding.Marshal(pk),
 			},
 		},
 	}

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -281,7 +281,7 @@ func (w *Wallet) AddSiafundOutput(id string, output types.SiafundOutput) (t type
 
 // AddArbitraryData adds arbitrary data to the transaction, returning a copy of
 // the transaction and the index of the new data within the transaction.
-func (w *Wallet) AddArbitraryData(id string, arb string) (t types.Transaction, adIndex uint64, err error) {
+func (w *Wallet) AddArbitraryData(id string, arb []byte) (t types.Transaction, adIndex uint64, err error) {
 	counter := w.mu.Lock()
 	defer w.mu.Unlock(counter)
 

--- a/siag/keys.go
+++ b/siag/keys.go
@@ -78,7 +78,7 @@ func generateKeys(requiredKeys int, totalKeys int, folder string, keyname string
 	for i := range keys {
 		unlockConditions.PublicKeys = append(unlockConditions.PublicKeys, types.SiaPublicKey{
 			Algorithm: types.SignatureEd25519,
-			Key:       string(pubKeys[i][:]),
+			Key:       pubKeys[i][:],
 		})
 	}
 	for i := range keys {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -43,7 +43,7 @@ func TestBlockHeader(t *testing.T) {
 	b.Nonce[2] = 2
 	b.Timestamp = 3
 	b.MinerPayouts = []SiacoinOutput{{Value: NewCurrency64(4)}}
-	b.Transactions = []Transaction{{ArbitraryData: []string{"5"}}}
+	b.Transactions = []Transaction{{ArbitraryData: [][]byte{[]byte{'5'}}}}
 
 	id1 := b.ID()
 	id2 := BlockID(crypto.HashBytes(encoding.Marshal(b.Header())))
@@ -117,7 +117,7 @@ func TestBlockCalculateSubsidy(t *testing.T) {
 
 	// Add a single no-fee transaction and check again.
 	txn = Transaction{
-		ArbitraryData: []string{"NonSia"},
+		ArbitraryData: [][]byte{[]byte{'6'}},
 	}
 	b.Transactions = append(b.Transactions, txn)
 	if b.CalculateSubsidy(0).Cmp(expected) != 0 {
@@ -140,7 +140,7 @@ func TestBlockCalculateSubsidy(t *testing.T) {
 
 	// Add an empty transaction to the beginning.
 	txn = Transaction{
-		ArbitraryData: []string{"NonSia"},
+		ArbitraryData: [][]byte{[]byte{'7'}},
 	}
 	b.Transactions = append([]Transaction{txn}, b.Transactions...)
 	if b.CalculateSubsidy(0).Cmp(expected) != 0 {

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -46,7 +46,7 @@ var (
 )
 
 type (
-	Signature string
+	Signature []byte
 
 	// CoveredFields indicates which fields in a transaction have been covered by
 	// the signature. (Note that the signature does not sign the fields
@@ -79,7 +79,7 @@ type (
 	// the protocol via a soft-fork.
 	SiaPublicKey struct {
 		Algorithm Specifier
-		Key       string
+		Key       []byte
 	}
 
 	// A TransactionSignature is a signature that is included in the transaction.

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -34,7 +34,7 @@ func TestSigHash(t *testing.T) {
 		SiafundInputs:         []SiafundInput{SiafundInput{}},
 		SiafundOutputs:        []SiafundOutput{SiafundOutput{}},
 		MinerFees:             []Currency{Currency{}},
-		ArbitraryData:         []string{"one", "two"},
+		ArbitraryData:         [][]byte{[]byte{'o'}, []byte{'t'}},
 		TransactionSignatures: []TransactionSignature{
 			TransactionSignature{
 				CoveredFields: CoveredFields{
@@ -106,7 +106,7 @@ func TestTransactionValidCoveredFields(t *testing.T) {
 		SiafundInputs:         []SiafundInput{SiafundInput{}},
 		SiafundOutputs:        []SiafundOutput{SiafundOutput{}},
 		MinerFees:             []Currency{Currency{}},
-		ArbitraryData:         []string{"one", "two"},
+		ArbitraryData:         [][]byte{[]byte{'o'}, []byte{'t'}},
 		TransactionSignatures: []TransactionSignature{
 			TransactionSignature{
 				CoveredFields: CoveredFields{

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -14,7 +14,7 @@ func TestUnlockHash(t *testing.T) {
 		PublicKeys: []SiaPublicKey{
 			SiaPublicKey{
 				Algorithm: SignatureEntropy,
-				Key:       "fake key",
+				Key:       []byte{'f', 'a', 'k', 'e'},
 			},
 		},
 		SignaturesRequired: 3,
@@ -176,7 +176,7 @@ func TestTransactionValidSignatures(t *testing.T) {
 	// entropy type, which should never be accepted.
 	uc := UnlockConditions{
 		PublicKeys: []SiaPublicKey{
-			{Algorithm: SignatureEd25519, Key: string(pk[:])},
+			{Algorithm: SignatureEd25519, Key: pk[:]},
 			{},
 			{Algorithm: SignatureEntropy},
 		},
@@ -327,15 +327,15 @@ func TestTransactionValidSignatures(t *testing.T) {
 	txn.TransactionSignatures[0] = tmpTxn0
 
 	// Insert a malformed public key into the transaction.
-	txn.SiacoinInputs[0].UnlockConditions.PublicKeys[0].Key = "malformed"
+	txn.SiacoinInputs[0].UnlockConditions.PublicKeys[0].Key = []byte{'b', 'a', 'd'}
 	err = txn.validSignatures(10)
 	if err == nil {
 		t.Error(err)
 	}
-	txn.SiacoinInputs[0].UnlockConditions.PublicKeys[0].Key = string(pk[:])
+	txn.SiacoinInputs[0].UnlockConditions.PublicKeys[0].Key = pk[:]
 
 	// Insert a malformed signature into the transaction.
-	txn.TransactionSignatures[0].Signature = "malformed"
+	txn.TransactionSignatures[0].Signature = []byte{'m', 'a', 'l'}
 	err = txn.validSignatures(10)
 	if err == nil {
 		t.Error(err)

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -9,11 +9,15 @@ import (
 	"github.com/NebulousLabs/Sia/crypto"
 )
 
+const (
+	SpecifierLen = 16
+)
+
 type (
 	Siafund Currency // arbitrary-precision unsigned integer
 
-	// A Specifier is a fixed-length string that serves two purposes. In the
-	// wire protocol, they are used to identify a particular encoding
+	// A Specifier is a fixed-length byte-array that serves two purposes. In
+	// the wire protocol, they are used to identify a particular encoding
 	// algorithm, signature algorithm, etc. This allows nodes to communicate on
 	// their own terms; for example, to reduce bandwidth costs, a node might
 	// only accept compressed messages.
@@ -22,7 +26,7 @@ type (
 	// consensus types have an associated ID, calculated by hashing the data
 	// contained in the type. By prepending the data with Specifier, we can
 	// guarantee that distinct types will never produce the same hash.
-	Specifier [16]byte
+	Specifier [SpecifierLen]byte
 
 	// IDs are used to refer to a type without revealing its contents. They
 	// are constructed by hashing specific fields of the type, along with a
@@ -49,7 +53,7 @@ type (
 		SiafundInputs         []SiafundInput
 		SiafundOutputs        []SiafundOutput
 		MinerFees             []Currency
-		ArbitraryData         []string
+		ArbitraryData         [][]byte
 		TransactionSignatures []TransactionSignature
 	}
 

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -141,13 +141,13 @@ func TestCorrectFileContractRevisions(t *testing.T) {
 func TestTransactionFitsInABlock(t *testing.T) {
 	// Try a transaction that will fit in a block, followed by one that won't.
 	data := make([]byte, BlockSizeLimit/2)
-	txn := Transaction{ArbitraryData: []string{string(data)}}
+	txn := Transaction{ArbitraryData: [][]byte{data}}
 	err := txn.fitsInABlock()
 	if err != nil {
 		t.Error(err)
 	}
 	data = make([]byte, BlockSizeLimit)
-	txn.ArbitraryData[0] = string(data)
+	txn.ArbitraryData[0] = data
 	err = txn.fitsInABlock()
 	if err != ErrTransactionTooLarge {
 		t.Error(err)
@@ -388,7 +388,7 @@ func TestTransactionStandaloneValid(t *testing.T) {
 
 	// Violate fitsInABlock.
 	data := make([]byte, BlockSizeLimit)
-	txn.ArbitraryData = []string{string(data)}
+	txn.ArbitraryData = [][]byte{data}
 	err = txn.StandaloneValid(0)
 	if err == nil {
 		t.Error("failed to trigger fitsInABlock error")


### PR DESCRIPTION
Compatibility unit testing is not complete, but I wanted to PR this so Adam could have it.

I removed all strings from the types package, which means blocks, etc. should now be compatible with JSON.

This change is neither a hardfork or a softfork