### PR TITLE
Processed transactions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -103,13 +103,12 @@ func (srv *Server) initAPI(addr string) {
 		handleHTTPRequest(mux, "/wallet/address", srv.walletAddressHandler)           // GET
 		handleHTTPRequest(mux, "/wallet/backup", srv.walletBackupHandler)             // POST
 		handleHTTPRequest(mux, "/wallet/encrypt", srv.walletEncryptHandler)           // POST
-		handleHTTPRequest(mux, "/wallet/history", srv.walletHistoryHandler)           // GET, $(addr) GET
 		handleHTTPRequest(mux, "/wallet/lock", srv.walletLockHandler)                 // PUT
 		handleHTTPRequest(mux, "/wallet/seeds", srv.walletSeedsHandler)               // GET, POST
 		handleHTTPRequest(mux, "/wallet/siacoins", srv.walletSiacoinsHandler)         // POST
 		handleHTTPRequest(mux, "/wallet/siafunds", srv.walletSiafundsHandler)         // POST
 		handleHTTPRequest(mux, "/wallet/transaction", srv.walletTransactionHandler)   // $(id) GET
-		handleHTTPRequest(mux, "/wallet/transactions", srv.walletTransactionsHandler) // GET
+		handleHTTPRequest(mux, "/wallet/transactions", srv.walletTransactionsHandler) // GET, $(addr) GET
 		handleHTTPRequest(mux, "/wallet/unlock", srv.walletUnlockHandler)             // PUT
 	}
 

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -39,6 +39,18 @@ type (
 		PrimarySeed string `json:"primaryseed"`
 	}
 
