### PR TITLE
Consensus api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -35,8 +35,9 @@ func (srv *Server) initAPI(addr string) {
 	handleHTTPRequest(mux, "/", srv.unrecognizedCallHandler)
 
 	// Consensus API Calls
-	handleHTTPRequest(mux, "/consensus/status", srv.consensusStatusHandler)
-	handleHTTPRequest(mux, "/consensus/synchronize", srv.consensusSynchronizeHandler)
+	handleHTTPRequest(mux, "/consensus", srv.consensusHandler)                        // GET
+	handleHTTPRequest(mux, "/consensus/synchronize", srv.consensusSynchronizeHandler) // GET
+	handleHTTPRequest(mux, "/consensus/status", srv.consensusStatusHandler)           // DEPRECATED.
 
 	// Daemon API Calls
 	handleHTTPRequest(mux, "/daemon/stop", srv.daemonStopHandler)

--- a/api/consensus.go
+++ b/api/consensus.go
@@ -4,15 +4,85 @@ import (
 	"net/http"
 
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// The ConsensusSetStatus struct contains general information about the
+// consensus set, with tags to have idiomatic json encodings.
+type ConsensusSetStatus struct {
+	Height       types.BlockHeight `json:"height"`
+	CurrentBlock types.BlockID     `json:"currentblock"`
+	Target       types.Target      `json:"target"`
+}
+
+// DEPRECATED
+//
+// The ConsensusInfo struct contains general information about the consensus
+// set.
 type ConsensusInfo struct {
 	Height       types.BlockHeight
 	CurrentBlock types.BlockID
 	Target       types.Target
 }
 
+// consensusHandlerGET handles a GET request to /consensus.
+func (srv *Server) consensusHandlerGET(w http.ResponseWriter, req *http.Request) {
+	currentTarget, exists := srv.cs.ChildTarget(srv.currentBlock.ID())
+	if build.DEBUG {
+		if !exists {
+			panic("server has nonexistent current block")
+		}
+	}
+
+	writeJSON(w, ConsensusSetStatus{
+		types.BlockHeight(srv.blockchainHeight),
+		srv.currentBlock.ID(),
+		currentTarget,
+	})
+}
+
+// consensusHandler handles the API calls to /consensus.
+func (srv *Server) consensusHandler(w http.ResponseWriter, req *http.Request) {
+	lockID := srv.mu.RLock()
+	defer srv.mu.RUnlock(lockID)
+
+	if req.Method == "" || req.Method == "GET" {
+		srv.consensusHandlerGET(w, req)
+		return
+	}
+
+	writeError(w, "unrecognized method when calling /consensus", http.StatusBadRequest)
+}
+
+// consensusSynchronizeHandlerGET handles a GET request to
+// /consensus/synchronize.
+func (srv *Server) consensusSynchronizeHandlerGET(w http.ResponseWriter, req *http.Request) {
+	peers := srv.gateway.Peers()
+	if len(peers) == 0 {
+		writeError(w, "No peers available for syncing", http.StatusInternalServerError)
+		return
+	}
+	randPeer, err := crypto.RandIntn(len(peers))
+	if err != nil {
+		writeError(w, "System error", http.StatusInternalServerError)
+	}
+	go srv.cs.Synchronize(peers[randPeer])
+	writeSuccess(w)
+}
+
+// consensusSynchronizeHandler handles the API call asking for the consensus to
+// synchronize with other peers.
+func (srv *Server) consensusSynchronizeHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method == "" || req.Method == "GET" {
+		srv.consensusSynchronizeHandlerGET(w, req)
+		return
+	}
+	writeError(w, "unrecognized method when calling /consensus/synchronize", http.StatusBadRequest)
+}
+
+// DEPRECATED
+//
 // consensusStatusHandler handles the API call asking for the consensus status.
 func (srv *Server) consensusStatusHandler(w http.ResponseWriter, req *http.Request) {
 	lockID := srv.mu.RLock()
@@ -26,24 +96,8 @@ func (srv *Server) consensusStatusHandler(w http.ResponseWriter, req *http.Reque
 	}
 
 	writeJSON(w, ConsensusInfo{
-		srv.blockchainHeight,
+		types.BlockHeight(srv.blockchainHeight),
 		srv.currentBlock.ID(),
 		currentTarget,
 	})
-}
-
-// consensusSynchronizeHandler handles the API call asking for the consensus to
-// synchronize with other peers.
-func (srv *Server) consensusSynchronizeHandler(w http.ResponseWriter, req *http.Request) {
-	peers := srv.gateway.Peers()
-	if len(peers) == 0 {
-		writeError(w, "No peers available for syncing", http.StatusInternalServerError)
-		return
-	}
-
-	// TODO: How should this be handled? Multiple simultaneous peers? First
-	// peer is a bad method.
-	go srv.cs.Synchronize(peers[0])
-
-	writeSuccess(w)
 }

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -34,7 +34,7 @@ func TestConsensusSynchronizeGET(t *testing.T) {
 	}
 
 	st := newServerTester("TestConsensusSynchronizeGET", t)
-	st.callAPI("/consensus/synchronize") // TODO: err = 
+	st.callAPI("/consensus/synchronize") // TODO: err =
 
 	// TODO: Need some way to tell that a peer was out of sync, and then
 	// in-sync. The problem is that currently, if there are peers they should

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -29,12 +29,13 @@ func TestConsensusGET(t *testing.T) {
 
 // TestConsensusSynchronizeGET probes the GET call to /consensus/synchronize.
 func TestConsensusSynchronizeGET(t *testing.T) {
+	t.Skip("no known way to add peers without automatically performing a synchronize")
 	if testing.Short() {
 		t.SkipNow()
 	}
 
 	st := newServerTester("TestConsensusSynchronizeGET", t)
-	st.callAPI("/consensus/synchronize") // TODO: err =
+	st.callAPI("/consensus/synchronize")
 
 	// TODO: Need some way to tell that a peer was out of sync, and then
 	// in-sync. The problem is that currently, if there are peers they should

--- a/api/server.go
+++ b/api/server.go
@@ -23,7 +23,7 @@ type Server struct {
 	exp     modules.Explorer
 
 	// Consensus set variables.
-	blockchainHeight types.BlockHeight
+	blockchainHeight int
 	currentBlock     types.Block
 
 	apiServer *graceful.Server
@@ -43,6 +43,8 @@ func NewServer(APIaddr string, s *consensus.ConsensusSet, g modules.Gateway, h m
 		tpool:   tp,
 		wallet:  w,
 		exp:     exp,
+
+		blockchainHeight: -1,
 
 		mu: sync.New(modules.SafeMutexDelay, 1),
 	}

--- a/api/update.go
+++ b/api/update.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/types"
 )
 
 // ReceiveConsensusSetUpdate gets called by the consensus set every time there
@@ -11,7 +10,7 @@ func (srv *Server) ReceiveConsensusSetUpdate(cc modules.ConsensusChange) {
 	lockID := srv.mu.Lock()
 	defer srv.mu.Unlock(lockID)
 
-	srv.blockchainHeight -= types.BlockHeight(len(cc.RevertedBlocks))
-	srv.blockchainHeight += types.BlockHeight(len(cc.AppliedBlocks))
+	srv.blockchainHeight -= len(cc.RevertedBlocks)
+	srv.blockchainHeight += len(cc.AppliedBlocks)
 	srv.currentBlock = cc.AppliedBlocks[len(cc.AppliedBlocks)-1]
 }

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,6 +1,48 @@
 Siad API
 ========
 
+The siad API is currently under construction. The deprecated way of doing
+things is documented at the end of the (incomplete) new documentation.
+
+Consensus
+---------
+
+Queries:
+
+* /consensus [GET]
+* /consensus/synchronize [GET]
+
+#### /consensus [GET]
+
+Function: Returns information about the consensus set, such as the current
+block height.
+
+Parameters: none
+
+Response:
+```
+struct {
+	height       int
+	currentBlock string
+	target       string
+}
+```
+
+#### /consensus/synchronize [GET]
+
+Function: Sends a command to the consensus package to try synchronizing to the
+network.
+
+Parameters: none
+
+Response:
+```
+UNDECIDED
+```
+
+Siad API (Deprecated)
+=====================
+
 All API calls return JSON objects. If there is an error, the error is returned
 in plaintext with an appropriate HTTP error code. The standard response is {
 "Success": true }. In this document, the API responses are defined as Go

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -138,7 +138,7 @@ type ConsensusSet interface {
 
 	// ConsensusChange returns the ith consensus change that was broadcast to
 	// subscribers by the consensus set. An error is returned if i consensus
-	// changes have not been broadcast. The primary purpose of this funciton is
+	// changes have not been broadcast. The primary purpose of this function is
 	// to rescan the blockchain.
 	ConsensusChange(i int) (ConsensusChange, error)
 

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -1,0 +1,117 @@
+package profile
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+	"time"
+)
+
+// There's a global lock on cpu and memory profiling, because I'm not sure what
+// happens if multiple threads call each at the same time. This lock might be
+// unnecessary.
+var (
+	cpuActive bool
+	cpuLock   sync.Mutex
+	memActive bool
+	memLock   sync.Mutex
+)
+
+// startCPUProfile starts cpu profiling. An error will be returned if a cpu
+// profiler is already running.
+func StartCPUProfile(profileDir, identifier string) error {
+	// Lock the cpu profile lock so that only one profiler is running at a
+	// time.
+	cpuLock.Lock()
+	if cpuActive {
+		cpuLock.Unlock()
+		return errors.New("cannot start cpu profilier, a profiler is already running")
+	}
+	cpuActive = true
+	cpuLock.Unlock()
+
+	// Start profiling into the profile dir, using the identifer. The timestamp
+	// of the start time of the profiling will be included in the filenmae.
+	cpuProfileFile, err := os.Create(filepath.Join(profileDir, "cpu-profile-"+identifier+"-"+time.Now().Format(time.RFC3339Nano)+".prof"))
+	if err != nil {
+		return err
+	}
+	pprof.StartCPUProfile(cpuProfileFile)
+	return nil
+}
+
+// stopCPUProfile stops cpu profiling.
+func StopCPUProfile() {
+	cpuLock.Lock()
+	if cpuActive {
+		pprof.StopCPUProfile()
+		cpuActive = false
+	}
+	cpuLock.Unlock()
+}
+
+// saveMemProfile saves the current memory structure of the program. An error
+// will be returned if memory profiling is already in progress. Unlike for cpu
+// profiling, there is no 'stopMemProfile' call - everything happens at once.
+func SaveMemProfile(profileDir, identifier string) error {
+	memLock.Lock()
+	if memActive {
+		memLock.Unlock()
+		return errors.New("cannot start memory profiler, a memory profiler is already running")
+	}
+	memActive = true
+	memLock.Unlock()
+
+	// Save the memory profile.
+	memFile, err := os.Create(filepath.Join(profileDir, "mem-profile-"+identifier+"-"+time.Now().Format(time.RFC3339Nano)+".prof"))
+	if err != nil {
+		return err
+	}
+	pprof.WriteHeapProfile(memFile)
+
+	memLock.Lock()
+	memActive = false
+	memLock.Unlock()
+	return nil
+}
+
+// StartContinuousProfiling starts profiling in a gothread, logging at
+// intervals various metrics such as the number of gothreads and some memory
+// statistics.
+func StartContinuousProfile(profileDir string) {
+	err := os.MkdirAll(profileDir, 0700)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Create a logger to infrequently log performance statistics.
+	go func() {
+		// Create a logger for the goroutine.
+		logFile, err := os.OpenFile(filepath.Join(profileDir, "continuousProfiling.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
+		if err != nil {
+			fmt.Println("Goroutine logging failed:", err)
+			return
+		}
+		log := log.New(logFile, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
+		log.Println("Continuous profiling started.")
+
+		// Infinite loop to print out the goroutine count.
+		sleepTime := time.Second * 3
+		for {
+			// Sleep for an exponential amount of time each iteration, this
+			// keeps the size of the log small while still providing lots of
+			// information.
+			time.Sleep(sleepTime)
+			sleepTime = time.Duration(1.5 * float64(sleepTime))
+			var m runtime.MemStats
+			runtime.ReadMemStats(&m)
+			log.Printf("\n\tGoroutines: %v\n\tAlloc: %v\n\tTotalAlloc: %v\n\tHeapAlloc: %v\n\tHeapSys: %v\n", runtime.NumGoroutine(), m.Alloc, m.TotalAlloc, m.HeapAlloc, m.HeapSys)
+		}
+	}()
+}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"path/filepath"
 	"runtime"
-	"runtime/pprof"
 	"time"
 
 	"github.com/NebulousLabs/Sia/api"
@@ -19,6 +16,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules/renter"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	"github.com/NebulousLabs/Sia/modules/wallet"
+	"github.com/NebulousLabs/Sia/profile"
 
 	"github.com/spf13/cobra"
 )
@@ -29,18 +27,11 @@ func startDaemon() error {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Print a startup message.
-	fmt.Println("siad is loading")
+	//
+	// TODO: This message can be removed once the api starts up in under 1/2
+	// second.
+	fmt.Println("siad is loading, may take a minute or two")
 	loadStart := time.Now().UnixNano()
-
-	// Establish cpu profiling. The current implementation only profiles
-	// loading the blockchain into memory.
-	if config.Siad.Profile {
-		cpuProfileFile, err := os.Create(filepath.Join(config.Siad.ProfileDir, "startup-cpu-profile.prof"))
-		if err != nil {
-			return err
-		}
-		pprof.StartCPUProfile(cpuProfileFile)
-	}
 
 	// Create all of the modules.
 	gateway, err := gateway.New(config.Siad.RPCaddr, filepath.Join(config.Siad.SiaDir, modules.GatewayDir))
@@ -91,25 +82,16 @@ func startDaemon() error {
 	// that daemon startup has completed. A gofunc is used with the hope that
 	// srv.Serve() will start running before the value is sent down the
 	// channel.
+	//
+	// TODO: There are better ways to approach this.
 	go func() {
 		started <- struct{}{}
 	}()
 
-	// Stop the cpu profiler now that the initial blockchain loading is
-	// complete.
-	if config.Siad.Profile {
-		pprof.StopCPUProfile()
-	}
-
-	// Save the memory profile.
-	memFile, err := os.Create(filepath.Join(config.Siad.ProfileDir, "mem-profile.prof"))
-	if err != nil {
-		fmt.Println("Memory profiling failed:", err)
-		return err
-	}
-	pprof.WriteHeapProfile(memFile)
-
 	// Print a 'startup complete' message.
+	//
+	// TODO: This message can be removed once the api starts up in under 1/2
+	// second.
 	startupTime := time.Now().UnixNano() - loadStart
 	fmt.Println("siad has finished loading after", float64(startupTime)/1e9, "seconds")
 
@@ -125,31 +107,7 @@ func startDaemon() error {
 func startDaemonCmd(*cobra.Command, []string) {
 	// Create the profiling directory if profiling is enabled.
 	if config.Siad.Profile {
-		err := os.MkdirAll(config.Siad.ProfileDir, 0700)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-
-		// Create a logger to infrequently log performance statistics.
-		go func() {
-			// Create a logger for the goroutine.
-			logFile, err := os.OpenFile(filepath.Join(config.Siad.ProfileDir, "profiling.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
-			if err != nil {
-				fmt.Println("Goroutine logging failed:", err)
-				return
-			}
-			log := log.New(logFile, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
-			log.Println("Goroutine logger started. The number of goroutines in use will be printed every 30 seoncds.")
-
-			// Inifinite loop to print out the goroutine count.
-			for {
-				var m runtime.MemStats
-				runtime.ReadMemStats(&m)
-				log.Printf("\n\tGoroutines: %v\n\tAlloc: %v\n\tTotalAlloc: %v\n\tHeapAlloc: %v\n\tHeapSys: %v", runtime.NumGoroutine(), m.Alloc, m.TotalAlloc, m.HeapAlloc, m.HeapSys)
-				time.Sleep(time.Minute * 5)
-			}
-		}()
+		go profile.StartContinuousProfile(config.Siad.ProfileDir)
 	}
 
 	// Start siad. startDaemon will only return when it is shutting down.


### PR DESCRIPTION
The api paradigm was switched up, and I moved over the consensus api calls. The one thing we haven't figured out is how to return an error string when the api call fails. I'm not sure what is idiomatic, but I would want to be as idiomatic and RESTful as possible.

I added a profiling package that should make profiling a lot easier. Siad, when passed a profiling flag, will make a log with basic profiling information.

There are additional calls that make it easy to start and stop memory and cpu profiling.

http/pprof is not used anywhere currently. Profiling is not done by default. The log sizes are pretty small even if you do turn on profiling.