### PR TITLE
General improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ install:
   - make
 
 script: make test-long && make cover
+
+sudo: false

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -136,6 +136,11 @@ type ConsensusSet interface {
 	// run any required closing routines.
 	Close() error
 
+	// ConsensusChange returns the consensus change that occured at the input
+	// index. An error is returned if there is not a change at the provided
+	// index.
+	ConsensusChange(int) (ConsensusChange, error)
+
 	// ConsensusSetSubscribe will subscribe another module to the consensus
 	// set. Every time that there is a change to the consensus set, an update
 	// will be sent to the module via the 'ReceiveConsensusSetUpdate' function.

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -136,10 +136,11 @@ type ConsensusSet interface {
 	// run any required closing routines.
 	Close() error
 
-	// ConsensusChange returns the consensus change that occured at the input
-	// index. An error is returned if there is not a change at the provided
-	// index.
-	ConsensusChange(int) (ConsensusChange, error)
+	// ConsensusChange returns the ith consensus change that was broadcast to
+	// subscribers by the consensus set. An error is returned if i consensus
+	// changes have not been broadcast. The primary purpose of this funciton is
+	// to rescan the blockchain.
+	ConsensusChange(i int) (ConsensusChange, error)
 
 	// ConsensusSetSubscribe will subscribe another module to the consensus
 	// set. Every time that there is a change to the consensus set, an update

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -84,6 +84,14 @@ type ConsensusSet struct {
 	siafundOutputs        map[types.SiafundOutputID]types.SiafundOutput
 	delayedSiacoinOutputs map[types.BlockHeight]map[types.SiacoinOutputID]types.SiacoinOutput
 
+	// fileContractExpirations is not actually a part of the consensus set, but
+	// it is needed to get decent order notation on the file contract lookups.
+	// It is a map of heights to maps of file contract ids. The other table is
+	// needed because of file contract revisions - you need to have random
+	// access lookups to file contracts for when revisions are submitted to the
+	// blockchain.
+	fileContractExpirations map[types.BlockHeight]map[types.FileContractID]struct{}
+
 	// Modules subscribed to the consensus set will receive an ordered list of
 	// changes that occur to the consensus set.
 	consensusChanges []modules.ConsensusChange
@@ -123,6 +131,8 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 		fileContracts:         make(map[types.FileContractID]types.FileContract),
 		siafundOutputs:        make(map[types.SiafundOutputID]types.SiafundOutput),
 		delayedSiacoinOutputs: make(map[types.BlockHeight]map[types.SiacoinOutputID]types.SiacoinOutput),
+
+		fileContractExpirations: make(map[types.BlockHeight]map[types.FileContractID]struct{}),
 
 		gateway: gateway,
 

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -93,9 +93,9 @@ type ConsensusSet struct {
 	fileContractExpirations map[types.BlockHeight]map[types.FileContractID]struct{}
 
 	// Modules subscribed to the consensus set will receive an ordered list of
-	// changes that occur to the consensus set.
-	consensusChanges []modules.ConsensusChange
-	subscriptions    []chan struct{}
+	// changes that occur to the consensus set, computed using the changeLog.
+	changeLog     []changeEntry
+	subscriptions []chan struct{}
 
 	// block database, used for saving/loading the current path
 	db persist.DB

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -140,6 +140,8 @@ func TestApplyMissedStorageProof(t *testing.T) {
 		MissedProofOutputs: []types.SiacoinOutput{{Value: types.NewCurrency64(290e3)}},
 	}
 	cst.cs.fileContracts[types.FileContractID{}] = expiringFC // assign the contract a 0-id.
+	cst.cs.fileContractExpirations[bn.height] = make(map[types.FileContractID]struct{})
+	cst.cs.fileContractExpirations[bn.height][types.FileContractID{}] = struct{}{}
 	cst.cs.applyMissedStorageProof(bn, types.FileContractID{})
 	_, exists := cst.cs.fileContracts[types.FileContractID{}]
 	if exists {
@@ -225,6 +227,8 @@ func TestApplyFileContractMaintenance(t *testing.T) {
 		MissedProofOutputs: []types.SiacoinOutput{{Value: types.NewCurrency64(290e3)}},
 	}
 	cst.cs.fileContracts[types.FileContractID{}] = expiringFC // assign the contract a 0-id.
+	cst.cs.fileContractExpirations[bn.height] = make(map[types.FileContractID]struct{})
+	cst.cs.fileContractExpirations[bn.height][types.FileContractID{}] = struct{}{}
 	cst.cs.applyFileContractMaintenance(bn)
 	_, exists := cst.cs.fileContracts[types.FileContractID{}]
 	if exists {

--- a/modules/consensus/subscribers.go
+++ b/modules/consensus/subscribers.go
@@ -3,7 +3,15 @@ package consensus
 import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
 )
+
+// A changeEntry records a change to the consensus set that happened, and is
+// used during subscriptions.
+type changeEntry struct {
+	revertedBlocks []types.BlockID
+	appliedBlocks  []types.BlockID
+}
 
 // threadedSendUpdates sends updates to a specific subscriber as they become
 // available. One thread is needed per subscriber. A separate function was
@@ -18,17 +26,83 @@ import (
 // consensus set while it makes a blocking call to the subscriber. If the
 // subscriber deadlocks or has problems, the thread will stall indefinitely,
 // but the rest of consensus will not be disrupted.
-func (s *ConsensusSet) threadedSendUpdates(update chan struct{}, subscriber modules.ConsensusSetSubscriber) {
+func (cs *ConsensusSet) threadedSendUpdates(update chan struct{}, subscriber modules.ConsensusSetSubscriber) {
 	i := 0
 	for {
-		id := s.mu.RLock()
-		updateCount := len(s.consensusChanges)
-		s.mu.RUnlock(id)
+		id := cs.mu.RLock()
+		updateCount := len(cs.changeLog)
+		cs.mu.RUnlock(id)
 		for i < updateCount {
-			// Get the set of blocks that changed since the previous update.
-			id := s.mu.RLock()
-			cc := s.consensusChanges[i]
-			s.mu.RUnlock(id)
+			// Build the consensus change that occured at the current index.
+			var cc modules.ConsensusChange
+			id := cs.mu.RLock()
+			{
+				for _, revertedBlockID := range cs.changeLog[i].revertedBlocks {
+					revertedNode, exists := cs.blockMap[revertedBlockID]
+					// Sanity check - node should exist.
+					if build.DEBUG {
+						if !exists {
+							panic("grabbed a node that does not exist during a consensus change")
+						}
+					}
+
+					// Because the direction is 'revert', the order of the diffs needs to
+					// be flipped and the direction of the diffs also needs to be flipped.
+					cc.RevertedBlocks = append(cc.RevertedBlocks, revertedNode.block)
+					for i := len(revertedNode.siacoinOutputDiffs) - 1; i >= 0; i-- {
+						scod := revertedNode.siacoinOutputDiffs[i]
+						scod.Direction = !scod.Direction
+						cc.SiacoinOutputDiffs = append(cc.SiacoinOutputDiffs, scod)
+					}
+					for i := len(revertedNode.fileContractDiffs) - 1; i >= 0; i-- {
+						fcd := revertedNode.fileContractDiffs[i]
+						fcd.Direction = !fcd.Direction
+						cc.FileContractDiffs = append(cc.FileContractDiffs, fcd)
+					}
+					for i := len(revertedNode.siafundOutputDiffs) - 1; i >= 0; i-- {
+						sfod := revertedNode.siafundOutputDiffs[i]
+						sfod.Direction = !sfod.Direction
+						cc.SiafundOutputDiffs = append(cc.SiafundOutputDiffs, sfod)
+					}
+					for i := len(revertedNode.delayedSiacoinOutputDiffs) - 1; i >= 0; i-- {
+						dscod := revertedNode.delayedSiacoinOutputDiffs[i]
+						dscod.Direction = !dscod.Direction
+						cc.DelayedSiacoinOutputDiffs = append(cc.DelayedSiacoinOutputDiffs, dscod)
+					}
+					for i := len(revertedNode.siafundPoolDiffs) - 1; i >= 0; i-- {
+						sfpd := revertedNode.siafundPoolDiffs[i]
+						sfpd.Direction = modules.DiffRevert
+						cc.SiafundPoolDiffs = append(cc.SiafundPoolDiffs, sfpd)
+					}
+				}
+				for _, appliedBlockID := range cs.changeLog[i].appliedBlocks {
+					appliedNode, exists := cs.blockMap[appliedBlockID]
+					// Sanity check - node should exist.
+					if build.DEBUG {
+						if !exists {
+							panic("grabbed a node that does not exist during a consensus change")
+						}
+					}
+
+					cc.AppliedBlocks = append(cc.AppliedBlocks, appliedNode.block)
+					for _, scod := range appliedNode.siacoinOutputDiffs {
+						cc.SiacoinOutputDiffs = append(cc.SiacoinOutputDiffs, scod)
+					}
+					for _, fcd := range appliedNode.fileContractDiffs {
+						cc.FileContractDiffs = append(cc.FileContractDiffs, fcd)
+					}
+					for _, sfod := range appliedNode.siafundOutputDiffs {
+						cc.SiafundOutputDiffs = append(cc.SiafundOutputDiffs, sfod)
+					}
+					for _, dscod := range appliedNode.delayedSiacoinOutputDiffs {
+						cc.DelayedSiacoinOutputDiffs = append(cc.DelayedSiacoinOutputDiffs, dscod)
+					}
+					for _, sfpd := range appliedNode.siafundPoolDiffs {
+						cc.SiafundPoolDiffs = append(cc.SiafundPoolDiffs, sfpd)
+					}
+				}
+			}
+			cs.mu.RUnlock(id)
 
 			// Update the subscriber with the changes.
 			subscriber.ReceiveConsensusSetUpdate(cc)
@@ -42,7 +116,7 @@ func (s *ConsensusSet) threadedSendUpdates(update chan struct{}, subscriber modu
 
 // updateSubscribers will inform all subscribers of the new update to the
 // consensus set.
-func (s *ConsensusSet) updateSubscribers(revertedNodes []*blockNode, appliedNodes []*blockNode) {
+func (cs *ConsensusSet) updateSubscribers(revertedNodes []*blockNode, appliedNodes []*blockNode) {
 	// Sanity check - len(appliedNodes) should never be 0.
 	if build.DEBUG {
 		if len(appliedNodes) == 0 {
@@ -50,61 +124,18 @@ func (s *ConsensusSet) updateSubscribers(revertedNodes []*blockNode, appliedNode
 		}
 	}
 
-	// Take the nodes and condense them into a consensusChange object.
-	var cc modules.ConsensusChange
+	// Log the changes in the change log.
+	var ce changeEntry
 	for _, rn := range revertedNodes {
-		// Because the direction is 'revert', the order of the diffs needs to
-		// be flipped and the direction of the diffs also needs to be flipped.
-		cc.RevertedBlocks = append(cc.RevertedBlocks, rn.block)
-		for i := len(rn.siacoinOutputDiffs) - 1; i >= 0; i-- {
-			scod := rn.siacoinOutputDiffs[i]
-			scod.Direction = !scod.Direction
-			cc.SiacoinOutputDiffs = append(cc.SiacoinOutputDiffs, scod)
-		}
-		for i := len(rn.fileContractDiffs) - 1; i >= 0; i-- {
-			fcd := rn.fileContractDiffs[i]
-			fcd.Direction = !fcd.Direction
-			cc.FileContractDiffs = append(cc.FileContractDiffs, fcd)
-		}
-		for i := len(rn.siafundOutputDiffs) - 1; i >= 0; i-- {
-			sfod := rn.siafundOutputDiffs[i]
-			sfod.Direction = !sfod.Direction
-			cc.SiafundOutputDiffs = append(cc.SiafundOutputDiffs, sfod)
-		}
-		for i := len(rn.delayedSiacoinOutputDiffs) - 1; i >= 0; i-- {
-			dscod := rn.delayedSiacoinOutputDiffs[i]
-			dscod.Direction = !dscod.Direction
-			cc.DelayedSiacoinOutputDiffs = append(cc.DelayedSiacoinOutputDiffs, dscod)
-		}
-		for i := len(rn.siafundPoolDiffs) - 1; i >= 0; i-- {
-			sfpd := rn.siafundPoolDiffs[i]
-			sfpd.Direction = modules.DiffRevert
-			cc.SiafundPoolDiffs = append(cc.SiafundPoolDiffs, sfpd)
-		}
+		ce.revertedBlocks = append(ce.revertedBlocks, rn.block.ID())
 	}
 	for _, an := range appliedNodes {
-		cc.AppliedBlocks = append(cc.AppliedBlocks, an.block)
-		for _, scod := range an.siacoinOutputDiffs {
-			cc.SiacoinOutputDiffs = append(cc.SiacoinOutputDiffs, scod)
-		}
-		for _, fcd := range an.fileContractDiffs {
-			cc.FileContractDiffs = append(cc.FileContractDiffs, fcd)
-		}
-		for _, sfod := range an.siafundOutputDiffs {
-			cc.SiafundOutputDiffs = append(cc.SiafundOutputDiffs, sfod)
-		}
-		for _, dscod := range an.delayedSiacoinOutputDiffs {
-			cc.DelayedSiacoinOutputDiffs = append(cc.DelayedSiacoinOutputDiffs, dscod)
-		}
-		for _, sfpd := range an.siafundPoolDiffs {
-			cc.SiafundPoolDiffs = append(cc.SiafundPoolDiffs, sfpd)
-		}
+		ce.appliedBlocks = append(ce.appliedBlocks, an.block.ID())
 	}
-	// Add the changes to the change set.
-	s.consensusChanges = append(s.consensusChanges, cc)
+	cs.changeLog = append(cs.changeLog, ce)
 
 	// Notify each update channel that a new update is ready.
-	for _, subscriber := range s.subscriptions {
+	for _, subscriber := range cs.subscriptions {
 		// If the channel is already full, don't block.
 		select {
 		case subscriber <- struct{}{}:
@@ -115,22 +146,22 @@ func (s *ConsensusSet) updateSubscribers(revertedNodes []*blockNode, appliedNode
 
 // ConsensusSetNotify returns a channel that will be sent an empty struct every
 // time the consensus set changes.
-func (s *ConsensusSet) ConsensusSetNotify() <-chan struct{} {
+func (cs *ConsensusSet) ConsensusSetNotify() <-chan struct{} {
 	c := make(chan struct{}, modules.NotifyBuffer)
 	c <- struct{}{} // Notify subscriber about the genesis block.
-	id := s.mu.Lock()
-	s.subscriptions = append(s.subscriptions, c)
-	s.mu.Unlock(id)
+	id := cs.mu.Lock()
+	cs.subscriptions = append(cs.subscriptions, c)
+	cs.mu.Unlock(id)
 	return c
 }
 
 // ConsensusSetSubscribe accepts a new subscriber who will receive a call to
 // ReceiveConsensusSetUpdate every time there is a change in the consensus set.
-func (s *ConsensusSet) ConsensusSetSubscribe(subscriber modules.ConsensusSetSubscriber) {
+func (cs *ConsensusSet) ConsensusSetSubscribe(subscriber modules.ConsensusSetSubscriber) {
 	c := make(chan struct{}, modules.NotifyBuffer)
 	c <- struct{}{} // Notify subscriber about the genesis block.
-	id := s.mu.Lock()
-	s.subscriptions = append(s.subscriptions, c)
-	s.mu.Unlock(id)
-	go s.threadedSendUpdates(c, subscriber)
+	id := cs.mu.Lock()
+	cs.subscriptions = append(cs.subscriptions, c)
+	cs.mu.Unlock(id)
+	go cs.threadedSendUpdates(c, subscriber)
 }

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -81,7 +81,8 @@ type TransactionPool struct {
 	// up. To prevent deadlocks in the transaction pool, subscribers are
 	// updated in a separate thread which does not guarantee that a subscriber
 	// is always fully synchronized to the transaction pool.
-	consensusChanges        []modules.ConsensusChange
+	consensusChangeIndex    int   // Increments any time a consensus update is made.
+	consensusChanges        []int // The index of the consensus change from the consensus set. -1 means there was no change from the consensus set.
 	unconfirmedTransactions [][]types.Transaction
 	unconfirmedSiacoinDiffs [][]modules.SiacoinOutputDiff
 	subscribers             []chan struct{}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
+	"time"
 
 	"github.com/NebulousLabs/Sia/api"
 	"github.com/NebulousLabs/Sia/modules"
@@ -23,6 +27,20 @@ import (
 func startDaemon() error {
 	// Establish multithreading.
 	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	// Print a startup message.
+	fmt.Println("siad is loading")
+	loadStart := time.Now().UnixNano()
+
+	// Establish cpu profiling. The current implementation only profiles
+	// loading the blockchain into memory.
+	if config.Siad.Profile {
+		cpuProfileFile, err := os.Create(filepath.Join(config.Siad.ProfileDir, "startup-cpu-profile.prof"))
+		if err != nil {
+			return err
+		}
+		pprof.StartCPUProfile(cpuProfileFile)
+	}
 
 	// Create all of the modules.
 	gateway, err := gateway.New(config.Siad.RPCaddr, filepath.Join(config.Siad.SiaDir, modules.GatewayDir))
@@ -77,6 +95,16 @@ func startDaemon() error {
 		started <- struct{}{}
 	}()
 
+	// Stop the cpu profiler now that the initial blockchain loading is
+	// complete.
+	if config.Siad.Profile {
+		pprof.StopCPUProfile()
+	}
+
+	// Print a 'startup complete' message.
+	startupTime := time.Now().UnixNano() - loadStart
+	fmt.Println("siad has finished loading after", float64(startupTime) / 1e9, "seconds")
+
 	// Start serving api requests.
 	err = srv.Serve()
 	if err != nil {
@@ -87,6 +115,50 @@ func startDaemon() error {
 
 // startDaemonCmd is a passthrough function for startDaemon.
 func startDaemonCmd(*cobra.Command, []string) {
+	// Create the profiling directory if profiling is enabled.
+	if config.Siad.Profile {
+		err := os.MkdirAll(config.Siad.ProfileDir, 0700)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		// Create a goroutime to log the number of gothreads in use every 30
+		// seconds.
+		go func() {
+			// Create a logger for the goroutine.
+			logFile, err := os.OpenFile(filepath.Join(config.Siad.ProfileDir, "goroutineCount.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
+			if err != nil {
+				fmt.Println("Goroutine logging failed:", err)
+				return
+			}
+			log := log.New(logFile, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
+			log.Println("Goroutine logger started. The number of goroutines in use will be printed every 30 seoncds.")
+
+			// Inifinite loop to print out the goroutine count.
+			for {
+				log.Println(runtime.NumGoroutine())
+				time.Sleep(time.Second * 30)
+			}
+		}()
+
+		// Create a goroutine to update the memory profile.
+		go func() {
+			memFile, err := os.Create(filepath.Join(config.Siad.ProfileDir, "memprofile.prof"))
+			if err != nil {
+				fmt.Println("Memory profiling failed:", err)
+				return
+			}
+
+			// Infinite loop to update the memory profile.
+			for {
+				pprof.WriteHeapProfile(memFile)
+				time.Sleep(time.Minute)
+			}
+		}()
+	}
+
+	// Start siad. startDaemon will only return when it is shutting down.
 	err := startDaemon()
 	if err != nil {
 		fmt.Println(err)

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -103,7 +103,7 @@ func startDaemon() error {
 
 	// Print a 'startup complete' message.
 	startupTime := time.Now().UnixNano() - loadStart
-	fmt.Println("siad has finished loading after", float64(startupTime) / 1e9, "seconds")
+	fmt.Println("siad has finished loading after", float64(startupTime)/1e9, "seconds")
 
 	// Start serving api requests.
 	err = srv.Serve()

--- a/siad/main.go
+++ b/siad/main.go
@@ -29,6 +29,9 @@ type Config struct {
 		HostAddr string
 
 		SiaDir string
+
+		Profile    bool
+		ProfileDir string
 	}
 }
 
@@ -37,7 +40,6 @@ type Config struct {
 func init() {
 	// Initialize the started channel, only used for testing.
 	started = make(chan struct{}, 1)
-
 }
 
 // versionCmd is a cobra command that prints the version of siad.
@@ -67,6 +69,8 @@ func main() {
 	root.PersistentFlags().StringVarP(&config.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
 	root.PersistentFlags().StringVarP(&config.Siad.HostAddr, "host-addr", "H", ":9982", "which port the host listens on")
 	root.PersistentFlags().StringVarP(&config.Siad.SiaDir, "sia-directory", "d", "", "location of the sia directory")
+	root.PersistentFlags().BoolVarP(&config.Siad.Profile, "profile", "p", false, "enable profiling")
+	root.PersistentFlags().StringVarP(&config.Siad.ProfileDir, "profile-directory", "P", "profiles", "location of the profiling directory")
 
 	// Parse cmdline flags, overwriting both the default values and the config
 	// file values.


### PR DESCRIPTION
There's still a ways to go as far as performance is concerned. BUT:

1. file contract maintenance is now O(n) in the number of file contracts expiring, not O(n) in the total number of file contracts. Because of the use of maps, performance has actually decreased right now, because there are only a few thousand file contracts. I'm not sure where the break-even point is, but ideally we'll eventually have somewhere between 100k and 10m file contracts on the blockchain, this change was necessary.

2. The subscription model no longer saves an entire extra copy of the diff set, instead calculating it on the fly when needed.

3. Some profiling code got added to the daemon. You can run the profiler with '-p'. It's not very sophisticated at the moment, and I actually think that the memory profiler is broken in some ways. I still don't understand how to use the memory profiler.

4. We now use travis-CI's new build system. http://docs.travis-ci.com/user/migrating-from-legacy/

This concludes this round of me changing the consensus package. There's still a handful of tests that need to be written, but they are less critical. I plan on getting back to those before we release, probably the week before.

My next focus is going to be the transaction pool.