### PR TITLE
Reader/Writer encoding interfaces

### DIFF
--- a/doc/Encoding.md
+++ b/doc/Encoding.md
@@ -66,8 +66,9 @@ Marshal(foo{"bar", 3}) == append(Marshal("bar"), Marshal(3)...)
 ```
 
 Finally, if a type implements the SiaMarshaler interface, its MarshalSia
-method will be used to encode the type. The resulting byte slice will be
-length-prefixed like any other variable-length type. During decoding, the type
-is decoded as a byte slice, and then passed to UnmarshalSia. The most
-prevalent example of this is the `Currency` type, which is encoded as a
-variable-length big-endian unsigned integer.
+method will be used to encode the type. Similarly, if a type implements the
+SiaUnmarshal interface, its UnmarshalSia method will be used to decode the
+type. Note that unless a type implements both interfaces, it must conform to
+the spec above. Otherwise, it may encode and decode itself however desired.
+This may be an attractive option where speed is critical, since it allows for
+more compact representations, and bypasses the use of reflection.

--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -42,6 +42,16 @@ func (e *Encoder) Encode(v interface{}) error {
 	return e.encode(reflect.ValueOf(v))
 }
 
+// EncodeAll encodes a variable number of arguments.
+func (e *Encoder) EncodeAll(vs ...interface{}) error {
+	for i := range vs {
+		if err := e.Encode(vs[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // write catches instances where short writes do not return an error.
 func (e *Encoder) write(p []byte) error {
 	n, err := e.w.Write(p)
@@ -193,6 +203,16 @@ func (d *Decoder) Decode(v interface{}) (err error) {
 
 	d.decode(pval.Elem())
 	return
+}
+
+// DecodeAll decodes a variable number of arguments.
+func (d *Decoder) DecodeAll(vs ...interface{}) error {
+	for i := range vs {
+		if err := d.Decode(vs[i]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // readN reads n bytes and panics if the read fails.

--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -17,9 +17,9 @@ type SiaMarshaler interface {
 	MarshalSia() []byte
 }
 
-// A SiaUnmarshaler can decode itself from a byte slice.
+// A SiaUnmarshaler can decode itself from a reader.
 type SiaUnmarshaler interface {
-	UnmarshalSia([]byte) error
+	UnmarshalSia(io.Reader) error
 }
 
 // An Encoder writes objects to an output stream.
@@ -56,7 +56,7 @@ func (e *Encoder) write(p []byte) error {
 func (e *Encoder) encode(val reflect.Value) error {
 	// check for MarshalSia interface first
 	if m, ok := val.Interface().(SiaMarshaler); ok {
-		return WritePrefix(e.w, m.MarshalSia())
+		return e.write(m.MarshalSia())
 	}
 
 	switch val.Kind() {
@@ -221,7 +221,7 @@ func (d *Decoder) decode(val reflect.Value) {
 	// check for UnmarshalSia interface first
 	if val.CanAddr() {
 		if u, ok := val.Addr().Interface().(SiaUnmarshaler); ok {
-			err := u.UnmarshalSia(d.readPrefix())
+			err := u.UnmarshalSia(d)
 			if err != nil {
 				panic(err)
 			}

--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	maxDecodeLen = 10 * 1024 * 1024 // 10 MB
-	maxSliceLen  = 4 * 1024 * 1024  // 4 MB
+	maxDecodeLen = 10 * 1024 * 1024 // 10 MiB
+	maxSliceLen  = 4 * 1024 * 1024  // 4 MiB
 )
 
 var (

--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -95,6 +95,9 @@ func (e *Encoder) encode(val reflect.Value) error {
 		if err := e.write(EncUint64(uint64(val.Len()))); err != nil {
 			return err
 		}
+		if val.Len() == 0 {
+			return nil
+		}
 		fallthrough
 	case reflect.Array:
 		// special case for byte arrays
@@ -282,6 +285,8 @@ func (d *Decoder) decode(val reflect.Value) {
 		// them allocate a massive slice
 		if sliceLen > 1<<31-1 || sliceLen*uint64(val.Type().Elem().Size()) > maxSliceLen {
 			panic("slice is too large")
+		} else if sliceLen == 0 {
+			return
 		}
 		val.Set(reflect.MakeSlice(val.Type(), int(sliceLen), int(sliceLen)))
 		fallthrough

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -48,8 +48,8 @@ type (
 	}
 )
 
-func (t test5) MarshalSia() []byte {
-	return AddPrefix([]byte(t.s))
+func (t test5) MarshalSia(w io.Writer) error {
+	return WritePrefix(w, []byte(t.s))
 }
 
 func (t *test5) UnmarshalSia(r io.Reader) error {
@@ -58,9 +58,9 @@ func (t *test5) UnmarshalSia(r io.Reader) error {
 	return err
 }
 
-// reuse above methods, but with a pointer receiver
-func (t *test6) MarshalSia() []byte {
-	return AddPrefix([]byte(t.s))
+// same as above methods, but with a pointer receiver
+func (t *test6) MarshalSia(w io.Writer) error {
+	return WritePrefix(w, []byte(t.s))
 }
 
 func (t *test6) UnmarshalSia(r io.Reader) error {
@@ -107,7 +107,7 @@ func TestEncode(t *testing.T) {
 	for i := range testStructs {
 		err := enc.Encode(testStructs[i])
 		if err != io.ErrShortWrite {
-			t.Error("expected ErrShortWrite, got", err)
+			t.Errorf("testStructs[%d]: expected ErrShortWrite, got %v", i, err)
 		}
 	}
 	// special case, not covered by testStructs

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -237,3 +237,34 @@ func TestReadWriteFile(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 }
+
+func BenchmarkEncode(b *testing.B) {
+	buf := new(bytes.Buffer)
+	enc := NewEncoder(buf)
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		for i := range testStructs {
+			err := enc.Encode(testStructs[i])
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.SetBytes(int64(buf.Len()))
+}
+
+func BenchmarkDecode(b *testing.B) {
+	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
+	var numBytes int64
+	for i := 0; i < b.N; i++ {
+		numBytes = 0
+		for i := range testEncodings {
+			err := Unmarshal(testEncodings[i], emptyStructs[i])
+			if err != nil {
+				b.Fatal(err)
+			}
+			numBytes += int64(len(testEncodings[i]))
+		}
+	}
+	b.SetBytes(numBytes)
+}

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -251,7 +251,7 @@ func TestReadWriteFile(t *testing.T) {
 	}
 }
 
-// i5-4670K, 09-15-2015: 33 MB/s
+// i5-4670K, 9a90f86: 33 MB/s
 func BenchmarkEncode(b *testing.B) {
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(buf)
@@ -267,7 +267,7 @@ func BenchmarkEncode(b *testing.B) {
 	b.SetBytes(int64(buf.Len()))
 }
 
-// i5-4670K, 09-15-2015: 26 MB/s
+// i5-4670K, 9a90f86: 26 MB/s
 func BenchmarkDecode(b *testing.B) {
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	var numBytes int64

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -48,13 +48,26 @@ type (
 	}
 )
 
-func (t test5) MarshalSia() []byte { return []byte(t.s) }
+func (t test5) MarshalSia() []byte {
+	return AddPrefix([]byte(t.s))
+}
 
-func (t *test5) UnmarshalSia(b []byte) error { t.s = string(b); return nil }
+func (t *test5) UnmarshalSia(r io.Reader) error {
+	b, err := ReadPrefix(r, 256)
+	t.s = string(b)
+	return err
+}
 
-func (t *test6) MarshalSia() []byte { return []byte(t.s) }
+// reuse above methods, but with a pointer receiver
+func (t *test6) MarshalSia() []byte {
+	return AddPrefix([]byte(t.s))
+}
 
-func (t *test6) UnmarshalSia(b []byte) error { t.s = string(b); return nil }
+func (t *test6) UnmarshalSia(r io.Reader) error {
+	b, err := ReadPrefix(r, 256)
+	t.s = string(b)
+	return err
+}
 
 var testStructs = []interface{}{
 	test0{false, 65537, 256, "foo"},

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -251,6 +251,7 @@ func TestReadWriteFile(t *testing.T) {
 	}
 }
 
+// i5-4670K, 09-15-2015: 33 MB/s
 func BenchmarkEncode(b *testing.B) {
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(buf)
@@ -266,6 +267,7 @@ func BenchmarkEncode(b *testing.B) {
 	b.SetBytes(int64(buf.Len()))
 }
 
+// i5-4670K, 09-15-2015: 26 MB/s
 func BenchmarkDecode(b *testing.B) {
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	var numBytes int64

--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -48,7 +48,7 @@ func AddPrefix(b []byte) []byte {
 // WritePrefix writes a length-prefixed byte slice to w.
 func WritePrefix(w io.Writer, data []byte) error {
 	n, err := w.Write(AddPrefix(data))
-	if n != len(data)+8 {
+	if n != len(data)+8 && err == nil {
 		return io.ErrShortWrite
 	}
 	return err

--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -40,14 +40,9 @@ func ReadObject(r io.Reader, obj interface{}, maxLen uint64) error {
 	return Unmarshal(data, obj)
 }
 
-// AddPrefix prepends b with an 8-byte length prefix.
-func AddPrefix(b []byte) []byte {
-	return append(EncUint64(uint64(len(b))), b...)
-}
-
 // WritePrefix writes a length-prefixed byte slice to w.
 func WritePrefix(w io.Writer, data []byte) error {
-	n, err := w.Write(AddPrefix(data))
+	n, err := w.Write(append(EncUint64(uint64(len(data))), data...))
 	if n != len(data)+8 && err == nil {
 		return io.ErrShortWrite
 	}

--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -40,9 +40,14 @@ func ReadObject(r io.Reader, obj interface{}, maxLen uint64) error {
 	return Unmarshal(data, obj)
 }
 
+// AddPrefix prepends b with an 8-byte length prefix.
+func AddPrefix(b []byte) []byte {
+	return append(EncUint64(uint64(len(b))), b...)
+}
+
 // WritePrefix writes a length-prefixed byte slice to w.
 func WritePrefix(w io.Writer, data []byte) error {
-	n, err := w.Write(append(EncUint64(uint64(len(data))), data...))
+	n, err := w.Write(AddPrefix(data))
 	if n != len(data)+8 {
 		return io.ErrShortWrite
 	}

--- a/modules/consensus/accept_bench_test.go
+++ b/modules/consensus/accept_bench_test.go
@@ -12,7 +12,7 @@ import (
 // BenchmarkAcceptEmptyBlocks measures how quckly empty blocks are integrated
 // into the consensus set.
 //
-// David's Setup - 08-26-2015: 6.377 ms / op
+// i7-4770, 61ab2f5: 6.377 ms / op
 func BenchmarkAcceptEmptyBlocks(b *testing.B) {
 	cst, err := createConsensusSetTester("BenchmarkEmptyBlocks")
 	if err != nil {
@@ -62,7 +62,7 @@ func BenchmarkAcceptEmptyBlocks(b *testing.B) {
 // BenchmarkAcceptSmallBlocks measures how quickly smaller blocks are
 // integrated into the consensus set.
 //
-// David's Setup - 08-26-2015: 10.047 ms / op
+// i7-4770, 61ab2f5: 10.047 ms / op
 func BenchmarkAcceptAcceptSmallBlocks(b *testing.B) {
 	cst, err := createConsensusSetTester("BenchmarkAcceptSmallBlocks")
 	if err != nil {

--- a/types/block_bench_test.go
+++ b/types/block_bench_test.go
@@ -8,7 +8,7 @@ import (
 
 // BenchmarkEncodeEmptyBlock benchmarks encoding an empty block.
 //
-// i5-4670K, 09-15-2015: 48 MB/s
+// i5-4670K, 9a90f86: 48 MB/s
 func BenchmarkEncodeBlock(b *testing.B) {
 	var block Block
 	b.SetBytes(int64(len(encoding.Marshal(block))))
@@ -19,8 +19,8 @@ func BenchmarkEncodeBlock(b *testing.B) {
 
 // BenchmarkDecodeEmptyBlock benchmarks decoding an empty block.
 //
-// i7-4770,  08-20-2015: 38 MB/s
-// i5-4670K, 09-15-2015: 55 MB/s
+// i7-4770,  b0b162d: 38 MB/s
+// i5-4670K, 9a90f86: 55 MB/s
 func BenchmarkDecodeEmptyBlock(b *testing.B) {
 	var block Block
 	encodedBlock := encoding.Marshal(block)

--- a/types/block_bench_test.go
+++ b/types/block_bench_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/NebulousLabs/Sia/encoding"
 )
 
+func BenchmarkEncodeBlock(b *testing.B) {
+	var block Block
+	b.SetBytes(int64(len(encoding.Marshal(block))))
+	for i := 0; i < b.N; i++ {
+		encoding.Marshal(block)
+	}
+}
+
 // BenchmarkDecodeEmptyBlock benchmarks decoding an empty block.
 //
 // i7-4770, 08-20-2015: 38 MB/s

--- a/types/block_bench_test.go
+++ b/types/block_bench_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/NebulousLabs/Sia/encoding"
 )
 
+// BenchmarkEncodeEmptyBlock benchmarks encoding an empty block.
+//
+// i5-4670K, 09-15-2015: 48 MB/s
 func BenchmarkEncodeBlock(b *testing.B) {
 	var block Block
 	b.SetBytes(int64(len(encoding.Marshal(block))))
@@ -16,8 +19,9 @@ func BenchmarkEncodeBlock(b *testing.B) {
 
 // BenchmarkDecodeEmptyBlock benchmarks decoding an empty block.
 //
-// i7-4770, 08-20-2015: 38 MB/s
-func BenchmarkDecodeBlock(b *testing.B) {
+// i7-4770,  08-20-2015: 38 MB/s
+// i5-4670K, 09-15-2015: 55 MB/s
+func BenchmarkDecodeEmptyBlock(b *testing.B) {
 	var block Block
 	encodedBlock := encoding.Marshal(block)
 	b.SetBytes(int64(len(encodedBlock)))

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -250,3 +250,24 @@ func TestBlockMinerPayoutID(t *testing.T) {
 		knownIDs[id] = struct{}{}
 	}
 }
+
+// TestBlockEncodes probes the MarshalSia and UnmarshalSia methods of the
+// Block type.
+func TestBlockEncoding(t *testing.T) {
+	b := Block{
+		MinerPayouts: []SiacoinOutput{
+			{Value: CalculateCoinbase(0)},
+			{Value: CalculateCoinbase(0)},
+		},
+	}
+	var decB Block
+	err := encoding.Unmarshal(encoding.Marshal(b), &decB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decB.MinerPayouts) != len(b.MinerPayouts) ||
+		decB.MinerPayouts[0].Value.Cmp(b.MinerPayouts[0].Value) != 0 ||
+		decB.MinerPayouts[1].Value.Cmp(b.MinerPayouts[1].Value) != 0 {
+		t.Fatal("block changed after encode/decode:", b, decB)
+	}
+}

--- a/types/currency.go
+++ b/types/currency.go
@@ -183,12 +183,12 @@ func (c *Currency) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalSia implements the encoding.SiaMarshaler interface. It returns the
-// byte-slice representation of the Currency's internal big.Int.  Note that as
-// the bytes of the big.Int correspond to the absolute value of the integer,
-// there is no way to marshal a negative Currency.
-func (c Currency) MarshalSia() []byte {
-	return encoding.AddPrefix(c.i.Bytes())
+// MarshalSia implements the encoding.SiaMarshaler interface. It writes the
+// byte-slice representation of the Currency's internal big.Int to w. Note
+// that as the bytes of the big.Int correspond to the absolute value of the
+// integer, there is no way to marshal a negative Currency.
+func (c Currency) MarshalSia(w io.Writer) error {
+	return encoding.WritePrefix(w, c.i.Bytes())
 }
 
 // UnmarshalSia implements the encoding.SiaUnmarshaler interface.

--- a/types/currency.go
+++ b/types/currency.go
@@ -11,10 +11,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/encoding"
 )
 
 type (
@@ -186,11 +188,15 @@ func (c *Currency) UnmarshalJSON(b []byte) error {
 // the bytes of the big.Int correspond to the absolute value of the integer,
 // there is no way to marshal a negative Currency.
 func (c Currency) MarshalSia() []byte {
-	return c.i.Bytes()
+	return encoding.AddPrefix(c.i.Bytes())
 }
 
 // UnmarshalSia implements the encoding.SiaUnmarshaler interface.
-func (c *Currency) UnmarshalSia(b []byte) error {
+func (c *Currency) UnmarshalSia(r io.Reader) error {
+	b, err := encoding.ReadPrefix(r, 256)
+	if err != nil {
+		return err
+	}
 	c.i.SetBytes(b)
 	return nil
 }

--- a/types/currency_test.go
+++ b/types/currency_test.go
@@ -166,9 +166,13 @@ func TestCurrencyMarshalJSON(t *testing.T) {
 // the currency type.
 func TestCurrencyMarshalSia(t *testing.T) {
 	c := NewCurrency64(1656)
-	cMar := c.MarshalSia()
+	buf := new(bytes.Buffer)
+	err := c.MarshalSia(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var cUmar Currency
-	cUmar.UnmarshalSia(bytes.NewReader(cMar))
+	cUmar.UnmarshalSia(buf)
 	if c.Cmp(cUmar) != 0 {
 		t.Error("marshal and unmarshal mismatch for currency type")
 	}

--- a/types/currency_test.go
+++ b/types/currency_test.go
@@ -168,7 +168,7 @@ func TestCurrencyMarshalSia(t *testing.T) {
 	c := NewCurrency64(1656)
 	cMar := c.MarshalSia()
 	var cUmar Currency
-	cUmar.UnmarshalSia(cMar)
+	cUmar.UnmarshalSia(bytes.NewReader(cMar))
 	if c.Cmp(cUmar) != 0 {
 		t.Error("marshal and unmarshal mismatch for currency type")
 	}


### PR DESCRIPTION
`MarshalSia` and `UnmarshalSia` now take an `io.Writer` and `io.Reader`, respectively. This makes them better aligned with `Encode` and `Decode`. More importantly, it removes the need for all manually-marshaled data to be prefaced with a length prefix. This allows us to start writing `MarshalSia` methods for types where speed is important, e.g. `types.Block` (implemented here). Previously, doing so would have broken compatibility due to the length prefix.

After implementing `(Un)MarshalSia` methods for `types.Block`, non-rigorous benchmarking reveals the following speedups when encoding and decoding an empty block:
```
Encode benchmark: 38.70 MB/s -> 47.87 MB/s (23.7% faster)
Decode benchmark: 41.69 MB/s -> 55.80 MB/s (33.9% faster)
```
I suspect this speedup will only be magnified when we start manually marshaling transactions, and will be more noticeable with blocks that contain real data.