### PR TITLE
Block api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -66,7 +66,8 @@ func (srv *Server) initAPI(addr string) {
 
 	// Consensus API Calls
 	if srv.cs != nil {
-		handleHTTPRequest(mux, "/consensus", srv.consensusHandler) // GET
+		handleHTTPRequest(mux, "/consensus", srv.consensusHandler)            // GET
+		handleHTTPRequest(mux, "/consensus/block", srv.consensusBlockHandler) // GET
 	}
 
 	// Gateway API Calls - Unfinished

--- a/api/consensus.go
+++ b/api/consensus.go
@@ -1,19 +1,22 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// The ConsensusGET struct contains general information about the consensus
-// set, with tags to support idiomatic json encodings.
+// ConsensusGET contains general information about the consensus set, with tags
+// to support idiomatic json encodings.
 type ConsensusGET struct {
 	Height       types.BlockHeight `json:"height"`
 	CurrentBlock types.BlockID     `json:"currentblock"`
 	Target       types.Target      `json:"target"`
+}
+
+// ConsensusBlockGET contains a block.
+type ConsensusBlockGET struct {
+	Block types.Block `json:"block"`
 }
 
 // consensusHandlerGET handles a GET request to /consensus.
@@ -22,14 +25,7 @@ func (srv *Server) consensusHandlerGET(w http.ResponseWriter, req *http.Request)
 	defer srv.mu.RUnlock(id)
 
 	curblockID := srv.currentBlock.ID()
-	currentTarget, exists := srv.cs.ChildTarget(curblockID)
-	if build.DEBUG {
-		if !exists {
-			fmt.Printf("Could not find block %s\n", curblockID)
-			panic("server has nonexistent current block")
-		}
-	}
-
+	currentTarget, _ := srv.cs.ChildTarget(curblockID)
 	writeJSON(w, ConsensusGET{
 		Height:       types.BlockHeight(srv.blockchainHeight),
 		CurrentBlock: srv.currentBlock.ID(),
@@ -44,4 +40,30 @@ func (srv *Server) consensusHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	writeError(w, "unrecognized method when calling /consensus", http.StatusBadRequest)
+}
+
+// consensusBlockHandlerGET handles a GET request to /consensus/block.
+func (srv *Server) consensusBlockHandlerGET(w http.ResponseWriter, req *http.Request) {
+	height, err := scanBlockHeight(req.FormValue("height"))
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	block, exists := srv.cs.BlockAtHeight(height)
+	if !exists {
+		writeError(w, "no block found at given height", http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, ConsensusBlockGET{
+		Block: block,
+	})
+}
+
+// consensusBlockHandler handles the API calls to /consensus/block.
+func (srv *Server) consensusBlockHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method == "" || req.Method == "GET" {
+		srv.consensusBlockHandlerGET(w, req)
+		return
+	}
+	writeError(w, "unrecognized method when calling /consensus/block", http.StatusBadRequest)
 }

--- a/api/consensus.go
+++ b/api/consensus.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/NebulousLabs/Sia/types"
@@ -44,7 +45,8 @@ func (srv *Server) consensusHandler(w http.ResponseWriter, req *http.Request) {
 
 // consensusBlockHandlerGET handles a GET request to /consensus/block.
 func (srv *Server) consensusBlockHandlerGET(w http.ResponseWriter, req *http.Request) {
-	height, err := scanBlockHeight(req.FormValue("height"))
+	var height types.BlockHeight
+	_, err := fmt.Sscan(req.FormValue("height"), &height)
 	if err != nil {
 		writeError(w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/types"
@@ -12,7 +13,7 @@ func TestIntegrationConsensusGET(t *testing.T) {
 		t.SkipNow()
 	}
 
-	st, err := createServerTester("TestConsensusGET")
+	st, err := createServerTester("TestIntegrationConsensusGET")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,5 +31,35 @@ func TestIntegrationConsensusGET(t *testing.T) {
 	expectedTarget := types.Target{128}
 	if cg.Target != expectedTarget {
 		t.Error("wrong target returned in consensus GET call")
+	}
+}
+
+// TestIntegrationConsensusBlockGET probes the GET call to /consensus/block.
+func TestIntegrationConsensusBlockGET(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createServerTester("TestIntegrationConsensusBlockGET")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cbg ConsensusBlockGET
+	err = st.getAPI("/consensus/block?height=1", &cbg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block1, exists := st.cs.BlockAtHeight(1)
+	if !exists {
+		t.Fatal("unexpected dne")
+	}
+	if !reflect.DeepEqual(block1, cbg.Block) {
+		t.Fatal("blocks do not match")
+	}
+
+	// Sanity check - BlockAtHeight should be working.
+	gb := st.cs.GenesisBlock()
+	if block1.ParentID != gb.ID() {
+		t.Fatal("genesis block and block1 mismatch")
 	}
 }

--- a/api/scan.go
+++ b/api/scan.go
@@ -1,9 +1,7 @@
 package api
 
 import (
-	"errors"
 	"math/big"
-	"strconv"
 
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -22,17 +20,8 @@ func scanAmount(amount string) (types.Currency, bool) {
 // scanAddres scans a types.UnlockHash from a string.
 func scanAddress(addrStr string) (addr types.UnlockHash, err error) {
 	err = addr.LoadString(addrStr)
-	return
-}
-
-// scanBlockHeight scans a block height from a string.
-func scanBlockHeight(bhStr string) (types.BlockHeight, error) {
-	bhInt, err := strconv.Atoi(bhStr)
 	if err != nil {
-		return 0, err
+		return types.UnlockHash{}, err
 	}
-	if bhInt < 0 {
-		return 0, errors.New("negative block height not allowed")
-	}
-	return types.BlockHeight(bhInt), nil
+	return addr, nil
 }

--- a/api/scan.go
+++ b/api/scan.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"math/big"
+	"strconv"
+
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// scanAmount scans a types.Currency from a string.
+func scanAmount(amount string) (types.Currency, bool) {
+	// use SetString manually to ensure that amount does not contain
+	// multiple values, which would confuse fmt.Scan
+	i, ok := new(big.Int).SetString(amount, 10)
+	if !ok {
+		return types.Currency{}, ok
+	}
+	return types.NewCurrency(i), true
+}
+
+// scanAddres scans a types.UnlockHash from a string.
+func scanAddress(addrStr string) (addr types.UnlockHash, err error) {
+	err = addr.LoadString(addrStr)
+	return
+}
+
+// scanBlockHeight scans a block height from a string.
+func scanBlockHeight(bhStr string) (types.BlockHeight, error) {
+	bhInt, err := strconv.Atoi(bhStr)
+	if err != nil {
+		return 0, err
+	}
+	if bhInt < 0 {
+		return 0, errors.New("negative block height not allowed")
+	}
+	return types.BlockHeight(bhInt), nil
+}

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -107,23 +106,6 @@ func encryptionKeys(seedStr string) (validKeys []crypto.TwofishKey) {
 	}
 	validKeys = append(validKeys, crypto.TwofishKey(crypto.HashObject(seedStr)))
 	return validKeys
-}
-
-// scanAmount scans a types.Currency from a string.
-func scanAmount(amount string) (types.Currency, bool) {
-	// use SetString manually to ensure that amount does not contain
-	// multiple values, which would confuse fmt.Scan
-	i, ok := new(big.Int).SetString(amount, 10)
-	if !ok {
-		return types.Currency{}, ok
-	}
-	return types.NewCurrency(i), true
-}
-
-// scanAddres scans a types.UnlockHash from a string.
-func scanAddress(addrStr string) (addr types.UnlockHash, err error) {
-	err = addr.LoadString(addrStr)
-	return
 }
 
 // walletHandlerGET handles a GET request to /wallet.

--- a/doc/API.md
+++ b/doc/API.md
@@ -19,7 +19,8 @@ Consensus
 
 Queries:
 
-* /consensus [GET]
+* /consensus       [GET]
+* /consensus/block [GET]
 
 #### /consensus [GET]
 
@@ -42,6 +43,25 @@ struct {
 
 'Target' is the hash that needs to be met by a block for the block to be valid.
 The target is inversely proportional to the difficulty.
+
+#### /consensus/block [GET]
+
+Function: Returns the block found at a given height.
+
+Parameters:
+```
+height types.BlockHeight (uint64)
+```
+'height' is the height of the block that is being requested. The genesis block
+is at height 0, it's child is at height 1, etc.
+
+Response:
+```
+struct {
+	block types.Block
+}
+```
+'block' is a block. The struct is defined in types/block.go.
 
 Wallet
 ------

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -126,6 +126,10 @@ type (
 		// still be returned.
 		AcceptBlock(types.Block) error
 
+		// BlockAtHeight returns the block found at the input height, with a
+		// bool to indicate whether that block exists.
+		BlockAtHeight(types.BlockHeight) (types.Block, bool)
+
 		// ChildTarget returns the target required to extend the current heaviest
 		// fork. This function is typically used by miners looking to extend the
 		// heaviest fork.


### PR DESCRIPTION
added a call /consensus/block to get a block from the consensus set, height is a parameter.

Ranges are not allowed, mostly because I didn't want people to input a range exceeding 10,000, but maybe it's okay. Or maybe I could spend some more time on it and add the feature with a hardcoded limit to the request size.

Testing + documentation is included.