### PR TITLE
Keep track of the seen times of the most recent 144 blocks

### DIFF
--- a/modules/explorer.go
+++ b/modules/explorer.go
@@ -22,6 +22,7 @@ type (
 		Height              types.BlockHeight
 		Block               types.Block
 		Target              types.Target
+		MatureTime          types.Timestamp
 		TotalCurrency       types.Currency
 		ActiveContractCount uint64
 		ActiveContractCosts types.Currency

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -73,6 +73,9 @@ type Explorer struct {
 	// notify other modules when changes occur
 	subscriptions []chan struct{}
 
+	// updates is the number of updates that have been sent out to subscribers
+	updates uint64
+
 	mu *sync.RWMutex
 }
 

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -3,6 +3,7 @@ package explorer
 import (
 	"errors"
 	"os"
+	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/sync"
@@ -31,6 +32,17 @@ type Explorer struct {
 
 	// Used for caching the current blockchain height
 	blockchainHeight types.BlockHeight
+
+	// Used to  store the time blocks were seen.  Sholud only keep
+	// track of the most recent 144 blocks. Its size should always
+	// be types.MaturityDelay. SeenTimes  keeps track of that many
+	//  times,  and should  be  indexed  with (blockchainheight  %
+	// len(seenTimes))
+	seenTimes []time.Time
+
+	// stores the time that the blockexplorer started so that new
+	// seen blocks can be compared against it.
+	startTime time.Time
 
 	// currencySent keeps track of how much currency has been
 	// i.e. sending siacoin to somebody else
@@ -91,6 +103,8 @@ func New(cs modules.ConsensusSet, persistDir string) (e *Explorer, err error) {
 		currentBlock:       cs.GenesisBlock(),
 		genesisBlockID:     cs.GenesisBlock().ID(),
 		blockchainHeight:   0,
+		seenTimes:          make([]time.Time, types.MaturityDelay+1),
+		startTime:          time.Now(),
 		currencySent:       types.NewCurrency64(0),
 		activeContractCost: types.NewCurrency64(0),
 		totalContractCost:  types.NewCurrency64(0),

--- a/modules/explorer/info.go
+++ b/modules/explorer/info.go
@@ -65,10 +65,14 @@ func (e *Explorer) ExplorerStatus() modules.ExplorerStatus {
 		}
 	}
 
+	// Find the seen time of the block 144 ago in the list
+	matureBlockTime := e.seenTimes[(e.blockchainHeight-144)%types.BlockHeight(len(e.seenTimes))]
+
 	return modules.ExplorerStatus{
 		Height:              e.blockchainHeight,
 		Block:               e.currentBlock,
 		Target:              currentTarget,
+		MatureTime:          types.Timestamp(matureBlockTime.Unix()),
 		TotalCurrency:       totalCurrency(e.blockchainHeight),
 		ActiveContractCount: e.activeContracts,
 		ActiveContractCosts: e.activeContractCost,

--- a/modules/explorer/subscriptions.go
+++ b/modules/explorer/subscriptions.go
@@ -6,6 +6,7 @@ import (
 
 // updateSubscribers will inform subscribers of any updates to the block explorer
 func (e *Explorer) updateSubscribers() {
+	e.updates++
 	for _, subscriber := range e.subscriptions {
 		select {
 		case subscriber <- struct{}{}:
@@ -19,7 +20,9 @@ func (e *Explorer) updateSubscribers() {
 func (e *Explorer) ExplorerNotify() <-chan struct{} {
 	c := make(chan struct{}, modules.NotifyBuffer)
 	lockID := e.mu.Lock()
-	c <- struct{}{}
+	for i := uint64(0); i < e.updates; i++ {
+		c <- struct{}{}
+	}
 	e.subscriptions = append(e.subscriptions, c)
 	e.mu.Unlock(lockID)
 	return c

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -2,6 +2,7 @@ package explorer
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -35,6 +36,14 @@ func (e *Explorer) ReceiveConsensusSetUpdate(cc modules.ConsensusChange) {
 	// Handle incoming blocks
 	for _, block := range cc.AppliedBlocks {
 		e.blockchainHeight += 1
+
+		// Add the current time to seenTimes
+		if time.Unix(int64(block.Timestamp), 0).Before(e.startTime) {
+			e.seenTimes[e.blockchainHeight%types.BlockHeight(len(e.seenTimes))] = time.Unix(int64(block.Timestamp), 0)
+		} else {
+			e.seenTimes[e.blockchainHeight%types.BlockHeight(len(e.seenTimes))] = time.Now()
+		}
+
 		// add the block to the database.
 		err := e.addBlockDB(block)
 		if err != nil {

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -53,6 +53,6 @@ func (e *Explorer) ReceiveConsensusSetUpdate(cc modules.ConsensusChange) {
 	e.currentBlock = cc.AppliedBlocks[len(cc.AppliedBlocks)-1]
 
 	// Notify subscribers about updates
-	e.mu.Unlock(lockID)
 	e.updateSubscribers()
+	e.mu.Unlock(lockID)
 }

--- a/modules/explorer/update_test.go
+++ b/modules/explorer/update_test.go
@@ -9,9 +9,6 @@ import (
 // Mine a bunch of blocks, checking each time that the stored
 // value agrees with consensus
 func (et *explorerTester) testConsensusUpdates(t *testing.T) {
-	// Clear the notification about the genesis block
-	<-et.eUpdateChan
-
 	// 20 here is arbitrary
 	for i := types.BlockHeight(0); i < 20; i++ {
 		b, _ := et.miner.FindBlock()
@@ -28,6 +25,9 @@ func (et *explorerTester) testConsensusUpdates(t *testing.T) {
 }
 
 func TestConsensusUpdates(t *testing.T) {
-	et := createExplorerTester("TestExplorerConsensusUpdate", t)
+	et, err := createExplorerTester("TestExplorerConsensusUpdate", t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	et.testConsensusUpdates(t)
 }


### PR DESCRIPTION
As the update model doesn't differentiate between loaded blocks and recieved ones, I used the time that the module was created as a switch for to use the seen timestamp or the block timestamp.