### PR TITLE
Renewing

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -48,7 +48,7 @@ func handleHTTPRequest(mux *http.ServeMux, url string, handler http.HandlerFunc)
 }
 
 // initAPI determines which functions handle each API call.
-func (srv *Server) initAPI(addr string) {
+func (srv *Server) initAPI() {
 	mux := http.NewServeMux()
 
 	// 404 Calls
@@ -147,7 +147,7 @@ func (srv *Server) initAPI(addr string) {
 	// Create graceful HTTP server
 	srv.apiServer = &graceful.Server{
 		Timeout: apiTimeout,
-		Server:  &http.Server{Addr: addr, Handler: mux},
+		Server:  &http.Server{Handler: mux},
 	}
 }
 

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -57,7 +57,7 @@ func TestSignedUpdate(t *testing.T) {
 	}
 
 	// apply (bad signature)
-	resp, err := HttpGET("http://localhost" + st.server.apiServer.Addr + "/daemon/updates/apply?version=current")
+	resp, err := HttpGET("http://" + st.server.listener.Addr().String() + "/daemon/updates/apply?version=current")
 	if err != nil {
 		t.Fatal("GET failed:", err)
 	}

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -51,8 +51,10 @@ func TestSignedUpdate(t *testing.T) {
 
 	// newer version
 	uh.version = "100.0"
-	st.getAPI("/daemon/updates/check", &info)
-	if !info.Available {
+	err = st.getAPI("/daemon/updates/check", &info)
+	if err != nil {
+		t.Error(err)
+	} else if !info.Available {
 		t.Error("new version should be available")
 	}
 

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -25,8 +24,6 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 
 	// Check a wallet that has never been encrypted.
 	testdir := build.TempDir("api", "TestIntegrationWalletGETEncrypted")
-	APIAddr := ":" + strconv.Itoa(APIPort)
-	APIPort++
 	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal("Failed to create gateway:", err)
@@ -43,7 +40,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create wallet:", err)
 	}
-	srv, err := NewServer(APIAddr, cs, g, nil, nil, nil, nil, tp, w, nil)
+	srv, err := NewServer(":0", cs, g, nil, nil, nil, nil, tp, w, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,8 +83,6 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	}
 	// Create a server object without encrypting or unlocking the wallet.
 	testdir := build.TempDir("api", "TestIntegrationWalletBlankEncrypt")
-	APIAddr := ":" + strconv.Itoa(APIPort)
-	APIPort++
 	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +99,7 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := NewServer(APIAddr, cs, g, nil, nil, nil, nil, tp, w, nil)
+	srv, err := NewServer(":0", cs, g, nil, nil, nil, nil, tp, w, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -1,14 +1,8 @@
 package encoding
 
 import (
-	"errors"
 	"fmt"
 	"io"
-)
-
-var (
-	errNoData    = errors.New("no data")
-	errBadPrefix = errors.New("could not read full length prefix")
 )
 
 // ReadPrefix reads an 8-byte length prefixes, followed by the number of bytes
@@ -16,13 +10,8 @@ var (
 // specified maximum length.
 func ReadPrefix(r io.Reader, maxLen uint64) ([]byte, error) {
 	prefix := make([]byte, 8)
-	if n, err := io.ReadFull(r, prefix); n == 0 {
-		if err == nil {
-			err = errNoData
-		}
+	if _, err := io.ReadFull(r, prefix); err != nil {
 		return nil, err
-	} else if err != nil {
-		return nil, errBadPrefix
 	}
 	dataLen := DecUint64(prefix)
 	if dataLen > maxLen {

--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -17,7 +17,10 @@ var (
 func ReadPrefix(r io.Reader, maxLen uint64) ([]byte, error) {
 	prefix := make([]byte, 8)
 	if n, err := io.ReadFull(r, prefix); n == 0 {
-		return nil, errNoData
+		if err == nil {
+			err = errNoData
+		}
+		return nil, err
 	} else if err != nil {
 		return nil, errBadPrefix
 	}

--- a/encoding/prefix_test.go
+++ b/encoding/prefix_test.go
@@ -38,8 +38,8 @@ func TestReadPrefix(t *testing.T) {
 	// empty
 	b.Write([]byte{})
 	_, err = ReadPrefix(b, 3)
-	if err != errNoData {
-		t.Error("expected errNoData, got", err)
+	if err != io.EOF {
+		t.Error("expected EOF, got", err)
 	}
 
 	// less than 8 bytes
@@ -83,8 +83,8 @@ func TestReadObject(t *testing.T) {
 	// empty
 	b.Write([]byte{})
 	err = ReadObject(b, &obj, 0)
-	if err != errNoData {
-		t.Error("expected errNoData, got", err)
+	if err != io.EOF {
+		t.Error("expected EOF, got", err)
 	}
 
 	// bad object

--- a/encoding/prefix_test.go
+++ b/encoding/prefix_test.go
@@ -45,16 +45,14 @@ func TestReadPrefix(t *testing.T) {
 	// less than 8 bytes
 	b.Write([]byte{1, 2, 3})
 	_, err = ReadPrefix(b, 3)
-	if err != errBadPrefix {
-		t.Error("expected errBadPrefix, got", err)
+	if err != io.ErrUnexpectedEOF {
+		t.Error("expected unexpected EOF, got", err)
 	}
 
 	// exceed maxLen
 	b.Write(EncUint64(4))
 	_, err = ReadPrefix(b, 3)
-	if err == nil {
-		t.Error("expected errBadPrefix, got nil")
-	} else if err.Error() != "length 4 exceeds maxLen of 3" {
+	if err == nil || err.Error() != "length 4 exceeds maxLen of 3" {
 		t.Error("expected maxLen error, got", err)
 	}
 
@@ -91,10 +89,8 @@ func TestReadObject(t *testing.T) {
 	b.Write(EncUint64(3))
 	b.WriteString("foo") // strings need an additional length prefix
 	err = ReadObject(b, &obj, 3)
-	if err == nil {
-		t.Error("expected err, got nil")
-	} else if err.Error() != "could not decode type string: "+errBadPrefix.Error() {
-		t.Error("expected errBadPrefix, got", err)
+	if err == nil || err.Error() != "could not decode type string: "+io.ErrUnexpectedEOF.Error() {
+		t.Error("expected unexpected EOF, got", err)
 	}
 }
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -21,6 +21,10 @@ const (
 	maxContractLen         = 1 << 16 // The maximum allowed size of a file contract coming in over the wire. This does not include the file.
 )
 
+var (
+	defaultPrice = types.SiacoinPrecision.Div(types.NewCurrency64(4320 * 1024 * 1024 * 1024 / 200)) // 200 SC / GB / Month
+)
+
 // A contractObligation tracks a file contract that the host is obligated to
 // fulfill.
 type contractObligation struct {
@@ -90,11 +94,11 @@ func New(cs *consensus.ConsensusSet, hdb modules.HostDB, tpool modules.Transacti
 
 		// default host settings
 		HostSettings: modules.HostSettings{
-			TotalStorage: 10e9,                        // 10 GB
-			MaxFilesize:  5 * 1024 * 1024 * 1024,      // 5 GiB
-			MaxDuration:  144 * 60,                    // 60 days
-			WindowSize:   288,                         // 48 hours
-			Price:        types.NewCurrency64(100e12), // 0.1 siacoin / mb / week
+			TotalStorage: 10e9,                   // 10 GB
+			MaxFilesize:  5 * 1024 * 1024 * 1024, // 5 GiB
+			MaxDuration:  144 * 60,               // 60 days
+			WindowSize:   288,                    // 48 hours
+			Price:        defaultPrice,           // 200 SC / GB / Month
 			Collateral:   types.NewCurrency64(0),
 		},
 

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -29,7 +29,7 @@ type file struct {
 
 	name        string
 	size        uint64
-	contracts   map[modules.NetAddress]fileContract
+	contracts   map[types.FileContractID]fileContract
 	masterKey   crypto.TwofishKey
 	erasureCode modules.ErasureCoder
 	pieceSize   uint64
@@ -117,7 +117,7 @@ func newFile(name string, code modules.ErasureCoder, pieceSize, fileSize uint64)
 	return &file{
 		name:        name,
 		size:        fileSize,
-		contracts:   make(map[modules.NetAddress]fileContract),
+		contracts:   make(map[types.FileContractID]fileContract),
 		masterKey:   key,
 		erasureCode: code,
 		pieceSize:   pieceSize,

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -174,27 +174,30 @@ func (r *Renter) FileList() (files []modules.FileInfo) {
 // file must exist, and there must not be any file that already has the
 // replacement nickname.
 func (r *Renter) RenameFile(currentName, newName string) error {
-	lockID := r.mu.Lock()
-	defer r.mu.Unlock(lockID)
+	return errors.New("renaming is disabled")
 
-	// Check that the currentName exists and the newName doesn't.
-	file, exists := r.files[currentName]
-	if !exists {
-		return ErrUnknownNickname
-	}
-	_, exists = r.files[newName]
-	if exists {
-		return ErrNicknameOverload
-	}
+	/*
+		lockID := r.mu.Lock()
+		defer r.mu.Unlock(lockID)
 
-	// Do the renaming.
-	file.mu.Lock()
-	file.name = newName
-	file.mu.Unlock()
-	r.saveFile(file)
-	delete(r.files, currentName)
-	r.files[newName] = file
+		// Check that the currentName exists and the newName doesn't.
+		file, exists := r.files[currentName]
+		if !exists {
+			return ErrUnknownNickname
+		}
+		_, exists = r.files[newName]
+		if exists {
+			return ErrNicknameOverload
+		}
 
-	r.save()
-	return nil
+		// Do the renaming.
+		file.name = newName
+		r.saveFile(file)
+		delete(r.files, currentName)
+		r.files[newName] = file
+
+		r.save()
+		return nil
+
+	*/
 }

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -8,7 +8,7 @@ import (
 
 // TestFileAvailable probes the Available method of the file type.
 func TestFileAvailable(t *testing.T) {
-	rsc, _ := NewRSCode(2, 10)
+	rsc, _ := NewRSCode(1, 10)
 	f := &file{
 		size:        1000,
 		erasureCode: rsc,
@@ -19,7 +19,12 @@ func TestFileAvailable(t *testing.T) {
 		t.Error("file should not be available")
 	}
 
-	f.chunksUploaded = f.numChunks()
+	var fc fileContract
+	for i := uint64(0); i < f.numChunks(); i++ {
+		fc.Pieces = append(fc.Pieces, pieceData{Chunk: i, Piece: 0})
+	}
+	f.contracts = map[types.FileContractID]fileContract{types.FileContractID{}: fc}
+
 	if !f.Available() {
 		t.Error("file should be available")
 	}

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -106,21 +106,23 @@ func TestRenterDeleteFile(t *testing.T) {
 		t.Error("file was deleted, but is still reported in FileList")
 	}
 
-	// Put a file in the renter, then rename it.
-	rt.renter.files["1"] = &file{
-		name: "one",
-	}
-	rt.renter.RenameFile("1", "one")
-	// Call delete on the previous name.
-	err = rt.renter.DeleteFile("1")
-	if err != ErrUnknownNickname {
-		t.Error("Expected ErrUnknownNickname:", err)
-	}
-	// Call delete on the new name.
-	err = rt.renter.DeleteFile("one")
-	if err != nil {
-		t.Error(err)
-	}
+	/*
+		// Put a file in the renter, then rename it.
+		rt.renter.files["1"] = &file{
+			name: "one",
+		}
+		rt.renter.RenameFile("1", "one")
+		// Call delete on the previous name.
+		err = rt.renter.DeleteFile("1")
+		if err != ErrUnknownNickname {
+			t.Error("Expected ErrUnknownNickname:", err)
+		}
+		// Call delete on the new name.
+		err = rt.renter.DeleteFile("one")
+		if err != nil {
+			t.Error(err)
+		}
+	*/
 }
 
 // TestRenterFileList probes the FileList method of the renter type.
@@ -167,9 +169,8 @@ func TestRenterFileList(t *testing.T) {
 
 // TestRenterRenameFile probes the rename method of the renter.
 func TestRenterRenameFile(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
+	t.Skip("Renaming disabled")
+
 	rt, err := newRenterTester("TestRenterRenameFile")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -3,7 +3,7 @@ package renter
 import (
 	"testing"
 
-	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // TestFileAvailable probes the Available method of the file type.
@@ -36,7 +36,7 @@ func TestFileNickname(t *testing.T) {
 // TestFileExpiration probes the Expiration method of the file type.
 func TestFileExpiration(t *testing.T) {
 	f := &file{
-		contracts: make(map[modules.NetAddress]fileContract),
+		contracts: make(map[types.FileContractID]fileContract),
 	}
 
 	if f.Expiration() != 0 {
@@ -46,21 +46,21 @@ func TestFileExpiration(t *testing.T) {
 	// Add a contract.
 	fc := fileContract{}
 	fc.WindowStart = 100
-	f.contracts["foo"] = fc
+	f.contracts[types.FileContractID{0}] = fc
 	if f.Expiration() != 100 {
-		t.Error("file with expired contract should report as having no time remaining")
+		t.Error("file did not report lowest WindowStart")
 	}
 
 	// Add a contract with a lower WindowStart.
 	fc.WindowStart = 50
-	f.contracts["bar"] = fc
+	f.contracts[types.FileContractID{1}] = fc
 	if f.Expiration() != 50 {
 		t.Error("file did not report lowest WindowStart")
 	}
 
 	// Add a contract with a higher WindowStart.
 	fc.WindowStart = 75
-	f.contracts["baz"] = fc
+	f.contracts[types.FileContractID{2}] = fc
 	if f.Expiration() != 50 {
 		t.Error("file did not report lowest WindowStart")
 	}

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -285,6 +285,8 @@ func (hu *hostUploader) addPiece(p uploadPiece) error {
 	return nil
 }
 
+// revise revises fc to cover piece and uploads both the revision and the
+// piece data to the host.
 func (hu *hostUploader) revise(fc types.FileContract, piece []byte, height types.BlockHeight) error {
 	hu.conn.SetDeadline(time.Now().Add(30 * time.Second)) // sufficient to transfer 4 MB over 1 Mbps
 	defer hu.conn.SetDeadline(time.Time{})                // reset timeout after each revision
@@ -382,6 +384,8 @@ func (hu *hostUploader) revise(fc types.FileContract, piece []byte, height types
 	return nil
 }
 
+// newHostUploader negotiates an initial file contract with the specified host
+// and returns a hostUploader, which satisfies the uploader interface.
 func (r *Renter) newHostUploader(settings modules.HostSettings, filesize uint64, duration types.BlockHeight, masterKey crypto.TwofishKey) (*hostUploader, error) {
 	// reject hosts that are too expensive
 	if settings.Price.Cmp(maxPrice) > 0 {

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// the renter will not form contracts above this price
-	maxPrice = types.SiacoinPrecision.Div(types.NewCurrency64(4320 * 1024 * 1024 * 1024 / 400)) // 400 SC / GB / Month
+	maxPrice = types.SiacoinPrecision.Div(types.NewCurrency64(4320 * 1024 * 1024 * 1024 / 500)) // 500 SC / GB / Month
 
 	errTooExpensive = errors.New("host price was too high")
 )

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -71,7 +71,7 @@ func (hu *hostUploader) negotiateContract(filesize uint64, duration types.BlockH
 		return err
 	}
 	defer conn.Close()
-	conn.SetDeadline(time.Now().Add(15 * time.Second))
+	conn.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// inital calculations before connecting to host
 	lockID := hu.renter.mu.RLock()
@@ -288,8 +288,8 @@ func (hu *hostUploader) addPiece(p uploadPiece) error {
 // revise revises fc to cover piece and uploads both the revision and the
 // piece data to the host.
 func (hu *hostUploader) revise(fc types.FileContract, piece []byte, height types.BlockHeight) error {
-	hu.conn.SetDeadline(time.Now().Add(30 * time.Second)) // sufficient to transfer 4 MB over 1 Mbps
-	defer hu.conn.SetDeadline(time.Time{})                // reset timeout after each revision
+	hu.conn.SetDeadline(time.Now().Add(5 * time.Minute)) // sufficient to transfer 4 MB over 100 kbps
+	defer hu.conn.SetDeadline(time.Time{})               // reset timeout after each revision
 
 	// calculate new merkle root
 	r := bytes.NewReader(piece)

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -262,11 +262,9 @@ func (hu *hostUploader) addPiece(p uploadPiece) error {
 		return err
 	}
 
-	// Revise the file contract. If revision fails, submit most recent
-	// successful revision to the blockchain.
+	// revise the file contract
 	err = hu.revise(fc, encPiece, height)
 	if err != nil {
-		hu.renter.tpool.AcceptTransactionSet([]types.Transaction{hu.lastTxn})
 		return err
 	}
 

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -72,6 +72,7 @@ func (hu *hostUploader) negotiateContract(filesize uint64, duration types.BlockH
 		return err
 	}
 	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(15 * time.Second))
 
 	// inital calculations before connecting to host
 	lockID := hu.renter.mu.RLock()
@@ -288,6 +289,9 @@ func (hu *hostUploader) addPiece(p uploadPiece) error {
 }
 
 func (hu *hostUploader) revise(fc types.FileContract, piece []byte, height types.BlockHeight) error {
+	hu.conn.SetDeadline(time.Now().Add(30 * time.Second)) // sufficient to transfer 4 MB over 1 Mbps
+	defer hu.conn.SetDeadline(time.Time{})                // reset timeout after each revision
+
 	// calculate new merkle root
 	r := bytes.NewReader(piece)
 	buf := make([]byte, crypto.SegmentSize)

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -40,7 +40,6 @@ var (
 // save saves a file to w in shareable form. Files are stored in binary format
 // and gzipped to reduce size.
 func (f *file) save(w io.Writer) error {
-	// TODO: error checking
 	zip, _ := gzip.NewWriterLevel(w, gzip.BestCompression)
 	defer zip.Close()
 	enc := encoding.NewEncoder(zip)
@@ -94,7 +93,6 @@ func (f *file) save(w io.Writer) error {
 
 // load loads a file created by save.
 func (f *file) load(r io.Reader) error {
-	// TODO: error checking
 	zip, err := gzip.NewReader(r)
 	if err != nil {
 		return err
@@ -178,7 +176,9 @@ func (r *Renter) saveFile(f *file) error {
 	}
 
 	// Write file.
+	f.mu.RLock()
 	err = f.save(handle)
+	f.mu.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -240,7 +240,9 @@ func (r *Renter) load() error {
 	if err != nil {
 		return err
 	}
-	r.repairSet = data.Repairing
+	if data.Repairing != nil {
+		r.repairSet = data.Repairing
+	}
 	r.entropy = data.Entropy
 	var fcid types.FileContractID
 	for id, fc := range data.Contracts {

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
-	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -142,13 +141,13 @@ func (f *file) load(r io.Reader) error {
 	if err := dec.Decode(&nContracts); err != nil {
 		return err
 	}
-	f.contracts = make(map[modules.NetAddress]fileContract)
+	f.contracts = make(map[types.FileContractID]fileContract)
 	var contract fileContract
 	for i := uint64(0); i < nContracts; i++ {
 		if err := dec.Decode(&contract); err != nil {
 			return err
 		}
-		f.contracts[contract.IP] = contract
+		f.contracts[contract.ID] = contract
 	}
 	return nil
 }

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -176,9 +176,7 @@ func (r *Renter) saveFile(f *file) error {
 	}
 
 	// Write file.
-	f.mu.RLock()
 	err = f.save(handle)
-	f.mu.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/modules/renter/persist_test.go
+++ b/modules/renter/persist_test.go
@@ -16,7 +16,7 @@ import (
 // newTestingFile initializes a file object with random parameters.
 func newTestingFile() *file {
 	key, _ := crypto.GenerateTwofishKey()
-	data, _ := crypto.RandBytes(14)
+	data, _ := crypto.RandBytes(8)
 	nData, _ := crypto.RandIntn(10)
 	nParity, _ := crypto.RandIntn(10)
 	rsc, _ := NewRSCode(nData+1, nParity+1)
@@ -27,9 +27,6 @@ func newTestingFile() *file {
 		masterKey:   key,
 		erasureCode: rsc,
 		pieceSize:   encoding.DecUint64(data[6:8]),
-
-		bytesUploaded:  encoding.DecUint64(data[9:11]),
-		chunksUploaded: encoding.DecUint64(data[12:14]),
 	}
 }
 
@@ -49,12 +46,6 @@ func equalFiles(f1, f2 *file) error {
 	}
 	if f1.pieceSize != f2.pieceSize {
 		return fmt.Errorf("pieceSizes do not match: %v %v", f1.pieceSize, f2.pieceSize)
-	}
-	if f1.bytesUploaded != f2.bytesUploaded {
-		return fmt.Errorf("bytesUploaded does not match: %v %v", f1.bytesUploaded, f2.bytesUploaded)
-	}
-	if f1.chunksUploaded != f2.chunksUploaded {
-		return fmt.Errorf("chunksUploaded does not match: %v %v", f1.chunksUploaded, f2.chunksUploaded)
 	}
 	return nil
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -32,11 +32,6 @@ type Renter struct {
 	entropy       [32]byte          // used to generate signing keys
 	downloadQueue []*download
 
-	// a primitive blacklist is used to augment the hostdb's weights. Each
-	// negotiation failure increments the integer, and the probability of
-	// selecting the host for upload is 1/n.
-	blacklist map[modules.NetAddress]int
-
 	persistDir string
 	log        *log.Logger
 	mu         *sync.RWMutex
@@ -66,8 +61,6 @@ func New(cs modules.ConsensusSet, hdb modules.HostDB, wallet modules.Wallet, tpo
 		files:     make(map[string]*file),
 		contracts: make(map[types.FileContractID]types.FileContract),
 		repairSet: make(map[string]string),
-
-		blacklist: make(map[modules.NetAddress]int),
 
 		persistDir: persistDir,
 		mu:         sync.New(modules.SafeMutexDelay, 1),

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -32,6 +32,11 @@ type Renter struct {
 	entropy       [32]byte          // used to generate signing keys
 	downloadQueue []*download
 
+	// a primitive blacklist is used to augment the hostdb's weights. Each
+	// negotiation failure increments the integer, and the probability of
+	// selecting the host for upload is 1/n.
+	blacklist map[modules.NetAddress]int
+
 	persistDir string
 	log        *log.Logger
 	mu         *sync.RWMutex
@@ -61,6 +66,8 @@ func New(cs modules.ConsensusSet, hdb modules.HostDB, wallet modules.Wallet, tpo
 		files:     make(map[string]*file),
 		contracts: make(map[types.FileContractID]types.FileContract),
 		repairSet: make(map[string]string),
+
+		blacklist: make(map[modules.NetAddress]int),
 
 		persistDir: persistDir,
 		mu:         sync.New(modules.SafeMutexDelay, 1),

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -4,10 +4,9 @@ import (
 	"crypto/rand"
 	"errors"
 	"log"
-	"sync"
 
 	"github.com/NebulousLabs/Sia/modules"
-	safesync "github.com/NebulousLabs/Sia/sync"
+	"github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -31,12 +30,11 @@ type Renter struct {
 	contracts     map[types.FileContractID]types.FileContract
 	repairSet     map[string]string // map from nickname to filepath
 	entropy       [32]byte          // used to generate signing keys
-	hostLock      sync.Mutex
 	downloadQueue []*download
 
 	persistDir string
 	log        *log.Logger
-	mu         *safesync.RWMutex
+	mu         *sync.RWMutex
 }
 
 // New returns an empty renter.
@@ -65,7 +63,7 @@ func New(cs modules.ConsensusSet, hdb modules.HostDB, wallet modules.Wallet, tpo
 		repairSet: make(map[string]string),
 
 		persistDir: persistDir,
-		mu:         safesync.New(modules.SafeMutexDelay, 1),
+		mu:         sync.New(modules.SafeMutexDelay, 1),
 	}
 	_, err := rand.Read(r.entropy[:])
 	if err != nil {

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -88,15 +87,11 @@ func (f *file) repair(r io.ReaderAt, pieceMap map[uint64][]uint64, hosts []uploa
 			host := newHosts[j%len(newHosts)]
 			up := uploadPiece{pieces[pieceIndex], chunkIndex, pieceIndex}
 			go func(host uploader, up uploadPiece) {
-				err := host.addPiece(up)
-				if err == nil {
-					atomic.AddUint64(&f.bytesUploaded, uint64(len(up.data)))
-				}
+				_ = host.addPiece(up)
 				wg.Done()
 			}(host, up)
 		}
 		wg.Wait()
-		atomic.AddUint64(&f.chunksUploaded, 1)
 
 		// update contracts
 		for _, h := range hosts {

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -241,7 +241,7 @@ func (r *Renter) threadedRepairUploads() {
 				defer handle.Close()
 
 				// build host list
-				bytesPerHost := f.pieceSize * f.numChunks()
+				bytesPerHost := f.pieceSize * uint64(f.erasureCode.MinPieces()) * f.numChunks()
 				var hosts []uploader
 				randHosts := r.hostDB.RandomHosts(f.erasureCode.NumPieces() * 2)
 				for _, h := range randHosts {

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -101,7 +101,7 @@ func (f *file) repair(r io.ReaderAt, pieceMap map[uint64][]uint64, hosts []uploa
 		// update contracts
 		for _, h := range hosts {
 			contract := h.fileContract()
-			f.contracts[contract.IP] = contract
+			f.contracts[contract.ID] = contract
 		}
 	}
 

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -138,7 +138,8 @@ func (f *file) repair(r io.ReaderAt, pieceMap map[uint64][]uint64, hosts []uploa
 		newHosts := hosts
 		// don't bother encoding if there aren't any hosts to upload to
 		if len(newHosts) == 0 {
-			continue
+			println("no unique hosts")
+			newHosts = hosts
 		}
 
 		// read chunk data and encode
@@ -228,6 +229,12 @@ func (r *Renter) threadedRepairUploads() {
 			}
 
 			r.log.Printf("repairing %v chunks of %v", len(badChunks), name)
+			println("repairing")
+			for c, ps := range badChunks {
+				for _, p := range ps {
+					println(c, p)
+				}
+			}
 
 			// defer is really convenient for cleaning up resources, so an
 			// inline function is justified
@@ -261,6 +268,7 @@ func (r *Renter) threadedRepairUploads() {
 						continue
 					}
 					defer hostUploader.Close()
+					println("got host", h.IPAddress)
 
 					hosts = append(hosts, hostUploader)
 					if len(hosts) >= f.erasureCode.NumPieces() {

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -226,15 +226,18 @@ func (r *Renter) threadedRepairUploads() {
 
 			// build host list
 			var hosts []uploader
-			randHosts := r.hostDB.RandomHosts(f.erasureCode.NumPieces())
+			randHosts := r.hostDB.RandomHosts(f.erasureCode.NumPieces() * 2)
 			for i := range randHosts {
 				// TODO: use smarter duration
 				hostUploader, err := r.newHostUploader(randHosts[i], f.size, defaultDuration, f.masterKey)
 				if err != nil {
 					continue
 				}
-				defer hostUploader.Close()
+
 				hosts = append(hosts, hostUploader)
+				if len(hosts) >= f.erasureCode.NumPieces() {
+					break
+				}
 			}
 
 			err = f.repair(handle, badChunks, hosts)

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -239,6 +239,10 @@ func (r *Renter) threadedRepairUploads() {
 					break
 				}
 			}
+			if len(hosts) < f.erasureCode.MinPieces() {
+				r.log.Printf("failed to repair %v: not enough hosts", name)
+				continue
+			}
 
 			err = f.repair(handle, badChunks, hosts)
 			if err != nil {

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -227,9 +227,10 @@ func (r *Renter) threadedRepairUploads() {
 			// build host list
 			var hosts []uploader
 			randHosts := r.hostDB.RandomHosts(f.erasureCode.NumPieces() * 2)
-			for i := range randHosts {
+			r.hostLock.Lock()
+			for _, h := range randHosts {
 				// TODO: use smarter duration
-				hostUploader, err := r.newHostUploader(randHosts[i], f.size, defaultDuration, f.masterKey)
+				hostUploader, err := r.newHostUploader(h, f.size, defaultDuration, f.masterKey)
 				if err != nil {
 					continue
 				}
@@ -239,6 +240,7 @@ func (r *Renter) threadedRepairUploads() {
 					break
 				}
 			}
+			r.hostLock.Unlock()
 			if len(hosts) < f.erasureCode.MinPieces() {
 				r.log.Printf("failed to repair %v: not enough hosts", name)
 				continue

--- a/modules/renter/repair_test.go
+++ b/modules/renter/repair_test.go
@@ -39,7 +39,7 @@ func TestRepair(t *testing.T) {
 
 	// upload data to hosts
 	f := newFile("foo", rsc, pieceSize, dataSize)
-	err = f.upload(bytes.NewReader(data), hosts)
+	err = f.repair(bytes.NewReader(data), f.incompleteChunks(), hosts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -73,16 +73,9 @@ func (r *Renter) checkWalletBalance(up modules.FileUploadParams) error {
 	return nil
 }
 
-// Upload takes an upload parameters, which contain a file to upload, and then
-// creates a redundant copy of the file on the Sia network.
+// Upload instructs the renter to start tracking a file. The renter will
+// automatically upload and repair tracked files using a background loop.
 func (r *Renter) Upload(up modules.FileUploadParams) error {
-	// Open the file.
-	handle, err := os.Open(up.Filename)
-	if err != nil {
-		return err
-	}
-	defer handle.Close()
-
 	// Check for a nickname conflict.
 	lockID := r.mu.RLock()
 	_, exists := r.files[up.Nickname]
@@ -92,7 +85,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	}
 
 	// Check that the file is less than 5 GiB.
-	fileInfo, err := handle.Stat()
+	fileInfo, err := os.Stat(up.Filename)
 	if err != nil {
 		return err
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -76,10 +76,12 @@ func (f *file) upload(r io.Reader, hosts []uploader) error {
 		wg.Wait()
 
 		// update contracts
+		f.mu.Lock()
 		for _, h := range hosts {
 			contract := h.fileContract()
 			f.contracts[contract.ID] = contract
 		}
+		f.mu.Unlock()
 	}
 
 	return nil

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -179,6 +179,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	totalsize := up.PieceSize * uint64(up.ErasureCode.NumPieces()) * f.numChunks()
 	var hosts []uploader
 	randHosts := r.hostDB.RandomHosts(up.ErasureCode.NumPieces() * 2)
+	r.hostLock.Lock()
 	for _, h := range randHosts {
 		hostUploader, err := r.newHostUploader(h, totalsize, up.Duration, f.masterKey)
 		if err != nil {
@@ -192,6 +193,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 			break
 		}
 	}
+	r.hostLock.Unlock()
 	if len(hosts) < up.ErasureCode.MinPieces() {
 		return errors.New("not enough hosts to support upload")
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -81,7 +81,7 @@ func (f *file) upload(r io.Reader, hosts []uploader) error {
 		// update contracts
 		for _, h := range hosts {
 			contract := h.fileContract()
-			f.contracts[contract.IP] = contract
+			f.contracts[contract.ID] = contract
 		}
 	}
 

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -12,7 +12,7 @@ import (
 const (
 	defaultDuration     = 6000 // Duration that hosts will hold onto the file
 	defaultDataPieces   = 2    // Data pieces per erasure-coded chunk
-	defaultParityPieces = 10   // Parity pieces per erasure-coded chunk
+	defaultParityPieces = 8    // Parity pieces per erasure-coded chunk
 
 	// piece sizes
 	// NOTE: The encryption overhead is subtracted so that encrypted piece
@@ -89,13 +89,13 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	if err != nil {
 		return err
 	}
-	// NOTE: The upload max of 5 GiB is temporary and therefore does not have
+	// NOTE: The upload max of 20 GiB is temporary and therefore does not have
 	// a constant. This should be removed once micropayments + upload resuming
-	// are in place. 5 GiB is chosen to prevent confusion - on anybody's
-	// machine any file appearing to be under 5 GB will be below the hard
+	// are in place. 20 GiB is chosen to prevent confusion - on anybody's
+	// machine any file appearing to be under 20 GB will be below the hard
 	// limit.
-	if fileInfo.Size() > 5*1024*1024*1024 {
-		return errors.New("cannot upload a file larger than 5 GB")
+	if fileInfo.Size() > 20*1024*1024*1024 {
+		return errors.New("cannot upload a file larger than 20 GB")
 	}
 
 	// Fill in any missing upload params with sensible defaults.

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -83,7 +83,7 @@ func TestErasureUpload(t *testing.T) {
 
 	// upload data to hosts
 	f := newFile("foo", rsc, pieceSize, dataSize)
-	err = f.upload(bytes.NewReader(data), hosts)
+	err = f.repair(bytes.NewReader(data), f.incompleteChunks(), hosts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -174,8 +174,8 @@ func (w *Wallet) Unlocked() bool {
 // Lock will erase all keys from memory and prevent the wallet from spending
 // coins until it is unlocked.
 func (w *Wallet) Lock() error {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if !w.unlocked {
 		return modules.ErrLockedWallet
 	}


### PR DESCRIPTION
Files are now renewed before their contracts are set to expire. An offline check was implemented, but not used, since I think it'll be tricky to get right due to latency, and at this stage it may be overly aggressive anyway.

I also removed the `bytesUploaded` and `chunksUploaded` fields from the file object, since these can be calculated from the contract set. Unfortunately this meant adding a mutex, since the contracts are updated during the upload process. But then I realized I needed to add a mutex anyway, since the repair loop can now modify contracts in the background at any time. I worry about how much complexity this has introduced though. The renter does not feel very solid to me, and I take responsibility for that. A lot of the difficulty is tied to persistence; in-memory data structures have to be kept in sync with on-disk files. I hope that we can steadily improve the renter until it feels sturdy again.

This stuff hasn't been adequately tested. I'll be doing that tomorrow. I will also be enabling "lazy" contract formation, so that you can request as many hosts from the hostdb as you need, and you'll only form contracts with them once you actually start uploading data. The current upload algorithm doesn't ask for enough hosts, so I think this will result in fewer upload failures.