### PR TITLE
Moving addSignatures out of transactionbuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ dependencies:
 	go get -u github.com/laher/goxc
 	go get -u github.com/spf13/cobra
 	go get -u github.com/stretchr/graceful
+	go get -u github.com/stretchr/testify
 	go get -u golang.org/x/crypto/twofish
 	go get -u golang.org/x/tools/cmd/cover
 

--- a/modules/wallet/signtransaction.go
+++ b/modules/wallet/signtransaction.go
@@ -1,0 +1,64 @@
+package wallet
+
+import (
+	"bytes"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+type hashSigner func(crypto.Hash, crypto.SecretKey) (crypto.Signature, error)
+
+type signatureAdder func(*types.Transaction, types.CoveredFields, types.UnlockConditions, crypto.Hash, spendableKey) error
+
+// addSignatures will sign a transaction using a spendable key, with support
+// for multisig spendable keys. Because of the restricted input, the function
+// is compatible with both siacoin inputs and siafund inputs.
+func addSignatures(txn *types.Transaction, cf types.CoveredFields, uc types.UnlockConditions, parentID crypto.Hash, spendKey spendableKey) error {
+	return addSignaturesWithHashSigner(txn, cf, uc, parentID, spendKey, crypto.SignHash)
+}
+
+// addSignaturesWithHashSigner provides the same functionality as
+// addSignatures, but allows the caller to specify the hash signing function.
+func addSignaturesWithHashSigner(txn *types.Transaction, cf types.CoveredFields, uc types.UnlockConditions, parentID crypto.Hash, spendKey spendableKey, signHash hashSigner) error {
+	// Try to find the matching secret key for each public key - some public
+	// keys may not have a match. Some secret keys may be used multiple times,
+	// which is why public keys are used as the outer loop.
+	totalSignatures := uint64(0)
+	for i, siaPubKey := range uc.PublicKeys {
+		// Search for the matching secret key to the public key.
+		for j := range spendKey.SecretKeys {
+			pubKey := spendKey.SecretKeys[j].PublicKey()
+			if bytes.Compare(siaPubKey.Key, pubKey[:]) != 0 {
+				continue
+			}
+
+			// Found the right secret key, add a signature.
+			sig := types.TransactionSignature{
+				ParentID:       parentID,
+				CoveredFields:  cf,
+				PublicKeyIndex: uint64(i),
+			}
+			txn.TransactionSignatures = append(txn.TransactionSignatures, sig)
+			sigIndex := len(txn.TransactionSignatures) - 1
+			sigHash := txn.SigHash(sigIndex)
+			encodedSig, err := signHash(sigHash, spendKey.SecretKeys[j])
+			if err != nil {
+				return err
+			}
+			txn.TransactionSignatures[sigIndex].Signature = encodedSig[:]
+
+			// Count that the signature has been added, and break out of the
+			// secret key loop.
+			totalSignatures++
+			break
+		}
+
+		// If there are enough signatures to satisfy the unlock conditions,
+		// break out of the outer loop.
+		if totalSignatures == uc.SignaturesRequired {
+			break
+		}
+	}
+	return nil
+}

--- a/modules/wallet/signtransaction_test.go
+++ b/modules/wallet/signtransaction_test.go
@@ -1,0 +1,56 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// mockHashSigner serves as a mock replacement for crypto.SignHash.
+type mockHashSigner struct {
+	mock.Mock
+}
+
+func (hs *mockHashSigner) SignHash(hash crypto.Hash, key crypto.SecretKey) (sig crypto.Signature, err error) {
+	args := hs.Called(hash, key)
+	return args.Get(0).(crypto.Signature), args.Error(1)
+}
+
+func generateMockSignatureKeys() (sk crypto.SecretKey, pk crypto.PublicKey) {
+	sk[0] = 0x0a
+	sk[32] = 0x0b
+	return sk, sk.PublicKey()
+}
+
+func publicKeyToSiaPublicKey(pk crypto.PublicKey) (spk types.SiaPublicKey) {
+	spk.Key = pk[:]
+	return spk
+}
+
+func TestAddSignaturesOnEmptyTransaction(t *testing.T) {
+	sk, pk := generateMockSignatureKeys()
+	txn := types.Transaction{}
+	cf := types.CoveredFields{}
+	uc := types.UnlockConditions{}
+	uc.PublicKeys = append(uc.PublicKeys, publicKeyToSiaPublicKey(pk))
+	parentID := crypto.Hash{}
+	spendKey := spendableKey{}
+	spendKey.SecretKeys = append(spendKey.SecretKeys, sk)
+
+	// Create a mock hash signer that always returns a signature of
+	// {0x0c, 0x00, 0x00, ...}
+	hs := new(mockHashSigner)
+	var mockSignature crypto.Signature
+	mockSignature[0] = 0x0c
+	hs.On("SignHash", mock.Anything, sk).Return(mockSignature, nil)
+
+	addSignaturesWithHashSigner(&txn, cf, uc, parentID, spendKey, hs.SignHash)
+
+	assert.Equal(t, 1, len(txn.TransactionSignatures))
+	assert.Equal(t, mockSignature[:], txn.TransactionSignatures[0].Signature)
+	hs.AssertExpectations(t)
+}


### PR DESCRIPTION
Creating a separate file for the addSignatures function and making the
signature adding function a function pointer in transactionBuilder. This will
allow us to more easily test transactionBuilder, as the complex logic of
addSignatures can be mocked out.

This also adds a very limited unit test for addSignatures.