### PR TITLE
Fix data races and race condidion panics in /consensus call

### DIFF
--- a/api/consensus.go
+++ b/api/consensus.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -17,9 +18,14 @@ type ConsensusGET struct {
 
 // consensusHandlerGET handles a GET request to /consensus.
 func (srv *Server) consensusHandlerGET(w http.ResponseWriter, req *http.Request) {
-	currentTarget, exists := srv.cs.ChildTarget(srv.currentBlock.ID())
+	id := srv.mu.RLock()
+	defer srv.mu.RUnlock(id)
+
+	curblockID := srv.currentBlock.ID()
+	currentTarget, exists := srv.cs.ChildTarget(curblockID)
 	if build.DEBUG {
 		if !exists {
+			fmt.Printf("Could not find block %s\n", curblockID)
 			panic("server has nonexistent current block")
 		}
 	}

--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -19,7 +19,7 @@ var (
 
 func consensusstatuscmd() {
 	var cg api.ConsensusGET
-	err := getAPI("/consensus/status", &cg)
+	err := getAPI("/consensus", &cg)
 	if err != nil {
 		fmt.Println("Could not get daemon status:", err)
 		return


### PR DESCRIPTION
This solves most of the problems that you get when rapidly pinging siad with /consensus.
There is now an panic when decoding on occasion, so I'll be looking at that next.