### PR TITLE
Save loaded files

### DIFF
--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -334,6 +334,10 @@ func (r *Renter) loadSharedFiles(reader io.Reader) ([]string, error) {
 		r.files[f.name] = f
 		names[i] = f.name
 	}
+	// Save the files, and their renter metadata.
+	for _, f := range files {
+		r.saveFile(f)
+	}
 	err = r.save()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Binary and ASCII .sia files were not being saved to the renter directory after loading, which meant that they would be lost when siad closed. Files are now saved to disk after being loaded.

Note: this could also have been implemented by directly copying the .sia data into a single file. This would preserve the "grouping" of the original .sia file (the current implementation will create a separate .sia file for each file contained within the loaded .sia file). I wasn't sure if that behavior was desirable though.