### PR TITLE
Organization

### DIFF
--- a/api/host_test.go
+++ b/api/host_test.go
@@ -3,8 +3,6 @@ package api
 import (
 	"testing"
 	"time"
-
-	"github.com/NebulousLabs/Sia/types"
 )
 
 // announceHost puts a host announcement for the host into the blockchain.
@@ -66,7 +64,7 @@ func TestStorageProofs(t *testing.T) {
 	// Have the renter submit an upload to the host.
 	uploadName := "api.go"
 	st.callAPI("/renter/files/upload?pieces=1&nickname=api.go&source=" + uploadName)
-	time.Sleep(types.RenterZeroConfDelay + time.Second*10)
+	time.Sleep(time.Second * 10)
 
 	// Mine 25 blocks - the file will expire. (special constants)
 	for i := 0; i < 25; i++ {

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
-	"github.com/NebulousLabs/Sia/types"
 )
 
 // TestUploadAndDownload creates a network with a host and then uploads a file
@@ -35,7 +34,7 @@ func TestUploadAndDownload(t *testing.T) {
 	// TODO: There should be some way to just spinblock until the download
 	// completes. Except there's no exported function in the renter that will
 	// indicate if a download has completed or not.
-	time.Sleep(types.RenterZeroConfDelay + time.Second*10)
+	time.Sleep(time.Second * 10)
 
 	files := st.server.renter.FileList()
 	if len(files) != 1 || !files[0].Available() {

--- a/crypto/merkle.go
+++ b/crypto/merkle.go
@@ -71,13 +71,13 @@ func ReaderMerkleRoot(r io.Reader) (h Hash, err error) {
 }
 
 // BuildReaderProof will build a storage proof when given a reader.
-func BuildReaderProof(r io.Reader, proofIndex uint64) (base [SegmentSize]byte, hashSet []Hash, err error) {
+func BuildReaderProof(r io.Reader, proofIndex uint64) (base []byte, hashSet []Hash, err error) {
 	_, proofSet, _, err := merkletree.BuildReaderProof(r, NewHash(), SegmentSize, proofIndex)
 	if err != nil {
 		return
 	}
 	// convert proofSet to base and hashSet
-	copy(base[:], proofSet[0])
+	base = proofSet[0]
 	hashSet = make([]Hash, len(proofSet)-1)
 	for i, proof := range proofSet[1:] {
 		copy(hashSet[i][:], proof)
@@ -87,10 +87,10 @@ func BuildReaderProof(r io.Reader, proofIndex uint64) (base [SegmentSize]byte, h
 
 // VerifySegment will verify that a segment, given the proof, is a part of a
 // merkle root.
-func VerifySegment(base [SegmentSize]byte, hashSet []Hash, numSegments, proofIndex uint64, root Hash) bool {
+func VerifySegment(base []byte, hashSet []Hash, numSegments, proofIndex uint64, root Hash) bool {
 	// convert base and hashSet to proofSet
 	proofSet := make([][]byte, len(hashSet)+1)
-	proofSet[0] = base[:]
+	proofSet[0] = base
 	for i := range hashSet {
 		proofSet[i+1] = hashSet[i][:]
 	}

--- a/crypto/merkle_test.go
+++ b/crypto/merkle_test.go
@@ -86,3 +86,24 @@ func TestStorageProof(t *testing.T) {
 		t.Error("Verified a bad proof")
 	}
 }
+
+// TestPaddedStorageProof builds a storage proof that has padding in the last
+// segment, and then requests a proof on the padded segment.
+func TestPaddedStorageProof(t *testing.T) {
+	// generate proof data
+	data := make([]byte, (2*SegmentSize)+10)
+	rand.Read(data)
+	rootHash, err := ReaderMerkleRoot(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create and verify a proof for the last index.
+	baseSegment, hashSet, err := BuildReaderProof(bytes.NewReader(data), 2)
+	if err != nil {
+		t.Error(err)
+	}
+	if !VerifySegment(baseSegment, hashSet, 3, 2, rootHash) {
+		t.Error("padded segment proof failed")
+	}
+}

--- a/modules/blockexplorer/addblock.go
+++ b/modules/blockexplorer/addblock.go
@@ -198,7 +198,7 @@ func (be *BlockExplorer) addBlockDB(b types.Block) error {
 	// Insert the miner payouts as new outputs
 	for i, payout := range b.MinerPayouts {
 		tx.addAddress(payout.UnlockHash, crypto.Hash(b.ID()))
-		tx.addNewOutput(b.MinerPayoutID(i), crypto.Hash(b.ID()))
+		tx.addNewOutput(b.MinerPayoutID(uint64(i)), crypto.Hash(b.ID()))
 	}
 
 	// Insert each transaction
@@ -236,11 +236,11 @@ func (tx *boltTx) addTransaction(txn types.Transaction) {
 
 		for j, output := range contract.ValidProofOutputs {
 			tx.addAddress(output.UnlockHash, txid)
-			tx.addNewOutput(fcid.StorageProofOutputID(true, j), txid)
+			tx.addNewOutput(fcid.StorageProofOutputID(true, uint64(j)), txid)
 		}
 		for j, output := range contract.MissedProofOutputs {
 			tx.addAddress(output.UnlockHash, txid)
-			tx.addNewOutput(fcid.StorageProofOutputID(false, j), txid)
+			tx.addNewOutput(fcid.StorageProofOutputID(false, uint64(j)), txid)
 		}
 
 		tx.addAddress(contract.UnlockHash, txid)
@@ -255,11 +255,11 @@ func (tx *boltTx) addTransaction(txn types.Transaction) {
 		// people who may just need it.
 		for i, output := range revision.NewValidProofOutputs {
 			tx.addAddress(output.UnlockHash, txid)
-			tx.addNewOutput(revision.ParentID.StorageProofOutputID(true, i), txid)
+			tx.addNewOutput(revision.ParentID.StorageProofOutputID(true, uint64(i)), txid)
 		}
 		for i, output := range revision.NewMissedProofOutputs {
 			tx.addAddress(output.UnlockHash, txid)
-			tx.addNewOutput(revision.ParentID.StorageProofOutputID(false, i), txid)
+			tx.addNewOutput(revision.ParentID.StorageProofOutputID(false, uint64(i)), txid)
 		}
 
 		tx.addAddress(revision.NewUnlockHash, txid)

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -646,10 +646,10 @@ func (cst *consensusSetTester) testFileContractsBlocks() error {
 	txn = types.Transaction{
 		StorageProofs: []types.StorageProof{{
 			ParentID: validFCID,
-			Segment:  segment,
 			HashSet:  hashSet,
 		}},
 	}
+	copy(txn.StorageProofs[0].Segment[:], segment)
 	err = cst.tpool.AcceptTransaction(txn)
 	if err != nil {
 		return err

--- a/modules/consensus/applytransaction.go
+++ b/modules/consensus/applytransaction.go
@@ -161,7 +161,7 @@ func (cs *State) applyStorageProofs(bn *blockNode, t types.Transaction) {
 		// Add all of the outputs in the ValidProofOutputs of the contract.
 		for i, vpo := range fc.ValidProofOutputs {
 			// Sanity check - output should not already exist.
-			spoid := sp.ParentID.StorageProofOutputID(types.ProofValid, i)
+			spoid := sp.ParentID.StorageProofOutputID(types.ProofValid, uint64(i))
 			if build.DEBUG {
 				_, exists := cs.delayedSiacoinOutputs[bn.height+types.MaturityDelay][spoid]
 				if exists {

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -20,7 +20,7 @@ var (
 func (cs *State) applyMinerPayouts(bn *blockNode) {
 	for i, payout := range bn.block.MinerPayouts {
 		// Sanity check - input should not exist in the consensus set.
-		mpid := bn.block.MinerPayoutID(i)
+		mpid := bn.block.MinerPayoutID(uint64(i))
 		if build.DEBUG {
 			// Check the delayed outputs set.
 			_, exists := cs.delayedSiacoinOutputs[bn.height+types.MaturityDelay][mpid]
@@ -117,7 +117,7 @@ func (cs *State) applyMissedStorageProof(bn *blockNode, fcid types.FileContractI
 	// Add all of the outputs in the missed proof outputs to the consensus set.
 	for i, mpo := range fc.MissedProofOutputs {
 		// Sanity check - output should not already exist.
-		spoid := fcid.StorageProofOutputID(types.ProofMissed, i)
+		spoid := fcid.StorageProofOutputID(types.ProofMissed, uint64(i))
 		if build.DEBUG {
 			_, exists := cs.delayedSiacoinOutputs[bn.height+types.MaturityDelay][spoid]
 			if exists {

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -53,8 +53,8 @@ func (h *Host) threadedCreateStorageProof(obligation contractObligation, heightF
 		fmt.Println(err)
 		return
 	}
-
-	sp := types.StorageProof{obligation.ID, base, hashSet}
+	sp := types.StorageProof{obligation.ID, [crypto.SegmentSize]byte{}, hashSet}
+	copy(sp.Segment[:], base)
 
 	// Create and send the transaction.
 	id, err := h.wallet.RegisterTransaction(types.Transaction{})

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -129,7 +130,13 @@ func (r *Renter) negotiateContract(host modules.HostSettings, up modules.FileUpl
 	// transactions have propgated to the host's transaction pool. Instead,
 	// built into the protocol should be a step where any dependent
 	// transactions are automatically provided.
-	time.Sleep(types.RenterZeroConfDelay)
+	if build.Release == "standard" {
+		time.Sleep(time.Minute)
+	} else if build.Release == "testing" {
+		time.Sleep(time.Second * 15)
+	} else {
+		time.Sleep(time.Second)
+	}
 
 	// Perform the negotiations with the host through a network call.
 	conn, err := net.DialTimeout("tcp", string(host.IPAddress), 10e9)

--- a/types/block.go
+++ b/types/block.go
@@ -124,7 +124,7 @@ func (b Block) MerkleRoot() crypto.Hash {
 // MinerPayoutID returns the ID of the miner payout at the given index, which
 // is calculated by hashing the concatenation of the BlockID and the payout
 // index.
-func (b Block) MinerPayoutID(i int) SiacoinOutputID {
+func (b Block) MinerPayoutID(i uint64) SiacoinOutputID {
 	return SiacoinOutputID(crypto.HashAll(
 		b.ID(),
 		i,

--- a/types/constants.go
+++ b/types/constants.go
@@ -9,7 +9,6 @@ package types
 import (
 	"math/big"
 	"sync"
-	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 )
@@ -47,8 +46,6 @@ var (
 	MinimumCoinbase  uint64
 
 	GenesisSiafundAllocation []SiafundOutput
-
-	RenterZeroConfDelay time.Duration // TODO: This shouldn't exist here.
 )
 
 // init checks which build constant is in place and initializes the variables
@@ -87,8 +84,6 @@ func init() {
 				UnlockHash: UnlockConditions{}.UnlockHash(),
 			},
 		}
-
-		RenterZeroConfDelay = 15 * time.Second // TODO: This doesn't belong here.
 	} else if build.Release == "testing" {
 		// 'testing' settings are for automatic testing, and create much faster
 		// environments than a humand can interact with.
@@ -123,8 +118,6 @@ func init() {
 				UnlockHash: UnlockConditions{}.UnlockHash(),
 			},
 		}
-
-		RenterZeroConfDelay = 2 * time.Second // TODO: This doesn't belong here.
 	} else if build.Release == "standard" {
 		// 'standard' settings are for the full network. They are slow enough
 		// that the network is secure in a real-world byzantine environment.
@@ -187,8 +180,6 @@ func init() {
 		// increasingly potent dropoff for about 5 years, until inflation more
 		// or less permanently settles around 2%.
 		MinimumCoinbase = 30e3
-
-		RenterZeroConfDelay = 60 * time.Second // TODO: This doesn't belong here.
 
 		GenesisSiafundAllocation = []SiafundOutput{
 			{

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -110,12 +110,12 @@ func (fcid FileContractID) StorageProofOutputID(proofStatus ProofStatus, i uint6
 
 // Tax returns the amount of Currency that will be taxed from fc.
 func (fc FileContract) Tax() Currency {
-	// COMPATv0.4.0 - until the first 10000 blocks have been archived, they
+	// COMPATv0.4.0 - until the first 15,000 blocks have been archived, they
 	// will need to be handled in a special way.
 	CurrentHeightLock.Lock()
 	height := CurrentHeight
 	CurrentHeightLock.Unlock()
-	if (height < 12e3 && build.Release == "standard") || height < 10 {
+	if (height < 15e3 && build.Release == "standard") || (height < 10 && build.Release == "testing") {
 		return fc.Payout.MulFloat(0.039).RoundDown(SiafundCount)
 	}
 	return fc.Payout.MulTax().RoundDown(SiafundCount)

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -99,7 +99,7 @@ type (
 // the file contract that the proof is for, a boolean indicating whether the
 // proof was valid (true) or missed (false), and the index of the output
 // within the file contract.
-func (fcid FileContractID) StorageProofOutputID(proofStatus ProofStatus, i int) SiacoinOutputID {
+func (fcid FileContractID) StorageProofOutputID(proofStatus ProofStatus, i uint64) SiacoinOutputID {
 	return SiacoinOutputID(crypto.HashAll(
 		SpecifierStorageProofOutput,
 		fcid,


### PR DESCRIPTION
Was rather exhausted when I wrote some of this code. I did write tests for everything. Each commit is standalone.

For the last commit, which should maybe have a longer commit message, I fixed a bug where certain types of storage proofs were actually impossible. When creating merkle roots and verifying merkle proofs, the last segment of the file does not get padded out. Prior to this PR, when creating merkle proofs, the last segment of the file DID get padded out, which would result in invalid proofs being created. Invalid proofs would only be created if the segment that needed to be provided was the last segment (a rare occurrence) AND that segment was not the full 64 bytes.

This bug has been fixed. BuildMerkleProof now works correctly, and VerifyMerkleProof verifies the proofs correctly. This ends up being a softfork.