### PR TITLE
add compatibility support for the old transaction pool

### DIFF
--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -43,6 +43,12 @@ type TransactionPool interface {
 	// transactions.
 	AcceptTransactionSet([]types.Transaction) error
 
+	// COMPAT v0.3.3.3
+	//
+	// RelayTransaction is an RPC that accepts a transaction set from a
+	// peer.
+	RelayTransaction(PeerConn) error
+
 	// RelayTransactionSet is an RPC that accepts a transaction set from a
 	// peer.
 	RelayTransactionSet(PeerConn) error

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -286,7 +286,7 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 	go tp.gateway.Broadcast("RelayTransactionSet", ts)
 	tp.updateSubscribersTransactions()
 
-	// COMPAT 0.3.3.3
+	// COMPAT v0.3.3.3
 	//
 	// Transactions must be broadcast individually as well so that they will be
 	// seen by older nodes that don't support the "RelayTransactionSet" RPC.
@@ -298,6 +298,20 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 	}()
 
 	return nil
+}
+
+// COMPAT v0.3.3.3
+//
+// RelayTransactionSet is an RPC that accepts a transaction set from a peer. If
+// the accept is successful, the transaction will be relayed to the gateway's
+// other peers.
+func (tp *TransactionPool) RelayTransaction(conn modules.PeerConn) error {
+	var t types.Transaction
+	err := encoding.ReadObject(conn, &t, types.BlockSizeLimit)
+	if err != nil {
+		return err
+	}
+	return tp.AcceptTransactionSet([]types.Transaction{t})
 }
 
 // RelayTransactionSet is an RPC that accepts a transaction set from a peer. If

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -91,6 +91,7 @@ func New(cs modules.ConsensusSet, g modules.Gateway) (*TransactionPool, error) {
 
 	// Register RPCs
 	g.RegisterRPC("RelayTransactionSet", tp.RelayTransactionSet)
+	g.RegisterRPC("RelayTransaction", tp.RelayTransaction) // COMPAT v0.3.3.3
 
 	// Subscribe the transaction pool to the consensus set.
 	cs.ConsensusSetSubscribe(tp)


### PR DESCRIPTION
now transactions that get broadcast by the previous transaction pool will be seen by the new transaction pool.

That completes transaction pool compatibility.