### PR TITLE
Safer upload algorithm

### DIFF
--- a/modules/renter/download_test.go
+++ b/modules/renter/download_test.go
@@ -15,11 +15,11 @@ type testHost struct {
 	pieceMap  map[uint64][]pieceData // key is chunkIndex
 	pieceSize uint64
 	nAttempt  int // total number of download attempts
-	nFetch    int // number of successfull download attempts
+	nFetch    int // number of successful download attempts
 
 	// used to simulate real-world conditions
-	delay    time.Duration // download will take this long
-	failRate int           // download will randomly fail with probability 1/failRate
+	delay    time.Duration // transfers will take this long
+	failRate int           // transfers will randomly fail with probability 1/failRate
 }
 
 func (h *testHost) pieces(chunkIndex uint64) []pieceData {

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -66,8 +66,10 @@ func (f *file) upload(r io.Reader, hosts []uploader) error {
 		wg.Add(len(pieces))
 		for j, data := range pieces {
 			go func(j int, data []byte) {
-				hosts[j%len(hosts)].addPiece(uploadPiece{data, i, uint64(j)})
-				atomic.AddUint64(&f.bytesUploaded, uint64(len(data)))
+				err := hosts[j%len(hosts)].addPiece(uploadPiece{data, i, uint64(j)})
+				if err == nil {
+					atomic.AddUint64(&f.bytesUploaded, uint64(len(data)))
+				}
 				wg.Done()
 			}(j, data)
 		}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 
 	"github.com/NebulousLabs/Sia/crypto"
@@ -42,41 +43,11 @@ type uploader interface {
 	fileContract() fileContract
 }
 
-// uploadWorker uploads pieces to a host as directed by reqChan. When there
-// are no more pieces to upload, it sends the final version of the
-// fileContract down respChan.
-func (f *file) uploadWorker(host uploader, reqChan chan uploadPiece, respChan chan fileContract) {
-	for req := range reqChan {
-		err := host.addPiece(req)
-		if err != nil {
-			// TODO: how should this be handled?
-			break
-		}
-		atomic.AddUint64(&f.bytesUploaded, uint64(len(req.data)))
-	}
-	// reqChan was closed; send final fileContract
-	respChan <- host.fileContract()
-}
-
 // upload reads chunks from r and uploads them to hosts. It spawns a worker
 // for each host, and instructs them to upload pieces of each chunk.
 func (f *file) upload(r io.Reader, hosts []uploader) error {
-	// All requests are sent down the same channel. Since all workers are
-	// waiting on this channel, pieces will be uploaded by the first idle
-	// worker. This means faster uploaders will get more pieces than slow
-	// uploaders.
-	reqChan := make(chan uploadPiece)
-
-	// Once all requests have been sent, upload will read the resulting
-	// fileContracts from respChan and store them in f.
-	respChan := make(chan fileContract)
-
-	// spawn workers
-	for _, h := range hosts {
-		go f.uploadWorker(h, reqChan, respChan)
-	}
-
 	// encode and upload each chunk
+	var wg sync.WaitGroup
 	for i := uint64(0); ; i++ {
 		// read next chunk
 		chunk := make([]byte, f.chunkSize())
@@ -91,17 +62,22 @@ func (f *file) upload(r io.Reader, hosts []uploader) error {
 		if err != nil {
 			return err
 		}
-		// send upload requests to workers
+		// upload pieces, split evenly among hosts
+		wg.Add(len(pieces))
 		for j, data := range pieces {
-			reqChan <- uploadPiece{data, i, uint64(j)}
+			go func(j int, data []byte) {
+				hosts[j%len(hosts)].addPiece(uploadPiece{data, i, uint64(j)})
+				atomic.AddUint64(&f.bytesUploaded, uint64(len(data)))
+				wg.Done()
+			}(j, data)
 		}
+		wg.Wait()
 		atomic.AddUint64(&f.chunksUploaded, 1)
 	}
 
-	// signal workers to send their contracts
-	close(reqChan)
-	for range hosts {
-		contract := <-respChan
+	// gather final contracts
+	for _, h := range hosts {
+		contract := h.fileContract()
 		f.contracts[contract.IP] = contract
 	}
 


### PR DESCRIPTION
The old upload algorithm was fast, but could result in a dangerously skewed distribution of pieces if one host was much faster than the others (e.g. a host on the local network). The new algorithm distributes pieces evenly, but is bottlenecked by slow hosts.

As with the download test, I have also introduced random (20%) upload failures.
Old:
```
--- PASS: TestErasureUpload (0.51s)
	upload_test.go:95: Host #: 0	Delay: 1ms   	# Pieces: 343 (100x faster)
	upload_test.go:95: Host #: 1	Delay: 100ms	# Pieces: 0   (always fails)
	upload_test.go:95: Host #: 2	Delay: 100ms	# Pieces: 3
	upload_test.go:95: Host #: 3	Delay: 100ms	# Pieces: 3
	upload_test.go:95: Host #: 4	Delay: 100ms	# Pieces: 4
	upload_test.go:95: Host #: 5	Delay: 100ms	# Pieces: 3
	upload_test.go:95: Host #: 6	Delay: 100ms	# Pieces: 4
	upload_test.go:95: Host #: 7	Delay: 100ms	# Pieces: 4
	upload_test.go:95: Host #: 8	Delay: 100ms	# Pieces: 2
	upload_test.go:95: Host #: 9	Delay: 100ms	# Pieces: 4
	upload_test.go:95: Host #: 10	Delay: 100ms	# Pieces: 3
	upload_test.go:95: Host #: 11	Delay: 100ms	# Pieces: 5
```
New:
```
--- PASS: TestErasureUpload (3.98s)
	upload_test.go:95: Host #: 0	Delay: 1ms  	# Pieces: 34 (100x faster)
	upload_test.go:95: Host #: 1	Delay: 100ms	# Pieces: 0  (always fails)
	upload_test.go:95: Host #: 2	Delay: 100ms	# Pieces: 29
	upload_test.go:95: Host #: 3	Delay: 100ms	# Pieces: 30
	upload_test.go:95: Host #: 4	Delay: 100ms	# Pieces: 34
	upload_test.go:95: Host #: 5	Delay: 100ms	# Pieces: 35
	upload_test.go:95: Host #: 6	Delay: 100ms	# Pieces: 34
	upload_test.go:95: Host #: 7	Delay: 100ms	# Pieces: 30
	upload_test.go:95: Host #: 8	Delay: 100ms	# Pieces: 29
	upload_test.go:95: Host #: 9	Delay: 100ms	# Pieces: 32
	upload_test.go:95: Host #: 10	Delay: 100ms	# Pieces: 32
	upload_test.go:95: Host #: 11	Delay: 100ms	# Pieces: 33
```

(Fun fact: the old algo deadlocked if any piece failed to upload!! Who would write such unstable code? :P)