### PR TITLE
Migrate siac to Sia-Agent

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,7 +19,7 @@ const (
 func handleHTTPRequest(mux *http.ServeMux, url string, handler http.HandlerFunc) {
 	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
 		// prevent access from sources other than siac and Sia-UI
-		if !strings.Contains(req.UserAgent(), "Sia-Agent") && !strings.Contains(req.UserAgent(), "Sia-Miner") && req.UserAgent() != "" && !strings.Contains(req.UserAgent(), "Electron") && !strings.Contains(req.UserAgent(), "AtomShell") {
+		if !strings.Contains(req.UserAgent(), "Sia-Agent") && !strings.Contains(req.UserAgent(), "Sia-Miner") && req.UserAgent() != "" && req.UserAgent() != "Go 1.1 package http" && !strings.Contains(req.UserAgent(), "Electron") && !strings.Contains(req.UserAgent(), "AtomShell") {
 			writeError(w, "Browser access disabled due to security vulnerability. Use Sia-UI or siac.", http.StatusInternalServerError)
 			return
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -19,7 +19,7 @@ const (
 func handleHTTPRequest(mux *http.ServeMux, url string, handler http.HandlerFunc) {
 	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
 		// prevent access from sources other than siac and Sia-UI
-		if !strings.Contains(req.UserAgent(), "Sia-Agent") && !strings.Contains(req.UserAgent(), "Sia-Miner") && req.UserAgent() != "" && req.UserAgent() != "Go 1.1 package http" && !strings.Contains(req.UserAgent(), "Electron") && !strings.Contains(req.UserAgent(), "AtomShell") {
+		if !strings.Contains(req.UserAgent(), "Sia-Agent") && !strings.Contains(req.UserAgent(), "Sia-Miner") && req.UserAgent() != "" && !strings.Contains(req.UserAgent(), "Electron") && !strings.Contains(req.UserAgent(), "AtomShell") {
 			writeError(w, "Browser access disabled due to security vulnerability. Use Sia-UI or siac.", http.StatusInternalServerError)
 			return
 		}

--- a/siac/main.go
+++ b/siac/main.go
@@ -29,7 +29,7 @@ func apiGet(call string) (*http.Response, error) {
 		addr = net.JoinHostPort("localhost", port)
 	}
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "http://"+addr+call, nil)
+	req, _ := http.NewRequest("GET", "http://"+addr+call, nil)
 	req.Header.Add("User-Agent", "Sia-Agent")
 	resp, err := client.Do(req)
 	if err != nil {
@@ -80,7 +80,7 @@ func apiPost(call, vals string) (*http.Response, error) {
 	}
 
 	client := &http.Client{}
-	req, err := http.NewRequest("POST", "http://"+addr+call, strings.NewReader(vals))
+	req, _ := http.NewRequest("POST", "http://"+addr+call, strings.NewReader(vals))
 	req.Header.Add("User-Agent", "Sia-Agent")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := client.Do(req)

--- a/siac/main.go
+++ b/siac/main.go
@@ -29,8 +29,13 @@ func apiGet(call string) (*http.Response, error) {
 	if host, port, _ := net.SplitHostPort(addr); host == "" {
 		addr = net.JoinHostPort("localhost", port)
 	}
-
-	resp, err := http.Get("http://" + addr + call)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "http://"+addr+call, nil)
+	if err != nil {
+		return nil, errors.New("no response from daemon")
+	}
+	req.Header.Add("User-Agent", "Sia-Agent")
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.New("no response from daemon")
 	}
@@ -78,11 +83,14 @@ func apiPost(call, vals string) (*http.Response, error) {
 		addr = net.JoinHostPort("localhost", port)
 	}
 
-	data, err := url.ParseQuery(vals)
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", "http://"+addr+call, strings.NewReader(vals))
 	if err != nil {
-		return nil, errors.New("bad query string")
+		return nil, errors.New("no response from daemon")
 	}
-	resp, err := http.PostForm("http://"+addr+call, data)
+	req.Header.Add("User-Agent", "Sia-Agent")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.New("no response from daemon")
 	}

--- a/siac/main.go
+++ b/siac/main.go
@@ -30,9 +30,6 @@ func apiGet(call string) (*http.Response, error) {
 	}
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", "http://"+addr+call, nil)
-	if err != nil {
-		return nil, errors.New("no response from daemon")
-	}
 	req.Header.Add("User-Agent", "Sia-Agent")
 	resp, err := client.Do(req)
 	if err != nil {
@@ -84,9 +81,6 @@ func apiPost(call, vals string) (*http.Response, error) {
 
 	client := &http.Client{}
 	req, err := http.NewRequest("POST", "http://"+addr+call, strings.NewReader(vals))
-	if err != nil {
-		return nil, errors.New("no response from daemon")
-	}
 	req.Header.Add("User-Agent", "Sia-Agent")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := client.Do(req)

--- a/siac/main.go
+++ b/siac/main.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"reflect"
 	"strings"


### PR DESCRIPTION
Go 1.5 changed the default net.http user-agent causing siac to trigger "Browser access disabled due to security vulnerability. Use Sia-UI or siac." 

This pull is intended to migrate siac to using "Sia-Agent" and thus resolve that issue.