### PR TITLE
Move Delayed Siacoin Outputs to disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,27 +75,27 @@ test: clean fmt REBUILD
 test-v: clean fmt REBUILD
 	go test -race -v -short -tags='debug testing' -timeout=20s $(pkgs)
 test-long: clean fmt REBUILD
-	go test -v -race -tags='testing debug' -timeout=180s $(pkgs)
+	go test -v -race -tags='testing debug' -timeout=360s $(pkgs)
 bench: clean fmt REBUILD
 	go test -tags='testing' -timeout=120s -run=XXX -bench=. $(pkgs)
 cover: clean REBUILD
 	@mkdir -p cover/modules
 	@for package in $(pkgs); do                                                                                     \
-		go test -tags='testing debug' -timeout=180s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		go test -tags='testing debug' -timeout=360s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
 		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html                                          \
 		&& rm cover/$$package.out ;                                                                                 \
 	done
 cover-integration: clean REBUILD
 	@mkdir -p cover/modules
 	@for package in $(pkgs); do                                                                                     \
-		go test -run=TestIntegration -tags='testing debug' -timeout=180s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		go test -run=TestIntegration -tags='testing debug' -timeout=360s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
 		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html                                          \
 		&& rm cover/$$package.out ;                                                                                 \
 	done
 cover-unit: clean REBUILD
 	@mkdir -p cover/modules
 	@for package in $(pkgs); do                                                                                     \
-		go test -run=TestUnit -tags='testing debug' -timeout=180s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		go test -run=TestUnit -tags='testing debug' -timeout=360s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
 		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html                                          \
 		&& rm cover/$$package.out ;                                                                                 \
 	done

--- a/modules/consensus/applytransaction.go
+++ b/modules/consensus/applytransaction.go
@@ -155,7 +155,7 @@ func (cs *ConsensusSet) applyStorageProofs(pb *processedBlock, t types.Transacti
 			// Sanity check - output should not already exist.
 			spoid := sp.ParentID.StorageProofOutputID(types.ProofValid, uint64(i))
 			if build.DEBUG {
-				_, exists := cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid]
+				exists := cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid)
 				if exists {
 					panic(ErrDuplicateValidProofOutput)
 				}

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -504,10 +504,11 @@ func TestApplyStorageProofs(t *testing.T) {
 		t.Error("wrong id used when revising a file contract")
 	}
 	spoid0 := fcid0.StorageProofOutputID(types.ProofValid, 0)
-	sco, exists := cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid0]
+	exists = cst.cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid0)
 	if !exists {
 		t.Error("storage proof output not created after applying a storage proof")
 	}
+	sco := cst.cs.db.getDelayedSiacoinOutputs(pb.Height+types.MaturityDelay, spoid0)
 	if sco.Value.Cmp(types.NewCurrency64(290e3)) != 0 {
 		t.Error("storage proof output was created with the wrong value")
 	}
@@ -540,18 +541,20 @@ func TestApplyStorageProofs(t *testing.T) {
 		t.Error("output created when file contract had no corresponding output")
 	}
 	spoid2 := fcid2.StorageProofOutputID(types.ProofValid, 0)
-	sco, exists = cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid2]
+	exists = cst.cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid2)
 	if !exists {
 		t.Error("no output created by first output of file contract")
 	}
+	sco = cst.cs.db.getDelayedSiacoinOutputs(pb.Height+types.MaturityDelay, spoid2)
 	if sco.Value.Cmp(types.NewCurrency64(280e3)) != 0 {
 		t.Error("first siacoin output created has wrong value")
 	}
 	spoid3 := fcid2.StorageProofOutputID(types.ProofValid, 1)
-	sco, exists = cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid3]
+	exists = cst.cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid3)
 	if !exists {
 		t.Error("second output not created for storage proof")
 	}
+	sco = cst.cs.db.getDelayedSiacoinOutputs(pb.Height+types.MaturityDelay, spoid3)
 	if sco.Value.Cmp(types.NewCurrency64(300e3)) != 0 {
 		t.Error("second siacoin output has wrong value")
 	}
