### PR TITLE
Refactors crypto/signatures.go to use explicit interfaces and adds unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ dependencies:
 	go get -u github.com/laher/goxc
 	go get -u github.com/spf13/cobra
 	go get -u github.com/stretchr/graceful
+	go get -u github.com/stretchr/testify
 	go get -u golang.org/x/crypto/twofish
 	go get -u golang.org/x/tools/cmd/cover
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ dependencies:
 	go get -u github.com/laher/goxc
 	go get -u github.com/spf13/cobra
 	go get -u github.com/stretchr/graceful
-	go get -u github.com/stretchr/testify
 	go get -u golang.org/x/crypto/twofish
 	go get -u golang.org/x/tools/cmd/cover
 

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -21,7 +21,6 @@ type (
 )
 
 var (
-	ErrNilInput         = errors.New("cannot use nil input")
 	ErrInvalidSignature = errors.New("invalid signature")
 	ErrRandUnexpected   = errors.New("unexpected result from random number generator")
 )

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -21,6 +21,7 @@ type (
 )
 
 var (
+	ErrNilInput         = errors.New("cannot use nil input")
 	ErrInvalidSignature = errors.New("invalid signature")
 	ErrRandUnexpected   = errors.New("unexpected result from random number generator")
 )

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -37,14 +37,14 @@ type KeyPairGenerator interface {
 // returns the total number of bytes written to the buffer.
 type readBytesFunc func([]byte) (int, error)
 
-// deriveEd25519KeyPairFunc is a function pointer that matches the signature of
+// deriveEd25519Func is a function pointer that matches the signature of
 // ed25519.GenerateKey.
-type deriveEd25519KeyPairFunc func([EntropySize]byte) (ed25519.SecretKey, ed25519.PublicKey)
+type deriveEd25519Func func([EntropySize]byte) (ed25519.SecretKey, ed25519.PublicKey)
 
 // SignatureKeyGenerator is an implementation of KeyPairGenerator.
 type SignatureKeyGenerator struct {
 	readRandBytes readBytesFunc
-	deriveKeyPair deriveEd25519KeyPairFunc
+	deriveKeyPair deriveEd25519Func
 }
 
 // NewSignatureKeyGenerator creates a new SignatureKeyGenerator type that uses

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -30,7 +30,7 @@ var (
 // public-secret key pairs.
 type KeyPairGenerator interface {
 	Generate() (SecretKey, PublicKey, error)
-	GenerateDetermistically(entropy [EntropySize]byte) (SecretKey, PublicKey)
+	GenerateDetermistic(entropy [EntropySize]byte) (SecretKey, PublicKey)
 }
 
 // readBytesFunc is a function pointer that reads bytes into a buffer and

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -25,7 +25,7 @@ func (m *mockRandGenerator) Read(b []byte) (n int, err error) {
 	return args.Int(0), args.Error(1)
 }
 
-// mockKeyDeriver is a mock implementation of deriveEd25519KeyPairFunc, allowing
+// mockKeyDeriver is a mock implementation of deriveEd25519Func, allowing
 // tests to mock out calls to ed25519.GenerateKey.
 type mockKeyDeriver struct {
 	mock.Mock

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -2,58 +2,171 @@ package crypto
 
 import (
 	"crypto/rand"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/ed25519"
 )
+
+// mockRandGenerator is a mock implementation of readBytesFunc, allowing tests
+// to mock out calls to rand.Read and use a deterministic implementation
+// instead.
+type mockRandGenerator struct {
+	mock.Mock
+}
+
+func (m *mockRandGenerator) Read(b []byte) (n int, err error) {
+	args := m.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+// mockKeyDeriver is a mock implementation of deriveEd25519KeyPairFunc, allowing
+// tests to mock out calls to ed25519.GenerateKey.
+type mockKeyDeriver struct {
+	mock.Mock
+}
+
+func (m *mockKeyDeriver) Derive(b [EntropySize]byte) (sk ed25519.SecretKey, pk ed25519.PublicKey) {
+	args := m.Called(b)
+	return args.Get(0).(ed25519.SecretKey), args.Get(1).(ed25519.PublicKey)
+}
+
+// Create a testable version of SignatureKeyGenerator whose readRandBytes and
+// deriveKeyPair members are caller-specified.
+func NewTestableSignatureKeyGenerator(readBytes readBytesFunc, deriveKeyPair deriveEd25519KeyPairFunc) SignatureKeyGenerator {
+	return SignatureKeyGenerator{readBytes, deriveKeyPair}
+}
+
+// Test that the Generate method is properly calling its dependencies and
+// returning the expected key pair.
+func TestGenerateRandomKeyPair(t *testing.T) {
+	// Create a mock random number generator (note that it does not actually
+	// modify its buffer.
+	mockRandGenerator := new(mockRandGenerator)
+	mockRandGenerator.On("Read", mock.Anything).Return(EntropySize, nil)
+
+	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
+	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
+	mockEd22519 := new(mockKeyDeriver)
+	mockEd22519.On("Derive", *new([EntropySize]byte)).Return(derivedSk, derivedPk)
+
+	// Create a SignatureKeyGenerator using mocks.
+	skg := NewTestableSignatureKeyGenerator(mockRandGenerator.Read, mockEd22519.Derive)
+
+	// Create key pair.
+	skActual, pkActual, err := skg.Generate()
+
+	// Verify that Generate satisfied expectations.
+	assert.Nil(t, err)
+	assert.Equal(t, SecretKey(*derivedSk), skActual)
+	assert.Equal(t, PublicKey(*derivedPk), pkActual)
+
+	mockRandGenerator.AssertExpectations(t)
+	mockEd22519.AssertExpectations(t)
+}
+
+// Test that the Generate method fails if the call to readRandBytes fails.
+func TestGenerateRandomKeyPairFailsWhenRandFails(t *testing.T) {
+	// Create a mock random number generator that fails when called.
+	mockRandGenerator := new(mockRandGenerator)
+	mockRandGenerator.On("Read", mock.Anything).Return(EntropySize, errors.New("mock error from readRandBytes"))
+
+	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
+	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
+	mockEd22519 := new(mockKeyDeriver)
+	mockEd22519.On("Derive", *new([EntropySize]byte)).Return(derivedSk, derivedPk)
+
+	skg := NewTestableSignatureKeyGenerator(mockRandGenerator.Read, mockEd22519.Derive)
+	_, _, err := skg.Generate()
+	assert.NotNil(t, err, "Generate should fail when readRandBytes fails")
+}
+
+// Test that the Generate method fails if readRandBytes does not fill the
+// buffer.
+func TestGenerateRandomKeyPairFailsWhenRandWritesInsufficientBytes(t *testing.T) {
+	// Create a mock random number generator that succeeds but reports that it
+	// populated 1 less byte than the buffer size.
+	mockRandGenerator := new(mockRandGenerator)
+	mockRandGenerator.On("Read", mock.Anything).Return(EntropySize-1, nil)
+
+	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
+	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
+	mockEd22519 := new(mockKeyDeriver)
+	mockEd22519.On("Derive", *new([EntropySize]byte)).Return(derivedSk, derivedPk)
+
+	skg := NewTestableSignatureKeyGenerator(mockRandGenerator.Read, mockEd22519.Derive)
+	_, _, err := skg.Generate()
+	assert.Equal(t, ErrRandUnexpected, err, "Generate should fail when readRandBytes writes insufficient bytes")
+}
+
+// Test that the Generate method is properly calling its dependencies and
+// returning the expected key pair.
+func TestGenerateDeterministicKeyPair(t *testing.T) {
+	// Create entropy bytes, setting a few bytes explicitly instead of using a
+	// buffer of random bytes.
+	var entropy [EntropySize]byte
+	entropy[0] = 0x05
+	entropy[1] = 0x08
+
+	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
+	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
+	mockEd22519 := new(mockKeyDeriver)
+	mockEd22519.On("Derive", entropy).Return(derivedSk, derivedPk)
+
+	skg := NewTestableSignatureKeyGenerator(nil, mockEd22519.Derive)
+
+	// Create key pair.
+	skActual, pkActual := skg.GenerateDeterministic(entropy)
+	assert.Equal(t, SecretKey(*derivedSk), skActual)
+	assert.Equal(t, PublicKey(*derivedPk), pkActual)
+
+	mockEd22519.AssertExpectations(t)
+}
 
 // Creates and encodes a public key, and verifies that it decodes correctly,
 // does the same with a signature.
 func TestSignatureEncoding(t *testing.T) {
-	// Create key pair.
-	sk, pk, err := GenerateSignatureKeys()
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert := assert.New(t)
+	// Create a dummy key pair.
+	var sk SecretKey
+	sk[0] = 0x0a
+	sk[32] = 0x0b
+	pk := sk.PublicKey()
 
 	// Marshal and unmarshal the public key.
 	marshalledPK := encoding.Marshal(pk)
 	var unmarshalledPK PublicKey
-	err = encoding.Unmarshal(marshalledPK, &unmarshalledPK)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err := encoding.Unmarshal(marshalledPK, &unmarshalledPK)
+	assert.Nil(err)
 
 	// Test the public keys for equality.
-	if pk != unmarshalledPK {
-		t.Error("pubkey not the same after marshalling and unmarshalling")
-	}
+	assert.Equal(pk, unmarshalledPK, "pubkey not the same after marshalling and unmarshalling")
 
 	// Create a signature using the secret key.
 	var signedData Hash
 	rand.Read(signedData[:])
 	sig, err := SignHash(signedData, sk)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(err)
 
 	// Marshal and unmarshal the signature.
 	marshalledSig := encoding.Marshal(sig)
 	var unmarshalledSig Signature
 	err = encoding.Unmarshal(marshalledSig, &unmarshalledSig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(err)
 
 	// Test signatures for equality.
-	if sig != unmarshalledSig {
-		t.Error("signature not same after marshalling and unmarshalling")
-	}
+	assert.Equal(sig, unmarshalledSig, "signature not same after marshalling and unmarshalling")
 }
 
 // TestSigning creates a bunch of keypairs and signs random data with each of
 // them.
 func TestSigning(t *testing.T) {
+	require := require.New(t)
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -63,45 +176,37 @@ func TestSigning(t *testing.T) {
 	// iterations would normally cause a failure.
 	iterations := 200
 	for i := 0; i < iterations; i++ {
-		// Generate the keys.
-		sk, pk, err := GenerateSignatureKeys()
-		if err != nil {
-			t.Fatal(err)
-		}
+		skg := NewSignatureKeyGenerator()
+
+		// Create dummy key pair.
+		var entropy [EntropySize]byte
+		entropy[0] = 0x05
+		entropy[1] = 0x08
+		sk, pk := skg.GenerateDeterministic(entropy)
 
 		// Generate and sign the data.
 		var randData Hash
 		rand.Read(randData[:])
 		sig, err := SignHash(randData, sk)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(err)
 
 		// Verify the signature.
 		err = VerifyHash(randData, pk, sig)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(err)
 
 		// Attempt to verify after the data has been altered.
 		randData[0] += 1
 		err = VerifyHash(randData, pk, sig)
-		if err != ErrInvalidSignature {
-			t.Fatal(err)
-		}
+		require.Equal(ErrInvalidSignature, err)
 
 		// Restore the data and make sure the signature is valid again.
 		randData[0] -= 1
 		err = VerifyHash(randData, pk, sig)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(err)
 
 		// Attempt to verify after the signature has been altered.
 		sig[0] += 1
 		err = VerifyHash(randData, pk, sig)
-		if err != ErrInvalidSignature {
-			t.Fatal(err)
-		}
+		require.Equal(ErrInvalidSignature, err)
 	}
 }

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -28,7 +28,7 @@ func (kd *mockKeyDeriver) deriveKeyPair(entropy [EntropySize]byte) (ed25519.Secr
 
 // Test that the Generate method is properly calling its dependencies and
 // returning the expected key pair.
-func TestGenerateRandomKeyPair(t *testing.T) {
+func TestUnitGenerateRandomKeyPair(t *testing.T) {
 	var mockEntropy [EntropySize]byte
 	mockEntropy[0] = 5
 	mockEntropy[EntropySize-1] = 5
@@ -78,7 +78,7 @@ func (fr failingReader) Read([]byte) (int, error) {
 }
 
 // Test that the Generate method fails if the call to entropy source fails
-func TestGenerateRandomKeyPairFailsWhenRandFails(t *testing.T) {
+func TestUnitGenerateRandomKeyPairFailsWhenRandFails(t *testing.T) {
 	fr := failingReader{err: errors.New("mock error from entropy reader")}
 	g := stdGenerator{entropySource: &fr}
 	if _, _, err := g.Generate(); err == nil {
@@ -88,7 +88,7 @@ func TestGenerateRandomKeyPairFailsWhenRandFails(t *testing.T) {
 
 // Test that the GenerateDeterministic method is properly calling its
 // dependencies and returning the expected key pair.
-func TestGenerateDeterministicKeyPair(t *testing.T) {
+func TestUnitGenerateDeterministicKeyPair(t *testing.T) {
 	// Create entropy bytes, setting a few bytes explicitly instead of using a
 	// buffer of random bytes.
 	var mockEntropy [EntropySize]byte

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -5,127 +5,125 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-
 	"github.com/NebulousLabs/Sia/encoding"
-	"github.com/NebulousLabs/ed25519"
 )
 
-// mockRandGenerator is a mock implementation of readBytesFunc, allowing tests
-// to mock out calls to rand.Read and use a deterministic implementation
-// instead.
-type mockRandGenerator struct {
-	mock.Mock
+// mockEntropySource is a mock implementation of entropySource that allows the
+// client to specify the returned entropy and error.
+type mockEntropySource struct {
+	called  bool
+	entropy [EntropySize]byte
+	err     error
 }
 
-func (m *mockRandGenerator) Read(b []byte) (n int, err error) {
-	args := m.Called(b)
-	return args.Int(0), args.Error(1)
+func (es *mockEntropySource) getEntropy() (entropy [EntropySize]byte, err error) {
+	es.called = true
+	return es.entropy, es.err
 }
 
-// mockKeyDeriver is a mock implementation of deriveEd25519Func, allowing
-// tests to mock out calls to ed25519.GenerateKey.
+// mockKeyDeriver is a mock implementation of keyDeriver that saves its provided
+// entropy and allows the client to specify the returned SecretKey and
+// PublicKey.
 type mockKeyDeriver struct {
-	mock.Mock
+	called  bool
+	entropy [EntropySize]byte
+	sk      SecretKey
+	pk      PublicKey
 }
 
-func (m *mockKeyDeriver) Derive(b [EntropySize]byte) (sk ed25519.SecretKey, pk ed25519.PublicKey) {
-	args := m.Called(b)
-	return args.Get(0).(ed25519.SecretKey), args.Get(1).(ed25519.PublicKey)
+func (kd *mockKeyDeriver) deriveKeyPair(entropy [EntropySize]byte) (sk SecretKey, pk PublicKey) {
+	kd.called = true
+	kd.entropy = entropy
+	return kd.sk, kd.pk
 }
 
 // Test that the Generate method is properly calling its dependencies and
 // returning the expected key pair.
 func TestGenerateRandomKeyPair(t *testing.T) {
-	// Create a mock random number generator (note that it does not actually
-	// modify its buffer.
-	mockRandGenerator := new(mockRandGenerator)
-	mockRandGenerator.On("Read", mock.Anything).Return(EntropySize, nil)
+	var mockEntropy [EntropySize]byte
+	mockEntropy[0] = 0x0a
+	mockEntropy[EntropySize-1] = 0x0b
+	es := mockEntropySource{entropy: mockEntropy}
 
-	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
-	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
-	mockEd22519 := new(mockKeyDeriver)
-	mockEd22519.On("Derive", [EntropySize]byte{}).Return(derivedSk, derivedPk)
+	sk := SecretKey([SecretKeySize]byte{})
+	pk := PublicKey([PublicKeySize]byte{})
+	kd := mockKeyDeriver{sk: sk, pk: pk}
 
 	// Create a SignatureKeyGenerator using mocks.
-	skg := SignatureKeyGenerator{mockRandGenerator.Read, mockEd22519.Derive}
+	g := stdGenerator{&es, &kd}
 
 	// Create key pair.
-	skActual, pkActual, err := skg.Generate()
+	skActual, pkActual, err := g.Generate()
 
-	// Verify that Generate satisfied expectations.
-	assert.Nil(t, err)
-	assert.Equal(t, SecretKey(*derivedSk), skActual)
-	assert.Equal(t, PublicKey(*derivedPk), pkActual)
+	// Verify that we got back the expected results.
+	if err != nil {
+		t.Error(err)
+	}
+	if sk != skActual {
+		t.Errorf("Generated secret key does not match expected! expected = %v, actual = %v", sk, skActual)
+	}
+	if pk != pkActual {
+		t.Errorf("Generated public key does not match expected! expected = %v, actual = %v", pk, pkActual)
+	}
 
-	mockRandGenerator.AssertExpectations(t)
-	mockEd22519.AssertExpectations(t)
+	// Verify the dependencies were called correctly
+	if !es.called {
+		t.Error("entropySource was never called.")
+	}
+	if !kd.called {
+		t.Error("keyDeriver was never called.")
+	}
+	if mockEntropy != kd.entropy {
+		t.Error("keyDeriver was called with the wrong entropy. expected = %v, actual = %v", mockEntropy, kd.entropy)
+	}
 }
 
-// Test that the Generate method fails if the call to readRandBytes fails.
+// Test that the Generate method fails if the call to entropy source fails
 func TestGenerateRandomKeyPairFailsWhenRandFails(t *testing.T) {
-	// Create a mock random number generator that fails when called.
-	mockRandGenerator := new(mockRandGenerator)
-	mockRandGenerator.On("Read", mock.Anything).Return(EntropySize, errors.New("mock error from readRandBytes"))
-
-	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
-	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
-	mockEd22519 := new(mockKeyDeriver)
-	mockEd22519.On("Derive", [EntropySize]byte{}).Return(derivedSk, derivedPk)
-
-	skg := SignatureKeyGenerator{mockRandGenerator.Read, mockEd22519.Derive}
-	_, _, err := skg.Generate()
-	assert.NotNil(t, err, "Generate should fail when readRandBytes fails")
+	es := mockEntropySource{err: errors.New("mock error from entropy source")}
+	g := stdGenerator{es: &es}
+	if _, _, err := g.Generate(); err == nil {
+		t.Error("Generate should fail when entropy source fails.")
+	}
 }
 
-// Test that the Generate method fails if readRandBytes does not fill the
-// buffer.
-func TestGenerateRandomKeyPairFailsWhenRandWritesInsufficientBytes(t *testing.T) {
-	// Create a mock random number generator that succeeds but reports that it
-	// populated 1 less byte than the buffer size.
-	mockRandGenerator := new(mockRandGenerator)
-	mockRandGenerator.On("Read", mock.Anything).Return(EntropySize-1, nil)
-
-	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
-	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
-	mockEd22519 := new(mockKeyDeriver)
-	mockEd22519.On("Derive", [EntropySize]byte{}).Return(derivedSk, derivedPk)
-
-	skg := SignatureKeyGenerator{mockRandGenerator.Read, mockEd22519.Derive}
-	_, _, err := skg.Generate()
-	assert.Equal(t, ErrRandUnexpected, err, "Generate should fail when readRandBytes writes insufficient bytes")
-}
-
-// Test that the Generate method is properly calling its dependencies and
-// returning the expected key pair.
+// Test that the GenerateDeterministic method is properly calling its
+// dependencies and returning the expected key pair.
 func TestGenerateDeterministicKeyPair(t *testing.T) {
 	// Create entropy bytes, setting a few bytes explicitly instead of using a
 	// buffer of random bytes.
-	var entropy [EntropySize]byte
-	entropy[0] = 0x05
-	entropy[1] = 0x08
+	var mockEntropy [EntropySize]byte
+	mockEntropy[0] = 0x0a
+	mockEntropy[EntropySize-1] = 0x0b
 
-	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
-	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
-	mockEd22519 := new(mockKeyDeriver)
-	mockEd22519.On("Derive", entropy).Return(derivedSk, derivedPk)
-
-	skg := SignatureKeyGenerator{nil, mockEd22519.Derive}
+	sk := SecretKey([SecretKeySize]byte{})
+	pk := PublicKey([PublicKeySize]byte{})
+	kd := mockKeyDeriver{sk: sk, pk: pk}
+	g := stdGenerator{kd: &kd}
 
 	// Create key pair.
-	skActual, pkActual := skg.GenerateDeterministic(entropy)
-	assert.Equal(t, SecretKey(*derivedSk), skActual)
-	assert.Equal(t, PublicKey(*derivedPk), pkActual)
+	skActual, pkActual := g.GenerateDeterministic(mockEntropy)
 
-	mockEd22519.AssertExpectations(t)
+	// Verify that we got back the right results.
+	if sk != skActual {
+		t.Errorf("Generated secret key does not match expected! expected = %v, actual = %v", sk, skActual)
+	}
+	if pk != pkActual {
+		t.Errorf("Generated public key does not match expected! expected = %v, actual = %v", pk, pkActual)
+	}
+
+	// Verify the dependencies were called correctly.
+	if !kd.called {
+		t.Error("keyDeriver was never called.")
+	}
+	if mockEntropy != kd.entropy {
+		t.Error("keyDeriver was called with the wrong entropy. expected = %v, actual = %v", mockEntropy, kd.entropy)
+	}
 }
 
 // Creates and encodes a public key, and verifies that it decodes correctly,
 // does the same with a signature.
 func TestSignatureEncoding(t *testing.T) {
-	assert := assert.New(t)
 	// Create a dummy key pair.
 	var sk SecretKey
 	sk[0] = 0x0a
@@ -136,31 +134,41 @@ func TestSignatureEncoding(t *testing.T) {
 	marshalledPK := encoding.Marshal(pk)
 	var unmarshalledPK PublicKey
 	err := encoding.Unmarshal(marshalledPK, &unmarshalledPK)
-	assert.Nil(err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Test the public keys for equality.
-	assert.Equal(pk, unmarshalledPK, "pubkey not the same after marshalling and unmarshalling")
+	if pk != unmarshalledPK {
+		t.Error("pubkey not the same after marshalling and unmarshalling")
+	}
 
 	// Create a signature using the secret key.
 	var signedData Hash
 	rand.Read(signedData[:])
 	sig, err := SignHash(signedData, sk)
-	assert.Nil(err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Marshal and unmarshal the signature.
 	marshalledSig := encoding.Marshal(sig)
 	var unmarshalledSig Signature
 	err = encoding.Unmarshal(marshalledSig, &unmarshalledSig)
-	assert.Nil(err)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Test signatures for equality.
-	assert.Equal(sig, unmarshalledSig, "signature not same after marshalling and unmarshalling")
+	if sig != unmarshalledSig {
+		t.Error("signature not same after marshalling and unmarshalling")
+	}
+
 }
 
 // TestSigning creates a bunch of keypairs and signs random data with each of
 // them.
 func TestSigning(t *testing.T) {
-	require := require.New(t)
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -170,37 +178,45 @@ func TestSigning(t *testing.T) {
 	// iterations would normally cause a failure.
 	iterations := 200
 	for i := 0; i < iterations; i++ {
-		skg := NewSignatureKeyGenerator()
-
 		// Create dummy key pair.
 		var entropy [EntropySize]byte
 		entropy[0] = 0x05
 		entropy[1] = 0x08
-		sk, pk := skg.GenerateDeterministic(entropy)
+		sk, pk := StdKeyGen.GenerateDeterministic(entropy)
 
 		// Generate and sign the data.
 		var randData Hash
 		rand.Read(randData[:])
 		sig, err := SignHash(randData, sk)
-		require.Nil(err)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Verify the signature.
 		err = VerifyHash(randData, pk, sig)
-		require.Nil(err)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Attempt to verify after the data has been altered.
 		randData[0] += 1
 		err = VerifyHash(randData, pk, sig)
-		require.Equal(ErrInvalidSignature, err)
+		if err != ErrInvalidSignature {
+			t.Fatal(err)
+		}
 
 		// Restore the data and make sure the signature is valid again.
 		randData[0] -= 1
 		err = VerifyHash(randData, pk, sig)
-		require.Nil(err)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Attempt to verify after the signature has been altered.
 		sig[0] += 1
 		err = VerifyHash(randData, pk, sig)
-		require.Equal(ErrInvalidSignature, err)
+		if err != ErrInvalidSignature {
+			t.Fatal(err)
+		}
 	}
 }

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -47,7 +47,7 @@ func TestGenerateRandomKeyPair(t *testing.T) {
 	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
 	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
 	mockEd22519 := new(mockKeyDeriver)
-	mockEd22519.On("Derive", *new([EntropySize]byte)).Return(derivedSk, derivedPk)
+	mockEd22519.On("Derive", [EntropySize]byte{}).Return(derivedSk, derivedPk)
 
 	// Create a SignatureKeyGenerator using mocks.
 	skg := SignatureKeyGenerator{mockRandGenerator.Read, mockEd22519.Derive}
@@ -73,7 +73,7 @@ func TestGenerateRandomKeyPairFailsWhenRandFails(t *testing.T) {
 	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
 	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
 	mockEd22519 := new(mockKeyDeriver)
-	mockEd22519.On("Derive", *new([EntropySize]byte)).Return(derivedSk, derivedPk)
+	mockEd22519.On("Derive", [EntropySize]byte{}).Return(derivedSk, derivedPk)
 
 	skg := SignatureKeyGenerator{mockRandGenerator.Read, mockEd22519.Derive}
 	_, _, err := skg.Generate()
@@ -91,7 +91,7 @@ func TestGenerateRandomKeyPairFailsWhenRandWritesInsufficientBytes(t *testing.T)
 	derivedSk := ed25519.SecretKey(new([SecretKeySize]byte))
 	derivedPk := ed25519.PublicKey(new([PublicKeySize]byte))
 	mockEd22519 := new(mockKeyDeriver)
-	mockEd22519.On("Derive", *new([EntropySize]byte)).Return(derivedSk, derivedPk)
+	mockEd22519.On("Derive", [EntropySize]byte{}).Return(derivedSk, derivedPk)
 
 	skg := SignatureKeyGenerator{mockRandGenerator.Read, mockEd22519.Derive}
 	_, _, err := skg.Generate()

--- a/modules/consensus/accept_txntypes_test.go
+++ b/modules/consensus/accept_txntypes_test.go
@@ -429,7 +429,7 @@ func (cst *consensusSetTester) testFileContractRevision() {
 	file.Seek(0, 0)
 
 	// Create a spendable unlock hash for the file contract.
-	sk, pk, err := crypto.GenerateSignatureKeys()
+	sk, pk, err := crypto.StdKeyGen.Generate()
 	if err != nil {
 		panic(err)
 	}
@@ -739,11 +739,11 @@ func (cst *consensusSetTester) testPaymentChannelBlocks() error {
 
 	// Create a 2-of-2 unlock conditions, 1 key for each the sender and the
 	// receiver in the payment channel.
-	sk1, pk1, err := crypto.GenerateSignatureKeys() // Funding entity.
+	sk1, pk1, err := crypto.StdKeyGen.Generate() // Funding entity.
 	if err != nil {
 		return err
 	}
-	sk2, pk2, err := crypto.GenerateSignatureKeys() // Receiving entity.
+	sk2, pk2, err := crypto.StdKeyGen.Generate() // Receiving entity.
 	if err != nil {
 		return err
 	}
@@ -767,7 +767,7 @@ func (cst *consensusSetTester) testPaymentChannelBlocks() error {
 	// txn needs to be fully custom. To get a custom txn, manually create an
 	// address and then use the wallet to fund that address.
 	channelSize := types.NewCurrency64(10e3)
-	channelFundingSK, channelFundingPK, err := crypto.GenerateSignatureKeys()
+	channelFundingSK, channelFundingPK, err := crypto.StdKeyGen.Generate()
 	if err != nil {
 		return err
 	}
@@ -947,7 +947,7 @@ func (cst *consensusSetTester) testPaymentChannelBlocks() error {
 		// txn needs to be fully custom. To get a custom txn, manually create an
 		// address and then use the wallet to fund that address.
 		channelSize := types.NewCurrency64(10e3)
-		channelFundingSK, channelFundingPK, err := crypto.GenerateSignatureKeys()
+		channelFundingSK, channelFundingPK, err := crypto.StdKeyGen.Generate()
 		if err != nil {
 			return err
 		}
@@ -1068,7 +1068,7 @@ func (cst *consensusSetTester) testPaymentChannelBlocks() error {
 		// txn needs to be fully custom. To get a custom txn, manually create an
 		// address and then use the wallet to fund that address.
 		channelSize := types.NewCurrency64(10e3)
-		channelFundingSK, channelFundingPK, err := crypto.GenerateSignatureKeys()
+		channelFundingSK, channelFundingPK, err := crypto.StdKeyGen.Generate()
 		if err != nil {
 			return err
 		}

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -108,7 +108,8 @@ func New(cs *consensus.ConsensusSet, hdb modules.HostDB, tpool modules.Transacti
 	h.spaceRemaining = h.TotalStorage
 
 	// Generate signing key, for revising contracts.
-	sk, pk, err := crypto.GenerateSignatureKeys()
+	skg := crypto.NewSignatureKeyGenerator()
+	sk, pk, err := skg.Generate()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -108,8 +108,7 @@ func New(cs *consensus.ConsensusSet, hdb modules.HostDB, tpool modules.Transacti
 	h.spaceRemaining = h.TotalStorage
 
 	// Generate signing key, for revising contracts.
-	skg := crypto.NewSignatureKeyGenerator()
-	sk, pk, err := skg.Generate()
+	sk, pk, err := crypto.StdKeyGen.Generate()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -88,8 +88,7 @@ func (hu *hostUploader) negotiateContract(filesize uint64, duration types.BlockH
 
 	// create our own key by combining the renter entropy with the host key
 	entropy := crypto.HashAll(hu.renter.entropy, hostPublicKey)
-	skg := crypto.NewSignatureKeyGenerator()
-	ourSK, ourPK := skg.GenerateDeterministic(entropy)
+	ourSK, ourPK := crypto.StdKeyGen.GenerateDeterministic(entropy)
 	ourPublicKey := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
 		Key:       ourPK[:],

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -88,7 +88,8 @@ func (hu *hostUploader) negotiateContract(filesize uint64, duration types.BlockH
 
 	// create our own key by combining the renter entropy with the host key
 	entropy := crypto.HashAll(hu.renter.entropy, hostPublicKey)
-	ourSK, ourPK := crypto.DeterministicSignatureKeys(entropy)
+	skg := crypto.NewSignatureKeyGenerator()
+	ourSK, ourPK := skg.GenerateDeterministic(entropy)
 	ourPublicKey := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
 		Key:       ourPK[:],

--- a/modules/renter/negotiate_test.go
+++ b/modules/renter/negotiate_test.go
@@ -72,7 +72,8 @@ func TestReviseContract(t *testing.T) {
 	}
 
 	// generate keys
-	sk, pk, err := crypto.GenerateSignatureKeys()
+	skg := crypto.NewSignatureKeyGenerator()
+	sk, pk, err := skg.Generate()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/negotiate_test.go
+++ b/modules/renter/negotiate_test.go
@@ -72,8 +72,7 @@ func TestReviseContract(t *testing.T) {
 	}
 
 	// generate keys
-	skg := crypto.NewSignatureKeyGenerator()
-	sk, pk, err := skg.Generate()
+	sk, pk, err := crypto.StdKeyGen.Generate()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -54,8 +54,7 @@ func generateUnlockConditions(pk crypto.PublicKey) types.UnlockConditions {
 func generateSpendableKey(seed modules.Seed, index uint64) spendableKey {
 	// Generate the keys and unlock conditions.
 	entropy := crypto.HashAll(seed, index)
-	skg := crypto.NewSignatureKeyGenerator()
-	sk, pk := skg.GenerateDeterministic(entropy)
+	sk, pk := crypto.StdKeyGen.GenerateDeterministic(entropy)
 	return spendableKey{
 		UnlockConditions: generateUnlockConditions(pk),
 		SecretKeys:       []crypto.SecretKey{sk},

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -54,7 +54,8 @@ func generateUnlockConditions(pk crypto.PublicKey) types.UnlockConditions {
 func generateSpendableKey(seed modules.Seed, index uint64) spendableKey {
 	// Generate the keys and unlock conditions.
 	entropy := crypto.HashAll(seed, index)
-	sk, pk := crypto.DeterministicSignatureKeys(entropy)
+	skg := crypto.NewSignatureKeyGenerator()
+	sk, pk := skg.GenerateDeterministic(entropy)
 	return spendableKey{
 		UnlockConditions: generateUnlockConditions(pk),
 		SecretKeys:       []crypto.SecretKey{sk},

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -168,7 +168,8 @@ func TestTransactionValidCoveredFields(t *testing.T) {
 // Transaction type.
 func TestTransactionValidSignatures(t *testing.T) {
 	// Create keys for use in signing and verifying.
-	sk, pk, err := crypto.GenerateSignatureKeys()
+	skg := crypto.NewSignatureKeyGenerator()
+	sk, pk, err := skg.Generate()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -168,8 +168,7 @@ func TestTransactionValidCoveredFields(t *testing.T) {
 // Transaction type.
 func TestTransactionValidSignatures(t *testing.T) {
 	// Create keys for use in signing and verifying.
-	skg := crypto.NewSignatureKeyGenerator()
-	sk, pk, err := skg.Generate()
+	sk, pk, err := crypto.StdKeyGen.Generate()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types/validtransaction_bench_test.go
+++ b/types/validtransaction_bench_test.go
@@ -14,10 +14,11 @@ func BenchmarkStandaloneValid(b *testing.B) {
 	// make a transaction numSigs with valid inputs with valid signatures
 	b.ReportAllocs()
 	txn := Transaction{}
+	skg := crypto.NewSignatureKeyGenerator()
 	sk := make([]crypto.SecretKey, numSigs)
 	pk := make([]crypto.PublicKey, numSigs)
 	for i := 0; i < numSigs; i++ {
-		s, p, err := crypto.GenerateSignatureKeys()
+		s, p, err := skg.Generate()
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/types/validtransaction_bench_test.go
+++ b/types/validtransaction_bench_test.go
@@ -14,11 +14,10 @@ func BenchmarkStandaloneValid(b *testing.B) {
 	// make a transaction numSigs with valid inputs with valid signatures
 	b.ReportAllocs()
 	txn := Transaction{}
-	skg := crypto.NewSignatureKeyGenerator()
 	sk := make([]crypto.SecretKey, numSigs)
 	pk := make([]crypto.PublicKey, numSigs)
 	for i := 0; i < numSigs; i++ {
-		s, p, err := skg.Generate()
+		s, p, err := crypto.StdKeyGen.Generate()
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Refactors crypto.GenerateSignatureKeys and crypto.DeterministicSignatureKeys
so that they now depend on explicit interfaces.

Adds unit tests to exercise the new Generate and GenerateDeterministic
functions.