### PR TITLE
Better peer culling

### DIFF
--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -112,8 +112,8 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 
 	// Spawn the peer and node managers. These will attempt to keep the peer
 	// and node lists healthy.
-	go g.peerManager()
-	go g.nodeManager()
+	go g.threadedPeerManager()
+	go g.threadedNodeManager()
 
 	// Spawn the primary listener.
 	go g.listen()

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -110,9 +110,10 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	// Automatically forward the RPC port, if possible.
 	go g.forwardPort(port)
 
-	// Spawn the connector loop. This will continually attempt to add nodes as
-	// peers to ensure we stay well-connected.
-	go g.makeOutboundConnections()
+	// Spawn the peer and node managers. These will attempt to keep the peer
+	// and node lists healthy.
+	go g.peerManager()
+	go g.nodeManager()
 
 	// Spawn the primary listener.
 	go g.listen()

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -113,11 +113,11 @@ func (g *Gateway) sendAddress(conn modules.PeerConn) error {
 	return encoding.WriteObject(conn, g.Address())
 }
 
-// nodeManager tries to keep the Gateway's node list healthy. As long as the
-// Gateway has fewer than minNodeListSize nodes, it asks a random peer for
-// more nodes. It also continually pings nodes in order to establish their
+// threadedNodeManager tries to keep the Gateway's node list healthy. As long
+// as the Gateway has fewer than minNodeListSize nodes, it asks a random peer
+// for more nodes. It also continually pings nodes in order to establish their
 // connectivity. Unresponsive nodes are aggressively removed.
-func (g *Gateway) nodeManager() {
+func (g *Gateway) threadedNodeManager() {
 	for {
 		time.Sleep(5 * time.Second)
 

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -144,18 +144,16 @@ func (g *Gateway) nodeManager() {
 
 		// try to connect
 		conn, err := net.DialTimeout("tcp", string(node), dialTimeout)
-		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		if err != nil {
 			id = g.mu.Lock()
 			g.removeNode(node)
 			g.save()
 			g.mu.Unlock(id)
-		} else if err != nil {
 			continue
 		}
 		// if connection succeeds, supply an unacceptable version to ensure
 		// they won't try to add us as a peer
 		encoding.WriteObject(conn, "0.0.0")
 		conn.Close()
-
 	}
 }

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -155,5 +155,8 @@ func (g *Gateway) nodeManager() {
 		// they won't try to add us as a peer
 		encoding.WriteObject(conn, "0.0.0")
 		conn.Close()
+		// sleep for an extra 10 minutes after success; we don't want to spam
+		// connectable nodes
+		time.Sleep(10 * time.Minute)
 	}
 }

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -233,9 +233,9 @@ func (g *Gateway) Disconnect(addr modules.NetAddress) error {
 	return nil
 }
 
-// peerManager tries to keep the Gateway well-connected. As long as the
-// Gateway is not well-connected, it tries to connect to random nodes.
-func (g *Gateway) peerManager() {
+// threadedPeerManager tries to keep the Gateway well-connected. As long as
+// the Gateway is not well-connected, it tries to connect to random nodes.
+func (g *Gateway) threadedPeerManager() {
 	for {
 		// If we are well-connected, sleep in increments of five minutes until
 		// we are no longer well-connected.

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -255,7 +255,7 @@ func (g *Gateway) peerManager() {
 			sleepTime = 5 * time.Second
 		}
 
-		g.Connect(addr)
+		go g.Connect(addr)
 	}
 }
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -252,6 +252,7 @@ func (g *Gateway) makeOutboundConnections() {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				id = g.mu.Lock()
 				g.removeNode(addr)
+				g.save()
 				g.mu.Unlock(id)
 			}
 		}


### PR DESCRIPTION
`makeOutboundConnections` has been split into two functions, `peerManager` and `nodeManager`.

`peerManager` keeps the gateway well-connected by forming new connections to peers until reaching 8 total connections.

`nodeManager` keeps the node list healthy by pinging nodes and aggressively culling those that are unresponsive.

Tests pass, and coverage is okay, but these functions really ought to be tested in the wild. My guess is that it will take longer to get peers now. `makeOutboundConnections` tried to form up to 100 connections before sleeping; `peerManager` only tries to form one. However, these changes should (eventually) improve the average node list, such that fewer connection attempts are needed.