### PR TITLE
fix bounds error in mining pool

### DIFF
--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -64,6 +64,9 @@ func (m *Miner) prepareNewBlock() {
 		delete(m.blockMem, m.headerMem[m.memProgress])
 		delete(m.arbDataMem, m.headerMem[m.memProgress])
 		m.memProgress++
+		if m.memProgress == headerForWorkMemory {
+			m.memProgress = 0
+		}
 	}
 }
 


### PR DESCRIPTION
I think this might have been a problem in 0.3.3.3 as well. Causes seg faults 5% of the time that you mine a block.

fixed now.

I tested the miner, and the problems that people were reporting really just indicate that the wallet was locked. This problem is unrelated, though I'm glad I was able to dig it up nonetheless.