### PR TITLE
Some architecture changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,23 +5,27 @@ all: install
 # dependencies installs all of the dependencies that are required for building
 # Sia.
 dependencies:
-	go install -race std
+	# Consensus Dependencies
 	go get -u github.com/NebulousLabs/demotemutex
 	go get -u github.com/NebulousLabs/ed25519
-	go get -u github.com/NebulousLabs/entropy-mnemonics
 	go get -u github.com/NebulousLabs/go-upnp
 	go get -u github.com/NebulousLabs/merkletree
-	go get -u github.com/bgentry/speakeasy
+	go get -u github.com/inconshreveable/muxado
 	go get -u github.com/boltdb/bolt
 	go get -u github.com/dchest/blake2b
+	go get -u golang.org/x/crypto/twofish
+	# Module + Daemon Dependencies
+	go get -u github.com/NebulousLabs/entropy-mnemonics
 	go get -u github.com/inconshreveable/go-update
-	go get -u github.com/inconshreveable/muxado
 	go get -u github.com/kardianos/osext
 	go get -u github.com/klauspost/reedsolomon
-	go get -u github.com/laher/goxc
-	go get -u github.com/spf13/cobra
 	go get -u github.com/stretchr/graceful
-	go get -u golang.org/x/crypto/twofish
+	# Frontend Dependencies
+	go get -u github.com/bgentry/speakeasy
+	go get -u github.com/spf13/cobra
+	# Developer Dependencies
+	go install -race std
+	go get -u github.com/laher/goxc
 	go get -u golang.org/x/tools/cmd/cover
 
 # fmt calls go fmt on all packages.

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,15 @@ dependencies:
 	# Consensus Dependencies
 	go get -u github.com/NebulousLabs/demotemutex
 	go get -u github.com/NebulousLabs/ed25519
-	go get -u github.com/NebulousLabs/go-upnp
 	go get -u github.com/NebulousLabs/merkletree
-	go get -u github.com/inconshreveable/muxado
 	go get -u github.com/boltdb/bolt
 	go get -u github.com/dchest/blake2b
 	go get -u golang.org/x/crypto/twofish
 	# Module + Daemon Dependencies
 	go get -u github.com/NebulousLabs/entropy-mnemonics
+	go get -u github.com/NebulousLabs/go-upnp
 	go get -u github.com/inconshreveable/go-update