@@ -681,7 +684,7 @@ func TestApplySiafundInputs(t *testing.T) {
 	if pb.SiafundOutputDiffs[0].ID != ids[0] {
 		t.Error("wrong id used when consuming a siafund output")
 	}
-	if len(cst.cs.delayedSiacoinOutputs[cst.cs.height()+types.MaturityDelay]) != 2 { // 1 for a block subsidy, 1 for the siafund claim.
+	if cst.cs.db.lenDelayedSiacoinOutputsHeight(cst.cs.height()+types.MaturityDelay) != 2 { // 1 for a block subsidy, 1 for the siafund claim.
 		t.Error("siafund claim was not created")
 	}
 }

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -44,23 +44,10 @@ type ConsensusSet struct {
 	// prove
 	dosBlocks map[types.BlockID]struct{}
 
-	// These are the consensus variables. All nodes with the same current path
-	// will also have these variables matching.
-	//
 	// The siafundPool tracks the total number of siacoins that have been
 	// taxed from file contracts. Unless a reorg occurs, the siafundPool
 	// should never decrease.
-	//
-	// siacoinOutputs, fileContracts, and siafundOutputs keep track of the
-	// unspent outputs and active contracts present in the current path. If an
-	// output is spent or a contract expires, it is removed from the consensus
-	// set. These objects may also be removed in the event of a reorg.
-	//
-	// delayedSiacoinOutputs are siacoin outputs that have been created in a
-	// block, but are not allowed to be spent until a certain height. When
-	// that height is reached, they are moved to the siacoinOutputs map.
-	siafundPool           types.Currency
-	delayedSiacoinOutputs map[types.BlockHeight]map[types.SiacoinOutputID]types.SiacoinOutput
+	siafundPool types.Currency
 
 	// fileContractExpirations is not actually a part of the consensus set, but
 	// it is needed to get decent order notation on the file contract lookups.
@@ -75,8 +62,18 @@ type ConsensusSet struct {
 	changeLog   []changeEntry
 	subscribers []modules.ConsensusSetSubscriber
 
-	// block database, used for saving/loading the current path,
-	// and storing processed blocks
+	// The set database stores the consensus set on disk. The
+	// variables it contains are siacoinOutputs, fileContracts,
+	// and siafundOutputs. They keep track of the unspent outputs
+	// and active contracts present in the current path. If an
+	// output is spent or a contract expires, it is removed from
+	// the consensus set.
+	//
+	// It also holds delayedSiacoinOutputs, which are siacoin
+	// outputs that have been created in a block, but are not
+	// allowed to be spent until a certain height. When that
+	// height is reached, they are moved to the siacoinOutputs
+	// map.
 	db *setDB
 
 	// gateway, for receiving/relaying blocks to/from peers
@@ -102,8 +99,6 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 	// Create the ConsensusSet object.
 	cs := &ConsensusSet{
 		dosBlocks: make(map[types.BlockID]struct{}),
-
-		delayedSiacoinOutputs: make(map[types.BlockHeight]map[types.SiacoinOutputID]types.SiacoinOutput),
 
 		fileContractExpirations: make(map[types.BlockHeight]map[types.FileContractID]struct{}),
 

--- a/modules/consensus/consistency.go
+++ b/modules/consensus/consistency.go
@@ -200,7 +200,7 @@ func (cs *ConsensusSet) consensusSetHash() crypto.Hash {
 		}
 		sort.Sort(delayedSiacoinOutputs)
 		for _, delayedSiacoinOutputID := range delayedSiacoinOutputs {
-			delayedSiacoinOutput, _ := cs.delayedSiacoinOutputs[i][types.SiacoinOutputID(delayedSiacoinOutputID)]
+			delayedSiacoinOutput := cs.db.getDelayedSiacoinOutputs(i, types.SiacoinOutputID(delayedSiacoinOutputID))
 			tree.PushObject(delayedSiacoinOutput)
 			tree.PushObject(delayedSiacoinOutputID)
 		}

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -96,6 +96,7 @@ func (cs *ConsensusSet) applyMaturedSiacoinOutputs(pb *processedBlock) {
 		}
 	}
 	delete(cs.delayedSiacoinOutputs, pb.Height)
+	cs.db.rmDelayedSiacoinOutputs(pb.Height)
 }
 
 // applyMissedStorageProof adds the outputs and diffs that result from a file

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -105,7 +105,6 @@ func (cs *ConsensusSet) applyMaturedSiacoinOutputs(pb *processedBlock) {
 			panic("deleting non-empty map")
 		}
 	}
-	delete(cs.delayedSiacoinOutputs, pb.Height)
 	cs.db.rmDelayedSiacoinOutputs(pb.Height)
 }
 

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -23,7 +23,7 @@ func (cs *ConsensusSet) applyMinerPayouts(pb *processedBlock) {
 		mpid := pb.Block.MinerPayoutID(uint64(i))
 		if build.DEBUG {
 			// Check the delayed outputs set.
-			_, exists := cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][mpid]
+			exists := cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, mpid)
 			if exists {
 				panic(errPayoutsAlreadyPaid)
 			}
