### PR TITLE
User-specified announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Troubleshooting
   siad tries to verify your connectivity by pinging your external IPv4 address.
   This method is sufficient for most people, but for unusual setups it may
   report false negatives. To override this check, you can "force" the
-  announcement by running `siac host announce --force`. Don't use this lightly!
+  announcement by running `siac host announce [ip:port]`. You can determine
+  your external IP by running `siac gateway` or using a 3rd-party service.
 
 - I mined a block, but I didn't receive any money.
 

--- a/api/host.go
+++ b/api/host.go
@@ -3,16 +3,18 @@ package api
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // hostAnnounceHandler handles the API call to get the host to announce itself
 // to the network.
 func (srv *Server) hostAnnounceHandler(w http.ResponseWriter, req *http.Request) {
 	// Announce checks that the host is connectible before proceeding. The
-	// user can override this check with the 'force' flag.
+	// user can override this check by manually specifying the address.
 	var err error
-	if req.FormValue("force") == "true" {
-		err = srv.host.ForceAnnounce()
+	if addr := req.FormValue("address"); addr != "" {
+		err = srv.host.ForceAnnounce(modules.NetAddress(addr))
 	} else {
 		err = srv.host.Announce()
 	}

--- a/doc/API.md
+++ b/doc/API.md
@@ -671,7 +671,12 @@ Queries:
 Function: The host will announce itself to the network as a source of storage.
 Generally only needs to be called once.
 
-Parameters: none
+Parameters:
+```
+address string
+```
+`address` is an optional parameter that specifies the address to be announced.
+Supplying this parameters will also override standard connectivity checks.
 
 Response: standard
 

--- a/modules/host.go
+++ b/modules/host.go
@@ -47,9 +47,9 @@ type Host interface {
 	// host cannot reach itself or if the external ip address is unknown.
 	Announce() error
 
-	// ForceAnnounce announces the host on the blockchain, regardless of
-	// connectivity.
-	ForceAnnounce() error
+	// ForceAnnounce announces the specified address on the blockchain,
+	// regardless of connectivity.
+	ForceAnnounce(NetAddress) error
 
 	// SetConfig sets the hosting parameters of the host.
 	SetSettings(HostSettings)

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -51,10 +51,6 @@ func (h *Host) announce(addr modules.NetAddress) error {
 // arbitrary data, signing the transaction, and submitting it to the
 // transaction pool.
 func (h *Host) Announce() error {
-	lockID := h.mu.RLock()
-	addr := h.myAddr
-	h.mu.RUnlock(lockID)
-
 	// Generate an unlock hash, if necessary
 	if h.UnlockHash == (types.UnlockHash{}) {
 		uc, err := h.wallet.NextAddress()
@@ -67,6 +63,12 @@ func (h *Host) Announce() error {
 			return err
 		}
 	}
+
+	// Get the external IP again; it may have changed.
+	h.learnHostname()
+	lockID := h.mu.RLock()
+	addr := h.myAddr
+	h.mu.RUnlock(lockID)
 
 	// Check that the host's ip address is both known and reachable.
 	if addr.Host() == "::1" {

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -14,7 +14,7 @@ func TestAnnouncement(t *testing.T) {
 	ht := CreateHostTester("TestAnnouncement", t)
 
 	// Place the announcement.
-	err := ht.host.ForceAnnounce()
+	err := ht.host.ForceAnnounce("foo")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/persist_test.go
+++ b/modules/renter/persist_test.go
@@ -126,11 +126,19 @@ func TestRenterSaveLoad(t *testing.T) {
 	defer rt.Close()
 
 	// Create and save some files
-	f1 := newTestingFile()
+	var f1, f2, f3 *file
+	f1 = newTestingFile()
+	f2 = newTestingFile()
+	f3 = newTestingFile()
+	// names must not conflict
+	for f2.name == f1.name || f2.name == f3.name {
+		f2 = newTestingFile()
+	}
+	for f3.name == f1.name || f3.name == f2.name {
+		f3 = newTestingFile()
+	}
 	rt.renter.saveFile(f1)
-	f2 := newTestingFile()
 	rt.renter.saveFile(f2)
-	f3 := newTestingFile()
 	rt.renter.saveFile(f3)
 
 	// load should now load the files into memory.

--- a/siac/README.md
+++ b/siac/README.md
@@ -88,8 +88,8 @@ siacoins to.
 a unit, for example MS, S, mS, ps, etc. If no unit is given hastings
 is assumed. `dest` must be a valid siacoin address.
 
-* `siac wallet lock` locks a wallet. After calling, the wallet must be unlocked using the
-encryption password in order to use it further
+* `siac wallet lock` locks a wallet. After calling, the wallet must be unlocked
+using the encryption password in order to use it further
 
 * `siac wallet seeds` returns the list of secret seeds in use by the
 wallet. These can be used to regenerate the wallet
@@ -116,11 +116,10 @@ You can call this many times to configure you host before
 announcing. Alternatively, you can manually adjust these parameters
 inside the `host/config.json` file.
 
-* `siac host announce [-f]` makes an host announcement. If the `-f` flag
-is passed, it will force the announcement. Otherwise, you cannot
-annonuce multiple times. Announcing a second time after changing
-settings is not necessary, as the announcement only contains enough
-information to reach your host.
+* `siac host announce` makes an host announcement. You may optionally
+supply a specific address to be announced; this allows you to announce a domain
+name. Announcing a second time after changing settings is not necessary, as the
+announcement only contains enough information to reach your host.
 
 * `siac host status` outputs some of your hosting settings.
 

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -37,8 +37,11 @@ Available settings:
 		Use:   "announce",
 		Short: "Announce yourself as a host",
 		Long: `Announce yourself as a host on the network.
-The --force flag can be used to override connectivity checks.`,
-		Run: wrap(hostannouncecmd)}
+You may also supply a specific address to be announced, e.g.:
+	siac host announce my-host-domain.com:9001
+Doing so will override the standard connectivity checks.`,
+		Run: hostannouncecmd,
+	}
 
 	hostStatusCmd = &cobra.Command{
 		Use:   "status",
@@ -67,12 +70,17 @@ func hostconfigcmd(param, value string) {
 	fmt.Println("Host settings updated.")
 }
 
-func hostannouncecmd() {
-	args := ""
-	if force {
-		args = "force=true"
+func hostannouncecmd(cmd *cobra.Command, args []string) {
+	var err error
+	switch len(args) {
+	case 0:
+		err = post("/host/announce", "")
+	case 1:
+		err = post("/host/announce", "address="+args[0])
+	default:
+		cmd.Usage()
+		return
 	}
-	err := post("/host/announce", args)
 	if err != nil {
 		fmt.Println("Could not announce host:", err)
 		return

--- a/siac/main.go
+++ b/siac/main.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	addr         string
-	force        bool
 	initPassword bool
 )
 
@@ -196,7 +195,6 @@ func main() {
 
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")
-	root.PersistentFlags().BoolVarP(&force, "force", "f", false, "force certain commands")
 
 	// run
 	root.Execute()


### PR DESCRIPTION
The user can now supply a specific address to be announced. This allows you to announce a domain instead of an IP. It also replaces the old "force" flag; now we assume that if you supply an address, you want to force the announcement. I like this because it means if you want to force an announcement, you have to lookup your IP first.