### PR TITLE
Path db

### DIFF
--- a/modules/consensus/accept_bench_test.go
+++ b/modules/consensus/accept_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/gateway"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // benchmarkEmptyBlocks is a benchmark that mines many blocks, and
@@ -32,8 +33,9 @@ func benchmarkEmptyBlocks(b *testing.B) error {
 	if err != nil {
 		return errors.New("Error creating tester: " + err.Error())
 	}
-	for _, bID := range cst.cs.currentPath[1:] {
-		err = cs.AcceptBlock(cst.cs.blockMap[bID].block)
+	h := cst.cs.db.pathHeight()
+	for i := types.BlockHeight(1); i < h; i++ {
+		err = cs.AcceptBlock(cst.cs.blockMap[cst.cs.db.getPath(i)].block)
 		if err != nil {
 			return err
 		}

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -90,7 +90,7 @@ func (cst *consensusSetTester) testBlockKnownHandling() error {
 	}
 
 	// Try the genesis block edge case.
-	genesisBlock := cst.cs.blockMap[cst.cs.db.path(0)].block
+	genesisBlock := cst.cs.blockMap[cst.cs.db.getPath(0)].block
 	err = cst.cs.acceptBlock(genesisBlock)
 	if err != ErrBlockKnown {
 		return errors.New("expecting known block err: " + err.Error())
@@ -365,7 +365,7 @@ func (cst *consensusSetTester) testSimpleBlock() error {
 		return errors.New("the state's current block is not reporting as the recently mined block.")
 	}
 	// Check that the current path has updated correctly.
-	if block.ID() != cst.cs.db.path(newNode.height) {
+	if block.ID() != cst.cs.db.getPath(newNode.height) {
 		return errors.New("the state's current path didn't update correctly after accepting a new block")
 	}
 

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -90,7 +90,7 @@ func (cst *consensusSetTester) testBlockKnownHandling() error {
 	}
 
 	// Try the genesis block edge case.
-	genesisBlock := cst.cs.blockMap[cst.cs.currentPath[0]].block
+	genesisBlock := cst.cs.blockMap[cst.cs.db.path(0)].block
 	err = cst.cs.acceptBlock(genesisBlock)
 	if err != ErrBlockKnown {
 		return errors.New("expecting known block err: " + err.Error())
@@ -365,7 +365,7 @@ func (cst *consensusSetTester) testSimpleBlock() error {
 		return errors.New("the state's current block is not reporting as the recently mined block.")
 	}
 	// Check that the current path has updated correctly.
-	if block.ID() != cst.cs.currentPath[newNode.height] {
+	if block.ID() != cst.cs.db.path(newNode.height) {
 		return errors.New("the state's current path didn't update correctly after accepting a new block")
 	}
 

--- a/modules/consensus/blocknode.go
+++ b/modules/consensus/blocknode.go
@@ -36,7 +36,7 @@ type blockNode struct {
 	// prevents duplicate work from being performed.
 	//
 	// Note that diffsGenerated == true iff the node has ever been in the
-	// ConsensusSet's currentPath; this is because diffs must be generated to
+	// ConsensusSet's current path; this is because diffs must be generated to
 	// apply the node.
 	diffsGenerated            bool
 	siacoinOutputDiffs        []modules.SiacoinOutputDiff

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -159,7 +159,6 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 	cs.blockMap[genesisBlock.ID()] = cs.blockRoot
 
 	// Fill out the consensus information for the genesis block.
-	cs.currentPath[0] = genesisBlock.ID()
 	cs.siacoinOutputs[genesisBlock.MinerPayoutID(0)] = types.SiacoinOutput{
 		Value:      types.CalculateCoinbase(0),
 		UnlockHash: types.ZeroUnlockHash,
@@ -177,6 +176,7 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 		cs.commitSiafundOutputDiff(sfod, modules.DiffApply)
 		cs.blockRoot.siafundOutputDiffs = append(cs.blockRoot.siafundOutputDiffs, sfod)
 	}
+	cs.currentPath[0] = genesisBlock.ID()
 
 	// Send out genesis block update.
 	cs.updateSubscribers(nil, []*blockNode{cs.blockRoot})

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"os"
 
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
@@ -177,9 +176,6 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 		}
 		cs.commitSiafundOutputDiff(sfod, modules.DiffApply)
 		cs.blockRoot.siafundOutputDiffs = append(cs.blockRoot.siafundOutputDiffs, sfod)
-	}
-	if build.DEBUG {
-		cs.blockRoot.consensusSetHash = cs.consensusSetHash()
 	}
 
 	// Send out genesis block update.

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -52,6 +52,12 @@ type ConsensusSet struct {
 	// current path from disk and true otherwise
 	updatePath bool // DEPRECATED
 
+	// blocksLoaded is the number of blocks that have been loaded
+	// from memory. This variable only exists while some
+	// structures are still in memory, and should always equal
+	// db.pathHeight after loading from disk
+	blocksLoaded types.BlockHeight
+
 	// The blockRoot is the block node that contains the genesis block.
 	blockRoot *blockNode
 
@@ -199,5 +205,8 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 
 // Close safely closes the block database.
 func (cs *ConsensusSet) Close() error {
+	lockID := cs.mu.Lock()
+	defer cs.mu.Unlock(lockID)
+	cs.db.open = false
 	return cs.db.Close()
 }

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -56,7 +56,7 @@ type ConsensusSet struct {
 	// from memory. This variable only exists while some
 	// structures are still in memory, and should always equal
 	// db.pathHeight after loading from disk
-	blocksLoaded types.BlockHeight
+	blocksLoaded types.BlockHeight // DEPRECATED
 
 	// The blockRoot is the block node that contains the genesis block.
 	blockRoot *blockNode

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -62,9 +62,6 @@ type ConsensusSet struct {
 	blockMap  map[types.BlockID]*blockNode
 	dosBlocks map[types.BlockID]struct{}
 
-	// The currentPath is the longest known blockchain.
-	currentPath []types.BlockID
-
 	// These are the consensus variables. All nodes with the same current path
 	// will also have these variables matching.
 	//
@@ -128,8 +125,6 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 		blockMap:  make(map[types.BlockID]*blockNode),
 		dosBlocks: make(map[types.BlockID]struct{}),
 
-		currentPath: make([]types.BlockID, 1),
-
 		siacoinOutputs:        make(map[types.SiacoinOutputID]types.SiacoinOutput),
 		fileContracts:         make(map[types.FileContractID]types.FileContract),
 		siafundOutputs:        make(map[types.SiafundOutputID]types.SiafundOutput),
@@ -176,7 +171,6 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 		cs.commitSiafundOutputDiff(sfod, modules.DiffApply)
 		cs.blockRoot.siafundOutputDiffs = append(cs.blockRoot.siafundOutputDiffs, sfod)
 	}
-	cs.currentPath[0] = genesisBlock.ID()
 
 	// Send out genesis block update.
 	cs.updateSubscribers(nil, []*blockNode{cs.blockRoot})

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -197,6 +197,8 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 		return nil, err
 	}
 
+	cs.updatePath = true
+
 	// Register RPCs
 	gateway.RegisterRPC("SendBlocks", cs.sendBlocks)
 	gateway.RegisterRPC("RelayBlock", cs.RelayBlock)

--- a/modules/consensus/consistency.go
+++ b/modules/consensus/consistency.go
@@ -30,7 +30,7 @@ func (cs *ConsensusSet) checkCurrentPath() error {
 			return errors.New("current path block not found in block map")
 		}
 		// Current node should match the id in the current path.
-		if currentNode.block.ID() != cs.db.path(i) {
+		if currentNode.block.ID() != cs.db.getPath(i) {
 			return errors.New("current path points to an incorrect block")
 		}
 		// Height of node needs to be listed correctly.
@@ -150,7 +150,7 @@ func (cs *ConsensusSet) consensusSetHash() crypto.Hash {
 
 	// Add all the blocks in the current path TODO: along with their diffs.
 	for i := 0; i < int(cs.db.pathHeight()); i++ {
-		tree.PushObject(cs.db.path(types.BlockHeight(i)))
+		tree.PushObject(cs.db.getPath(types.BlockHeight(i)))
 	}
 
 	// Add all of the siacoin outputs, sorted by id.

--- a/modules/consensus/consistency.go
+++ b/modules/consensus/consistency.go
@@ -30,7 +30,7 @@ func (cs *ConsensusSet) checkCurrentPath() error {
 			return errors.New("current path block not found in block map")
 		}
 		// Current node should match the id in the current path.
-		if currentNode.block.ID() != cs.currentPath[i] {
+		if currentNode.block.ID() != cs.db.path(i) {
 			return errors.New("current path points to an incorrect block")
 		}
 		// Height of node needs to be listed correctly.
@@ -149,8 +149,8 @@ func (cs *ConsensusSet) consensusSetHash() crypto.Hash {
 	tree.PushObject(cs.currentBlockNode().earliestChildTimestamp())
 
 	// Add all the blocks in the current path TODO: along with their diffs.
-	for i := 0; i < len(cs.currentPath); i++ {
-		tree.PushObject(cs.currentPath[types.BlockHeight(i)])
+	for i := 0; i < int(cs.db.pathHeight()); i++ {
+		tree.PushObject(cs.db.path(types.BlockHeight(i)))
 	}
 
 	// Add all of the siacoin outputs, sorted by id.

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -332,6 +332,10 @@ func (cs *ConsensusSet) generateAndApplyDiff(bn *blockNode) error {
 
 	// Update the state to point to the new block.
 	cs.currentPath = append(cs.currentPath, bn.block.ID())
+	err := cs.db.addPath(bn.block)
+	if err != nil {
+		return err
+	}
 	cs.delayedSiacoinOutputs[bn.height+types.MaturityDelay] = make(map[types.SiacoinOutputID]types.SiacoinOutput)
 
 	// diffsGenerated is set to true as soon as we start changing the set of
@@ -367,9 +371,5 @@ func (cs *ConsensusSet) generateAndApplyDiff(bn *blockNode) error {
 	if build.DEBUG {
 		bn.consensusSetHash = cs.consensusSetHash()
 	}
-	err := cs.db.addBlockMap(*bn)
-	if err != nil {
-		return err
-	}
-	return cs.db.pushPath(bn.block)
+	return cs.db.addBlockMap(*bn)
 }

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -291,14 +291,14 @@ func (cs *ConsensusSet) updateCurrentPath(bn *blockNode, dir modules.DiffDirecti
 		if cs.updatePath {
 			err := cs.db.pushPath(bn.block.ID())
 
-			if err != nil {
+			if build.DEBUG && err != nil {
 				panic(err)
 			}
 		}
 		cs.blocksLoaded += 1
 	} else {
 		err := cs.db.popPath()
-		if err != nil {
+		if build.DEBUG && err != nil {
 			panic(err)
 		}
 		cs.blocksLoaded -= 1

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -290,7 +290,7 @@ func (cs *ConsensusSet) updateCurrentPath(bn *blockNode, dir modules.DiffDirecti
 	if dir == modules.DiffApply {
 		cs.currentPath = append(cs.currentPath, bn.block.ID())
 		if cs.updatePath {
-			cs.db.pushPath(bn.block)
+			cs.db.pushPath(bn.block.ID())
 		}
 	} else {
 		cs.currentPath = cs.currentPath[:len(cs.currentPath)-1]
@@ -332,7 +332,7 @@ func (cs *ConsensusSet) generateAndApplyDiff(bn *blockNode) error {
 
 	// Update the state to point to the new block.
 	cs.currentPath = append(cs.currentPath, bn.block.ID())
-	err := cs.db.addPath(bn.block)
+	err := cs.db.addPath(bn.block.ID())
 	if err != nil {
 		return err
 	}

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -296,6 +296,7 @@ func (cs *ConsensusSet) updateCurrentPath(bn *blockNode, dir modules.DiffDirecti
 		cs.currentPath = cs.currentPath[:len(cs.currentPath)-1]
 		if cs.updatePath {
 			cs.db.popPath()
+			3
 		}
 	}
 }

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -288,16 +288,9 @@ func (cs *ConsensusSet) deleteObsoleteDelayedOutputMaps(bn *blockNode, dir modul
 func (cs *ConsensusSet) updateCurrentPath(bn *blockNode, dir modules.DiffDirection) {
 	// Update the current path.
 	if dir == modules.DiffApply {
-		cs.currentPath = append(cs.currentPath, bn.block.ID())
-		if cs.updatePath {
-			cs.db.pushPath(bn.block.ID())
-		}
+		cs.db.pushPath(bn.block.ID())
 	} else {
-		cs.currentPath = cs.currentPath[:len(cs.currentPath)-1]
-		if cs.updatePath {
-			cs.db.popPath()
-			3
-		}
+		cs.db.popPath()
 	}
 }
 
@@ -307,7 +300,9 @@ func (cs *ConsensusSet) commitDiffSet(bn *blockNode, dir modules.DiffDirection) 
 	cs.createUpcomingDelayedOutputMaps(bn, dir)
 	cs.commitNodeDiffs(bn, dir)
 	cs.deleteObsoleteDelayedOutputMaps(bn, dir)
-	cs.updateCurrentPath(bn, dir)
+	if cs.updatePath {
+		cs.updateCurrentPath(bn, dir)
+	}
 }
 
 // generateAndApplyDiff will verify the block and then integrate it into the
@@ -331,7 +326,6 @@ func (cs *ConsensusSet) generateAndApplyDiff(bn *blockNode) error {
 	}
 
 	// Update the state to point to the new block.
-	cs.currentPath = append(cs.currentPath, bn.block.ID())
 	err := cs.db.addPath(bn.block.ID())
 	if err != nil {
 		return err

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -335,7 +335,7 @@ func (cs *ConsensusSet) generateAndApplyDiff(bn *blockNode) error {
 	}
 
 	// Update the state to point to the new block.
-	err := cs.db.addPath(bn.block.ID())
+	err := cs.db.pushPath(bn.block.ID())
 	if err != nil {
 		return err
 	}

--- a/modules/consensus/fork.go
+++ b/modules/consensus/fork.go
@@ -19,8 +19,8 @@ var (
 func (cs *ConsensusSet) deleteNode(bn *blockNode) {
 	// Sanity check - the node being deleted should not be in the current path.
 	if build.DEBUG {
-		if types.BlockHeight(len(cs.currentPath)) > bn.height &&
-			cs.currentPath[bn.height] == bn.block.ID() {
+		if types.BlockHeight(cs.db.pathHeight()) > bn.height &&
+			cs.db.path(bn.height) == bn.block.ID() {
 			panic(errDeleteCurrentPath)
 		}
 	}
@@ -55,7 +55,7 @@ func (cs *ConsensusSet) backtrackToCurrentPath(bn *blockNode) []*blockNode {
 	path := []*blockNode{bn}
 	for {
 		// Stop when we reach the common parent.
-		if bn.height <= cs.height() && cs.currentPath[bn.height] == bn.block.ID() {
+		if bn.height <= cs.height() && cs.db.path(bn.height) == bn.block.ID() {
 			break
 		}
 		bn = bn.parent
@@ -68,9 +68,9 @@ func (cs *ConsensusSet) backtrackToCurrentPath(bn *blockNode) []*blockNode {
 // 'bn' is the current block. Blocks are returned in the order that they were
 // reverted.  'bn' is not reverted.
 func (cs *ConsensusSet) revertToNode(bn *blockNode) (revertedNodes []*blockNode) {
-	// Sanity check - make sure that bn is in the currentPath.
+	// Sanity check - make sure that bn is in the current path.
 	if build.DEBUG {
-		if cs.height() < bn.height || cs.currentPath[bn.height] != bn.block.ID() {
+		if cs.height() < bn.height || cs.db.path(bn.height) != bn.block.ID() {
 			panic(errExternalRevert)
 		}
 	}
@@ -85,9 +85,9 @@ func (cs *ConsensusSet) revertToNode(bn *blockNode) (revertedNodes []*blockNode)
 }
 
 // applyUntilNode will successively apply the blocks between the consensus
-// set's currentPath and 'bn'.
+// set's current path and 'bn'.
 func (s *ConsensusSet) applyUntilNode(bn *blockNode) (appliedNodes []*blockNode, err error) {
-	// Backtrack to the common parent of 'bn' and currentPath and then apply the new nodes.
+	// Backtrack to the common parent of 'bn' and current path and then apply the new nodes.
 	newPath := s.backtrackToCurrentPath(bn)
 	for _, node := range newPath[1:] {
 		// If the diffs for this node have already been generated, apply diffs

--- a/modules/consensus/fork.go
+++ b/modules/consensus/fork.go
@@ -20,7 +20,7 @@ func (cs *ConsensusSet) deleteNode(bn *blockNode) {
 	// Sanity check - the node being deleted should not be in the current path.
 	if build.DEBUG {
 		if types.BlockHeight(cs.db.pathHeight()) > bn.height &&
-			cs.db.path(bn.height) == bn.block.ID() {
+			cs.db.getPath(bn.height) == bn.block.ID() {
 			panic(errDeleteCurrentPath)
 		}
 	}
@@ -55,7 +55,7 @@ func (cs *ConsensusSet) backtrackToCurrentPath(bn *blockNode) []*blockNode {
 	path := []*blockNode{bn}
 	for {
 		// Stop when we reach the common parent.
-		if bn.height <= cs.height() && cs.db.path(bn.height) == bn.block.ID() {
+		if bn.height <= cs.height() && cs.db.getPath(bn.height) == bn.block.ID() {
 			break
 		}
 		bn = bn.parent
@@ -70,7 +70,7 @@ func (cs *ConsensusSet) backtrackToCurrentPath(bn *blockNode) []*blockNode {
 func (cs *ConsensusSet) revertToNode(bn *blockNode) (revertedNodes []*blockNode) {
 	// Sanity check - make sure that bn is in the current path.
 	if build.DEBUG {
-		if cs.height() < bn.height || cs.db.path(bn.height) != bn.block.ID() {
+		if cs.height() < bn.height || cs.db.getPath(bn.height) != bn.block.ID() {
 			panic(errExternalRevert)
 		}
 	}

--- a/modules/consensus/info.go
+++ b/modules/consensus/info.go
@@ -23,7 +23,7 @@ func (s *ConsensusSet) currentBlockNode() *blockNode {
 
 // height returns the current height of the state.
 func (s *ConsensusSet) height() types.BlockHeight {
-	return s.db.pathHeight() - 1
+	return s.blocksLoaded
 }
 
 // CurrentBlock returns the highest block on the tallest fork.

--- a/modules/consensus/info.go
+++ b/modules/consensus/info.go
@@ -13,7 +13,7 @@ type ConsensusSetInfo struct {
 
 // currentBlockID returns the ID of the current block.
 func (cs *ConsensusSet) currentBlockID() types.BlockID {
-	return cs.currentPath[cs.height()]
+	return cs.db.path(cs.height())
 }
 
 // currentBlockNode returns the blockNode of the current block.
@@ -23,7 +23,7 @@ func (s *ConsensusSet) currentBlockNode() *blockNode {
 
 // height returns the current height of the state.
 func (s *ConsensusSet) height() types.BlockHeight {
-	return types.BlockHeight(len(s.currentPath) - 1)
+	return s.db.pathHeight() - 1
 }
 
 // CurrentBlock returns the highest block on the tallest fork.
@@ -67,7 +67,7 @@ func (s *ConsensusSet) EarliestChildTimestamp(bid types.BlockID) (timestamp type
 func (s *ConsensusSet) GenesisBlock() types.Block {
 	lockID := s.mu.RLock()
 	defer s.mu.RUnlock(lockID)
-	return s.blockMap[s.currentPath[0]].block
+	return s.blockMap[s.db.path(0)].block
 }
 
 // Height returns the height of the current blockchain (the longest fork).
@@ -87,7 +87,7 @@ func (s *ConsensusSet) InCurrentPath(bid types.BlockID) bool {
 	if !exists {
 		return false
 	}
-	return s.currentPath[node.height] == bid
+	return s.db.path(node.height) == bid
 }
 
 // StorageProofSegment returns the segment to be used in the storage proof for

--- a/modules/consensus/info.go
+++ b/modules/consensus/info.go
@@ -13,7 +13,7 @@ type ConsensusSetInfo struct {
 
 // currentBlockID returns the ID of the current block.
 func (cs *ConsensusSet) currentBlockID() types.BlockID {
-	return cs.db.path(cs.height())
+	return cs.db.getPath(cs.height())
 }
 
 // currentBlockNode returns the blockNode of the current block.
@@ -67,7 +67,7 @@ func (s *ConsensusSet) EarliestChildTimestamp(bid types.BlockID) (timestamp type
 func (s *ConsensusSet) GenesisBlock() types.Block {
 	lockID := s.mu.RLock()
 	defer s.mu.RUnlock(lockID)
-	return s.blockMap[s.db.path(0)].block
+	return s.blockMap[s.db.getPath(0)].block
 }
 
 // Height returns the height of the current blockchain (the longest fork).
@@ -87,7 +87,7 @@ func (s *ConsensusSet) InCurrentPath(bid types.BlockID) bool {
 	if !exists {
 		return false
 	}
-	return s.db.path(node.height) == bid
+	return s.db.getPath(node.height) == bid
 }
 
 // StorageProofSegment returns the segment to be used in the storage proof for

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -16,7 +16,7 @@ func (cs *ConsensusSet) initSetDB() error {
 	if err != nil {
 		return err
 	}
-	err = cs.db.addPath(cs.blockRoot.block)
+	err = cs.db.addPath(cs.blockRoot.block.ID())
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (cs *ConsensusSet) load(saveDir string) error {
 	// Check that the db's genesis block matches our genesis block.
 	bID := cs.db.getPath(0)
 	// If this happens, print a warning and start a new db.
-	if bid != cs.currentPath[0] {
+	if bid != cs.blockRoot.block.ID() {
 		println("WARNING: blockchain has wrong genesis block. A new blockchain will be created.")
 		cs.db.Close()
 		err = os.Rename(filepath.Join(saveDir, "set.db"), filepath.Join(saveDir, "set.db.bck"))

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -80,7 +80,8 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 		// Blocks loaded from disk are trusted, don't bother with verification.
 		lockID := cs.mu.Lock()
-		// This gaurd is for when the program is stopped. It is temporary.
+		// This guard is for when the program is stopped. It is temporary.
+		// DEPRICATED
 		if !cs.db.open {
 			break
 		}

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -16,7 +16,7 @@ func (cs *ConsensusSet) initSetDB() error {
 	if err != nil {
 		return err
 	}
-	err = cs.db.addPath(cs.blockRoot.block.ID())
+	err = cs.db.pushPath(cs.blockRoot.block.ID())
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (cs *ConsensusSet) load(saveDir string) error {
 	}
 
 	// Check that the db's genesis block matches our genesis block.
-	bID := cs.db.getPath(0)
+	bid := cs.db.getPath(0)
 	// If this happens, print a warning and start a new db.
 	if bid != cs.blockRoot.block.ID() {
 		println("WARNING: blockchain has wrong genesis block. A new blockchain will be created.")
@@ -61,7 +61,7 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 	// The state cannot be easily reverted to a point where the
 	// consensusSetHash can be re-made. Load from disk instead
-	pb, err := cs.db.getBlockMap(bID)
+	pb, err := cs.db.getBlockMap(bid)
 	if err != nil {
 		return err
 	}
@@ -71,8 +71,8 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 	// load blocks from the db, starting after the genesis block
 	for i := types.BlockHeight(1); i < height; i++ {
-		bID := cs.db.getPath(i)
-		pb, err := cs.db.getBlockMap(bID)
+		bid := cs.db.getPath(i)
+		pb, err := cs.db.getBlockMap(bid)
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 		// Blocks loaded from disk are trusted, don't bother with verification.
 		lockID := cs.mu.Lock()
-		// This gaurd is for when the program is stopped
+		// This gaurd is for when the program is stopped. It is temporary.
 		if !cs.db.open {
 			break
 		}

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -20,6 +20,8 @@ func (cs *ConsensusSet) initSetDB() error {
 	if err != nil {
 		return err
 	}
+	// Explicit initilization preferred to implicit
+	cs.blocksLoaded = 0
 	if build.DEBUG {
 		cs.blockRoot.consensusSetHash = cs.consensusSetHash()
 	}
@@ -64,6 +66,8 @@ func (cs *ConsensusSet) load(saveDir string) error {
 		return err
 	}
 	cs.blockRoot.consensusSetHash = pb.ConsensusSetHash
+	// Explicit initilization preferred to implicit
+	cs.blocksLoaded = 0
 
 	// load blocks from the db, starting after the genesis block
 	for i := types.BlockHeight(1); i < height; i++ {
@@ -76,6 +80,10 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 		// Blocks loaded from disk are trusted, don't bother with verification.
 		lockID := cs.mu.Lock()
+		// This gaurd is for when the program is stopped
+		if !cs.db.open {
+			break
+		}
 		cs.blockMap[bn.block.ID()] = &bn
 		cs.updatePath = false
 		cs.commitDiffSet(&bn, modules.DiffApply)

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -20,20 +20,14 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 	// Check the height. If the height is 0, then it's a new file and the
 	// genesis block should be added.
-	height, err := db.pathHeight()
-	if err != nil {
-		return err
-	}
+	height := db.pathHeight()
 	if height == 0 {
 		// add genesis block
 		return db.pushPath(cs.blockRoot.block)
 	}
 
 	// Check that the db's genesis block matches our genesis block.
-	bid, err := db.getPath(0)
-	if err != nil {
-		return err
-	}
+	bID := db.getPath(0)
 	// If this happens, print a warning and start a new db.
 	if bid != cs.currentPath[0] {
 		println("WARNING: blockchain has wrong genesis block. A new blockchain will be created.")
@@ -49,12 +43,8 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 	// load blocks from the db, starting after the genesis block
 	for i := types.BlockHeight(1); i < height; i++ {
-		bid, err := db.getPath(i)
-		if err != nil {
-			// should never happen
-			return err
-		}
-		pb, err := db.getBlockMap(bid)
+		bID := db.getPath(i)
+		pb, err := db.getBlockMap(bID)
 		if err != nil {
 			return err
 		}

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -205,19 +205,25 @@ func (db *setDB) popPath() error {
 }
 
 // path retreives the block id of a block at a given hegiht from the path
-func (db *setDB) getPath(h types.BlockHeight) (id types.BlockID, err error) {
+func (db *setDB) getPath(h types.BlockHeight) (id types.BlockID) {
 	idBytes, err := db.getItem("Path", h)
 	if err != nil {
-		return
+		panic(err)
 	}
 	err = encoding.Unmarshal(idBytes, &id)
+	if err != nil {
+		panic(err)
+	}
 	return
 }
 
 // pathHeight returns the size of the current path
-func (db *setDB) pathHeight() (types.BlockHeight, error) {
+func (db *setDB) pathHeight() types.BlockHeight {
 	h, err := db.BucketSize("Path")
-	return types.BlockHeight(h), err
+	if err != nil {
+		panic(err)
+	}
+	return types.BlockHeight(h)
 }
 
 // addBlockMap adds a block node to the block map

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -59,8 +59,7 @@ type processedBlock struct {
 // DEPRECATED
 func bnToPb(bn blockNode) processedBlock {
 	pb := processedBlock{
-		Block:  bn.block,
-		Parent: bn.parent.block.ID(),
+		Block: bn.block,
 
 		Height:      bn.height,
 		Depth:       bn.depth,
@@ -78,6 +77,10 @@ func bnToPb(bn blockNode) processedBlock {
 	for _, c := range bn.children {
 		pb.Children = append(pb.Children, c.block.ID())
 	}
+	if bn.parent != nil {
+		pb.Parent = bn.parent.block.ID()
+	}
+
 	return pb
 }
 

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -188,8 +188,8 @@ func (db *setDB) getItem(bucket string, key interface{}) (item []byte, err error
 
 // pushPath inserts a block into the database at the "end" of the chain, i.e.
 // the current height + 1.
-func (db *setDB) pushPath(block types.Block) error {
-	value := encoding.Marshal(block.ID())
+func (db *setDB) pushPath(bid types.BlockID) error {
+	value := encoding.Marshal(bid)
 	return db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("Path"))
 		key := encoding.EncUint64(uint64(b.Stats().KeyN))
@@ -207,7 +207,7 @@ func (db *setDB) popPath() error {
 	})
 }
 
-// path retreives the block id of a block at a given hegiht from the path
+// getPath retreives the block id of a block at a given hegiht from the path
 func (db *setDB) getPath(h types.BlockHeight) (id types.BlockID) {
 	idBytes, err := db.getItem("Path", h)
 	if err != nil {

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -27,6 +27,9 @@ var (
 // consensus set
 type setDB struct {
 	*persist.BoltDatabase
+	// The open flag is used to prevent reading from the database
+	// after closing sia when the loading loop is still running
+	open bool
 }
 
 // processedBlock is a copy/rename of blockNode, with the pointers to
@@ -135,7 +138,7 @@ func openDB(filename string) (*setDB, error) {
 		}
 		return nil
 	})
-	return &setDB{db}, nil
+	return &setDB{db, true}, nil
 }
 
 // addItem should only be called from this file, and adds a new item

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -29,7 +29,7 @@ type setDB struct {
 	*persist.BoltDatabase
 	// The open flag is used to prevent reading from the database
 	// after closing sia when the loading loop is still running
-	open bool
+	open bool // DEPRECATED
 }
 
 // processedBlock is a copy/rename of blockNode, with the pointers to

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -71,7 +71,7 @@ func (s *ConsensusSet) blockHistory() (blockIDs [32]types.BlockID) {
 	knownBlocks := make([]types.BlockID, 0, 32)
 	step := types.BlockHeight(1)
 	for height := s.height(); ; height -= step {
-		knownBlocks = append(knownBlocks, s.db.path(height))
+		knownBlocks = append(knownBlocks, s.db.getPath(height))
 
 		// after 12, start doubling
 		if len(knownBlocks) >= 12 {
@@ -85,7 +85,7 @@ func (s *ConsensusSet) blockHistory() (blockIDs [32]types.BlockID) {
 		}
 	}
 	// always include the genesis block
-	knownBlocks = append(knownBlocks, s.db.path(0))
+	knownBlocks = append(knownBlocks, s.db.getPath(0))
 
 	copy(blockIDs[:], knownBlocks)
 	return
@@ -110,7 +110,7 @@ func (s *ConsensusSet) sendBlocks(conn modules.PeerConn) error {
 	lockID := s.mu.RLock()
 	for _, id := range knownBlocks {
 		bn, exists := s.blockMap[id]
-		if exists && bn.height <= s.height() && id == s.db.path(bn.height) {
+		if exists && bn.height <= s.height() && id == s.db.getPath(bn.height) {
 			found = true
 			start = bn.height + 1 // start at child
 			break
@@ -140,7 +140,7 @@ func (s *ConsensusSet) sendBlocks(conn modules.PeerConn) error {
 			height := s.height()
 			// TODO: unit test for off-by-one errors here
 			for i := start; i <= height && i < start+MaxCatchUpBlocks; i++ {
-				node, exists := s.blockMap[s.db.path(i)]
+				node, exists := s.blockMap[s.db.getPath(i)]
 				if build.DEBUG && !exists {
 					panic("blockMap is missing a block whose ID is in the current path")
 				}

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"errors"
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -43,6 +44,9 @@ func (s *ConsensusSet) receiveBlocks(conn modules.PeerConn) error {
 			// Blocks received during synchronize aren't trusted; activate full
 			// verification.
 			lockID := s.mu.Lock()
+			if !s.db.open {
+				return errors.New("database not open")
+			}
 			s.verificationRigor = fullVerification
 			acceptErr := s.acceptBlock(block)
 			s.mu.Unlock(lockID)

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -62,7 +62,7 @@ func (cs *ConsensusSet) storageProofSegment(fcid types.FileContractID) (index ui
 	if triggerHeight > cs.height() {
 		return 0, ErrUnfinishedFileContract
 	}
-	triggerID := cs.currentPath[triggerHeight]
+	triggerID := cs.db.path(triggerHeight)
 
 	// Get the index by appending the file contract ID to the trigger block and
 	// taking the hash, then converting the hash to a numerical value and

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -62,7 +62,7 @@ func (cs *ConsensusSet) storageProofSegment(fcid types.FileContractID) (index ui
 	if triggerHeight > cs.height() {
 		return 0, ErrUnfinishedFileContract
 	}
-	triggerID := cs.db.path(triggerHeight)
+	triggerID := cs.db.getPath(triggerHeight)
 
 	// Get the index by appending the file contract ID to the trigger block and
 	// taking the hash, then converting the hash to a numerical value and


### PR DESCRIPTION
In short, moves the currentPath structure in consensus to disk, and fixes associated bugs.

Proposal for error handling: panic on read, and error catch on writes. We do a fair amount of verification when modifying the structures, so it makes sense to use this existing structure. Ideally, database inconsistencies would be caught on write where they can be handled more elegantly (e.g. rejecting a call to acceptBlock).

Also worth noting that this is on top of the Set db pull request.