@@ -57,8 +57,18 @@ func (cs *ConsensusSet) applyMaturedSiacoinOutputs(pb *processedBlock) {
 		return
 	}
 
+	// Gather the matured outputs from the delayed outputs map
+	var dscoids []types.SiacoinOutputID
+	var dscos []types.SiacoinOutput
+	cs.db.forEachDelayedSiacoinOutputsHeight(pb.Height, func(id types.SiacoinOutputID, sco types.SiacoinOutput) {
+		dscoids = append(dscoids, id)
+		dscos = append(dscos, sco)
+	})
 	// Add all of the matured outputs to the full siaocin output set.
-	for dscoid, dsco := range cs.delayedSiacoinOutputs[pb.Height] {
+	for i := 0; i < len(dscos); i++ {
+		dscoid := dscoids[i]
+		dsco := dscos[i]
+
 		// Sanity check - the output should not already be in siacoinOuptuts.
 		if build.DEBUG {
 			exists := cs.db.inSiacoinOutputs(dscoid)
@@ -91,7 +101,7 @@ func (cs *ConsensusSet) applyMaturedSiacoinOutputs(pb *processedBlock) {
 	// Delete the map that held the now-matured outputs.
 	// Sanity check - map should be empty.
 	if build.DEBUG {
-		if len(cs.delayedSiacoinOutputs[pb.Height]) != 0 {
+		if cs.db.lenDelayedSiacoinOutputsHeight(pb.Height) != 0 {
 			panic("deleting non-empty map")
 		}
 	}
@@ -116,7 +126,7 @@ func (cs *ConsensusSet) applyMissedStorageProof(pb *processedBlock, fcid types.F
 		// Sanity check - output should not already exist.
 		spoid := fcid.StorageProofOutputID(types.ProofMissed, uint64(i))
 		if build.DEBUG {
-			_, exists := cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid]
+			exists := cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid)
 			if exists {
 				panic(errPayoutsAlreadyPaid)
 			}

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -88,7 +88,6 @@ func TestApplyMinerPayouts(t *testing.T) {
 		if r != errPayoutsAlreadyPaid {
 			t.Error(r)
 		}
-		delete(cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay], mpid0)
 		cst.cs.db.rmDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, mpid0)
 		cst.cs.db.addSiacoinOutputs(mpid0, types.SiacoinOutput{})
 		cst.cs.applyMinerPayouts(pb)
@@ -117,9 +116,7 @@ func TestApplyMaturedSiacoinOutputs(t *testing.T) {
 		}
 	}()
 	cst.cs.db.addSiacoinOutputs(types.SiacoinOutputID{}, types.SiacoinOutput{})
-	cst.cs.delayedSiacoinOutputs[pb.Height] = make(map[types.SiacoinOutputID]types.SiacoinOutput)
 	cst.cs.db.addDelayedSiacoinOutputs(pb.Height)
-	cst.cs.delayedSiacoinOutputs[pb.Height][types.SiacoinOutputID{}] = types.SiacoinOutput{}
 	cst.cs.db.addDelayedSiacoinOutputsHeight(pb.Height, types.SiacoinOutputID{}, types.SiacoinOutput{})
 	cst.cs.applyMaturedSiacoinOutputs(pb)
 }
@@ -202,7 +199,6 @@ func TestApplyMissedStorageProof(t *testing.T) {
 		}
 
 		// Trigger errPayoutsAlreadyPaid from siacoin outputs.
-		delete(cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay], spoid)
 		cst.cs.db.rmDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid)
 		cst.cs.db.addSiacoinOutputs(spoid, types.SiacoinOutput{})
 		cst.cs.applyMissedStorageProof(pb, types.FileContractID{})
