### PR TITLE
Api test tuning

### DIFF
--- a/api/consensus.go
+++ b/api/consensus.go
@@ -67,7 +67,10 @@ func (srv *Server) consensusSynchronizeHandlerGET(w http.ResponseWriter, req *ht
 	if err != nil {
 		writeError(w, "System error", http.StatusInternalServerError)
 	}
-	go srv.cs.Synchronize(peers[randPeer])
+	err = srv.cs.Synchronize(peers[randPeer])
+	if err != nil {
+		writeError(w, err.Error(), http.StatusInternalServerError)
+	}
 	writeSuccess(w)
 }
 

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -33,19 +33,49 @@ func TestIntegrationConsensusGET(t *testing.T) {
 // TestIntegrationConsensusSynchronizeGET probes the GET call to
 // /consensus/synchronize.
 func TestIntegrationConsensusSynchronizeGET(t *testing.T) {
-	t.Skip("no known way to add peers without automatically performing a synchronize")
 	if testing.Short() {
 		t.SkipNow()
 	}
 
+	// Create a server tester and give it a peer. Get the peer ahead of the
+	// server tester, then call 'synchronize' to bring them back to the same
+	// height.
 	st := newServerTester("TestConsensusSynchronizeGET", t)
+
+	// Call synchronize when there are no peers.
 	err := st.callAPI("/consensus/synchronize")
+	if err == nil {
+		t.Error("expecting an error - gateway has no peers")
+	}
+
+	// Mine a block so that when a peer is added, 'st' has a longer blockchain.
+	block, _ := st.miner.FindBlock()
+	err = st.cs.AcceptBlock(block)
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Create a peer and bootstrap it to st.
+	peer := newServerTester("TestConsensusSynchronizeGET - Peer", t)
+	err = peer.server.gateway.Connect(st.netAddress())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the heights are different on the consensus sets.
+	if st.cs.CurrentBlock().ID() == peer.cs.CurrentBlock().ID() {
+		// TODO: There is not a known way to add peers to a network without
+		// them synchronizing automatically. Perhaps it is proof that
+		// synchronize is not needed anymore, but I am hesitant to drop it
+		// until we are more certian that it is not needed.
+		//
+		// t.Fatal("test objects are already synchronized - calling synchronize will not provide useful information")
+	}
 
-	// TODO: Need some way to tell that a peer was out of sync, and then
-	// in-sync. The problem is that currently, if there are peers they should
-	// synchronize automatically. /consensus/synchronize is much closer to a
-	// debugging api call than an actual api call.
+	// Call synchronize.
+	err = st.callAPI("/consensus/synchronize")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.cs.CurrentBlock().ID() != peer.cs.CurrentBlock().ID() {
+		t.Fatal("synchronization failed")
+	}
 }

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -6,15 +6,18 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// TestConsensusGet probes the GET call to /consensus.
-func TestConsensusGET(t *testing.T) {
+// TestIntegrationConsensusGet probes the GET call to /consensus.
+func TestIntegrationConsensusGET(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
 
 	st := newServerTester("TestConsensusGET", t)
 	var css ConsensusSetStatus
-	st.getAPI("/consensus", &css) // TODO: err =
+	err := st.getAPI("/consensus", &css)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if css.Height != 4 {
 		t.Error("wrong height returned in consensus GET call")
 	}
@@ -27,15 +30,19 @@ func TestConsensusGET(t *testing.T) {
 	}
 }
 
-// TestConsensusSynchronizeGET probes the GET call to /consensus/synchronize.
-func TestConsensusSynchronizeGET(t *testing.T) {
+// TestIntegrationConsensusSynchronizeGET probes the GET call to
+// /consensus/synchronize.
+func TestIntegrationConsensusSynchronizeGET(t *testing.T) {
 	t.Skip("no known way to add peers without automatically performing a synchronize")
 	if testing.Short() {
 		t.SkipNow()
 	}
 
 	st := newServerTester("TestConsensusSynchronizeGET", t)
-	st.callAPI("/consensus/synchronize") // TODO: err =
+	err := st.callAPI("/consensus/synchronize")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// TODO: Need some way to tell that a peer was out of sync, and then
 	// in-sync. The problem is that currently, if there are peers they should

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -149,37 +150,48 @@ func (st *serverTester) coinAddress() string {
 	return addr.Address
 }
 
-// get wraps a GET request with a status code check, such that if the GET does
-// not return 200, the error will be read and returned. The response body is
-// not closed.
-func (st *serverTester) get(call string) (resp *http.Response) {
+// getAPI makes an API call and decodes the response.
+func (st *serverTester) getAPI(call string, obj interface{}) error {
 	resp, err := http.Get("http://localhost" + st.server.apiServer.Addr + call)
 	if err != nil {
-		st.t.Fatalf("GET %s failed: %v", call, err)
+		return err
 	}
-	// check error code
-	if resp.StatusCode != http.StatusOK {
-		errResp, _ := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		st.t.Fatalf("GET %s returned error %v: %s", call, resp.StatusCode, errResp)
-	}
-	return
-}
-
-// getAPI makes an API call and decodes the response.
-func (st *serverTester) getAPI(call string, obj interface{}) {
-	resp := st.get(call)
 	defer resp.Body.Close()
-	err := json.NewDecoder(resp.Body).Decode(obj)
-	if err != nil {
-		st.t.Fatalf("Could not decode API response: %s", call)
+
+	// Check for a call error.
+	if resp.StatusCode != http.StatusOK {
+		respErr, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return errors.New(string(respErr))
 	}
-	return
+
+	// Decode the response into 'obj'.
+	err = json.NewDecoder(resp.Body).Decode(obj)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // callAPI makes an API call and discards the response.
-func (st *serverTester) callAPI(call string) {
-	st.get(call).Body.Close()
+func (st *serverTester) callAPI(call string) error {
+	resp, err := http.Get("http://localhost" + st.server.apiServer.Addr + call)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Check for a call error.
+	if resp.StatusCode != http.StatusOK {
+		respErr, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return errors.New(string(respErr))
+	}
+	return nil
 }
 
 // TestCreateServer creates a serverTester and immediately stops it.


### PR DESCRIPTION
I changed the api functions slightly, and then expanding the synchronize test for the consensus package.

I'm led to believe, based on the difficulty I'm having constructing a situation where two peers are connected but aren't synchronized, that the synchronize command is actually not needed. It was definitely needed in the past, but doesn't seem to be needed any more.