### PR TITLE
Finish moving structures to disk

### DIFF
--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -49,14 +49,6 @@ type ConsensusSet struct {
 	// should never decrease.
 	siafundPool types.Currency
 
-	// fileContractExpirations is not actually a part of the consensus set, but
-	// it is needed to get decent order notation on the file contract lookups.
-	// It is a map of heights to maps of file contract ids. The other table is
-	// needed because of file contract revisions - you need to have random
-	// access lookups to file contracts for when revisions are submitted to the
-	// blockchain.
-	fileContractExpirations map[types.BlockHeight]map[types.FileContractID]struct{}
-
 	// Modules subscribed to the consensus set will receive an ordered list of
 	// changes that occur to the consensus set, computed using the changeLog.
 	changeLog   []changeEntry
@@ -74,6 +66,15 @@ type ConsensusSet struct {
 	// allowed to be spent until a certain height. When that
 	// height is reached, they are moved to the siacoinOutputs
 	// map.
+	//
+	// The database also holds the file contract expirations.
+	// FileContractExpirations is not actually a part of the
+	// consensus set, but it is needed to get decent order
+	// notation on the file contract lookups.  It is a map of
+	// heights to maps of file contract ids. The other table is
+	// needed because of file contract revisions - you need to
+	// have random access lookups to file contracts for when
+	// revisions are submitted to the blockchain.
 	db *setDB
 
 	// gateway, for receiving/relaying blocks to/from peers
@@ -99,8 +100,6 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 	// Create the ConsensusSet object.
 	cs := &ConsensusSet{
 		dosBlocks: make(map[types.BlockID]struct{}),
-
-		fileContractExpirations: make(map[types.BlockHeight]map[types.FileContractID]struct{}),
 
 		gateway: gateway,
 

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -24,18 +24,6 @@ var (
 // consensus.  It accepts blocks and constructs a blockchain, forking when
 // necessary.
 type ConsensusSet struct {
-	// updateDatabase is a flag that determines if a block will be
-	// added to the database when commiting diffs. It should be
-	// false when loading the current path from disk and true
-	// otherwise
-	updateDatabase bool // DEPRECATED
-
-	// blocksLoaded is the number of blocks that have been loaded
-	// from memory. This variable only exists while some
-	// structures are still in memory, and should always equal
-	// db.pathHeight after loading from disk
-	blocksLoaded types.BlockHeight // DEPRECATED
-
 	// The blockRoot is the block node that contains the genesis block.
 	blockRoot *processedBlock
 
@@ -149,8 +137,6 @@ func New(gateway modules.Gateway, saveDir string) (*ConsensusSet, error) {
 
 	// Load the saved processed blocks into memory and send out updates
 	cs.loadDiffs()
-
-	cs.updateDatabase = true
 
 	// Register RPCs
 	gateway.RegisterRPC("SendBlocks", cs.sendBlocks)

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -75,6 +75,9 @@ func (cs *ConsensusSet) commitFileContractDiff(fcd modules.FileContractDiff, dir
 		_, exists := cs.fileContractExpirations[fcd.FileContract.WindowEnd]
 		if !exists {
 			cs.fileContractExpirations[fcd.FileContract.WindowEnd] = make(map[types.FileContractID]struct{})
+			if cs.updateDatabase {
+				cs.db.addFCExpirations(fcd.FileContract.WindowEnd)
+			}
 		}
 
 		// Sanity check - file contract expiration pointer should not already
@@ -86,6 +89,9 @@ func (cs *ConsensusSet) commitFileContractDiff(fcd modules.FileContractDiff, dir
 			}
 		}
 		cs.fileContractExpirations[fcd.FileContract.WindowEnd][fcd.ID] = struct{}{}
+		if cs.updateDatabase {
+			cs.db.addFCExpirationsHeight(fcd.FileContract.WindowEnd, fcd.ID)
+		}
 	} else {
 		if cs.updateDatabase {
 			cs.db.rmFileContracts(fcd.ID)
@@ -102,6 +108,9 @@ func (cs *ConsensusSet) commitFileContractDiff(fcd modules.FileContractDiff, dir
 			}
 		}
 		delete(cs.fileContractExpirations[fcd.FileContract.WindowEnd], fcd.ID)
+		if cs.updateDatabase {
+			cs.db.rmFCExpirationsHeight(fcd.FileContract.WindowEnd, fcd.ID)
+		}
 	}
 }
 

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -160,6 +160,7 @@ func (cs *ConsensusSet) commitSiafundPoolDiff(sfpd modules.SiafundPoolDiff, dir 
 			}
 		}
 		cs.siafundPool = sfpd.Adjusted
+		cs.db.updateSiafundPool(cs.siafundPool)
 	} else {
 		// Sanity check - sfpd.Adjusted should equal the current siafund pool.
 		if build.DEBUG {
@@ -168,6 +169,7 @@ func (cs *ConsensusSet) commitSiafundPoolDiff(sfpd modules.SiafundPoolDiff, dir 
 			}
 		}
 		cs.siafundPool = sfpd.Previous
+		cs.db.updateSiafundPool(cs.siafundPool)
 	}
 }
 

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -36,9 +36,6 @@ var (
 
 // commitSiacoinOutputDiff applies or reverts a SiacoinOutputDiff.
 func (cs *ConsensusSet) commitSiacoinOutputDiff(scod modules.SiacoinOutputDiff, dir modules.DiffDirection) {
-	if !cs.updateDatabase {
-		return
-	}
 	// Sanity check - should not be adding an output twice, or deleting an
 	// output that does not exist.
 	if build.DEBUG {
@@ -57,9 +54,6 @@ func (cs *ConsensusSet) commitSiacoinOutputDiff(scod modules.SiacoinOutputDiff, 
 
 // commitFileContractDiff applies or reverts a FileContractDiff.
 func (cs *ConsensusSet) commitFileContractDiff(fcd modules.FileContractDiff, dir modules.DiffDirection) {
-	if !cs.updateDatabase {
-		return
-	}
 	// Sanity check - should not be adding a contract twice, or deleting a
 	// contract that does not exist.
 	if build.DEBUG {
@@ -106,11 +100,6 @@ func (cs *ConsensusSet) commitFileContractDiff(fcd modules.FileContractDiff, dir
 
 // commitSiafundOutputDiff applies or reverts a SiafundOutputDiff.
 func (cs *ConsensusSet) commitSiafundOutputDiff(sfod modules.SiafundOutputDiff, dir modules.DiffDirection) {
-	// This function only modifies the database now, so the whole
-	// nothing happens when this flag is false
-	if !cs.updateDatabase {
-		return
-	}
 	// Sanity check - should not be adding an output twice, or deleting an
 	// output that does not exist.
 	if build.DEBUG {
@@ -131,9 +120,6 @@ func (cs *ConsensusSet) commitSiafundOutputDiff(sfod modules.SiafundOutputDiff, 
 
 // commitDelayedSiacoinOutputDiff applies or reverts a delayedSiacoinOutputDiff.
 func (cs *ConsensusSet) commitDelayedSiacoinOutputDiff(dscod modules.DelayedSiacoinOutputDiff, dir modules.DiffDirection) {
-	if !cs.updateDatabase {
-		return
-	}
 	// Sanity check - should not be adding an output twice, or deleting an
 	// output that does not exist.
 	if build.DEBUG {
@@ -213,9 +199,6 @@ func (cs *ConsensusSet) commitDiffSetSanity(pb *processedBlock, dir modules.Diff
 // createUpcomingDelayeOutputdMaps creates the delayed siacoin output maps that
 // will be used when applying delayed siacoin outputs in the diff set.
 func (cs *ConsensusSet) createUpcomingDelayedOutputMaps(pb *processedBlock, dir modules.DiffDirection) {
-	if !cs.updateDatabase {
-		return
-	}
 	if dir == modules.DiffApply {
 		if build.DEBUG {
 			// Sanity check - the output map being created should not already
@@ -282,15 +265,12 @@ func (cs *ConsensusSet) commitNodeDiffs(pb *processedBlock, dir modules.DiffDire
 // deleteObsoleteDelayedOutputMaps deletes the delayed siacoin output maps that
 // are no longer in use.
 func (cs *ConsensusSet) deleteObsoleteDelayedOutputMaps(pb *processedBlock, dir modules.DiffDirection) {
-	if !cs.updateDatabase {
-		return
-	}
 	if dir == modules.DiffApply {
 		// There are no outputs that mature in the first MaturityDelay blocks.
 		if pb.Height > types.MaturityDelay {
 			// Sanity check - the map being deleted should be empty.
 			if build.DEBUG {
-				if cs.updateDatabase && cs.db.lenDelayedSiacoinOutputsHeight(pb.Height) != 0 {
+				if cs.db.lenDelayedSiacoinOutputsHeight(pb.Height) != 0 {
 					panic(errDeletingNonEmptyDelayedMap)
 				}
 			}
@@ -311,21 +291,15 @@ func (cs *ConsensusSet) deleteObsoleteDelayedOutputMaps(pb *processedBlock, dir 
 func (cs *ConsensusSet) updateCurrentPath(pb *processedBlock, dir modules.DiffDirection) {
 	// Update the current path.
 	if dir == modules.DiffApply {
-		if cs.updateDatabase {
-			err := cs.db.pushPath(pb.Block.ID())
-			if build.DEBUG && err != nil {
-				panic(err)
-			}
+		err := cs.db.pushPath(pb.Block.ID())
+		if build.DEBUG && err != nil {
+			panic(err)
 		}
-		cs.blocksLoaded += 1
 	} else {
-		if cs.updateDatabase {
-			err := cs.db.popPath()
-			if build.DEBUG && err != nil {
-				panic(err)
-			}
+		err := cs.db.popPath()
+		if build.DEBUG && err != nil {
+			panic(err)
 		}
-		cs.blocksLoaded -= 1
 	}
 }
 
@@ -363,7 +337,6 @@ func (cs *ConsensusSet) generateAndApplyDiff(pb *processedBlock) error {
 	if err != nil {
 		return err
 	}
-	cs.blocksLoaded += 1
 	cs.db.addDelayedSiacoinOutputs(pb.Height + types.MaturityDelay)
 
 	// diffsGenerated is set to true as soon as we start changing the set of

--- a/modules/consensus/info.go
+++ b/modules/consensus/info.go
@@ -22,7 +22,8 @@ func (cs *ConsensusSet) currentProcessedBlock() *processedBlock {
 
 // height returns the current height of the state.
 func (s *ConsensusSet) height() types.BlockHeight {
-	return s.blocksLoaded
+	// Off by one as the genesis block doesn't count.
+	return s.db.pathHeight() - 1
 }
 
 // CurrentBlock returns the highest block on the tallest fork.

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -183,7 +183,6 @@ func (cs *ConsensusSet) applyFileContractMaintenance(pb *processedBlock) {
 			panic("an expiring file contract was missed")
 		}
 	}
-	delete(cs.fileContractExpirations, pb.Height)
 	cs.db.rmFCExpirations(pb.Height)
 	return
 }

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -180,7 +180,9 @@ func (cs *ConsensusSet) applyFileContractMaintenance(pb *processedBlock) {
 		}
 	}
 	delete(cs.fileContractExpirations, pb.Height)
-
+	if cs.db.inFCExpirations(pb.Height) {
+		cs.db.rmFCExpirations(pb.Height)
+	}
 	return
 }
 

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -146,7 +146,9 @@ func TestApplyMissedStorageProof(t *testing.T) {
 	// Assign the contract a 0-id.
 	cst.cs.db.addFileContracts(types.FileContractID{}, expiringFC)
 	cst.cs.fileContractExpirations[pb.Height] = make(map[types.FileContractID]struct{})
+	cst.cs.db.addFCExpirations(pb.Height)
 	cst.cs.fileContractExpirations[pb.Height][types.FileContractID{}] = struct{}{}
+	cst.cs.db.addFCExpirationsHeight(pb.Height, types.FileContractID{})
 	cst.cs.applyMissedStorageProof(pb, types.FileContractID{})
 	exists := cst.cs.db.inFileContracts(types.FileContractID{})
 	if exists {
@@ -235,7 +237,9 @@ func TestApplyFileContractMaintenance(t *testing.T) {
 	// Assign the contract a 0-id.
 	cst.cs.db.addFileContracts(types.FileContractID{}, expiringFC)
 	cst.cs.fileContractExpirations[pb.Height] = make(map[types.FileContractID]struct{})
+	cst.cs.db.addFCExpirations(pb.Height)
 	cst.cs.fileContractExpirations[pb.Height][types.FileContractID{}] = struct{}{}
+	cst.cs.db.addFCExpirationsHeight(pb.Height, types.FileContractID{})
 	cst.cs.applyFileContractMaintenance(pb)
 	exists := cst.cs.db.inFileContracts(types.FileContractID{})
 	if exists {

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -145,9 +145,7 @@ func TestApplyMissedStorageProof(t *testing.T) {
 	}
 	// Assign the contract a 0-id.
 	cst.cs.db.addFileContracts(types.FileContractID{}, expiringFC)
-	cst.cs.fileContractExpirations[pb.Height] = make(map[types.FileContractID]struct{})
 	cst.cs.db.addFCExpirations(pb.Height)
-	cst.cs.fileContractExpirations[pb.Height][types.FileContractID{}] = struct{}{}
 	cst.cs.db.addFCExpirationsHeight(pb.Height, types.FileContractID{})
 	cst.cs.applyMissedStorageProof(pb, types.FileContractID{})
 	exists := cst.cs.db.inFileContracts(types.FileContractID{})
@@ -236,9 +234,7 @@ func TestApplyFileContractMaintenance(t *testing.T) {
 	}
 	// Assign the contract a 0-id.
 	cst.cs.db.addFileContracts(types.FileContractID{}, expiringFC)
-	cst.cs.fileContractExpirations[pb.Height] = make(map[types.FileContractID]struct{})
 	cst.cs.db.addFCExpirations(pb.Height)
-	cst.cs.fileContractExpirations[pb.Height][types.FileContractID{}] = struct{}{}
 	cst.cs.db.addFCExpirationsHeight(pb.Height, types.FileContractID{})
 	cst.cs.applyFileContractMaintenance(pb)
 	exists := cst.cs.db.inFileContracts(types.FileContractID{})

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -29,7 +29,6 @@ func (cs *ConsensusSet) initSetDB() error {
 	// Update the siafundoutput diffs map for the genesis block on
 	// disk. This needs to happen between the database being
 	// opened/initilized and the consensus set hash being calculated
-	cs.updateDatabase = true
 	for _, sfod := range cs.blockRoot.SiafundOutputDiffs {
 		cs.commitSiafundOutputDiff(sfod, modules.DiffApply)
 	}
@@ -40,8 +39,6 @@ func (cs *ConsensusSet) initSetDB() error {
 		UnlockHash: types.UnlockHash{},
 	})
 
-	// Explicit initilization preferred to implicit for blocksLoaded
-	cs.blocksLoaded = 0
 	if build.DEBUG {
 		cs.blockRoot.ConsensusSetHash = cs.consensusSetHash()
 		cs.db.updateBlockMap(cs.blockRoot)
@@ -88,8 +85,6 @@ func (cs *ConsensusSet) load(saveDir string) error {
 	pb := cs.db.getBlockMap(bid)
 
 	cs.blockRoot.ConsensusSetHash = pb.ConsensusSetHash
-	// Explicit initilization preferred to implicit
-	cs.blocksLoaded = 0
 
 	return nil
 }
@@ -111,14 +106,6 @@ func (cs *ConsensusSet) loadDiffs() {
 
 		// Blocks loaded from disk are trusted, don't bother with verification.
 		lockID := cs.mu.Lock()
-		// This guard is for when the program is stopped. It is temporary.
-		// DEPRECATED
-		if !cs.db.open {
-			break
-		}
-		cs.updateDatabase = false
-		cs.commitDiffSet(pb, modules.DiffApply)
-		cs.updateDatabase = true
 		cs.updateSubscribers(nil, []*processedBlock{pb})
 		cs.mu.Unlock(lockID)
 	}

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -49,6 +49,7 @@ func openDB(filename string) (*setDB, error) {
 		"Path",
 		"BlockMap",
 		"Metadata",
+		"SiafundPool",
 		"DelayedSiacoinOutputs",
 		"FileContractExpirations",
 	}
@@ -134,7 +135,7 @@ func (db *setDB) checkConsistencyGuard() bool {
 // addItem should only be called from this file, and adds a new item
 // to the database
 //
-// addItem and getItem are part of consensus due to stricter error
+// addItem and getItem are part of consensus as oopp due to stricter error
 // conditions than a generic bolt implementation
 func (db *setDB) addItem(bucket string, key, value interface{}) error {
 	// Check that this transaction is guarded by consensusGuard.
@@ -715,4 +716,35 @@ func (db *setDB) forEachFCExpirationsHeight(h types.BlockHeight, fn func(k types
 		fn(key)
 		return nil
 	})
+}
+
+// setSiafundPool sets the siafund pool
+func (db *setDB) setSiafundPool(sfp types.Currency) error {
+	return db.addItem("SiafundPool", []byte("SiafundPool"), sfp)
+}
+
+// updateSiafundPool updates the saved siafund pool on disk
+func (db *setDB) updateSiafundPool(sfp types.Currency) {
+	err := db.rmItem("SiafundPool", []byte("SiafundPool"))
+	if build.DEBUG && err != nil {
+		panic(err)
+	}
+	err = db.addItem("SiafundPool", []byte("SiafundPool"), sfp)
+	if build.DEBUG && err != nil {
+		panic(err)
+	}
+}
+
+// getSiafundPool retrieves the value of the saved siafund pool
+func (db *setDB) getSiafundPool() types.Currency {
+	sfpBytes, err := db.getItem("SiafundPool", []byte("SiafundPool"))
+	if build.DEBUG && err != nil {
+		panic(err)
+	}
+	var sfp types.Currency
+	err = encoding.Unmarshal(sfpBytes, &sfp)
+	if build.DEBUG && err != nil {
+		panic(err)
+	}
+	return sfp
 }

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -71,7 +71,7 @@ func openDB(filename string) (*setDB, error) {
 }
 
 // startConsistencyGuard increments the first guard. If this is not
-// equal to the second, a transaction is taking place in the database.
+// equal to the second, a transaction is taking place in the database
 func (db *setDB) startConsistencyGuard() {
 	err := db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("Metadata"))

--- a/modules/consensus/setdb.go
+++ b/modules/consensus/setdb.go
@@ -50,6 +50,7 @@ func openDB(filename string) (*setDB, error) {
 		"BlockMap",
 		"Metadata",
 		"DelayedSiacoinOutputs",
+		"FileContractExpirations",
 	}
 
 	// Create buckets


### PR DESCRIPTION
This last pr covers file contract expirations and the siafund pool. The siafund pool is still kept in memory as it is just one value which is used a fair amount, but mirrored on disk on every change for loading.

With these two variables moved to disk, the consensus set can be restored without reapplying every block from disk, greatly speeding up startup. They still need to be loaded onto disk to broadcast updates, but I expect that if this is time consuming it would be a relatively simple fix.