@@ -210,7 +206,6 @@ func TestApplyMissedStorageProof(t *testing.T) {
 	// Trigger errPayoutsAlreadyPaid from delayed outputs.
 	cst.cs.db.rmFileContracts(types.FileContractID{})
 	cst.cs.db.addFileContracts(types.FileContractID{}, expiringFC)
-	cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid] = types.SiacoinOutput{}
 	cst.cs.db.addDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid, types.SiacoinOutput{})
 	cst.cs.applyMissedStorageProof(pb, types.FileContractID{})
 }

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -88,6 +88,7 @@ func TestApplyMinerPayouts(t *testing.T) {
 			t.Error(r)
 		}
 		delete(cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay], mpid0)
+		cst.cs.db.rmDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, mpid0)
 		cst.cs.db.addSiacoinOutputs(mpid0, types.SiacoinOutput{})
 		cst.cs.applyMinerPayouts(pb)
 	}()
@@ -116,7 +117,9 @@ func TestApplyMaturedSiacoinOutputs(t *testing.T) {
 	}()
 	cst.cs.db.addSiacoinOutputs(types.SiacoinOutputID{}, types.SiacoinOutput{})
 	cst.cs.delayedSiacoinOutputs[pb.Height] = make(map[types.SiacoinOutputID]types.SiacoinOutput)
+	cst.cs.db.addDelayedSiacoinOutputs(pb.Height)
 	cst.cs.delayedSiacoinOutputs[pb.Height][types.SiacoinOutputID{}] = types.SiacoinOutput{}
+	cst.cs.db.addDelayedSiacoinOutputsHeight(pb.Height, types.SiacoinOutputID{}, types.SiacoinOutput{})
 	cst.cs.applyMaturedSiacoinOutputs(pb)
 }
 
@@ -199,6 +202,7 @@ func TestApplyMissedStorageProof(t *testing.T) {
 
 		// Trigger errPayoutsAlreadyPaid from siacoin outputs.
 		delete(cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay], spoid)
+		cst.cs.db.rmDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid)
 		cst.cs.db.addSiacoinOutputs(spoid, types.SiacoinOutput{})
 		cst.cs.applyMissedStorageProof(pb, types.FileContractID{})
 	}()
@@ -206,6 +210,7 @@ func TestApplyMissedStorageProof(t *testing.T) {
 	cst.cs.db.rmFileContracts(types.FileContractID{})
 	cst.cs.db.addFileContracts(types.FileContractID{}, expiringFC)
 	cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid] = types.SiacoinOutput{}
