### PR TITLE
More organization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ install: fmt REBUILD
 
 # release builds and installs release binaries.
 release: REBUILD
-	go install -a -race ./...
+	go install -a -race -tags='debug' ./...
+release-std: REBUILD
+	go install -a ./...
 
 # xc builds and packages release binaries for all systems by using goxc.
 # Cross Compile - makes binaries for windows, linux, and mac, 32 and 64 bit.

--- a/api/server.go
+++ b/api/server.go
@@ -32,7 +32,7 @@ type Server struct {
 }
 
 // NewServer creates a new API server from the provided modules.
-func NewServer(APIaddr string, s *consensus.State, g modules.Gateway, h modules.Host, hdb modules.HostDB, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet, be modules.BlockExplorer) (*Server, error) {
+func NewServer(APIaddr string, s *consensus.ConsensusSet, g modules.Gateway, h modules.Host, hdb modules.HostDB, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet, be modules.BlockExplorer) (*Server, error) {
 	srv := &Server{
 		cs:      s,
 		gateway: g,

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -33,7 +33,7 @@ var (
 // serverTester contains a server and a set of channels for keeping all of the
 // modules synchronized during testing.
 type serverTester struct {
-	cs      *consensus.State
+	cs      *consensus.ConsensusSet
 	gateway modules.Gateway
 	host    modules.Host
 	hostdb  modules.HostDB

--- a/modules/blockexplorer/blockexplorer_test.go
+++ b/modules/blockexplorer/blockexplorer_test.go
@@ -16,7 +16,7 @@ import (
 // Explorer tester struct is the helper object for explorer
 // testing. It holds the helper modules for its testing
 type explorerTester struct {
-	cs      *consensus.State
+	cs      *consensus.ConsensusSet
 	gateway modules.Gateway
 	miner   modules.Miner
 	tpool   modules.TransactionPool

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -23,7 +23,7 @@ var (
 )
 
 // validHeader does some early, low computation verification on the block.
-func (cs *State) validHeader(b types.Block) error {
+func (cs *ConsensusSet) validHeader(b types.Block) error {
 	// Grab the parent of the block and verify the ID of the child meets the
 	// target. This is done as early as possible to enforce that any
 	// block-related DoS must use blocks that have sufficient work.
@@ -81,7 +81,7 @@ func (cs *State) validHeader(b types.Block) error {
 // node, the blockchain is forked to put the new block and its parents at the
 // tip. An error will be returned if block verification fails or if the block
 // does not extend the longest fork.
-func (cs *State) addBlockToTree(b types.Block) (revertedNodes, appliedNodes []*blockNode, err error) {
+func (cs *ConsensusSet) addBlockToTree(b types.Block) (revertedNodes, appliedNodes []*blockNode, err error) {
 	parentNode := cs.blockMap[b.ParentID]
 	// COMPATv0.4.0
 	//
@@ -114,7 +114,7 @@ func (cs *State) addBlockToTree(b types.Block) (revertedNodes, appliedNodes []*b
 // blocks from a trust source, such as blocks that were previously verified and
 // saved to disk. The value of 'cs.verificationRigor' should be set before
 // 'acceptBlock' is called.
-func (cs *State) acceptBlock(b types.Block) error {
+func (cs *ConsensusSet) acceptBlock(b types.Block) error {
 	// See if the block is known already.
 	_, exists := cs.dosBlocks[b.ID()]
 	if exists {
@@ -167,7 +167,7 @@ func (cs *State) acceptBlock(b types.Block) error {
 // on a fork that is heavier than the current fork. If the block is accepted,
 // it will be relayed to connected peers. This function should only be called
 // for new, untrusted blocks.
-func (cs *State) AcceptBlock(b types.Block) error {
+func (cs *ConsensusSet) AcceptBlock(b types.Block) error {
 	lockID := cs.mu.Lock()
 	defer cs.mu.Unlock(lockID)
 
@@ -186,7 +186,7 @@ func (cs *State) AcceptBlock(b types.Block) error {
 }
 
 // RelayBlock is an RPC that accepts a block from a peer.
-func (cs *State) RelayBlock(conn modules.PeerConn) error {
+func (cs *ConsensusSet) RelayBlock(conn modules.PeerConn) error {
 	// Decode the block from the connection.
 	var b types.Block
 	err := encoding.ReadObject(conn, &b, types.BlockSizeLimit)

--- a/modules/consensus/applytransaction.go
+++ b/modules/consensus/applytransaction.go
@@ -21,7 +21,7 @@ var (
 
 // applySiacoinInputs takes all of the siacoin inputs in a transaction and
 // applies them to the state, updating the diffs in the block node.
-func (cs *State) applySiacoinInputs(bn *blockNode, t types.Transaction) {
+func (cs *ConsensusSet) applySiacoinInputs(bn *blockNode, t types.Transaction) {
 	// Remove all siacoin inputs from the unspent siacoin outputs list.
 	for _, sci := range t.SiacoinInputs {
 		// Sanity check - the input should exist within the blockchain.
@@ -44,7 +44,7 @@ func (cs *State) applySiacoinInputs(bn *blockNode, t types.Transaction) {
 
 // applySiacoinOutputs takes all of the siacoin outputs in a transaction and
 // applies them to the state, updating the diffs in the block node.
-func (cs *State) applySiacoinOutputs(bn *blockNode, t types.Transaction) {
+func (cs *ConsensusSet) applySiacoinOutputs(bn *blockNode, t types.Transaction) {
 	// Add all siacoin outputs to the unspent siacoin outputs list.
 	for i, sco := range t.SiacoinOutputs {
 		// Sanity check - the output should not exist within the state.
@@ -69,7 +69,7 @@ func (cs *State) applySiacoinOutputs(bn *blockNode, t types.Transaction) {
 // applyFileContracts iterates through all of the file contracts in a
 // transaction and applies them to the state, updating the diffs in the block
 // node.
-func (cs *State) applyFileContracts(bn *blockNode, t types.Transaction) {
+func (cs *ConsensusSet) applyFileContracts(bn *blockNode, t types.Transaction) {
 	for i, fc := range t.FileContracts {
 		// Sanity check - the file contract should not exists within the state.
 		fcid := t.FileContractID(i)
@@ -104,7 +104,7 @@ func (cs *State) applyFileContracts(bn *blockNode, t types.Transaction) {
 // applyFileContractRevisions iterates through all of the file contract
 // revisions in a transaction and applies them to the state, updating the diffs
 // in the block node.
-func (cs *State) applyFileContractRevisions(bn *blockNode, t types.Transaction) {
+func (cs *ConsensusSet) applyFileContractRevisions(bn *blockNode, t types.Transaction) {
 	for _, fcr := range t.FileContractRevisions {
 		// Sanity check - termination should affect an existing contract.
 		fc, exists := cs.fileContracts[fcr.ParentID]
@@ -148,7 +148,7 @@ func (cs *State) applyFileContractRevisions(bn *blockNode, t types.Transaction) 
 // applyStorageProofs iterates through all of the storage proofs in a
 // transaction and applies them to the state, updating the diffs in the block
 // node.
-func (cs *State) applyStorageProofs(bn *blockNode, t types.Transaction) {
+func (cs *ConsensusSet) applyStorageProofs(bn *blockNode, t types.Transaction) {
 	for _, sp := range t.StorageProofs {
 		// Sanity check - the file contract of the storage proof should exist.
 		fc, exists := cs.fileContracts[sp.ParentID]
@@ -192,7 +192,7 @@ func (cs *State) applyStorageProofs(bn *blockNode, t types.Transaction) {
 
 // applySiafundInputs takes all of the siafund inputs in a transaction and
 // applies them to the state, updating the diffs in the block node.
-func (cs *State) applySiafundInputs(bn *blockNode, t types.Transaction) {
+func (cs *ConsensusSet) applySiafundInputs(bn *blockNode, t types.Transaction) {
 	for _, sfi := range t.SiafundInputs {
 		// Sanity check - the input should exist within the blockchain.
 		if build.DEBUG {
@@ -235,7 +235,7 @@ func (cs *State) applySiafundInputs(bn *blockNode, t types.Transaction) {
 
 // applySiafundOutputs takes all of the siafund outputs in a transaction and
 // applies them to the state, updating the diffs in the block node.
-func (cs *State) applySiafundOutputs(bn *blockNode, t types.Transaction) {
+func (cs *ConsensusSet) applySiafundOutputs(bn *blockNode, t types.Transaction) {
 	for i, sfo := range t.SiafundOutputs {
 		// Sanity check - the output should not exist within the blockchain.
 		sfoid := t.SiafundOutputID(i)
@@ -260,10 +260,10 @@ func (cs *State) applySiafundOutputs(bn *blockNode, t types.Transaction) {
 	}
 }
 
-// applyTransaction applies the contents of a transaction to the State. This
-// produces a set of diffs, which are stored in the blockNode containing the
-// transaction. No verification is done by this function.
-func (cs *State) applyTransaction(bn *blockNode, t types.Transaction) {
+// applyTransaction applies the contents of a transaction to the ConsensusSet.
+// This produces a set of diffs, which are stored in the blockNode containing
+// the transaction. No verification is done by this function.
+func (cs *ConsensusSet) applyTransaction(bn *blockNode, t types.Transaction) {
 	// Apply each component of the transaction. Miner fees are handled
 	// elsewhere.
 	cs.applySiacoinInputs(bn, t)

--- a/modules/consensus/blocknode.go
+++ b/modules/consensus/blocknode.go
@@ -36,8 +36,8 @@ type blockNode struct {
 	// prevents duplicate work from being performed.
 	//
 	// Note that diffsGenerated == true iff the node has ever been in the
-	// State's currentPath; this is because diffs must be generated to apply
-	// the node.
+	// ConsensusSet's currentPath; this is because diffs must be generated to
+	// apply the node.
 	diffsGenerated            bool
 	siacoinOutputDiffs        []modules.SiacoinOutputDiff
 	fileContractDiffs         []modules.FileContractDiff

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -44,7 +44,7 @@ type verificationRigor byte
 // of the blockchain. Broadly speaking, it is responsible for maintaining
 // consensus.  It accepts blocks and constructs a blockchain, forking when
 // necessary.
-type State struct {
+type ConsensusSet struct {
 	// verificationRigor is a flag that tells the state whether or not to do
 	// transaction verification while accepting a block. This should help speed
 	// up loading blocks from memory.
@@ -104,16 +104,16 @@ type State struct {
 	mu *sync.RWMutex
 }
 
-// New returns a new State, containing at least the genesis block. If there is
-// an existing block database present in saveDir, it will be loaded. Otherwise,
-// a new database will be created.
-func New(gateway modules.Gateway, saveDir string) (*State, error) {
+// New returns a new ConsensusSet, containing at least the genesis block. If
+// there is an existing block database present in saveDir, it will be loaded.
+// Otherwise, a new database will be created.
+func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 	if gateway == nil {
 		return nil, ErrNilGateway
 	}
 
-	// Create the State object.
-	cs := &State{
+	// Create the ConsensusSet object.
+	cs := &ConsensusSet{
 		blockMap:  make(map[types.BlockID]*blockNode),
 		dosBlocks: make(map[types.BlockID]struct{}),
 
@@ -201,6 +201,6 @@ func New(gateway modules.Gateway, saveDir string) (*State, error) {
 }
 
 // Close safely closes the block database.
-func (cs *State) Close() error {
+func (cs *ConsensusSet) Close() error {
 	return cs.db.Close()
 }

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -40,9 +40,10 @@ var (
 // sources, the computationally expensive steps can be skipped.
 type verificationRigor byte
 
-// The State is the object responsible for tracking the current status of the
-// blockchain. Broadly speaking, it is responsible for maintaining consensus.
-// It accepts blocks and constructs a blockchain, forking when necessary.
+// The ConsensusSet is the object responsible for tracking the current status
+// of the blockchain. Broadly speaking, it is responsible for maintaining
+// consensus.  It accepts blocks and constructs a blockchain, forking when
+// necessary.
 type State struct {
 	// verificationRigor is a flag that tells the state whether or not to do
 	// transaction verification while accepting a block. This should help speed

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -22,7 +22,7 @@ type consensusSetTester struct {
 	tpool   modules.TransactionPool
 	wallet  modules.Wallet
 
-	cs *State
+	cs *ConsensusSet
 
 	persistDir string
 

--- a/modules/consensus/consistency.go
+++ b/modules/consensus/consistency.go
@@ -16,7 +16,7 @@ var (
 
 // checkCurrentPath looks at the blocks in the current path and verifies that
 // they are all ordered correctly and in the block map.
-func (cs *State) checkCurrentPath() error {
+func (cs *ConsensusSet) checkCurrentPath() error {
 	currentNode := cs.currentBlockNode()
 	for i := cs.height(); i != 0; i-- {
 		// The block should be in the block map.
@@ -44,7 +44,7 @@ func (cs *State) checkCurrentPath() error {
 
 // checkDelayedSiacoinOutputMaps checks that the delayed siacoin output maps
 // have the right number of maps at the right heights.
-func (cs *State) checkDelayedSiacoinOutputMaps() error {
+func (cs *ConsensusSet) checkDelayedSiacoinOutputMaps() error {
 	expected := 0
 	for i := cs.height() + 1; i <= cs.height()+types.MaturityDelay; i++ {
 		if !(i > types.MaturityDelay) {
@@ -65,7 +65,7 @@ func (cs *State) checkDelayedSiacoinOutputMaps() error {
 
 // checkSiacoins counts the number of siacoins in the database and verifies
 // that it matches the sum of all the coinbases.
-func (cs *State) checkSiacoins() error {
+func (cs *ConsensusSet) checkSiacoins() error {
 	expectedSiacoins := types.ZeroCurrency
 	for i := types.BlockHeight(0); i <= cs.height(); i++ {
 		expectedSiacoins = expectedSiacoins.Add(types.CalculateCoinbase(i))
@@ -97,7 +97,7 @@ func (cs *State) checkSiacoins() error {
 }
 
 // checkSiafunds counts the siafund outputs and checks that there are 10,000.
-func (cs *State) checkSiafunds() error {
+func (cs *ConsensusSet) checkSiafunds() error {
 	totalSiafunds := types.ZeroCurrency
 	for _, sfo := range cs.siafundOutputs {
 		totalSiafunds = totalSiafunds.Add(sfo.Value)
@@ -109,7 +109,7 @@ func (cs *State) checkSiafunds() error {
 }
 
 // consensusSetHash returns the Merkle root of the current state of consensus.
-func (cs *State) consensusSetHash() crypto.Hash {
+func (cs *ConsensusSet) consensusSetHash() crypto.Hash {
 	// Items of interest:
 	// 1.	genesis block
 	// 3.	current height
@@ -196,7 +196,7 @@ func (cs *State) consensusSetHash() crypto.Hash {
 
 // checkRewindApply rewinds and reapplies the current block, checking that the
 // consensus set hashes meet the expected values.
-func (cs *State) checkRewindApply() error {
+func (cs *ConsensusSet) checkRewindApply() error {
 	// Do nothing if the DEBUG flag is not set.
 	if !build.DEBUG {
 		return nil
@@ -220,7 +220,7 @@ func (cs *State) checkRewindApply() error {
 
 // checkConsistency runs a series of checks to make sure that the consensus set
 // is consistent with some rules that should always be true.
-func (cs *State) checkConsistency() error {
+func (cs *ConsensusSet) checkConsistency() error {
 	err := cs.checkCurrentPath()
 	if err != nil {
 		return err

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -33,7 +33,7 @@ var (
 )
 
 // commitSiacoinOutputDiff applies or reverts a SiacoinOutputDiff.
-func (cs *State) commitSiacoinOutputDiff(scod modules.SiacoinOutputDiff, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitSiacoinOutputDiff(scod modules.SiacoinOutputDiff, dir modules.DiffDirection) {
 	// Sanity check - should not be adding an output twice, or deleting an
 	// output that does not exist.
 	if build.DEBUG {
@@ -51,7 +51,7 @@ func (cs *State) commitSiacoinOutputDiff(scod modules.SiacoinOutputDiff, dir mod
 }
 
 // commitFileContractDiff applies or reverts a FileContractDiff.
-func (cs *State) commitFileContractDiff(fcd modules.FileContractDiff, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitFileContractDiff(fcd modules.FileContractDiff, dir modules.DiffDirection) {
 	// Sanity check - should not be adding a contract twice, or deleting a
 	// contract that does not exist.
 	if build.DEBUG {
@@ -69,7 +69,7 @@ func (cs *State) commitFileContractDiff(fcd modules.FileContractDiff, dir module
 }
 
 // commitSiafundOutputDiff applies or reverts a SiafundOutputDiff.
-func (cs *State) commitSiafundOutputDiff(sfod modules.SiafundOutputDiff, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitSiafundOutputDiff(sfod modules.SiafundOutputDiff, dir modules.DiffDirection) {
 	// Sanity check - should not be adding an output twice, or deleting an
 	// output that does not exist.
 	if build.DEBUG {
@@ -87,7 +87,7 @@ func (cs *State) commitSiafundOutputDiff(sfod modules.SiafundOutputDiff, dir mod
 }
 
 // commitDelayedSiacoinOutputDiff applies or reverts a delayedSiacoinOutputDiff.
-func (cs *State) commitDelayedSiacoinOutputDiff(dscod modules.DelayedSiacoinOutputDiff, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitDelayedSiacoinOutputDiff(dscod modules.DelayedSiacoinOutputDiff, dir modules.DiffDirection) {
 	// Sanity check - should not be adding an output twoice, or deleting an
 	// output that does not exist.
 	if build.DEBUG {
@@ -109,7 +109,7 @@ func (cs *State) commitDelayedSiacoinOutputDiff(dscod modules.DelayedSiacoinOutp
 }
 
 // commitSiafundPoolDiff applies or reverts a SiafundPoolDiff.
-func (cs *State) commitSiafundPoolDiff(sfpd modules.SiafundPoolDiff, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitSiafundPoolDiff(sfpd modules.SiafundPoolDiff, dir modules.DiffDirection) {
 	// Sanity check - siafund pool should only ever increase.
 	if build.DEBUG {
 		if sfpd.Adjusted.Cmp(sfpd.Previous) < 0 {
@@ -141,7 +141,7 @@ func (cs *State) commitSiafundPoolDiff(sfpd modules.SiafundPoolDiff, dir modules
 
 // commitDiffSetSanity performs a series of sanity checks before commiting a
 // diff set.
-func (cs *State) commitDiffSetSanity(bn *blockNode, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitDiffSetSanity(bn *blockNode, dir modules.DiffDirection) {
 	// Sanity checks.
 	if build.DEBUG {
 		// Diffs should have already been generated for this node.
@@ -165,7 +165,7 @@ func (cs *State) commitDiffSetSanity(bn *blockNode, dir modules.DiffDirection) {
 
 // createUpcomingDelayeOutputdMaps creates the delayed siacoin output maps that
 // will be used when applying delayed siacoin outputs in the diff set.
-func (cs *State) createUpcomingDelayedOutputMaps(bn *blockNode, dir modules.DiffDirection) {
+func (cs *ConsensusSet) createUpcomingDelayedOutputMaps(bn *blockNode, dir modules.DiffDirection) {
 	if dir == modules.DiffApply {
 		if build.DEBUG {
 			// Sanity check - the output map being created should not already
@@ -193,7 +193,7 @@ func (cs *State) createUpcomingDelayedOutputMaps(bn *blockNode, dir modules.Diff
 }
 
 // commitNodeDiffs commits all of the diffs in a block node.
-func (cs *State) commitNodeDiffs(bn *blockNode, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitNodeDiffs(bn *blockNode, dir modules.DiffDirection) {
 	if dir == modules.DiffApply {
 		for _, scod := range bn.siacoinOutputDiffs {
 			cs.commitSiacoinOutputDiff(scod, dir)
@@ -231,7 +231,7 @@ func (cs *State) commitNodeDiffs(bn *blockNode, dir modules.DiffDirection) {
 
 // deleteObsoleteDelayedOutputMaps deletes the delayed siacoin output maps that
 // are no longer in use.
-func (cs *State) deleteObsoleteDelayedOutputMaps(bn *blockNode, dir modules.DiffDirection) {
+func (cs *ConsensusSet) deleteObsoleteDelayedOutputMaps(bn *blockNode, dir modules.DiffDirection) {
 	if dir == modules.DiffApply {
 		// There are no outputs that mature in the first MaturityDelay blocks.
 		if bn.height > types.MaturityDelay {
@@ -255,7 +255,7 @@ func (cs *State) deleteObsoleteDelayedOutputMaps(bn *blockNode, dir modules.Diff
 }
 
 // updateCurrentPath updates the current path after applying a diff set.
-func (cs *State) updateCurrentPath(bn *blockNode, dir modules.DiffDirection) {
+func (cs *ConsensusSet) updateCurrentPath(bn *blockNode, dir modules.DiffDirection) {
 	// Update the current path.
 	if dir == modules.DiffApply {
 		cs.currentPath = append(cs.currentPath, bn.block.ID())
@@ -267,7 +267,7 @@ func (cs *State) updateCurrentPath(bn *blockNode, dir modules.DiffDirection) {
 }
 
 // commitDiffSet applies or reverts the diffs in a blockNode.
-func (cs *State) commitDiffSet(bn *blockNode, dir modules.DiffDirection) {
+func (cs *ConsensusSet) commitDiffSet(bn *blockNode, dir modules.DiffDirection) {
 	cs.commitDiffSetSanity(bn, dir)
 	cs.createUpcomingDelayedOutputMaps(bn, dir)
 	cs.commitNodeDiffs(bn, dir)
@@ -280,7 +280,7 @@ func (cs *State) commitDiffSet(bn *blockNode, dir modules.DiffDirection) {
 // transactions are allowed to depend on each other. We can't be sure that a
 // transaction is valid unless we have applied all of the previous transactions
 // in the block, which means we need to apply while we verify.
-func (cs *State) generateAndApplyDiff(bn *blockNode) error {
+func (cs *ConsensusSet) generateAndApplyDiff(bn *blockNode) error {
 	// Sanity check
 	if build.DEBUG {
 		// Generate should only be called if the diffs have not yet been

--- a/modules/consensus/fork.go
+++ b/modules/consensus/fork.go
@@ -16,7 +16,7 @@ var (
 
 // deleteNode recursively deletes its children from the set of known blocks.
 // The node being deleted should not be a part of the current path.
-func (cs *State) deleteNode(bn *blockNode) {
+func (cs *ConsensusSet) deleteNode(bn *blockNode) {
 	// Sanity check - the node being deleted should not be in the current path.
 	if build.DEBUG {
 		if types.BlockHeight(len(cs.currentPath)) > bn.height &&
@@ -48,9 +48,10 @@ func (cs *State) deleteNode(bn *blockNode) {
 }
 
 // backtrackToCurrentPath traces backwards from 'bn' until it reaches a node in
-// the State's current path (the "common parent"). It returns the (inclusive)
-// set of nodes between the common parent and 'bn', starting from the former.
-func (cs *State) backtrackToCurrentPath(bn *blockNode) []*blockNode {
+// the ConsensusSet's current path (the "common parent"). It returns the
+// (inclusive) set of nodes between the common parent and 'bn', starting from
+// the former.
+func (cs *ConsensusSet) backtrackToCurrentPath(bn *blockNode) []*blockNode {
 	path := []*blockNode{bn}
 	for {
 		// Stop when we reach the common parent.
@@ -63,10 +64,10 @@ func (cs *State) backtrackToCurrentPath(bn *blockNode) []*blockNode {
 	return path
 }
 
-// revertToNode will revert blocks from the State's current path until 'bn' is
-// the current block. Blocks are returned in the order that they were reverted.
-// 'bn' is not reverted.
-func (cs *State) revertToNode(bn *blockNode) (revertedNodes []*blockNode) {
+// revertToNode will revert blocks from the ConsensusSet's current path until
+// 'bn' is the current block. Blocks are returned in the order that they were
+// reverted.  'bn' is not reverted.
+func (cs *ConsensusSet) revertToNode(bn *blockNode) (revertedNodes []*blockNode) {
 	// Sanity check - make sure that bn is in the currentPath.
 	if build.DEBUG {
 		if cs.height() < bn.height || cs.currentPath[bn.height] != bn.block.ID() {
@@ -83,9 +84,9 @@ func (cs *State) revertToNode(bn *blockNode) (revertedNodes []*blockNode) {
 	return
 }
 
-// applyUntilNode will successively apply the blocks between the state's
-// currentPath and 'bn'.
-func (s *State) applyUntilNode(bn *blockNode) (appliedNodes []*blockNode, err error) {
+// applyUntilNode will successively apply the blocks between the consensus
+// set's currentPath and 'bn'.
+func (s *ConsensusSet) applyUntilNode(bn *blockNode) (appliedNodes []*blockNode, err error) {
 	// Backtrack to the common parent of 'bn' and currentPath and then apply the new nodes.
 	newPath := s.backtrackToCurrentPath(bn)
 	for _, node := range newPath[1:] {
@@ -106,9 +107,9 @@ func (s *State) applyUntilNode(bn *blockNode) (appliedNodes []*blockNode, err er
 
 // forkBlockchain will move the consensus set onto the 'newNode' fork. An error
 // will be returned if any of the blocks applied in the transition are found to
-// be invalid. forkBlockchain is atomic; the State is only updated if the
-// function returns nil.
-func (cs *State) forkBlockchain(newNode *blockNode) (revertedNodes, appliedNodes []*blockNode, err error) {
+// be invalid. forkBlockchain is atomic; the ConsensusSet is only updated if
+// the function returns nil.
+func (cs *ConsensusSet) forkBlockchain(newNode *blockNode) (revertedNodes, appliedNodes []*blockNode, err error) {
 	// In debug mode, record the old state hash before attempting the fork.
 	// This variable is otherwise unused.
 	var oldHash crypto.Hash

--- a/modules/consensus/info.go
+++ b/modules/consensus/info.go
@@ -4,30 +4,30 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// StateInfo contains basic information about the State.
-type StateInfo struct {
+// ConsensusSetInfo contains basic information about the ConsensusSet.
+type ConsensusSetInfo struct {
 	CurrentBlock types.BlockID
 	Height       types.BlockHeight
 	Target       types.Target
 }
 
 // currentBlockID returns the ID of the current block.
-func (cs *State) currentBlockID() types.BlockID {
+func (cs *ConsensusSet) currentBlockID() types.BlockID {
 	return cs.currentPath[cs.height()]
 }
 
 // currentBlockNode returns the blockNode of the current block.
-func (s *State) currentBlockNode() *blockNode {
+func (s *ConsensusSet) currentBlockNode() *blockNode {
 	return s.blockMap[s.currentBlockID()]
 }
 
 // height returns the current height of the state.
-func (s *State) height() types.BlockHeight {
+func (s *ConsensusSet) height() types.BlockHeight {
 	return types.BlockHeight(len(s.currentPath) - 1)
 }
 
 // CurrentBlock returns the highest block on the tallest fork.
-func (s *State) CurrentBlock() types.Block {
+func (s *ConsensusSet) CurrentBlock() types.Block {
 	counter := s.mu.RLock()
 	defer s.mu.RUnlock(counter)
 	return s.currentBlockNode().block
@@ -35,7 +35,7 @@ func (s *State) CurrentBlock() types.Block {
 
 // ChildTarget does not need a lock, as the values being read are not changed
 // once they have been created.
-func (s *State) ChildTarget(bid types.BlockID) (target types.Target, exists bool) {
+func (s *ConsensusSet) ChildTarget(bid types.BlockID) (target types.Target, exists bool) {
 	lockID := s.mu.RLock()
 	defer s.mu.RUnlock(lockID)
 
@@ -49,7 +49,7 @@ func (s *State) ChildTarget(bid types.BlockID) (target types.Target, exists bool
 
 // EarliestChildTimestamp returns the earliest timestamp that the next block can
 // have in order for it to be considered valid.
-func (s *State) EarliestChildTimestamp(bid types.BlockID) (timestamp types.Timestamp, exists bool) {
+func (s *ConsensusSet) EarliestChildTimestamp(bid types.BlockID) (timestamp types.Timestamp, exists bool) {
 	id := s.mu.RLock()
 	defer s.mu.RUnlock(id)
 	bn, exists := s.blockMap[bid]
@@ -61,14 +61,14 @@ func (s *State) EarliestChildTimestamp(bid types.BlockID) (timestamp types.Times
 }
 
 // GenesisBlock returns the genesis block.
-func (s *State) GenesisBlock() types.Block {
+func (s *ConsensusSet) GenesisBlock() types.Block {
 	lockID := s.mu.RLock()
 	defer s.mu.RUnlock(lockID)
 	return s.blockMap[s.currentPath[0]].block
 }
 
 // Height returns the height of the current blockchain (the longest fork).
-func (s *State) Height() types.BlockHeight {
+func (s *ConsensusSet) Height() types.BlockHeight {
 	counter := s.mu.RLock()
 	defer s.mu.RUnlock(counter)
 	return s.height()
@@ -76,7 +76,7 @@ func (s *State) Height() types.BlockHeight {
 
 // InCurrentPath returns true if the block presented is in the current path,
 // false otherwise.
-func (s *State) InCurrentPath(bid types.BlockID) bool {
+func (s *ConsensusSet) InCurrentPath(bid types.BlockID) bool {
 	lockID := s.mu.RLock()
 	defer s.mu.RUnlock(lockID)
 
@@ -89,7 +89,7 @@ func (s *State) InCurrentPath(bid types.BlockID) bool {
 
 // StorageProofSegment returns the segment to be used in the storage proof for
 // a given file contract.
-func (cs *State) StorageProofSegment(fcid types.FileContractID) (index uint64, err error) {
+func (cs *ConsensusSet) StorageProofSegment(fcid types.FileContractID) (index uint64, err error) {
 	lockID := cs.mu.RLock()
 	defer cs.mu.RUnlock(lockID)
 	return cs.storageProofSegment(fcid)

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -9,8 +9,8 @@ import (
 )
 
 // load pulls all the blocks that have been saved to disk into memory, using
-// them to fill out the State.
-func (cs *State) load(saveDir string) error {
+// them to fill out the ConsensusSet.
+func (cs *ConsensusSet) load(saveDir string) error {
 	db, err := persist.OpenDB(filepath.Join(saveDir, "chain.db"))
 	if err != nil {
 		return err

--- a/modules/consensus/subscribers.go
+++ b/modules/consensus/subscribers.go
@@ -18,7 +18,7 @@ import (
 // consensus set while it makes a blocking call to the subscriber. If the
 // subscriber deadlocks or has problems, the thread will stall indefinitely,
 // but the rest of consensus will not be disrupted.
-func (s *State) threadedSendUpdates(update chan struct{}, subscriber modules.ConsensusSetSubscriber) {
+func (s *ConsensusSet) threadedSendUpdates(update chan struct{}, subscriber modules.ConsensusSetSubscriber) {
 	i := 0
 	for {
 		id := s.mu.RLock()
@@ -42,7 +42,7 @@ func (s *State) threadedSendUpdates(update chan struct{}, subscriber modules.Con
 
 // updateSubscribers will inform all subscribers of the new update to the
 // consensus set.
-func (s *State) updateSubscribers(revertedNodes []*blockNode, appliedNodes []*blockNode) {
+func (s *ConsensusSet) updateSubscribers(revertedNodes []*blockNode, appliedNodes []*blockNode) {
 	// Sanity check - len(appliedNodes) should never be 0.
 	if build.DEBUG {
 		if len(appliedNodes) == 0 {
@@ -115,7 +115,7 @@ func (s *State) updateSubscribers(revertedNodes []*blockNode, appliedNodes []*bl
 
 // ConsensusSetNotify returns a channel that will be sent an empty struct every
 // time the consensus set changes.
-func (s *State) ConsensusSetNotify() <-chan struct{} {
+func (s *ConsensusSet) ConsensusSetNotify() <-chan struct{} {
 	c := make(chan struct{}, modules.NotifyBuffer)
 	c <- struct{}{} // Notify subscriber about the genesis block.
 	id := s.mu.Lock()
@@ -126,7 +126,7 @@ func (s *State) ConsensusSetNotify() <-chan struct{} {
 
 // ConsensusSetSubscribe accepts a new subscriber who will receive a call to
 // ReceiveConsensusSetUpdate every time there is a change in the consensus set.
-func (s *State) ConsensusSetSubscribe(subscriber modules.ConsensusSetSubscriber) {
+func (s *ConsensusSet) ConsensusSetSubscribe(subscriber modules.ConsensusSetSubscriber) {
 	c := make(chan struct{}, modules.NotifyBuffer)
 	c <- struct{}{} // Notify subscriber about the genesis block.
 	id := s.mu.Lock()

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -26,7 +26,7 @@ var (
 
 // validSiacoins checks that the siacoin inputs and outputs are valid in the
 // context of the current consensus set.
-func (cs *State) validSiacoins(t types.Transaction) (err error) {
+func (cs *ConsensusSet) validSiacoins(t types.Transaction) (err error) {
 	var inputSum types.Currency
 	for _, sci := range t.SiacoinInputs {
 		// Check that the input spends an existing output.
@@ -50,7 +50,7 @@ func (cs *State) validSiacoins(t types.Transaction) (err error) {
 
 // storageProofSegment returns the index of the segment that needs to be proven
 // exists in a file contract.
-func (cs *State) storageProofSegment(fcid types.FileContractID) (index uint64, err error) {
+func (cs *ConsensusSet) storageProofSegment(fcid types.FileContractID) (index uint64, err error) {
 	// Get the file contract associated with the input id.
 	fc, exists := cs.fileContracts[fcid]
 	if !exists {
@@ -81,7 +81,7 @@ func (cs *State) storageProofSegment(fcid types.FileContractID) (index uint64, e
 
 // validStorageProofs checks that the storage proofs are valid in the context
 // of the consensus set.
-func (cs *State) validStorageProofs(t types.Transaction) error {
+func (cs *ConsensusSet) validStorageProofs(t types.Transaction) error {
 	for _, sp := range t.StorageProofs {
 		// Check that the storage proof itself is valid.
 		segmentIndex, err := cs.storageProofSegment(sp.ParentID)
@@ -123,7 +123,7 @@ func (cs *State) validStorageProofs(t types.Transaction) error {
 
 // validFileContractRevision checks that each file contract revision is valid
 // in the context of the current consensus set.
-func (cs *State) validFileContractRevisions(t types.Transaction) (err error) {
+func (cs *ConsensusSet) validFileContractRevisions(t types.Transaction) (err error) {
 	for _, fcr := range t.FileContractRevisions {
 		// Check that the revision revises an existing contract.
 		fc, exists := cs.fileContracts[fcr.ParentID]
@@ -171,7 +171,7 @@ func (cs *State) validFileContractRevisions(t types.Transaction) (err error) {
 
 // validSiafunds checks that the siafund portions of the transaction are valid
 // in the context of the consensus set.
-func (cs *State) validSiafunds(t types.Transaction) (err error) {
+func (cs *ConsensusSet) validSiafunds(t types.Transaction) (err error) {
 	// Compare the number of input siafunds to the output siafunds.
 	var siafundInputSum types.Currency
 	var siafundOutputSum types.Currency
@@ -199,7 +199,7 @@ func (cs *State) validSiafunds(t types.Transaction) (err error) {
 
 // ValidStorageProofs checks that the storage proofs are valid in the context
 // of the consensus set.
-func (cs *State) ValidStorageProofs(t types.Transaction) (err error) {
+func (cs *ConsensusSet) ValidStorageProofs(t types.Transaction) (err error) {
 	id := cs.mu.RLock()
 	defer cs.mu.RUnlock(id)
 	return cs.validStorageProofs(t)
@@ -207,8 +207,9 @@ func (cs *State) ValidStorageProofs(t types.Transaction) (err error) {
 
 // validTransaction checks that all fields are valid within the current
 // consensus state. If not an error is returned.
-func (cs *State) validTransaction(t types.Transaction) error {
-	// Skip transaction verification if the State is accepting trusted blocks.
+func (cs *ConsensusSet) validTransaction(t types.Transaction) error {
+	// Skip transaction verification if the ConsensusSet is accepting trusted
+	// blocks.
 	if cs.verificationRigor != fullVerification {
 		return nil
 	}
@@ -246,7 +247,7 @@ func (cs *State) validTransaction(t types.Transaction) error {
 // determine if they are valid. An error is returned IFF they are not a valid
 // set in the current consensus set. The size of the transactions and the set
 // is not checked.
-func (cs *State) TryTransactions(txns []types.Transaction) error {
+func (cs *ConsensusSet) TryTransactions(txns []types.Transaction) error {
 	// applyTransaction will apply the diffs from a transaction and store them
 	// in a block node. diffHolder is the blockNode that tracks the temporary
 	// changes. At the end of the function, all changes that were made to the

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -210,7 +210,7 @@ func (cs *ConsensusSet) ValidStorageProofs(t types.Transaction) (err error) {
 func (cs *ConsensusSet) validTransaction(t types.Transaction) error {
 	// Skip transaction verification if the ConsensusSet is accepting trusted
 	// blocks.
-	if cs.verificationRigor != fullVerification {
+	if cs.verificationRigor != fullVerification && (build.Release == "testing" || !build.DEBUG) {
 		return nil
 	}
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -30,7 +30,7 @@ type contractObligation struct {
 // A Host contains all the fields necessary for storing files for clients and
 // performing the storage proofs on the received files.
 type Host struct {
-	cs          *consensus.State
+	cs          *consensus.ConsensusSet
 	hostdb      modules.HostDB
 	tpool       modules.TransactionPool
 	wallet      modules.Wallet
@@ -56,7 +56,7 @@ type Host struct {
 }
 
 // New returns an initialized Host.
-func New(cs *consensus.State, hdb modules.HostDB, tpool modules.TransactionPool, wallet modules.Wallet, addr string, saveDir string) (*Host, error) {
+func New(cs *consensus.ConsensusSet, hdb modules.HostDB, tpool modules.TransactionPool, wallet modules.Wallet, addr string, saveDir string) (*Host, error) {
 	if cs == nil {
 		return nil, errors.New("host cannot use a nil state")
 	}

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -18,7 +18,7 @@ import (
 // A hostTester is the helper object for host testing, including helper modules
 // and methods for controlling synchronization.
 type hostTester struct {
-	cs      *consensus.State
+	cs      *consensus.ConsensusSet
 	gateway modules.Gateway
 	miner   modules.Miner
 	tpool   modules.TransactionPool

--- a/modules/hostdb/hostdb.go
+++ b/modules/hostdb/hostdb.go
@@ -34,7 +34,7 @@ var (
 // host based on their hosting parameters, and then can select hosts at random
 // for uploading files.
 type HostDB struct {
-	consensusSet *consensus.State
+	consensusSet *consensus.ConsensusSet
 	gateway      modules.Gateway
 
 	// The hostTree is the root node of the tree that organizes hosts by
@@ -63,7 +63,7 @@ type HostDB struct {
 
 // New returns a host database that will still crawling the hosts it finds on
 // the blockchain.
-func New(cs *consensus.State, g modules.Gateway) (hdb *HostDB, err error) {
+func New(cs *consensus.ConsensusSet, g modules.Gateway) (hdb *HostDB, err error) {
 	// Check for nil dependencies.
 	if cs == nil {
 		err = ErrNilConsensusSet

--- a/modules/hostdb/hostdb_test.go
+++ b/modules/hostdb/hostdb_test.go
@@ -25,7 +25,7 @@ import (
 // is submitted to the transaction pool (such as a new transaction),
 // tpoolUpdateWait should be called.
 type hdbTester struct {
-	cs      *consensus.State
+	cs      *consensus.ConsensusSet
 	gateway modules.Gateway
 	host    modules.Host
 	miner   modules.Miner

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -19,7 +19,7 @@ var (
 // A Renter is responsible for tracking all of the files that a user has
 // uploaded to Sia, as well as the locations and health of these files.
 type Renter struct {
-	cs          *consensus.State
+	cs          *consensus.ConsensusSet
 	hostDB      modules.HostDB
 	wallet      modules.Wallet
 	blockHeight types.BlockHeight
@@ -34,7 +34,7 @@ type Renter struct {
 }
 
 // New returns an empty renter.
-func New(cs *consensus.State, hdb modules.HostDB, wallet modules.Wallet, saveDir string) (*Renter, error) {
+func New(cs *consensus.ConsensusSet, hdb modules.HostDB, wallet modules.Wallet, saveDir string) (*Renter, error) {
 	if cs == nil {
 		return nil, ErrNilCS
 	}

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -17,7 +17,7 @@ import (
 
 // renterTester contains all of the modules that are used while testing the renter.
 type renterTester struct {
-	cs     *consensus.State
+	cs     *consensus.ConsensusSet
 	hostdb modules.HostDB
 	miner  modules.Miner
 	tpool  modules.TransactionPool

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -14,8 +14,10 @@ var (
 	// ErrTransactionPoolDuplicate is returned when a duplicate transaction is
 	// submitted to the transaction pool.
 	ErrTransactionPoolDuplicate = errors.New("transaction is a duplicate")
-	PrefixNonSia                = types.Specifier{'N', 'o', 'n', 'S', 'i', 'a'}
-	PrefixStrNonSia             = "NonSia" // COMPATv0.3.3.3
+	ErrInvalidArbPrefix         = errors.New("transaction contains non-standard arbitrary data")
+
+	PrefixNonSia    = types.Specifier{'N', 'o', 'n', 'S', 'i', 'a'}
+	PrefixStrNonSia = "NonSia" // COMPATv0.3.3.3
 )
 
 // A TransactionPoolSubscriber receives updates about the confirmed and

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -97,6 +97,8 @@ func (tp *TransactionPool) IsStandardTransaction(t types.Transaction) (err error
 		if strings.HasPrefix(strData, modules.PrefixStrNonSia) {
 			continue
 		}
+
+		return modules.ErrInvalidArbPrefix
 	}
 
 	return

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -19,7 +19,7 @@ import (
 // transaction pool or consensus set, updateWait() should be called or
 // desynchronization could be introduced.
 type tpoolTester struct {
-	cs      *consensus.State
+	cs      *consensus.ConsensusSet
 	gateway modules.Gateway
 	tpool   *TransactionPool
 	miner   modules.Miner

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -15,7 +15,7 @@ import (
 // A Wallet tester contains a ConsensusTester and has a bunch of helpful
 // functions for facilitating wallet integration testing.
 type walletTester struct {
-	cs     *consensus.State
+	cs     *consensus.ConsensusSet
 	tpool  modules.TransactionPool
 	miner  modules.Miner
 	wallet *Wallet


### PR DESCRIPTION
I added the 'debug' flag to the `make release`, I'm surprised it wasn't already enabled. I had to disable a few of the debug stuff, as well as optimize others, simply because it was very slow otherwise. Right now, with both 'debug' and '-race' enabled, verifying the whole blockchain takes about 2 minutes on my machine. The majority of that time is garbage collection and the race library, I forget exactly but I think it's something like 95% between the two of them, even with the signatures, hashing, and encoding being so slow.

I'm guessing the majority of that is because of the sheer volume of threads that we use, and because we create a lot of new memory when hashing things.

I also created a release-std, which doesn't have the race libraries or the debug flag enabled, which is useful for profiling what the user is going to experience.

The ConsensusSet finally got renamed from the State.

Some obsolete documentation got updated, but it'd still be really nice to revisit the whitepaper.