### PR TITLE
Repairing

### DIFF
--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -13,6 +13,11 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 )
 
+var (
+	errInsufficientHosts  = errors.New("insufficient hosts to recover file")
+	errInsufficientPieces = errors.New("couldn't fetch enough pieces to recover data")
+)
+
 // A fetcher fetches pieces from a host. This interface exists to facilitate
 // easy testing.
 type fetcher interface {
@@ -110,7 +115,7 @@ func checkHosts(hosts []fetcher, minPieces int, numChunks uint64) error {
 			pieces += len(h.pieces(i))
 		}
 		if pieces < minPieces {
-			return errors.New("insufficient hosts to recover file")
+			return errInsufficientHosts
 		}
 	}
 	return nil
@@ -194,7 +199,7 @@ func (d *download) run(w io.Writer) error {
 			}
 		}
 		if left != 0 {
-			return errors.New("couldn't fetch enough pieces to recover data")
+			return errInsufficientPieces
 		}
 
 		// Write pieces to w. We always write chunkSize bytes unless this is

--- a/modules/renter/download_test.go
+++ b/modules/renter/download_test.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"crypto/rand"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 type testHost struct {
+	ip        modules.NetAddress
 	data      []byte
 	pieceMap  map[uint64][]pieceData // key is chunkIndex
 	pieceSize uint64
@@ -20,6 +23,8 @@ type testHost struct {
 	// used to simulate real-world conditions
 	delay    time.Duration // transfers will take this long
 	failRate int           // transfers will randomly fail with probability 1/failRate
+
+	sync.Mutex
 }
 
 func (h *testHost) pieces(chunkIndex uint64) []pieceData {

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -83,7 +83,7 @@ func (f *file) Available() bool {
 // reaches 100%.
 func (f *file) UploadProgress() float32 {
 	totalBytes := f.pieceSize * uint64(f.erasureCode.NumPieces()) * f.numChunks()
-	return 100 * float32(atomic.LoadUint64(&f.bytesUploaded)) / float32(totalBytes)
+	return 100 * (float32(atomic.LoadUint64(&f.bytesUploaded)) / float32(totalBytes))
 }
 
 // Nickname returns the nickname of the file.

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -46,8 +46,11 @@ func (hu *hostUploader) Close() error {
 	encoding.WriteObject(hu.conn, types.Transaction{})
 	hu.conn.Close()
 	// submit the most recent revision to the blockchain
-	hu.renter.tpool.AcceptTransactionSet([]types.Transaction{hu.lastTxn})
-	return nil
+	err := hu.renter.tpool.AcceptTransactionSet([]types.Transaction{hu.lastTxn})
+	if err != nil {
+		hu.renter.log.Println("Could not submit final contract revision:", err)
+	}
+	return err
 }
 
 // negotiateContract establishes a connection to a host and negotiates an

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -52,6 +52,7 @@ func (hu *hostUploader) Close() error {
 
 // negotiateContract establishes a connection to a host and negotiates an
 // initial file contract according to the terms of the host.
+// TODO: better error messages. In many cases we simply return "no data"
 func (hu *hostUploader) negotiateContract(filesize uint64, duration types.BlockHeight) error {
 	conn, err := net.DialTimeout("tcp", string(hu.settings.IPAddress), 15*time.Second)
 	if err != nil {

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -41,6 +41,10 @@ func (hu *hostUploader) fileContract() fileContract {
 	return hu.contract
 }
 
+func (hu *hostUploader) addr() modules.NetAddress {
+	return hu.settings.IPAddress
+}
+
 func (hu *hostUploader) Close() error {
 	// send an empty revision to indicate that we are finished
 	encoding.WriteObject(hu.conn, types.Transaction{})

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -187,7 +187,7 @@ func (r *Renter) save() error {
 		Contracts map[string]types.FileContract
 		Repairing map[string]string
 		Entropy   [32]byte
-	}{make(map[string]types.FileContract), r.repairing, r.entropy}
+	}{make(map[string]types.FileContract), r.repairSet, r.entropy}
 	// Convert renter's contract map to a JSON-friendly type.
 	for id, fc := range r.contracts {
 		b, _ := id.MarshalJSON()
@@ -234,7 +234,7 @@ func (r *Renter) load() error {
 	if err != nil {
 		return err
 	}
-	r.repairing = data.Repairing
+	r.repairSet = data.Repairing
 	r.entropy = data.Entropy
 	var fcid types.FileContractID
 	for id, fc := range data.Contracts {

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -185,8 +185,9 @@ func (r *Renter) saveFile(f *file) error {
 func (r *Renter) save() error {
 	data := struct {
 		Contracts map[string]types.FileContract
+		Repairing map[string]string
 		Entropy   [32]byte
-	}{make(map[string]types.FileContract), r.entropy}
+	}{make(map[string]types.FileContract), r.repairing, r.entropy}
 	// Convert renter's contract map to a JSON-friendly type.
 	for id, fc := range r.contracts {
 		b, _ := id.MarshalJSON()
@@ -223,15 +224,17 @@ func (r *Renter) load() error {
 		}
 	}
 
-	// Load contracts and entropy.
+	// Load contracts, repair set, and entropy.
 	data := struct {
 		Contracts map[string]types.FileContract
+		Repairing map[string]string
 		Entropy   [32]byte
 	}{}
 	err = persist.LoadFile(saveMetadata, &data, filepath.Join(r.persistDir, PersistFilename))
 	if err != nil {
 		return err
 	}
+	r.repairing = data.Repairing
 	r.entropy = data.Entropy
 	var fcid types.FileContractID
 	for id, fc := range data.Contracts {

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -172,7 +172,13 @@ func (r *Renter) saveFile(f *file) error {
 	}
 
 	// Write file.
-	return f.save(handle)
+	err = f.save(handle)
+	if err != nil {
+		return err
+	}
+
+	// Commit the SafeFile.
+	return handle.Commit()
 }
 
 // save stores the current renter data to disk.

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -359,13 +359,9 @@ func (r *Renter) loadSharedFiles(reader io.Reader) ([]string, error) {
 		r.files[f.name] = f
 		names[i] = f.name
 	}
-	// Save the files, and their renter metadata.
+	// Save the files.
 	for _, f := range files {
 		r.saveFile(f)
-	}
-	err = r.save()
-	if err != nil {
-		return nil, err
 	}
 
 	return names, nil

--- a/modules/renter/persist_test.go
+++ b/modules/renter/persist_test.go
@@ -142,7 +142,9 @@ func TestRenterSaveLoad(t *testing.T) {
 	rt.renter.saveFile(f3)
 
 	// load should now load the files into memory.
+	id := rt.renter.mu.Lock()
 	err = rt.renter.load()
+	rt.renter.mu.Unlock(id)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -28,7 +28,8 @@ type Renter struct {
 
 	files         map[string]*file
 	contracts     map[types.FileContractID]types.FileContract
-	entropy       [32]byte // used to generate signing keys
+	repairing     map[string]string // map from nickname to filepath
+	entropy       [32]byte          // used to generate signing keys
 	downloadQueue []*download
 
 	persistDir string
@@ -72,7 +73,9 @@ func New(cs modules.ConsensusSet, hdb modules.HostDB, wallet modules.Wallet, tpo
 		return nil, err
 	}
 
-	r.cs.ConsensusSetSubscribe(r)
+	cs.ConsensusSetSubscribe(r)
+
+	go r.threadedRepairUploads()
 
 	return r, nil
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -28,7 +28,7 @@ type Renter struct {
 
 	files         map[string]*file
 	contracts     map[types.FileContractID]types.FileContract
-	repairing     map[string]string // map from nickname to filepath
+	repairSet     map[string]string // map from nickname to filepath
 	entropy       [32]byte          // used to generate signing keys
 	downloadQueue []*download
 
@@ -60,6 +60,7 @@ func New(cs modules.ConsensusSet, hdb modules.HostDB, wallet modules.Wallet, tpo
 
 		files:     make(map[string]*file),
 		contracts: make(map[types.FileContractID]types.FileContract),
+		repairSet: make(map[string]string),
 
 		persistDir: persistDir,
 		mu:         sync.New(modules.SafeMutexDelay, 1),

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -1,0 +1,82 @@
+package renter
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+)
+
+// repair attempts to repair a file by uploading missing pieces to more hosts.
+func (f *file) repair(r io.ReaderAt, hosts []uploader) error {
+	// determine which chunks need to be repaired
+	// TODO: inefficient -- O(2n) on number of pieces
+	present := make([][]bool, f.numChunks())
+	for i := range present {
+		present[i] = make([]bool, f.erasureCode.NumPieces())
+	}
+	for _, fc := range f.contracts {
+		for _, p := range fc.Pieces {
+			present[p.Chunk][p.Piece] = true
+		}
+	}
+	missing := make(map[uint64][]uint64)
+	for chunkIndex, pieceBools := range present {
+		for pieceIndex, ok := range pieceBools {
+			if !ok {
+				missing[uint64(chunkIndex)] = append(missing[uint64(chunkIndex)], uint64(pieceIndex))
+			}
+		}
+	}
+
+	// For each chunk with missing pieces, re-encode the chunk and upload each
+	// missing piece.
+	var wg sync.WaitGroup
+	for chunkIndex, missingPieces := range missing {
+		// read chunk data
+		// NOTE: ReadAt is stricter than Read, and is guaranteed to return an
+		// error after a partial read.
+		chunk := make([]byte, f.chunkSize())
+		_, err := r.ReadAt(chunk, int64(chunkIndex*f.chunkSize()))
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			return err
+		}
+
+		// encode
+		pieces, err := f.erasureCode.Encode(chunk)
+		if err != nil {
+			return err
+		}
+		// upload pieces, split evenly among hosts
+		wg.Add(len(missingPieces))
+		for j, pieceIndex := range missingPieces {
+			host := hosts[j%len(hosts)]
+			up := uploadPiece{pieces[pieceIndex], chunkIndex, pieceIndex}
+			go func(host uploader, up uploadPiece) {
+				err := host.addPiece(up)
+				if err == nil {
+					atomic.AddUint64(&f.bytesUploaded, uint64(len(up.data)))
+				}
+				wg.Done()
+			}(host, up)
+		}
+		wg.Wait()
+		atomic.AddUint64(&f.chunksUploaded, 1)
+
+		// update contracts
+		for _, h := range hosts {
+			contract := h.fileContract()
+			f.contracts[contract.IP] = contract
+		}
+	}
+
+	return nil
+}
+
+// threadedRepairUploads improves the health of files tracked by the renter by
+// reuploading their missing pieces. Multiple repair attempts may be necessary
+// before the file reaches full redundancy.
+//
+// TODO: can't have this running on foreign .sia files...
+func (r *Renter) threadedRepairUploads() {
+
+}

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // repair attempts to repair a file by uploading missing pieces to more hosts.
@@ -79,6 +80,8 @@ func (f *file) repair(r io.ReaderAt, hosts []uploader) error {
 // before the file reaches full redundancy.
 func (r *Renter) threadedRepairUploads() {
 	for {
+		time.Sleep(5 * time.Second)
+
 		// make copy of repair set under lock
 		repairing := make(map[string]string)
 		id := r.mu.RLock()
@@ -131,6 +134,9 @@ func (r *Renter) threadedRepairUploads() {
 				delete(r.repairSet, name)
 				r.mu.Unlock(id)
 			}
+
+			// close the file
+			handle.Close()
 
 			// close the host connections
 			for i := range hosts {

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -79,10 +79,10 @@ func (f *file) repair(r io.ReaderAt, hosts []uploader) error {
 // before the file reaches full redundancy.
 func (r *Renter) threadedRepairUploads() {
 	for {
-		// make copy of r.repairing under lock
+		// make copy of repair set under lock
 		repairing := make(map[string]string)
 		id := r.mu.RLock()
-		for name, path := range r.repairing {
+		for name, path := range r.repairSet {
 			repairing[name] = path
 		}
 		r.mu.RUnlock(id)
@@ -95,7 +95,7 @@ func (r *Renter) threadedRepairUploads() {
 			if !ok {
 				r.log.Printf("failed to repair %v: no longer tracking that file", name)
 				id = r.mu.Lock()
-				delete(r.repairing, name)
+				delete(r.repairSet, name)
 				r.mu.Unlock(id)
 				continue
 			}
@@ -105,7 +105,7 @@ func (r *Renter) threadedRepairUploads() {
 			if err != nil {
 				r.log.Printf("failed to repair %v: %v", name, err)
 				id = r.mu.Lock()
-				delete(r.repairing, name)
+				delete(r.repairSet, name)
 				r.mu.Unlock(id)
 				continue
 			}
@@ -128,7 +128,7 @@ func (r *Renter) threadedRepairUploads() {
 			if err != nil {
 				r.log.Printf("failed to repair %v: %v", name, err)
 				id = r.mu.Lock()
-				delete(r.repairing, name)
+				delete(r.repairSet, name)
 				r.mu.Unlock(id)
 			}
 

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -177,6 +177,14 @@ func (r *Renter) threadedRepairUploads() {
 				r.mu.Unlock(id)
 			}
 
+			// save the repaired file data
+			err = r.saveFile(f)
+			if err != nil {
+				// definitely bad, but we probably shouldn't delete from the
+				// repair set if this happens
+				r.log.Printf("failed to save repaired file %v: %v", name, err)
+			}
+
 			// close the file
 			handle.Close()
 

--- a/modules/renter/repair_test.go
+++ b/modules/renter/repair_test.go
@@ -1,0 +1,82 @@
+package renter
+
+import (
+	"bytes"
+	"crypto/rand"
+	"strconv"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// TestRepair tests that the repair method can repeatedly improve the
+// redundancy of an unavailable file until it becomes available.
+func TestRepair(t *testing.T) {
+	// generate data
+	const dataSize = 777
+	data := make([]byte, dataSize)
+	rand.Read(data)
+
+	// create Reed-Solomon encoder
+	rsc, err := NewRSCode(4, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create hosts
+	const pieceSize = 10
+	hosts := make([]uploader, rsc.NumPieces())
+	for i := range hosts {
+		hosts[i] = &testHost{
+			ip:        modules.NetAddress(strconv.Itoa(i)),
+			pieceMap:  make(map[uint64][]pieceData),
+			pieceSize: pieceSize,
+			failRate:  3, // 33% failure rate
+		}
+	}
+	// make one host always fail
+	hosts[0].(*testHost).failRate = 1
+
+	// upload data to hosts
+	f := newFile("foo", rsc, pieceSize, dataSize)
+	err = f.upload(bytes.NewReader(data), hosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// download data (should fail)
+	dhosts := make([]fetcher, len(hosts))
+	for i := range dhosts {
+		dhosts[i] = hosts[i].(*testHost)
+	}
+	d := f.newDownload(dhosts, "")
+	buf := new(bytes.Buffer)
+	err = d.run(buf)
+	if err != errInsufficientPieces {
+		t.Fatalf("download should not have succeeded: expected %v, got %v", errInsufficientPieces, err)
+	}
+
+	// repair until file becomes available
+	const maxAttempts = 20
+	for i := 0; i < maxAttempts; i++ {
+		err = f.repair(bytes.NewReader(data), hosts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		buf.Reset()
+		err = d.run(buf)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		t.Fatalf("file not repaired after %v attempts: %v", maxAttempts, err)
+	}
+
+	// check data integrity
+	buf.Truncate(dataSize)
+	if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("recovereed data does not match original")
+	}
+}

--- a/modules/renter/repair_test.go
+++ b/modules/renter/repair_test.go
@@ -59,7 +59,7 @@ func TestRepair(t *testing.T) {
 	// repair until file becomes available
 	const maxAttempts = 20
 	for i := 0; i < maxAttempts; i++ {
-		err = f.repair(bytes.NewReader(data), hosts)
+		err = f.repair(bytes.NewReader(data), f.incompleteChunks(), hosts)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -205,6 +205,11 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("failed to upload any file pieces")
 	}
 
+	// Add file to repair set.
+	lockID = r.mu.Lock()
+	r.repairing[up.Nickname] = up.Filename
+	r.mu.Unlock(lockID)
+
 	// Save the .sia file to the renter directory.
 	err = r.saveFile(f)
 	if err != nil {

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -40,6 +40,9 @@ type uploader interface {
 	// fileContract returns the fileContract containing the metadata of all
 	// previously added pieces.
 	fileContract() fileContract
+
+	// addr returns the IP address of the uploader.
+	addr() modules.NetAddress
 }
 
 // upload reads chunks from r and uploads them to hosts. It spawns a worker

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -74,12 +74,12 @@ func (f *file) upload(r io.Reader, hosts []uploader) error {
 		}
 		wg.Wait()
 		atomic.AddUint64(&f.chunksUploaded, 1)
-	}
 
-	// gather final contracts
-	for _, h := range hosts {
-		contract := h.fileContract()
-		f.contracts[contract.IP] = contract
+		// update contracts
+		for _, h := range hosts {
+			contract := h.fileContract()
+			f.contracts[contract.IP] = contract
+		}
 	}
 
 	return nil

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 
@@ -120,12 +119,6 @@ func (r *Renter) checkWalletBalance(up modules.FileUploadParams) error {
 // Upload takes an upload parameters, which contain a file to upload, and then
 // creates a redundant copy of the file on the Sia network.
 func (r *Renter) Upload(up modules.FileUploadParams) error {
-	// TODO: This type of restriction is something that should be handled by
-	// the frontend, not the backend.
-	if filepath.Ext(up.Filename) != filepath.Ext(up.Nickname) {
-		return errors.New("nickname and file name must have the same extension")
-	}
-
 	// Open the file.
 	handle, err := os.Open(up.Filename)
 	if err != nil {

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -208,7 +208,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 
 	// Add file to repair set.
 	lockID = r.mu.Lock()
-	r.repairing[up.Nickname] = up.Filename
+	r.repairSet[up.Nickname] = up.Filename
 	r.save()
 	r.mu.Unlock(lockID)
 

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -124,6 +124,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	if err != nil {
 		return err
 	}
+	defer handle.Close()
 
 	// Check for a nickname conflict.
 	lockID := r.mu.RLock()

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -180,6 +180,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	for i := range randHosts {
 		hostUploader, err := r.newHostUploader(randHosts[i], totalsize, up.Duration, f.masterKey)
 		if err != nil {
+			r.log.Printf("Upload: could not form contract with %v: %v", randHosts[i].IPAddress, err)
 			continue
 		}
 		defer hostUploader.Close()

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -209,6 +209,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	// Add file to repair set.
 	lockID = r.mu.Lock()
 	r.repairing[up.Nickname] = up.Filename
+	r.save()
 	r.mu.Unlock(lockID)
 
 	// Save the .sia file to the renter directory.

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 func (h *testHost) addPiece(p uploadPiece) error {
@@ -37,6 +38,10 @@ func (h *testHost) fileContract() fileContract {
 	}
 	fc.IP = h.ip
 	return fc
+}
+
+func (h *testHost) addr() modules.NetAddress {
+	return h.ip
 }
 
 // TestErasureUpload tests parallel uploading of erasure-coded data.

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 )
 
+// addPiece adds a piece to the testHost. It randomly fails according to the
+// testHost's parameters.
 func (h *testHost) addPiece(p uploadPiece) error {
 	// simulate I/O delay
 	time.Sleep(h.delay)
@@ -31,6 +33,8 @@ func (h *testHost) addPiece(p uploadPiece) error {
 	return nil
 }
 
+// fileContract returns the file contract that would have been created if
+// testHost were a real host.
 func (h *testHost) fileContract() fileContract {
 	var fc fileContract
 	for _, ps := range h.pieceMap {

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -13,6 +13,9 @@ func (h *testHost) addPiece(p uploadPiece) error {
 	// simulate I/O delay
 	time.Sleep(h.delay)
 
+	h.Lock()
+	defer h.Unlock()
+
 	// randomly fail
 	if n, _ := crypto.RandIntn(h.failRate); n == 0 {
 		return crypto.ErrNilInput
@@ -27,7 +30,14 @@ func (h *testHost) addPiece(p uploadPiece) error {
 	return nil
 }
 
-func (h *testHost) fileContract() fileContract { return fileContract{} }
+func (h *testHost) fileContract() fileContract {
+	var fc fileContract
+	for _, ps := range h.pieceMap {
+		fc.Pieces = append(fc.Pieces, ps...)
+	}
+	fc.IP = h.ip
+	return fc
+}
 
 // TestErasureUpload tests parallel uploading of erasure-coded data.
 func TestErasureUpload(t *testing.T) {

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -27,23 +27,19 @@ func RandomSuffix() string {
 	return str[:20]
 }
 
-// A safeFile is a file that is stored under a temporary filename. When the
-// safeFile is closed, it will be renamed to the "final" filename. This allows
-// for atomic updating of files; otherwise, an unexpected shutdown could leave
-// a valuable file in a corrupted state.
+// A safeFile is a file that is stored under a temporary filename. When Commit
+// is called, the file is renamed to its "final" filename. This allows for
+// atomic updating of files; otherwise, an unexpected shutdown could leave a
+// valuable file in a corrupted state. Callers must still Close the file handle
+// as usual.
 type safeFile struct {
 	*os.File
 	finalName string
 }
 
-// Close renames the file to the intended final filename, and then closes the
-// file handle.
-func (sf *safeFile) Close() error {
-	err := os.Rename(sf.finalName+"_temp", sf.finalName)
-	if err != nil {
-		return err
-	}
-	return sf.File.Close()
+// Commit renames the file to the intended final filename.
+func (sf *safeFile) Commit() error {
+	return os.Rename(sf.finalName+"_temp", sf.finalName)
 }
 
 func NewSafeFile(filename string) (*safeFile, error) {


### PR DESCRIPTION
plus some other minor tweaks.

the `repair` function is tested and seems to do the job, but `threadedRepairFiles` hasn't been tested yet since it's still trying to create real hostUploaders. Some more mocking work will be necessary in order to facilitate testing. Also, `repair` is far too similar to `upload` for my liking. If I gave it some more thought I could probably reduce the overlap quite a bit.

The renter now stores a list of files that it is repairing, in the form of a map from nicknames -> paths on disk. Currently, files are repaired IFF they are uploaded by the user, and you can't disable repairing. The repair loop runs infinitely without any sort of `time.Sleep` delay, and it doesn't remove files even after they reach 100% redundancy (this is because we may add uptime checking later, so that if a host goes offline, those pieces will be repaired). These should probably be changed; just wanted to get some feedback first.

The renter API is going to overhauled soon to make it more RESTful. We'll also want to add an API call to toggle repairing on a file. Note that this call would require a path on disk to the original file (and we have to be careful there, because if the file doesn't actually contain the original data, you'll wind up corrupting the file pretty severely).