+	// WalletSiacoinsPOST contains the transaction sent in the POST call to
+	// /wallet/siafunds.
+	WalletSiacoinsPOST struct {
+		TransactionIDs []types.TransactionID `json:"transactionids"`
+	}
+
+	// WalletSiafundsPOST contains the transaction sent in the POST call to
+	// /wallet/siafunds.
+	WalletSiafundsPOST struct {
+		TransactionIDs []types.TransactionID `json:"transactionids"`
+	}
+
 	// WalletSeedGet contains the seeds used by the wallet.
 	WalletSeedsGET struct {
 		PrimarySeed        string   `json:"primaryseed"`
@@ -311,12 +323,18 @@ func (srv *Server) walletSiacoinsHandlerPOST(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	_, err = srv.wallet.SendSiacoins(amount, dest)
+	txns, err := srv.wallet.SendSiacoins(amount, dest)
 	if err != nil {
 		writeError(w, "error after call to /wallet/siacoins: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	writeSuccess(w)
+	var txids []types.TransactionID
+	for _, txn := range txns {
+		txids = append(txids, txn.ID())
+	}
+	writeJSON(w, WalletSiacoinsPOST{
+		TransactionIDs: txids,
+	})
 }
 
 // walletSiacoinsHandler handles API calls to /wallet/siacoins.
@@ -341,12 +359,18 @@ func (srv *Server) walletSiafundsHandlerPOST(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	_, err = srv.wallet.SendSiafunds(amount, dest)
+	txns, err := srv.wallet.SendSiafunds(amount, dest)
 	if err != nil {
 		writeError(w, "error after call to /wallet/siafunds: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	writeSuccess(w)
+	var txids []types.TransactionID
+	for _, txn := range txns {
+		txids = append(txids, txn.ID())
+	}
+	writeJSON(w, WalletSiafundsPOST{
+		TransactionIDs: txids,
+	})
 }
 
 // walletSiafundsHandler handles API calls to /wallet/siafunds.

--- a/doc/API.md
+++ b/doc/API.md
@@ -271,7 +271,15 @@ destination string
 
 'destination' is the address that is receiving the coins.
 
-Response: standard
+Response:
+```
+struct {
+	transactionids []types.TransactionID (string)
+}
+```
+'transactionids' are the ids of the transactions that were created when sending
+the coins. The last transaction contains the output headed to the
+'destination'.
 
 #### /wallet/siafunds [POST]
 
@@ -292,7 +300,15 @@ destination string
 
 'destination' is the address that is receiving the funds.
 
-Response: standard
+Response:
+```
+struct {
+	transactionids []types.TransactionID (string)
+}
+```
+'transactionids' are the ids of the transactions that were created when sending
+the coins. The last transaction contains the output headed to the
+'destination'.
 
 #### /wallet/transaction/$(id) [GET]
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -359,7 +359,7 @@ the transaction. Outputs related to file contracts are excluded.
 
 A modules.ProcessedInput takes the following form:
 ```
-struct modules.ProcessedTransaction {
+struct modules.ProcessedInput {
 	fundtype       types.Specifier  (string)
 	walletaddress  bool
 	relatedaddress types.UnlockHash (string)
@@ -384,7 +384,7 @@ wallet.
 
 A modules.ProcessedOutput takes the following form:
 ```
-struct modules.ProcessedTransaction {
+struct modules.ProcessedOutput {
 	fundtype       types.Specifier   (string)
 	maturityheight types.BlockHeight (int)
 	walletaddress  bool

--- a/modules/wallet/history_test.go
+++ b/modules/wallet/history_test.go
@@ -1,5 +1,6 @@
 package wallet
 
+/*
 import (
 	"testing"
 
@@ -123,3 +124,4 @@ func TestIntegrationAddressHistory(t *testing.T) {
 		t.Error("addresses unconfirmed transactions should be empty")
 	}
 }
+*/

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -27,11 +27,16 @@ func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incoming
 	lockID := w.mu.Lock()
 	defer w.mu.Unlock(lockID)
 
-	for _, uwt := range w.unconfirmedWalletTransactions {
-		if uwt.FundType == types.SpecifierSiacoinOutput {
-			incomingSiacoins = incomingSiacoins.Add(uwt.Value)
-		} else if uwt.FundType == types.SpecifierSiacoinInput {
-			outgoingSiacoins = outgoingSiacoins.Add(uwt.Value)
+	for _, upt := range w.unconfirmedProcessedTransactions {
+		for _, input := range upt.Inputs {
+			if input.FundType == types.SpecifierSiacoinInput && input.WalletAddress {
+				outgoingSiacoins = outgoingSiacoins.Add(input.Value)
+			}
+		}
+		for _, output := range upt.Outputs {
+			if output.FundType == types.SpecifierSiacoinOutput && output.WalletAddress {
+				incomingSiacoins = incomingSiacoins.Add(output.Value)
+			}
 		}
 	}
 	return

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -76,16 +76,16 @@ func decryptSeedFile(masterKey crypto.TwofishKey, sf SeedFile) (seed modules.See
 	expectedDecryptedVerification := make([]byte, 32)
 	decryptedVerification, err := decryptionKey.DecryptBytes(sf.EncryptionVerification)
 	if err != nil {
-		return seed, err
+		return modules.Seed{}, err
 	}
 	if !bytes.Equal(expectedDecryptedVerification, decryptedVerification) {
-		return seed, modules.ErrBadEncryptionKey
+		return modules.Seed{}, modules.ErrBadEncryptionKey
 	}
 
 	// Decrypt and return the seed.
 	plainSeed, err := decryptionKey.DecryptBytes(sf.Seed)
 	if err != nil {
-		return seed, err
+		return modules.Seed{}, err
 	}
 	copy(seed[:], plainSeed)
 	return seed, nil

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -74,6 +74,9 @@ func (w *Wallet) Transaction(txid types.TransactionID) (modules.ProcessedTransac
 	lockID := w.mu.Lock()
 	defer w.mu.Unlock(lockID)
 	pt, exists := w.processedTransactionMap[txid]
+	if !exists {
+		return modules.ProcessedTransaction{}, exists
+	}
 	return *pt, exists
 }
 

--- a/modules/wallet/transactions_test.go
+++ b/modules/wallet/transactions_test.go
@@ -1,19 +1,18 @@
 package wallet
 
-/*
 import (
 	"testing"
 
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// TestIntegrationTransactionHistory checks that the transaction history is
-// being correctly recorded and extended.
-func TestIntegrationTransactionHistory(t *testing.T) {
+// TestIntegrationTransactions checks that the transaction history is being
+// correctly recorded and extended.
+func TestIntegrationTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestTransactionHistory")
+	wt, err := createWalletTester("TestIntegrationTransactions")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,30 +22,28 @@ func TestIntegrationTransactionHistory(t *testing.T) {
 	// has money, which means types.MaturityDelay+1 blocks are created, and
 	// each block is going to have a transaction (the miner payout) going to
 	// the wallet.
-	history, err := wt.wallet.History(0, 100)
+	txns, err := wt.wallet.Transactions(0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(history) != int(types.MaturityDelay+1) {
+	if len(txns) != int(types.MaturityDelay+1) {
 		t.Error("unexpected transaction history length")
 	}
-	_, err = wt.wallet.SendSiacoins(types.NewCurrency64(5000), types.UnlockHash{})
+	sendTxns, err := wt.wallet.SendSiacoins(types.NewCurrency64(5000), types.UnlockHash{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// No more confirmed transactions have been added.
-	history, err = wt.wallet.History(0, 100)
+	txns, err = wt.wallet.Transactions(0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(history) != int(types.MaturityDelay+1) {
+	if len(txns) != int(types.MaturityDelay+1) {
 		t.Error("unexpected transaction history length")
 	}
-	// Four transactions were added: to fund the parent txn (an input), create
-	// an exact output (an output) for the child, and refund the parent (an
-	// output), and then an input to the child transaction (an input). The
-	// output of the child transaction is not tracked by the wallet.
-	if len(wt.wallet.UnconfirmedHistory()) != 4 {
+	// Two transactions added to unconfirmed pool - 1 to fund the exact output,
+	// and 1 to hold the exact output.
+	if len(wt.wallet.UnconfirmedTransactions()) != 2 {
 		t.Error("was expecting 4 unconfirmed transactions")
 	}
 
@@ -55,31 +52,44 @@ func TestIntegrationTransactionHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A confirmed transaction was added for the miner payout, and the 4
+	// A confirmed transaction was added for the miner payout, and the 2
 	// transactions that were previously unconfirmed.
-	history, err = wt.wallet.History(0, 100)
+	txns, err = wt.wallet.Transactions(0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(history) != int(types.MaturityDelay+2+4) {
+	if len(txns) != int(types.MaturityDelay+2+2) {
 		t.Error("unexpected transaction history length")
 	}
 
 	// Try getting a partial history for just the previous block.
-	txns, err := wt.wallet.History(types.MaturityDelay+3, types.MaturityDelay+3)
+	txns, err = wt.wallet.Transactions(types.MaturityDelay+3, types.MaturityDelay+3)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The partial should include one transaction for a block, and 4 for the
+	// The partial should include one transaction for a block, and 2 for the
 	// send that occured.
-	if len(txns) != 5 {
+	if len(txns) != 3 {
 		t.Error(len(txns))
+	}
+
+	// Check that transactions can be queried individually.
+	txn, exists := wt.wallet.Transaction(sendTxns[0].ID())
+	if !exists {
+		t.Fatal("unable to query transaction")
+	}
+	if txn.TransactionID != sendTxns[0].ID() {
+		t.Error("wrong transaction was fetched")
+	}
+	_, exists = wt.wallet.Transaction(types.TransactionID{})
+	if exists {
+		t.Error("able to query a nonexisting transction")
 	}
 }
 
-// TestIntegrationAddressHistory checks grabbing the history for a single
+// TestIntegrationAddressTransactions checks grabbing the history for a single
 // address.
-func TestIntegrationAddressHistory(t *testing.T) {
+func TestIntegrationAddressTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -101,11 +111,11 @@ func TestIntegrationAddressHistory(t *testing.T) {
 	}
 
 	// Check the confirmed balance of the address.
-	addrHist, err := wt.wallet.AddressHistory(addr)
-	if err != errNoHistoryForAddr {
-		t.Fatal(err)
+	addrHist := wt.wallet.AddressTransactions(addr)
+	if len(addrHist) != 0 {
+		t.Error("address should be empty - no confirmed transactions")
 	}
-	if len(wt.wallet.AddressUnconfirmedHistory(addr)) == 0 {
+	if len(wt.wallet.AddressUnconfirmedTransactions(addr)) == 0 {
 		t.Error("addresses unconfirmed transactions should not be empty")
 	}
 	b, _ := wt.miner.FindBlock()
@@ -113,15 +123,11 @@ func TestIntegrationAddressHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	addrHist, err = wt.wallet.AddressHistory(addr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	addrHist = wt.wallet.AddressTransactions(addr)
 	if len(addrHist) == 0 {
 		t.Error("address history should have some transactions")
 	}
-	if len(wt.wallet.AddressUnconfirmedHistory(addr)) != 0 {
+	if len(wt.wallet.AddressUnconfirmedTransactions(addr)) != 0 {
 		t.Error("addresses unconfirmed transactions should be empty")
 	}
 }
-*/

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -8,68 +8,6 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// revertOutput reverts an output from the wallet. The output must be the
-// output in the most recent wallet transaction of the wallet transaction array
-// if the unlock hash belongs to the wallet. If the unlock hash is
-// unrecognized, this function is a no-op.
-func (w *Wallet) revertWalletTransaction(uh types.UnlockHash, wtid modules.WalletTransactionID) {
-	_, exists := w.keys[uh]
-	if !exists {
-		// The wallet only applies and reverts transactions that are relevant
-		// to a key it knows.
-		return
-	}
-
-	// Sanity check - the output should exist in the wallet transaction map
-	// because a prior addition to the map is being reverted.
-	_, exists = w.walletTransactionMap[wtid]
-	if build.DEBUG && !exists {
-		panic("wallet transaction not found in the wallet transaction map")
-	}
-	delete(w.walletTransactionMap, wtid)
-
-	// Sanity check - the last element of the wallet transaction array
-	// should be the item we are deleteing.
-	lastIndex := len(w.walletTransactions) - 1
-	if build.DEBUG && wtid != modules.CalculateWalletTransactionID(w.walletTransactions[lastIndex].TransactionID, w.walletTransactions[lastIndex].OutputID) {
-		panic("wallet transactions are being deleted in the wrong order")
-	}
-	w.walletTransactions = w.walletTransactions[:lastIndex]
-}
-
-// applyWalletTransaction adds a wallet transaction to the wallet transaction
-// history.
-func (w *Wallet) applyWalletTransaction(fundType types.Specifier, uh types.UnlockHash, t types.Transaction, confirmationTime types.Timestamp, oid types.OutputID, value types.Currency) bool {
-	_, exists := w.keys[uh]
-	if !exists {
-		// The wallet only applies and reverts transactions that are relevant
-		// to a key it knows.
-		return false
-	}
-
-	// Sanity check - the output should not exist in the wallet transaction
-	// map, this should be the first time it was created.
-	wtid := modules.CalculateWalletTransactionID(t.ID(), oid)
-	_, exists = w.walletTransactionMap[wtid]
-	if exists && build.DEBUG {
-		panic("a wallet transaction is being added for the second time")
-	}
-	wt := modules.WalletTransaction{
-		TransactionID:         t.ID(),
-		ConfirmationHeight:    w.consensusSetHeight,
-		ConfirmationTimestamp: confirmationTime,
-
-		FundType:       fundType,
-		OutputID:       oid,
-		RelatedAddress: uh,
-		Value:          value,
-	}
-	w.walletTransactions = append(w.walletTransactions, wt)
-	w.walletTransactionMap[wtid] = &w.walletTransactions[len(w.walletTransactions)-1]
-	w.historicOutputs[oid] = value
-	return true
-}
-
 // ProcessConsensusChange parses a consensus change to update the set of
 // confirmed outputs known to the wallet.
 func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
@@ -138,30 +76,28 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// related to the wallet. Wallet transactions must be removed in the same
 	// order they were added.
 	for _, block := range cc.RevertedBlocks {
+		// Remove any transactions that have been reverted.
 		for i := len(block.Transactions) - 1; i >= 0; i-- {
+			// If the transaction is relevant to the wallet, it will be the
+			// most recent transaction appended to w.processedTransactions.
+			// Relevance can be determined just by looking at the last element
+			// of w.processedTransactions.
 			txn := block.Transactions[i]
-			// Revert all wallet transactions made from items in the
-			// transaction - use the reverse order of apply because using a
-			// slice means its easiet to remove the last element.
 			txid := txn.ID()
-			for i := len(txn.SiafundOutputs) - 1; i >= 0; i-- {
-				w.revertWalletTransaction(txn.SiafundOutputs[i].UnlockHash, modules.CalculateWalletTransactionID(txid, types.OutputID(txn.SiafundOutputID(i))))
+			if txid == w.processedTransactions[len(w.processedTransactions)-1].TransactionID {
+				w.processedTransactions = w.processedTransactions[:len(w.processedTransactions)-1]
+				delete(w.processedTransactionMap, txid)
 			}
-			for i := len(txn.SiafundInputs) - 1; i >= 0; i-- {
-				sfoid := txn.SiafundOutputID(i)
-				w.revertWalletTransaction(txn.SiafundInputs[i].ClaimUnlockHash, modules.CalculateWalletTransactionID(txid, types.OutputID(sfoid.SiaClaimOutputID())))
-				w.revertWalletTransaction(txn.SiafundInputs[i].UnlockConditions.UnlockHash(), modules.CalculateWalletTransactionID(txid, types.OutputID(txn.SiafundInputs[i].ParentID)))
-			}
-			for i := len(txn.SiacoinOutputs) - 1; i >= 0; i-- {
-				w.revertWalletTransaction(txn.SiacoinOutputs[i].UnlockHash, modules.CalculateWalletTransactionID(txid, types.OutputID(txn.SiacoinOutputID(i))))
-			}
-			for i := len(txn.SiacoinInputs) - 1; i >= 0; i-- {
-				w.revertWalletTransaction(txn.SiacoinInputs[i].UnlockConditions.UnlockHash(), modules.CalculateWalletTransactionID(txid, types.OutputID(txn.SiacoinInputs[i].ParentID)))
-			}
-			delete(w.transactions, txid)
 		}
-		for i := len(block.MinerPayouts) - 1; i >= 0; i-- {
-			w.revertWalletTransaction(block.MinerPayouts[i].UnlockHash, modules.CalculateWalletTransactionID(types.Transaction{}.ID(), types.OutputID(block.MinerPayoutID(uint64(i)))))
+
+		// Remove the miner payout transaction if applicable.
+		for _, mp := range block.MinerPayouts {
+			_, exists := w.keys[mp.UnlockHash]
+			if exists {
+				w.processedTransactions = w.processedTransactions[:len(w.processedTransactions)-1]
+				delete(w.processedTransactionMap, types.TransactionID(block.ID()))
+				break
+			}
 		}
 		w.consensusSetHeight--
 	}
@@ -169,35 +105,105 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// Apply all of the new blocks.
 	for _, block := range cc.AppliedBlocks {
 		w.consensusSetHeight++
-		// Apply any miner outputs.
+		// Apply the miner payout transaction if applicable.
+		minerPT := modules.ProcessedTransaction{
+			Transaction:           types.Transaction{},
+			TransactionID:         types.TransactionID(block.ID()),
+			ConfirmationHeight:    w.consensusSetHeight,
+			ConfirmationTimestamp: block.Timestamp,
+		}
+		relevant := false
 		for i, mp := range block.MinerPayouts {
-			w.applyWalletTransaction(types.SpecifierMinerPayout, mp.UnlockHash, types.Transaction{}, block.Timestamp, types.OutputID(block.MinerPayoutID(uint64(i))), mp.Value)
+			_, exists := w.keys[mp.UnlockHash]
+			if exists {
+				relevant = true
+			}
+			minerPT.Outputs = append(minerPT.Outputs, modules.ProcessedOutput{
+				FundType:       types.SpecifierMinerPayout,
+				MaturityHeight: w.consensusSetHeight + types.MaturityDelay,
+				WalletAddress:  exists,
+				RelatedAddress: mp.UnlockHash,
+				Value:          mp.Value,
+			})
+			w.historicOutputs[types.OutputID(block.MinerPayoutID(uint64(i)))] = mp.Value
+		}
+		if relevant {
+			w.processedTransactions = append(w.processedTransactions, minerPT)
+			w.processedTransactionMap[minerPT.TransactionID] = &w.processedTransactions[len(w.processedTransactions)-1]
 		}
 		for _, txn := range block.Transactions {
-			relevant := false // indicates whether the transaction is relevant to the wallet.
-			// Add a wallet transaction for all transaction elements.
+			relevant := false
+			pt := modules.ProcessedTransaction{
+				Transaction:           txn,
+				TransactionID:         txn.ID(),
+				ConfirmationHeight:    w.consensusSetHeight,
+				ConfirmationTimestamp: block.Timestamp,
+			}
 			for _, sci := range txn.SiacoinInputs {
-				if w.applyWalletTransaction(types.SpecifierSiacoinInput, sci.UnlockConditions.UnlockHash(), txn, block.Timestamp, types.OutputID(sci.ParentID), w.historicOutputs[types.OutputID(sci.ParentID)]) {
+				_, exists := w.keys[sci.UnlockConditions.UnlockHash()]
+				if exists {
 					relevant = true
 				}
+				pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
+					FundType:       types.SpecifierSiacoinInput,
+					WalletAddress:  exists,
+					RelatedAddress: sci.UnlockConditions.UnlockHash(),
+					Value:          w.historicOutputs[types.OutputID(sci.ParentID)],
+				})
 			}
 			for i, sco := range txn.SiacoinOutputs {
-				if w.applyWalletTransaction(types.SpecifierSiacoinOutput, sco.UnlockHash, txn, block.Timestamp, types.OutputID(txn.SiacoinOutputID(i)), sco.Value) {
+				_, exists := w.keys[sco.UnlockHash]
+				if exists {
 					relevant = true
 				}
+				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+					FundType:       types.SpecifierSiacoinOutput,
+					MaturityHeight: w.consensusSetHeight,
+					WalletAddress:  exists,
+					RelatedAddress: sco.UnlockHash,
+					Value:          sco.Value,
+				})
+				w.historicOutputs[types.OutputID(txn.SiacoinOutputID(i))] = sco.Value
 			}
 			for _, sfi := range txn.SiafundInputs {
-				if w.applyWalletTransaction(types.SpecifierSiafundInput, sfi.UnlockConditions.UnlockHash(), txn, block.Timestamp, types.OutputID(sfi.ParentID), w.historicOutputs[types.OutputID(sfi.ParentID)]) {
+				_, exists := w.keys[sfi.UnlockConditions.UnlockHash()]
+				if exists {
 					relevant = true
 				}
+				sfiValue := w.historicOutputs[types.OutputID(sfi.ParentID)]
+				pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
+					FundType:       types.SpecifierSiafundInput,
+					WalletAddress:  exists,
+					RelatedAddress: sfi.UnlockConditions.UnlockHash(),
+					Value:          sfiValue,
+				})
+				claimValue := w.siafundPool.Sub(w.historicClaimStarts[sfi.ParentID]).Mul(sfiValue)
+				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+					FundType:       types.SpecifierClaimOutput,
+					MaturityHeight: w.consensusSetHeight + types.MaturityDelay,
+					WalletAddress:  exists,
+					RelatedAddress: sfi.ClaimUnlockHash,
+					Value:          claimValue,
+				})
 			}
 			for i, sfo := range txn.SiafundOutputs {
-				if w.applyWalletTransaction(types.SpecifierSiafundOutput, sfo.UnlockHash, txn, block.Timestamp, types.OutputID(txn.SiafundOutputID(i)), sfo.Value) {
+				_, exists := w.keys[sfo.UnlockHash]
+				if exists {
 					relevant = true
 				}
+				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+					FundType:       types.SpecifierSiafundOutput,
+					MaturityHeight: w.consensusSetHeight,
+					WalletAddress:  exists,
+					RelatedAddress: sfo.UnlockHash,
+					Value:          sfo.Value,
+				})
+				w.historicOutputs[types.OutputID(txn.SiafundOutputID(i))] = sfo.Value
+				w.historicClaimStarts[txn.SiafundOutputID(i)] = sfo.ClaimStart
 			}
 			if relevant {
-				w.transactions[txn.ID()] = txn
+				w.processedTransactions = append(w.processedTransactions, pt)
+				w.processedTransactionMap[pt.TransactionID] = &w.processedTransactions[len(w.processedTransactions)-1]
 			}
 		}
 	}
@@ -217,48 +223,45 @@ func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction,
 		defer w.mu.Unlock(lockID)
 	}
 
-	w.unconfirmedTransactions = nil
-	w.unconfirmedWalletTransactions = nil
+	w.unconfirmedProcessedTransactions = nil
 	for _, txn := range txns {
-		relevant := false // indicates whether the transaction is relevant to the wallet
+		// To save on  code complexity, relveancy is determined while building
+		// up the wallet transaction.
+		relevant := false
+		pt := modules.ProcessedTransaction{
+			Transaction:           txn,
+			TransactionID:         txn.ID(),
+			ConfirmationHeight:    types.BlockHeight(math.MaxUint64),
+			ConfirmationTimestamp: types.Timestamp(math.MaxUint64),
+		}
 		for _, sci := range txn.SiacoinInputs {
 			_, exists := w.keys[sci.UnlockConditions.UnlockHash()]
 			if exists {
-				wt := modules.WalletTransaction{
-					TransactionID:         txn.ID(),
-					ConfirmationHeight:    types.BlockHeight(math.MaxUint64),
-					ConfirmationTimestamp: types.Timestamp(math.MaxUint64),
-
-					FundType:       types.SpecifierSiacoinInput,
-					OutputID:       types.OutputID(sci.ParentID),
-					RelatedAddress: sci.UnlockConditions.UnlockHash(),
-					Value:          w.historicOutputs[types.OutputID(sci.ParentID)],
-				}
-				w.unconfirmedWalletTransactions = append(w.unconfirmedWalletTransactions, wt)
 				relevant = true
 			}
+			pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
+				FundType:       types.SpecifierSiacoinInput,
+				WalletAddress:  exists,
+				RelatedAddress: sci.UnlockConditions.UnlockHash(),
+				Value:          w.historicOutputs[types.OutputID(sci.ParentID)],
+			})
 		}
 		for i, sco := range txn.SiacoinOutputs {
 			_, exists := w.keys[sco.UnlockHash]
 			if exists {
-				wt := modules.WalletTransaction{
-					TransactionID:         txn.ID(),
-					ConfirmationHeight:    types.BlockHeight(math.MaxUint64),
-					ConfirmationTimestamp: types.Timestamp(math.MaxUint64),
-
-					FundType:       types.SpecifierSiacoinOutput,
-					OutputID:       types.OutputID(txn.SiacoinOutputID(i)),
-					RelatedAddress: sco.UnlockHash,
-					Value:          sco.Value,
-				}
-				w.unconfirmedWalletTransactions = append(w.unconfirmedWalletTransactions, wt)
-				oid := types.OutputID(txn.SiacoinOutputID(i))
-				w.historicOutputs[oid] = sco.Value
 				relevant = true
 			}
+			pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+				FundType:       types.SpecifierSiacoinOutput,
+				MaturityHeight: types.BlockHeight(math.MaxUint64),
+				WalletAddress:  exists,
+				RelatedAddress: sco.UnlockHash,
+				Value:          sco.Value,
+			})
+			w.historicOutputs[types.OutputID(txn.SiacoinOutputID(i))] = sco.Value
 		}
 		if relevant {
-			w.unconfirmedTransactions = append(w.unconfirmedTransactions, txn)
+			w.unconfirmedProcessedTransactions = append(w.unconfirmedProcessedTransactions, pt)
 		}
 	}
 }

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -84,7 +84,7 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 			// of w.processedTransactions.
 			txn := block.Transactions[i]
 			txid := txn.ID()