+	cst.cs.db.addDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid, types.SiacoinOutput{})
 	cst.cs.applyMissedStorageProof(pb, types.FileContractID{})
 }
 

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -28,10 +28,11 @@ func TestApplyMinerPayouts(t *testing.T) {
 
 	// Apply the single miner payout.
 	cst.cs.applyMinerPayouts(pb)
-	dsco, exists := cst.cs.delayedSiacoinOutputs[cst.cs.height()+types.MaturityDelay][mpid0]
+	exists := cst.cs.db.inDelayedSiacoinOutputsHeight(cst.cs.height()+types.MaturityDelay, mpid0)
 	if !exists {
 		t.Error("miner payout was not created in the delayed outputs set")
 	}
+	dsco := cst.cs.db.getDelayedSiacoinOutputs(cst.cs.height()+types.MaturityDelay, mpid0)
 	if dsco.Value.Cmp(types.NewCurrency64(12)) != 0 {
 		t.Error("miner payout created with wrong currency value")
 	}
@@ -39,7 +40,7 @@ func TestApplyMinerPayouts(t *testing.T) {
 	if exists {
 		t.Error("miner payout was added to the siacoin output set")
 	}
-	if len(cst.cs.delayedSiacoinOutputs[cst.cs.height()+types.MaturityDelay]) != 2 { // 1 for consensus set creation, 1 for the output that just got added.
+	if cst.cs.db.lenDelayedSiacoinOutputsHeight(cst.cs.height()+types.MaturityDelay) != 2 { // 1 for consensus set creation, 1 for the output that just got added.
 		t.Error("wrong number of delayed siacoin outputs in consensus set")
 	}
 	if len(pb.DelayedSiacoinOutputDiffs) != 1 {
@@ -63,11 +64,11 @@ func TestApplyMinerPayouts(t *testing.T) {
 	mpid1 := pb2.Block.MinerPayoutID(0)
 	mpid2 := pb2.Block.MinerPayoutID(1)
 	cst.cs.applyMinerPayouts(pb2)
-	_, exists = cst.cs.delayedSiacoinOutputs[cst.cs.height()+types.MaturityDelay][mpid1]
+	exists = cst.cs.db.inDelayedSiacoinOutputsHeight(cst.cs.height()+types.MaturityDelay, mpid1)
 	if !exists {
 		t.Error("delayed siacoin output was not created")
 	}
-	_, exists = cst.cs.delayedSiacoinOutputs[cst.cs.height()+types.MaturityDelay][mpid2]
+	exists = cst.cs.db.inDelayedSiacoinOutputsHeight(cst.cs.height()+types.MaturityDelay, mpid2)
 	if !exists {
 		t.Error("delayed siacoin output was not created")
 	}
@@ -155,7 +156,7 @@ func TestApplyMissedStorageProof(t *testing.T) {
 		t.Error("file contract was not consumed in missed storage proof")
 	}
 	spoid := types.FileContractID{}.StorageProofOutputID(types.ProofMissed, 0)
-	_, exists = cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid]
+	exists = cst.cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid)
 	if !exists {
 		t.Error("missed proof output was never created")
 	}
@@ -246,7 +247,7 @@ func TestApplyFileContractMaintenance(t *testing.T) {
 		t.Error("file contract was not consumed in missed storage proof")
 	}
 	spoid := types.FileContractID{}.StorageProofOutputID(types.ProofMissed, 0)
-	_, exists = cst.cs.delayedSiacoinOutputs[pb.Height+types.MaturityDelay][spoid]
+	exists = cst.cs.db.inDelayedSiacoinOutputsHeight(pb.Height+types.MaturityDelay, spoid)
 	if !exists {
 		t.Error("missed proof output was never created")
 	}

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -539,7 +539,7 @@ func (db *setDB) inDelayedSiacoinOutputsHeight(h types.BlockHeight, id types.Sia
 
 // rmDelayedSiacoinOutputs removes a height and its corresponding
 // bucket from the set of delayed siacoin outputs. The map must be empty
-func (db *setDB) rmDelayedSiacoinOutputs(h types.BlockHeight) error {
+func (db *setDB) rmDelayedSiacoinOutputs(h types.BlockHeight) {
 	bucketID := append(prefix_dsco, encoding.Marshal(h)...)
 	err := db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketID)
@@ -552,10 +552,12 @@ func (db *setDB) rmDelayedSiacoinOutputs(h types.BlockHeight) error {
 		return tx.DeleteBucket(bucketID)
 	})
 	if err != nil {
-		// Again tricky, since returning here could cause inconsistency.
-		return err
+		panic(err)
 	}
-	return db.rmItem("DelayedSiacoinOutputs", h)
+	err = db.rmItem("DelayedSiacoinOutputs", h)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // rmDelayedSiacoinOutputsHeight removes a siacoin output with a given ID at the given height

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -595,15 +594,6 @@ func (db *setDB) forEachDelayedSiacoinOutputsHeight(h types.BlockHeight, fn func
 		fn(key, value)
 		return nil
 	})
-}
-
-func printHeight(h []byte) {
-	var x types.BlockHeight
-	err := encoding.Unmarshal(h[len(prefix_dsco):], x)
-	if err != nil {
-		panic("Really bad bucket name: " + string(h))
-	}
-	fmt.Printf("scanning bucket %s%d\n", prefix_dsco, x)
 }
 
 // forEachDelayedSiacoinOutputs applies a function to every siacoin

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -67,7 +67,7 @@ func openDB(filename string) (*setDB, error) {
 }
 
 // startConsistencyGuard increments the first guard. If this is not
-// equal to the second, a transaction is taking place in the database
+// equal to the second, a transaction is taking place in the database.
 func (db *setDB) startConsistencyGuard() {
 	err := db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("Metadata"))

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -14,10 +14,10 @@ var (
 
 func init() {
 	if build.Release == "dev" {
-		SafeMutexDelay = 7 * time.Second
+		SafeMutexDelay = 14 * time.Second
 	} else if build.Release == "standard" {
-		SafeMutexDelay = 60 * time.Second
+		SafeMutexDelay = 120 * time.Second
 	} else if build.Release == "testing" {
-		SafeMutexDelay = 3 * time.Second
+		SafeMutexDelay = 6 * time.Second
 	}
 }


### PR DESCRIPTION
As this was a map inside of a map, I implemented this as one bucket pointing to the id's of a bunch of other buckets in the same root level. It feels silly, but this allowed me to use all of the functions already in the set database for modifying top level buckets, making the code a bit cleaner.