### PR TITLE
Use database for some of block map

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -99,6 +99,10 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block) (revertedNodes, appliedNod
 
 	newNode := parentNode.newChild(b)
 	cs.blockMap[b.ID()] = newNode
+	err = cs.db.addBlockMap(*newNode)
+	if err != nil {
+		return nil, nil, err
+	}
 	if newNode.heavierThan(cs.currentBlockNode()) {
 		return cs.forkBlockchain(newNode)
 	}

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -375,5 +375,12 @@ func (cs *ConsensusSet) generateAndApplyDiff(bn *blockNode) error {
 	if build.DEBUG {
 		bn.consensusSetHash = cs.consensusSetHash()
 	}
+
+	// Replace the unprocessed block in the block map with a processed one
+	err = cs.db.rmBlockMap(bn.block.ID())
+	if err != nil {
+		return err
+	}
+
 	return cs.db.addBlockMap(*bn)
 }

--- a/modules/consensus/fork.go
+++ b/modules/consensus/fork.go
@@ -33,6 +33,7 @@ func (cs *ConsensusSet) deleteNode(bn *blockNode) {
 	// Remove the node from the block map, and from its parents list of
 	// children.
 	delete(cs.blockMap, bn.block.ID())
+	cs.db.rmBlockMap(bn.block.ID())
 	for i := range bn.parent.children {
 		if bn.parent.children[i] == bn {
 			// If 'i' is not the last element, remove it from the array by

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -61,21 +61,23 @@ func (cs *ConsensusSet) load(saveDir string) error {
 
 	// The state cannot be easily reverted to a point where the
 	// consensusSetHash can be re-made. Load from disk instead
-	pb, err := cs.db.getBlockMap(bid)
-	if err != nil {
-		return err
-	}
+	pb := cs.db.getBlockMap(bid)
+
 	cs.blockRoot.consensusSetHash = pb.ConsensusSetHash
 	// Explicit initilization preferred to implicit
 	cs.blocksLoaded = 0
 
+	return nil
+}
+
+// loadDiffs is a transitional function to load the processed blocks
+// from disk and move the diffs into memory
+func (cs *ConsensusSet) loadDiffs() {
+	height := cs.db.pathHeight()
 	// load blocks from the db, starting after the genesis block
 	for i := types.BlockHeight(1); i < height; i++ {
 		bid := cs.db.getPath(i)
-		pb, err := cs.db.getBlockMap(bid)
-		if err != nil {
-			return err
-		}
+		pb := cs.db.getBlockMap(bid)
 		bn := cs.pbToBn(pb)
 
 		// Blocks loaded from disk are trusted, don't bother with verification.
@@ -92,5 +94,4 @@ func (cs *ConsensusSet) load(saveDir string) error {
 		cs.updateSubscribers(nil, []*blockNode{&bn})
 		cs.mu.Unlock(lockID)
 	}
-	return nil
 }

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -87,7 +87,7 @@ func (cs *ConsensusSet) loadDiffs() {
 		if !cs.db.open {
 			break
 		}
-		cs.blockMap[bn.block.ID()] = &bn
+		cs.blockMap[bn.block.ID()] = &bn // DEPRICATED
 		cs.updatePath = false
 		cs.commitDiffSet(&bn, modules.DiffApply)
 		cs.updatePath = true

--- a/modules/consensus/persist_test.go
+++ b/modules/consensus/persist_test.go
@@ -1,0 +1,38 @@
+package consensus
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// TestSaveLoad populates a blockchain, saves it, loads it, and checks
+// the consensus set hash before and after
+func TestSaveLoad(t *testing.T) {
+	cst, err := createConsensusSetTester("TestSaveLoad")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cst.complexBlockSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldHash := cst.cs.consensusSetHash()
+	cst.cs.Close()
+
+	// Reassigning this will loose subscribers and such, but we
+	// just want to call load and get a hash
+	d := filepath.Join(build.SiaTestingDir, filepath.Join(modules.ConsensusDir, filepath.Join("TestSaveLoad", modules.ConsensusDir)))
+	cst.cs, err = New(cst.gateway, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newHash := cst.cs.consensusSetHash()
+	if oldHash != newHash {
+		t.Fatal("consensus set hash changed after load")
+	}
+}

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -93,7 +93,7 @@ func bnToPb(bn blockNode) processedBlock {
 func (cs *ConsensusSet) pbToBn(pb *processedBlock) blockNode {
 	parent, exists := cs.blockMap[pb.Parent]
 	if !exists {
-		panic("block parent not in consensus set")
+		parent = nil
 	}
 
 	bn := blockNode{
@@ -186,7 +186,26 @@ func (db *setDB) getItem(bucket string, key interface{}) (item []byte, err error
 		}
 		return nil
 	})
-	return
+	return item, err
+}
+
+func (db *setDB) rmItem(bucket string, key interface{}) error {
+	k := encoding.Marshal(key)
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucket))
+		if build.DEBUG {
+			// Sanity check to make sure the bucket exists.
+			if b == nil {
+				panic(errNilBucket)
+			}
+			// Sanity check to make sure you are deleting an item that exists
+			item := b.Get(k)
+			if item == nil {
+				panic(errNilItem)
+			}
+		}
+		return b.Delete(k)
+	})
 }
 
 // pushPath inserts a block into the database at the "end" of the chain, i.e.
@@ -233,19 +252,34 @@ func (db *setDB) pathHeight() types.BlockHeight {
 }
 
 // addBlockMap adds a block node to the block map
+// This will eventually take a processed block as an argument
 func (db *setDB) addBlockMap(bn blockNode) error {
 	return db.addItem("BlockMap", bn.block.ID(), bnToPb(bn))
 }
 
-// Function needs to have access to the blockMap inside consensusSet
-// because bnFromPb requires the parent ID. This could be fixed at
-// some point, as this function really should be part of setDB
-func (db *setDB) getBlockMap(id types.BlockID) (*processedBlock, error) {
+// getBlockMap queries the set database to return a processedBlock
+// with the given ID
+func (db *setDB) getBlockMap(id types.BlockID) *processedBlock {
 	bnBytes, err := db.getItem("BlockMap", id)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	var pb processedBlock
 	err = encoding.Unmarshal(bnBytes, &pb)
-	return &pb, err
+	if err != nil {
+		panic(err)
+	}
+	return &pb
+}
+
+// getBlockMapBn is a transitional wrapper for getting a block node
+// from the blockMap
+func (cs *ConsensusSet) getBlockMapBn(id types.BlockID) *blockNode {
+	bn := cs.pbToBn(cs.db.getBlockMap(id))
+	return &bn
+}
+
+// rmBlockMap removes a processedBlock from the blockMap bucket
+func (db *setDB) rmBlockMap(id types.BlockID) error {
+	return db.rmItem("BlockMap", id)
 }

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -24,13 +24,7 @@ func (cs *ConsensusSet) computeConsensusChange(i int) (cc modules.ConsensusChang
 	}
 
 	for _, revertedBlockID := range cs.changeLog[i].revertedBlocks {
-		revertedNode, exists := cs.blockMap[revertedBlockID]
-		// Sanity check - node should exist.
-		if build.DEBUG {
-			if !exists {
-				panic("grabbed a node that does not exist during a consensus change")
-			}
-		}
+		revertedNode := cs.getBlockMapBn(revertedBlockID)
 
 		// Because the direction is 'revert', the order of the diffs needs to
 		// be flipped and the direction of the diffs also needs to be flipped.
@@ -62,13 +56,7 @@ func (cs *ConsensusSet) computeConsensusChange(i int) (cc modules.ConsensusChang
 		}
 	}
 	for _, appliedBlockID := range cs.changeLog[i].appliedBlocks {
-		appliedNode, exists := cs.blockMap[appliedBlockID]
-		// Sanity check - node should exist.
-		if build.DEBUG {
-			if !exists {
-				panic("grabbed a node that does not exist during a consensus change")
-			}
-		}
+		appliedNode := cs.getBlockMapBn(appliedBlockID)
 
 		cc.AppliedBlocks = append(cc.AppliedBlocks, appliedNode.block)
 		for _, scod := range appliedNode.siacoinOutputDiffs {


### PR DESCRIPTION
Unfortunately, I can't completely get rid of cs.blockMap until I replace blockNode with processedBlock. 

As they are mostly different things, I'm attempting to make them separate pull requests.

This PR also changes the load sequence slightly, by opening the database, then returning to do the genesis block announcement, then loading all the diffs from the database.