### PR TITLE
More permissive Gateway

### DIFF
--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/sync"
 )
@@ -83,10 +84,18 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 		log:        logger,
 	}
 
-	// Load the old peer list. If it doesn't exist, no problem, but if it does,
+	// Load the old node list. If it doesn't exist, no problem, but if it does,
 	// we want to know about any errors preventing us from loading it.
 	if loadErr := g.load(); loadErr != nil && !os.IsNotExist(loadErr) {
 		return nil, loadErr
+	}
+
+	// Add the bootstrap peers to the node list.
+	if build.Release != "testing" {
+		for _, addr := range modules.BootstrapPeers {
+			g.addNode(addr)
+		}
+		g.save()
 	}
 
 	// Create listener and set address.

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -42,7 +42,7 @@ func TestPeers(t *testing.T) {
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestRPC2", t)
-	defer g1.Close()
+	defer g2.Close()
 	err := g1.Connect(g2.Address())
 	if err != nil {
 		t.Fatal("failed to connect:", err)

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -119,7 +119,11 @@ func (g *Gateway) sendAddress(conn modules.PeerConn) error {
 // connectivity. Unresponsive nodes are aggressively removed.
 func (g *Gateway) threadedNodeManager() {
 	for {
-		time.Sleep(5 * time.Second)
+		select {
+		case <-time.After(5 * time.Second):
+		case <-g.closeChan:
+			return
+		}
 
 		id := g.mu.RLock()
 		numNodes := len(g.nodes)
@@ -157,6 +161,10 @@ func (g *Gateway) threadedNodeManager() {
 		conn.Close()
 		// sleep for an extra 10 minutes after success; we don't want to spam
 		// connectable nodes
-		time.Sleep(10 * time.Minute)
+		select {
+		case <-time.After(10 * time.Minute):
+		case <-g.closeChan:
+			return
+		}
 	}
 }

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -161,7 +161,7 @@ func TestRelayNodes(t *testing.T) {
 	g2 := newTestingGateway("TestRelayNodes2", t)
 	defer g2.Close()
 	g3 := newTestingGateway("TestRelayNodes3", t)
-	defer g2.Close()
+	defer g3.Close()
 
 	// overwrite g3's address with a non-loopback address;
 	// otherwise it will be rejected

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -230,10 +230,15 @@ func (g *Gateway) threadedPeerManager() {
 		// If we are well-connected, sleep in increments of five minutes until
 		// we are no longer well-connected.
 		id := g.mu.RLock()
-		numPeers := len(g.peers)
+		numOutboundPeers := 0
+		for _, p := range g.peers {
+			if !p.inbound {
+				numOutboundPeers++
+			}
+		}
 		addr, err := g.randomNode()
 		g.mu.RUnlock(id)
-		if numPeers >= wellConnectedThreshold {
+		if numOutboundPeers >= wellConnectedThreshold {
 			time.Sleep(5 * time.Minute)
 			continue
 		}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -276,6 +276,7 @@ func (g *Gateway) threadedPeerManager() {
 	}
 }
 
+// Peers returns the addresses currently connected to the Gateway.
 func (g *Gateway) Peers() []modules.NetAddress {
 	id := g.mu.RLock()
 	defer g.mu.RUnlock(id)


### PR DESCRIPTION
The new `acceptConn` rules are detailed in the commit message of 3c6b222. Another important change is that only outbound connections will count towards the `wellConnectedThreshold`.

This latter change may be a problem, now that I think of it. The reason is that port-forwarded nodes are a scarce resource, and we don't want to overwhelm them with connections. Perhaps 3-5 outgoing connections would be healthier.