### PR TITLE
add txn purging to the renter

### DIFF
--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -91,7 +91,7 @@ func New(cs *consensus.ConsensusSet, hdb modules.HostDB, tpool modules.Transacti
 		// default host settings
 		HostSettings: modules.HostSettings{
 			TotalStorage: 10e9,                        // 10 GB
-			MaxFilesize:  1e9,                         // 1 GB
+			MaxFilesize:  5 * 1024 * 1024 * 1024,      // 5 GiB
 			MaxDuration:  144 * 60,                    // 60 days
 			WindowSize:   288,                         // 48 hours
 			Price:        types.NewCurrency64(100e12), // 0.1 siacoin / mb / week

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -173,6 +173,11 @@ type (
 		// View returns the incomplete transaction along with all of its
 		// parents.
 		View() (txn types.Transaction, parents []types.Transaction)
+
+		// Drop indicates that a transaction is no longer useful, will not be
+		// broadcast, and that all of the outputs can be reclaimed. 'Drop'
+		// should only be used before signatures are added.
+		Drop()
 	}
 
 	// Wallet stores and manages siacoins and siafunds. The wallet file is


### PR DESCRIPTION
If negotiation failed at some point, the transaction was left in limbo - outputs had been consumed according to the wallet, but actually had not been consumed since the transaction had failed. The transaction builder now includes a purge function that allows for outputs to be 'dropped'
from a transaction builder in the event of a failed transaction.
And the renter will now purge any in-progress transaction if negotiation fails, so that any outputs can be restored.