-			if txid == w.processedTransactions[len(w.processedTransactions)-1].TransactionID {
+			if len(w.processedTransactions) > 0 && txid == w.processedTransactions[len(w.processedTransactions)-1].TransactionID {
 				w.processedTransactions = w.processedTransactions[:len(w.processedTransactions)-1]
 				delete(w.processedTransactionMap, txid)
 			}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -82,12 +82,14 @@ type Wallet struct {
 	// historicOutputs is kept so that the values of transaction inputs can be
 	// determined. historicOutputs is never cleared, but in general should be
 	// small compared to the list of transactions.
-	walletTransactions            []modules.WalletTransaction
-	walletTransactionMap          map[modules.WalletTransactionID]*modules.WalletTransaction
-	transactions                  map[types.TransactionID]types.Transaction
-	unconfirmedWalletTransactions []modules.WalletTransaction
-	unconfirmedTransactions       []types.Transaction
-	historicOutputs               map[types.OutputID]types.Currency
+	processedTransactions            []modules.ProcessedTransaction
+	processedTransactionMap          map[types.TransactionID]*modules.ProcessedTransaction
+	unconfirmedProcessedTransactions []modules.ProcessedTransaction
+
+	// TODO: Storing the whole set of historic outputs is expensive and
+	// unnecessary. There's a better way to do it.
+	historicOutputs     map[types.OutputID]types.Currency
+	historicClaimStarts map[types.SiafundOutputID]types.Currency
 
 	persistDir string
 	log        *log.Logger
@@ -112,14 +114,15 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		cs:    cs,
 		tpool: tpool,
 
-		keys:            make(map[types.UnlockHash]spendableKey),
-		siacoinOutputs:  make(map[types.SiacoinOutputID]types.SiacoinOutput),
-		siafundOutputs:  make(map[types.SiafundOutputID]types.SiafundOutput),
-		historicOutputs: make(map[types.OutputID]types.Currency),
-		spentOutputs:    make(map[types.OutputID]types.BlockHeight),
+		keys:           make(map[types.UnlockHash]spendableKey),
+		siacoinOutputs: make(map[types.SiacoinOutputID]types.SiacoinOutput),
+		siafundOutputs: make(map[types.SiafundOutputID]types.SiafundOutput),
+		spentOutputs:   make(map[types.OutputID]types.BlockHeight),
 
-		transactions:         make(map[types.TransactionID]types.Transaction),
-		walletTransactionMap: make(map[modules.WalletTransactionID]*modules.WalletTransaction),
+		processedTransactionMap: make(map[types.TransactionID]*modules.ProcessedTransaction),
+
+		historicOutputs:     make(map[types.OutputID]types.Currency),
+		historicClaimStarts: make(map[types.SiafundOutputID]types.Currency),
 
 		persistDir: persistDir,
 		mu:         sync.New(modules.SafeMutexDelay, 1),

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -199,7 +199,7 @@ func TestSendSiacoins(t *testing.T) {
 	// Send 5000 hastings. The wallet will automatically add a fee. Outgoing
 	// unconfirmed siacoins - incoming unconfirmed siacoins should equal 5000 +
 	// fee.
-	tpoolFee := types.NewCurrency64(10).Mul(types.SiacoinPrecision) // TODO: tpool fee algo needs to be written.
+	tpoolFee := types.NewCurrency64(10).Mul(types.SiacoinPrecision)
 	_, err = wt.wallet.SendSiacoins(types.NewCurrency64(5000), types.UnlockHash{})
 	if err != nil {
 		t.Fatal(err)

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -29,6 +29,7 @@ var (
 	SpecifierStorageProofOutput   = Specifier{'s', 't', 'o', 'r', 'a', 'g', 'e', ' ', 'p', 'r', 'o', 'o', 'f'}
 	SpecifierSiafundInput         = Specifier{'s', 'i', 'a', 'f', 'u', 'n', 'd', ' ', 'i', 'n', 'p', 'u', 't'}
 	SpecifierSiafundOutput        = Specifier{'s', 'i', 'a', 'f', 'u', 'n', 'd', ' ', 'o', 'u', 't', 'p', 'u', 't'}
+	SpecifierClaimOutput          = Specifier{'c', 'l', 'a', 'i', 'm', ' ', 'o', 'u', 't', 'p', 'u', 't'}
 
 	ErrTransactionIDWrongLen = errors.New("input has wrong length to be an encoded transaction id")
 )


### PR DESCRIPTION
I am worried about the level of testing. Some of the history tests have been commented out because I completely changed the api. I will write them back in.

The full test suite passes, but I'm guessing there are a handful of latent bugs in this PR.

I changed the api according to have more descriptive wallet transactions. Also less confusing. Calling /wallet/siacoins now returns a list of transaction ids - the ids of the transactions that were created to send the siacoins.