+	go get -u github.com/inconshreveable/muxado
 	go get -u github.com/kardianos/osext
 	go get -u github.com/klauspost/reedsolomon
 	go get -u github.com/stretchr/graceful

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -39,7 +39,7 @@ type serverTester struct {
 	gateway   modules.Gateway
 	host      modules.Host
 	hostdb    modules.HostDB
-	miner     modules.Miner
+	miner     modules.TestMiner
 	renter    modules.Renter
 	tpool     modules.TransactionPool
 	exp       modules.Explorer

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -21,7 +21,7 @@ import (
 // the tester and the modules.
 type consensusSetTester struct {
 	gateway   modules.Gateway
-	miner     modules.Miner
+	miner     modules.TestMiner
 	tpool     modules.TransactionPool
 	wallet    modules.Wallet
 	walletKey crypto.TwofishKey

--- a/modules/explorer/explorer_test.go
+++ b/modules/explorer/explorer_test.go
@@ -20,7 +20,7 @@ import (
 type explorerTester struct {
 	cs        modules.ConsensusSet
 	gateway   modules.Gateway
-	miner     modules.Miner
+	miner     modules.TestMiner
 	tpool     modules.TransactionPool
 	wallet    modules.Wallet
 	walletKey crypto.TwofishKey

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -21,7 +21,7 @@ import (
 type hostTester struct {
 	cs        modules.ConsensusSet
 	gateway   modules.Gateway
-	miner     modules.Miner
+	miner     modules.TestMiner
 	tpool     modules.TransactionPool
 	wallet    modules.Wallet
 	walletKey crypto.TwofishKey

--- a/modules/hostdb/hostdb_test.go
+++ b/modules/hostdb/hostdb_test.go
@@ -24,7 +24,7 @@ type hdbTester struct {
 	cs      modules.ConsensusSet
 	gateway modules.Gateway
 	host    modules.Host
-	miner   modules.Miner
+	miner   modules.TestMiner
 	tpool   modules.TransactionPool
 	wallet  modules.Wallet
 

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -43,7 +43,7 @@ type CPUMiner interface {
 }
 
 // TestMiner provides direct acesss to block fetching, solving, and
-// manipulation.
+// manipulation. The primary use of this interface is integration testing.
 type TestMiner interface {
 	// AddBlock is an extension of FindBlock - AddBlock will submit the block
 	// after finding it.

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -9,45 +9,30 @@ const (
 	MinerDir = "miner"
 )
 
-// A BlockManager contains functions that can interface with external miners,
+// BlockManager contains functions that can interface with external miners,
 // providing and receiving blocks that have experienced nonce grinding.
 type BlockManager interface {
-	// BlockForWork returns a block that is ready for nonce grinding. All
-	// blocks returned by BlockForWork have a unique merkle root, meaning that
-	// each can safely start from nonce 0.
-	BlockForWork() (types.Block, crypto.Hash, types.Target, error)
-
 	// HeaderForWork returns a block header that can be grinded on and
 	// resubmitted to the miner. HeaderForWork() will remember the block that
 	// corresponds to the header for 50 calls.
 	HeaderForWork() (types.BlockHeader, types.Target, error)
 
-	// SubmitBlock takes a block that has been worked on and has a valid
-	// target. Typically used with external miners.
-	SubmitBlock(types.Block) error
-
 	// SubmitHeader takes a block header that has been worked on and has a
 	// valid target. A superior choice to SubmitBlock.
 	SubmitHeader(types.BlockHeader) error
+
+	// BlocksMined returns the number of blocks and stale blocks that have been
+	// mined using this miner.
+	BlocksMined() (goodBlocks, staleBlocks int)
 }
 
-// A CPUMiner provides access to a single-threaded cpu miner.
+// CPUMiner provides access to a single-threaded cpu miner.
 type CPUMiner interface {
-	// AddBlock is an extension of FindBlock - AddBlock will submit the block
-	// after finding it.
-	AddBlock() (types.Block, error)
-
 	// CPUHashrate returns the hashrate of the cpu miner in hashes per second.
 	CPUHashrate() int
 
 	// Mining returns true if the cpu miner is enabled, and false otherwise.
 	CPUMining() bool
-
-	// FindBlock will have the miner make 1 attempt to find a solved block that
-	// builds on the current consensus set. It will give up after a few
-	// seconds, returning the block and a bool indicating whether the block is
-	// sovled.
-	FindBlock() (types.Block, error)
 
 	// StartMining turns on the miner, which will endlessly work for new
 	// blocks.
@@ -55,6 +40,25 @@ type CPUMiner interface {
 
 	// StopMining turns off the miner, but keeps the same number of threads.
 	StopCPUMining()
+}
+
+// TestMiner provides direct acesss to block fetching, solving, and
+// manipulation.
+type TestMiner interface {
+	// AddBlock is an extension of FindBlock - AddBlock will submit the block
+	// after finding it.
+	AddBlock() (types.Block, error)
+
+	// BlockForWork returns a block that is ready for nonce grinding. All
+	// blocks returned by BlockForWork have a unique merkle root, meaning that
+	// each can safely start from nonce 0.
+	BlockForWork() (types.Block, crypto.Hash, types.Target, error)
+
+	// FindBlock will have the miner make 1 attempt to find a solved block that
+	// builds on the current consensus set. It will give up after a few
+	// seconds, returning the block and a bool indicating whether the block is
+	// sovled.
+	FindBlock() (types.Block, error)
 
 	// SolveBlock will have the miner make 1 attempt to solve the input block,
 	// which amounts to trying a few thousand different nonces. SolveBlock is
@@ -66,8 +70,4 @@ type CPUMiner interface {
 type Miner interface {
 	BlockManager
 	CPUMiner
-
-	// BlocksMined returns the number of blocks and stale blocks that have been
-	// mined using this miner.
-	BlocksMined() (goodBlocks, staleBlocks int)
 }

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -76,8 +76,8 @@ func (m *Miner) HeaderForWork() (types.BlockHeader, types.Target, error) {
 	if !m.wallet.Unlocked() {
 		return types.BlockHeader{}, types.Target{}, modules.ErrLockedWallet
 	}
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	err := m.checkAddress()
 	if err != nil {
 		return types.BlockHeader{}, types.Target{}, err
@@ -139,8 +139,8 @@ func (m *Miner) SubmitBlock(b types.Block) error {
 		m.log.Println("ERROR: an invalid block was submitted:", err)
 		return err
 	}
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	// Grab a new address for the miner. Call may fail if the wallet is locked
 	// or if the wallet addresses have been exhausted.
@@ -159,10 +159,10 @@ func (m *Miner) SubmitHeader(bh types.BlockHeader) error {
 	var zeroNonce [8]byte
 	lookupBH := bh
 	lookupBH.Nonce = zeroNonce
-	lockID := m.mu.Lock()
+	m.mu.Lock()
 	b, bExists := m.blockMem[lookupBH]
 	arbData, arbExists := m.arbDataMem[lookupBH]
-	m.mu.Unlock(lockID)
+	m.mu.Unlock()
 	if !bExists || !arbExists {
 		err := errors.New("block header returned late - block was cleared from memory")
 		m.log.Println("ERROR:", err)

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -70,27 +70,6 @@ func (m *Miner) prepareNewBlock() {
 	}
 }
 
-// BlockForWork returns a block that is ready for nonce grinding, along with
-// the root hash of the block.
-func (m *Miner) BlockForWork() (b types.Block, merkleRoot crypto.Hash, t types.Target, err error) {
-	// Check if the wallet is unlocked. If the wallet is unlocked, make sure
-	// that the miner has a recent address.
-	if !m.wallet.Unlocked() {
-		err = modules.ErrLockedWallet
-		return
-	}
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
-	err = m.checkAddress()
-	if err != nil {
-		return
-	}
-
-	b, t = m.blockForWork()
-	merkleRoot = b.MerkleRoot()
-	return b, merkleRoot, t, nil
-}
-
 // HeaderForWork returns a block that is ready for nonce grinding, along with
 // the root hash of the block.
 func (m *Miner) HeaderForWork() (types.BlockHeader, types.Target, error) {

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -129,8 +129,8 @@ func (m *Miner) HeaderForWork() (types.BlockHeader, types.Target, error) {
 	return header, m.target, nil
 }
 
-// submitBlock takes a solved block and submits it to the blockchain.
-// submitBlock should not be called with a lock.
+// SubmitBlock takes a solved block and submits it to the blockchain.
+// SubmitBlock should not be called with a lock.
 func (m *Miner) SubmitBlock(b types.Block) error {
 	// Give the block to the consensus set.
 	err := m.cs.AcceptBlock(b)
@@ -153,8 +153,7 @@ func (m *Miner) SubmitBlock(b types.Block) error {
 	return err
 }
 
-// submitBlock takes a solved block and submits it to the blockchain.
-// submitBlock should not be called with a lock.
+// SubmitHeader accepts a block header.
 func (m *Miner) SubmitHeader(bh types.BlockHeader) error {
 	// Fetch the block from the blockMem.
 	var zeroNonce [8]byte

--- a/modules/miner/cpuminer.go
+++ b/modules/miner/cpuminer.go
@@ -8,28 +8,28 @@ import (
 // only function that should be setting the mining flag to true.
 func (m *Miner) threadedMine() {
 	// There should not be another thread mining, and mining should be enabled.
-	lockID := m.mu.Lock()
+	m.mu.Lock()
 	if m.mining || !m.miningOn {
-		m.mu.Unlock(lockID)
+		m.mu.Unlock()
 		return
 	}
 	m.mining = true
-	m.mu.Unlock(lockID)
+	m.mu.Unlock()
 
 	// Solve blocks repeatedly.
 	for {
 		// Kill the thread if mining has been turned off.
-		lockID := m.mu.Lock()
+		m.mu.Lock()
 		m.cycleStart = time.Now()
 		if !m.miningOn {
 			m.mining = false
-			m.mu.Unlock(lockID)
+			m.mu.Unlock()
 			return
 		}
 
 		// Grab a block and try to solve it.
 		bfw, target := m.blockForWork()
-		m.mu.Unlock(lockID)
+		m.mu.Unlock()
 		b, solved := m.SolveBlock(bfw, target)
 		if solved {
 			err := m.SubmitBlock(b)
@@ -40,34 +40,34 @@ func (m *Miner) threadedMine() {
 
 		// Update the hashrate. If the block was solved, the full set of
 		// iterations was not completed, so the hashrate should not be updated.
-		lockID = m.mu.Lock()
+		m.mu.Lock()
 		if !solved {
 			nanosecondsElapsed := 1 + time.Since(m.cycleStart).Nanoseconds() // Add 1 to prevent divide by zero errors.
 			m.hashRate = 1e9 * iterationsPerAttempt / nanosecondsElapsed
 		}
-		m.mu.Unlock(lockID)
+		m.mu.Unlock()
 	}
 }
 
 // CPUHashrate returns an estimated cpu hashrate.
 func (m *Miner) CPUHashrate() int {
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return int(m.hashRate)
 }
 
 // CPUMining indicates whether the cpu miner is running.
 func (m *Miner) CPUMining() bool {
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.mining
 }
 
 // StartCPUMining will start a single threaded cpu miner. If the miner is
 // already running, nothing will happen.
 func (m *Miner) StartCPUMining() {
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.miningOn = true
 	go m.threadedMine()
 }
@@ -75,8 +75,8 @@ func (m *Miner) StartCPUMining() {
 // StopCPUMining will stop the cpu miner. If the cpu miner is already stopped,
 // nothing will happen.
 func (m *Miner) StopCPUMining() {
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.hashRate = 0
 	m.miningOn = false
 }

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -76,11 +76,12 @@ type Miner struct {
 	// indicates whether these is a thread that is actively mining. There may
 	// be some lag between starting the miner and a thread actually beginning
 	// to mine.
-	startTime time.Time
-	attempts  uint64
-	hashRate  int64
-	miningOn  bool
-	mining    bool
+
+	// CPUMiner variables.
+	miningOn   bool      // indicates if the miner is supposed to be running
+	mining     bool      // indicates if the miner is actually running
+	cycleStart time.Time // indicates the start time of the recent call to SolveBlock
+	hashRate   int64     // indicates hashes per second
 
 	persistDir string
 	log        *log.Logger

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -78,8 +78,7 @@ func createMinerTester(name string) (*minerTester, error) {
 
 	// Mine until the wallet has money.
 	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
-		b, _ := m.FindBlock()
-		err = cs.AcceptBlock(b)
+		_, err = m.AddBlock()
 		if err != nil {
 			return nil, err
 		}
@@ -88,9 +87,9 @@ func createMinerTester(name string) (*minerTester, error) {
 	return mt, nil
 }
 
-// TestMiner creates a miner, mines a few blocks, and checks that the wallet
-// balance is updating as the blocks get mined.
-func TestMiner(t *testing.T) {
+// TestIntegrationMiner creates a miner, mines a few blocks, and checks that
+// the wallet balance is updating as the blocks get mined.
+func TestIntegrationMiner(t *testing.T) {
 	mt, err := createMinerTester("TestMiner")
 	if err != nil {
 		t.Fatal(err)
@@ -112,5 +111,30 @@ func TestMiner(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestIntegrationNilMinerDependencies tests that the miner properly handles
+// nil inputs for its dependencies.
+func TestIntegrationNilMinerDependencies(t *testing.T) {
+	mt, err := createMinerTester("TestIntegrationNilMinerDependencies")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = New(mt.cs, mt.tpool, nil, "")
+	if err != errNilWallet {
+		t.Fatal(err)
+	}
+	_, err = New(mt.cs, nil, mt.wallet, "")
+	if err != errNilTpool {
+		t.Fatal(err)
+	}
+	_, err = New(nil, mt.tpool, mt.wallet, "")
+	if err != errNilCS {
+		t.Fatal(err)
+	}
+	_, err = New(nil, nil, nil, "")
+	if err == nil {
+		t.Fatal(err)
 	}
 }

--- a/modules/miner/testminer.go
+++ b/modules/miner/testminer.go
@@ -1,0 +1,96 @@
+package miner
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"unsafe"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// testminer.go implements the TestMiner interface, whose primary purpose is
+// integration testing.
+
+// BlockForWork returns a block that is ready for nonce grinding, along with
+// the root hash of the block.
+func (m *Miner) BlockForWork() (b types.Block, merkleRoot crypto.Hash, t types.Target, err error) {
+	// Check if the wallet is unlocked. If the wallet is unlocked, make sure
+	// that the miner has a recent address.
+	if !m.wallet.Unlocked() {
+		err = modules.ErrLockedWallet
+		return
+	}
+	lockID := m.mu.Lock()
+	defer m.mu.Unlock(lockID)
+	err = m.checkAddress()
+	if err != nil {
+		return
+	}
+
+	b, t = m.blockForWork()
+	merkleRoot = b.MerkleRoot()
+	return b, merkleRoot, t, nil
+}
+
+// AddBlock adds a block to the consensus set.
+func (m *Miner) AddBlock() (types.Block, error) {
+	block, err := m.FindBlock()
+	if err != nil {
+		return types.Block{}, err
+	}
+	err = m.cs.AcceptBlock(block)
+	if err != nil {
+		return types.Block{}, err
+	}
+	return block, nil
+}
+
+// FindBlock finds at most one block that extends the current blockchain.
+func (m *Miner) FindBlock() (types.Block, error) {
+	lockID := m.mu.Lock()
+	if !m.wallet.Unlocked() {
+		return types.Block{}, modules.ErrLockedWallet
+	}
+	err := m.checkAddress()
+	if err != nil {
+		return types.Block{}, err
+	}
+	m.mu.Unlock(lockID)
+
+	// Get a block for work.
+	lockID = m.mu.Lock()
+	bfw, target := m.blockForWork()
+	m.mu.Unlock(lockID)
+
+	block, ok := m.SolveBlock(bfw, target)
+	if !ok {
+		return types.Block{}, errors.New("could not solve block using limited hashing power")
+	}
+	return block, nil
+}
+
+// SolveBlock takes a block, target, and number of iterations as input and
+// tries to find a block that meets the target. This function can take a long
+// time to complete, and should not be called with a lock.
+func (m *Miner) SolveBlock(b types.Block, target types.Target) (types.Block, bool) {
+	// Assemble the header.
+	merkleRoot := b.MerkleRoot()
+	header := make([]byte, 80)
+	copy(header, b.ParentID[:])
+	binary.LittleEndian.PutUint64(header[40:48], uint64(b.Timestamp))
+	copy(header[48:], merkleRoot[:])
+
+	nonce := (*uint64)(unsafe.Pointer(&header[32]))
+	for i := 0; i < iterationsPerAttempt; i++ {
+		id := crypto.HashBytes(header)
+		if bytes.Compare(target[:], id[:]) >= 0 {
+			copy(b.Nonce[:], header[32:40])
+			return b, true
+		}
+		*nonce++
+	}
+	return b, false
+}

--- a/modules/miner/testminer.go
+++ b/modules/miner/testminer.go
@@ -23,8 +23,8 @@ func (m *Miner) BlockForWork() (b types.Block, merkleRoot crypto.Hash, t types.T
 		err = modules.ErrLockedWallet
 		return
 	}
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	err = m.checkAddress()
 	if err != nil {
 		return
@@ -50,7 +50,7 @@ func (m *Miner) AddBlock() (types.Block, error) {
 
 // FindBlock finds at most one block that extends the current blockchain.
 func (m *Miner) FindBlock() (types.Block, error) {
-	lockID := m.mu.Lock()
+	m.mu.Lock()
 	if !m.wallet.Unlocked() {
 		return types.Block{}, modules.ErrLockedWallet
 	}
@@ -58,12 +58,12 @@ func (m *Miner) FindBlock() (types.Block, error) {
 	if err != nil {
 		return types.Block{}, err
 	}
-	m.mu.Unlock(lockID)
+	m.mu.Unlock()
 
 	// Get a block for work.
-	lockID = m.mu.Lock()
+	m.mu.Lock()
 	bfw, target := m.blockForWork()
-	m.mu.Unlock(lockID)
+	m.mu.Unlock()
 
 	block, ok := m.SolveBlock(bfw, target)
 	if !ok {

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -10,8 +10,8 @@ import (
 // ProcessConsensusChange will update the miner's most recent block. This is a
 // part of the ConsensusSetSubscriber interface.
 func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	m.height -= types.BlockHeight(len(cc.RevertedBlocks))
 	m.height += types.BlockHeight(len(cc.AppliedBlocks))
@@ -40,8 +40,8 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 // set of transactions with the input transactions. This is a part of the
 // TransactionPoolSubscriber interface.
 func (m *Miner) ReceiveUpdatedUnconfirmedTransactions(unconfirmedTransactions []types.Transaction, _ modules.ConsensusChange) {
-	lockID := m.mu.Lock()
-	defer m.mu.Unlock(lockID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	m.transactions = nil
 	remainingSize := int(types.BlockSizeLimit - 5e3)

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -21,7 +21,7 @@ type renterTester struct {
 	cs        modules.ConsensusSet
 	gateway   modules.Gateway
 	hostdb    modules.HostDB
-	miner     modules.Miner
+	miner     modules.TestMiner
 	tpool     modules.TransactionPool
 	wallet    modules.Wallet
 	walletKey crypto.TwofishKey

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -21,7 +21,7 @@ type tpoolTester struct {
 	cs        modules.ConsensusSet
 	gateway   modules.Gateway
 	tpool     *TransactionPool
-	miner     modules.Miner
+	miner     modules.TestMiner
 	wallet    modules.Wallet
 	walletKey crypto.TwofishKey
 }

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -64,7 +64,6 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// Inform subscribers that an update has executed.
 	tp.consensusChangeIndex++
 	tp.mu.Demote()
-	tp.updateSubscribersConsensus(cc)
 	tp.updateSubscribersTransactions()
 	tp.mu.DemotedUnlock()
 }

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -15,7 +15,7 @@ import (
 // been encrypted, to make sure that locking, unlocking, and spending after
 // unlocking are all happening in the correct order and returning the correct
 // errors.
-func postEncryptionTesting(m modules.Miner, w *Wallet, masterKey crypto.TwofishKey) {
+func postEncryptionTesting(m modules.TestMiner, w *Wallet, masterKey crypto.TwofishKey) {
 	if !w.Encrypted() {
 		panic("wallet is not encrypted when starting postEncryptionTesting")
 	}

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -15,8 +15,8 @@ type sortedOutputs struct {
 // ConfirmedBalance returns the balance of the wallet according to all of the
 // confirmed transactions.
 func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalance types.Currency, siafundClaimBalance types.Currency) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	for _, sco := range w.siacoinOutputs {
 		siacoinBalance = siacoinBalance.Add(sco.Value)
@@ -32,8 +32,8 @@ func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalan
 // the unconfirmed transaction set. Refund outputs are included in this
 // reporting.
 func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	for _, upt := range w.unconfirmedProcessedTransactions {
 		for _, input := range upt.Inputs {

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -136,8 +136,8 @@ func (w *Wallet) createBackup(backupFilepath string) error {
 
 // CreateBackup creates a backup file at the desired filepath.
 func (w *Wallet) CreateBackup(backupFilepath string) error {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.createBackup(backupFilepath)
 }
 

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -230,8 +230,8 @@ func (w *Wallet) nextPrimarySeedAddress() (types.UnlockConditions, error) {
 
 // AllSeeds returns a list of all seeds known to and used by the wallet.
 func (w *Wallet) AllSeeds() ([]modules.Seed, error) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if !w.unlocked {
 		return nil, modules.ErrLockedWallet
 	}
@@ -240,8 +240,8 @@ func (w *Wallet) AllSeeds() ([]modules.Seed, error) {
 
 // PrimarySeed returns the decrypted primary seed of the wallet.
 func (w *Wallet) PrimarySeed() (modules.Seed, uint64, error) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if !w.unlocked {
 		return modules.Seed{}, 0, modules.ErrLockedWallet
 	}
@@ -251,8 +251,8 @@ func (w *Wallet) PrimarySeed() (modules.Seed, uint64, error) {
 // NextAddress returns an unlock hash that is ready to recieve siacoins or
 // siafunds. The address is generated using the primary address seed.
 func (w *Wallet) NextAddress() (types.UnlockConditions, error) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.nextPrimarySeedAddress()
 }
 
@@ -261,8 +261,8 @@ func (w *Wallet) NextAddress() (types.UnlockConditions, error) {
 // key. An error will be returned if the seed has already been integrated with
 // the wallet.
 func (w *Wallet) LoadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	err := w.checkMasterKey(masterKey)
 	if err != nil {
 		return err

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -71,8 +71,8 @@ func addSignatures(txn *types.Transaction, cf types.CoveredFields, uc types.Unlo
 // correct value. The siacoin input will not be signed until 'Sign' is called
 // on the transaction builder.
 func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
-	lockID := tb.wallet.mu.Lock()
-	defer tb.wallet.mu.Unlock(lockID)
+	tb.wallet.mu.Lock()
+	defer tb.wallet.mu.Unlock()
 
 	// Collect a value-sorted set of siacoin outputs.
 	var so sortedOutputs
@@ -202,8 +202,8 @@ func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
 // correct value. The siafund input will not be signed until 'Sign' is called
 // on the transaction builder.
 func (tb *transactionBuilder) FundSiafunds(amount types.Currency) error {
-	lockID := tb.wallet.mu.Lock()
-	defer tb.wallet.mu.Unlock(lockID)
+	tb.wallet.mu.Lock()
+	defer tb.wallet.mu.Unlock()
 
 	// Create and fund a parent transaction that will add the correct amount of
 	// siafunds to the transaction.
@@ -388,8 +388,8 @@ func (tb *transactionBuilder) AddTransactionSignature(sig types.TransactionSigna
 // pool so that other transactions may use them. 'Drop' should only be called
 // if a transaction is both unsigned and will not be used any further.
 func (tb *transactionBuilder) Drop() {
-	lockID := tb.wallet.mu.Lock()
-	defer tb.wallet.mu.Unlock(lockID)
+	tb.wallet.mu.Lock()
+	defer tb.wallet.mu.Unlock()
 
 	// Iterate through all parents and the transaction itself and restore all
 	// outputs to the list of available outputs.
@@ -459,8 +459,8 @@ func (tb *transactionBuilder) Sign(wholeTransaction bool) ([]types.Transaction, 
 
 	// For each siacoin input in the transaction that we added, provide a
 	// signature.
-	lockID := tb.wallet.mu.Lock()
-	defer tb.wallet.mu.Unlock(lockID)
+	tb.wallet.mu.Lock()
+	defer tb.wallet.mu.Unlock()
 	for _, inputIndex := range tb.siacoinInputs {
 		input := txn.SiacoinInputs[inputIndex]
 		key := tb.wallet.keys[input.UnlockConditions.UnlockHash()]

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -15,8 +15,8 @@ var (
 // AddressTransactions returns all of the wallet transactions associated with a
 // single unlock hash.
 func (w *Wallet) AddressTransactions(uh types.UnlockHash) (pts []modules.ProcessedTransaction) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	for _, pt := range w.processedTransactions {
 		relevant := false
@@ -42,8 +42,8 @@ func (w *Wallet) AddressTransactions(uh types.UnlockHash) (pts []modules.Process
 // AddressUnconfirmedHistory returns all of the unconfirmed wallet transactions
 // related to a specific address.
 func (w *Wallet) AddressUnconfirmedTransactions(uh types.UnlockHash) (pts []modules.ProcessedTransaction) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	// Scan the full list of unconfirmed transactions to see if there are any
 	// related transactions.
@@ -71,8 +71,8 @@ func (w *Wallet) AddressUnconfirmedTransactions(uh types.UnlockHash) (pts []modu
 // Transaction returns the transaction with the given id. 'False' is returned
 // if the transaction does not exist.
 func (w *Wallet) Transaction(txid types.TransactionID) (modules.ProcessedTransaction, bool) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	pt, exists := w.processedTransactionMap[txid]
 	if !exists {
 		return modules.ProcessedTransaction{}, exists
@@ -83,8 +83,8 @@ func (w *Wallet) Transaction(txid types.TransactionID) (modules.ProcessedTransac
 // Transactions returns all transactions relevant to the wallet that were
 // confirmed in the range [startHeight, endHeight].
 func (w *Wallet) Transactions(startHeight, endHeight types.BlockHeight) (pts []modules.ProcessedTransaction, err error) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	if startHeight > w.consensusSetHeight || startHeight > endHeight {
 		return nil, errOutOfBounds
@@ -107,7 +107,7 @@ func (w *Wallet) Transactions(startHeight, endHeight types.BlockHeight) (pts []m
 // UnconfirmedTransactions returns the set of unconfirmed transactions that are
 // relevant to the wallet.
 func (w *Wallet) UnconfirmedTransactions() []modules.ProcessedTransaction {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.unconfirmedProcessedTransactions
 }

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -177,8 +177,8 @@ func (w *Wallet) loadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 
 // LoadSiagKeys loads a set of siag-generated keys into the wallet.
 func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) error {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	err := w.checkMasterKey(masterKey)
 	if err != nil {
 		return err
@@ -189,8 +189,8 @@ func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 // Load033xWallet loads a v0.3.3.x wallet as an unseeded key, such that the
 // funds become spendable to the current wallet.
 func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string) error {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	err := w.checkMasterKey(masterKey)
 	if err != nil {
 		return err

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -209,8 +209,8 @@ func (w *Wallet) applyHistory(cc modules.ConsensusChange) {
 // ProcessConsensusChange parses a consensus change to update the set of
 // confirmed outputs known to the wallet.
 func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.updateConfirmedSet(cc)
 	w.revertHistory(cc)
 	w.applyHistory(cc)
@@ -219,8 +219,8 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 // ReceiveUpdatedUnconfirmedTransactions updates the wallet's unconfirmed
 // transaction set.
 func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction, _ modules.ConsensusChange) {
-	lockID := w.mu.Lock()
-	defer w.mu.Unlock(lockID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	w.unconfirmedProcessedTransactions = nil
 	for _, txn := range txns {

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -21,7 +21,7 @@ type walletTester struct {
 	cs      modules.ConsensusSet
 	gateway modules.Gateway
 	tpool   modules.TransactionPool
-	miner   modules.Miner
+	miner   modules.TestMiner
 	wallet  *Wallet
 
 	walletMasterKey crypto.TwofishKey


### PR DESCRIPTION
Miner and wallet moved to using stdlib sync.

Transaction pool no longer auto-subscribes you to the consensus set.

Dependencies are sorted by how they are used.

CPU hashrate algorithm simplified.

TestMiner split into its own interface, tester objects all now use a test miner instead of a full miner.

Some testing.