### PR TITLE
Sia-Agent is only whitelisted agent

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -39,14 +39,11 @@ func HttpPOST(url string, data string) (resp *http.Response, err error) {
 // the API.
 func handleHTTPRequest(mux *http.ServeMux, url string, handler http.HandlerFunc) {
 	mux.HandleFunc(url, func(w http.ResponseWriter, req *http.Request) {
-		permittedClients := []string{"Sia-Agent", "Sia-Miner", "Electron", "AtomShell"}
-		for _, pc := range permittedClients {
-			if strings.Contains(req.UserAgent(), pc) {
-				handler(w, req)
-				return
-			}
+		if !strings.Contains(req.UserAgent(), "Sia-Agent") {
+			writeError(w, "Browser access disabled due to security vulnerability. Use Sia-UI or siac.", http.StatusBadRequest)
+			return
 		}
-		writeError(w, "Browser access disabled due to security vulnerability. Use Sia-UI or siac.", http.StatusInternalServerError)
+		handler(w, req)
 	})
 }
 
@@ -95,8 +92,6 @@ func (srv *Server) initAPI(addr string) {
 		handleHTTPRequest(mux, "/miner/start", srv.minerStartHandler)
 		handleHTTPRequest(mux, "/miner/status", srv.minerStatusHandler)
 		handleHTTPRequest(mux, "/miner/stop", srv.minerStopHandler)
-		handleHTTPRequest(mux, "/miner/blockforwork", srv.minerBlockforworkHandler)
-		handleHTTPRequest(mux, "/miner/submitblock", srv.minerSubmitblockHandler)
 		handleHTTPRequest(mux, "/miner/headerforwork", srv.minerHeaderforworkHandler)
 		handleHTTPRequest(mux, "/miner/submitheader", srv.minerSubmitheaderHandler)
 	}

--- a/api/miner.go
+++ b/api/miner.go
@@ -17,17 +17,6 @@ type MinerStatus struct {
 	StaleBlocksMined int
 }
 
-// minerBlockforworkHandler handles the API call that retrieves a block for
-// work.
-func (srv *Server) minerBlockforworkHandler(w http.ResponseWriter, req *http.Request) {
-	bfw, _, target, err := srv.miner.BlockForWork()
-	if err != nil {
-		writeError(w, "call to /miner/blockforwork failed: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	w.Write(encoding.MarshalAll(target, bfw.Header(), bfw))
-}
-
 // minerHeaderforworkHandler handles the API call that retrieves a block header
 // for work.
 func (srv *Server) minerHeaderforworkHandler(w http.ResponseWriter, req *http.Request) {
@@ -60,28 +49,6 @@ func (srv *Server) minerStatusHandler(w http.ResponseWriter, req *http.Request) 
 // minerStopHandler handles the API call to stop the miner.
 func (srv *Server) minerStopHandler(w http.ResponseWriter, req *http.Request) {
 	srv.miner.StopCPUMining()
-	writeSuccess(w)
-}
-
-// minerSubmitblockHandler handles the API call to submit a block to the miner.
-func (srv *Server) minerSubmitblockHandler(w http.ResponseWriter, req *http.Request) {
-	var b types.Block
-	encodedBlock, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	err = encoding.Unmarshal(encodedBlock, &b)
-	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	err = srv.miner.SubmitBlock(b)
-	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
-		return
-	}
 	writeSuccess(w)
 }
 


### PR DESCRIPTION
All the others are obsolete.

Turns out that the miner was never setting a user agent in the first place, there must have been some sort of bug that was allowing a blank useragent to go through.

Either that, or a blank user agent used to be allowed (which I would believe).

I've updated the miner code, which means we'll need a miner 1.0.3