### PR TITLE
/wallet/status VisibleAddresses gives empty array

### DIFF
--- a/modules/wallet/info.go
+++ b/modules/wallet/info.go
@@ -11,8 +11,9 @@ import (
 // Info fills out and returns a WalletInfo struct.
 func (w *Wallet) Info() modules.WalletInfo {
 	wi := modules.WalletInfo{
-		Balance:     w.Balance(false),
-		FullBalance: w.Balance(true),
+		Balance:          w.Balance(false),
+		FullBalance:      w.Balance(true),
+		VisibleAddresses: []types.UnlockHash{},
 	}
 
 	counter := w.mu.RLock()


### PR DESCRIPTION
Before it would give nil, as I found from JS errors on the front end

There are at least 10 other instances of `[]` using `ctrl+f` across `API.md`. I'm not sure I'm the best person though to make all the changes for the API endpoints to return empty slices instead of nil.