### PR TITLE
Switch to vendored bolt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dependencies:
 	go get -u github.com/NebulousLabs/demotemutex
 	go get -u github.com/NebulousLabs/ed25519
 	go get -u github.com/NebulousLabs/merkletree
-	go get -u github.com/boltdb/bolt
+	go get -u github.com/NebulousLabs/bolt
 	go get -u github.com/dchest/blake2b
 	go get -u golang.org/x/crypto/twofish
 	# Module + Daemon Dependencies

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"time"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 var (

--- a/modules/consensus/applytransaction.go
+++ b/modules/consensus/applytransaction.go
@@ -4,11 +4,11 @@ package consensus
 // There is an assumption that the transaction has already been verified.
 
 import (
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // applySiacoinInputs takes all of the siacoin inputs in a transaction and

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -9,13 +9,13 @@ package consensus
 import (
 	"errors"
 
-	"github.com/NebulousLabs/demotemutex"
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
+	"github.com/NebulousLabs/demotemutex"
 )
 
 var (

--- a/modules/consensus/consistency.go
+++ b/modules/consensus/consistency.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // manageErr handles an error detected by the consistency checks.

--- a/modules/consensus/consistency.go
+++ b/modules/consensus/consistency.go
@@ -23,55 +23,6 @@ func manageErr(tx *bolt.Tx, err error) {
 	}
 }
 
-// refreshDB saves, deletes, and then restores all of the buckets in the
-// database. This eliminates bugs during reorgs. The exact source of the bugs
-// is unknown, but the problem is that after excessive use by Sia, calling
-// Delete on a bucket will occasionally delete many more elements than the
-// single element being targeted. It is strongly suspected that this is due to
-// an error in the boltdb code, but the source remains unknown for the time
-// being. Refreshing the database between blocks has solved the issue for the
-// time being - it is currently unknown whether large blocks are able to
-// trigger the error, but it is suspected that large blocks are safe.
-func refreshDB(tx *bolt.Tx) {
-	// Get a list of buckets.
-	var bucketNames [][]byte
-	err := tx.ForEach(func(bucketName []byte, _ *bolt.Bucket) error {
-		bucketNames = append(bucketNames, bucketName)
-		return nil
-	})
-	if err != nil {
-		manageErr(tx, err)
-	}
-
-	for _, bucketName := range bucketNames {
-		var keys [][]byte
-		var values [][]byte
-		err := tx.Bucket(bucketName).ForEach(func(k, v []byte) error {
-			keys = append(keys, k)
-			values = append(values, v)
-			return nil
-		})
-		if err != nil {
-			manageErr(tx, err)
-		}
-
-		err = tx.DeleteBucket(bucketName)
-		if err != nil {
-			manageErr(tx, err)
-		}
-		bucket, err := tx.CreateBucket(bucketName)
-		if err != nil {
-			manageErr(tx, err)
-		}
-		for i := range keys {
-			err := bucket.Put(keys[i], values[i])
-			if err != nil {
-				manageErr(tx, err)
-			}
-		}
-	}
-}
-
 // consensusChecksum grabs a checksum of the consensus set by pushing all of
 // the elements in sorted order into a merkle tree and taking the root. All
 // consensus sets with the same current block should have identical consensus
@@ -378,7 +329,7 @@ func (cs *ConsensusSet) checkConsistency(tx *bolt.Tx) {
 	checkDSCOs(tx)
 	checkSiacoinCount(tx)
 	checkSiafundCount(tx)
-	// cs.checkRevertApply(tx)
+	cs.checkRevertApply(tx)
 	cs.checkingConsistency = false
 }
 

--- a/modules/consensus/consistency_helpers_test.go
+++ b/modules/consensus/consistency_helpers_test.go
@@ -1,9 +1,9 @@
 package consensus
 
 import (
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/crypto"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // dbConsensusChecksum is a convenience function to call consensusChecksum

--- a/modules/consensus/database.go
+++ b/modules/consensus/database.go
@@ -13,13 +13,13 @@ package consensus
 import (
 	"errors"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 var (

--- a/modules/consensus/database_helpers_test.go
+++ b/modules/consensus/database_helpers_test.go
@@ -4,10 +4,10 @@ package consensus
 // compatibility with the test suite.
 
 import (
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // dbBlockHeight is a convenience function allowing blockHeight to be called

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -3,12 +3,12 @@ package consensus
 import (
 	"errors"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 var (

--- a/modules/consensus/diffs_test.go
+++ b/modules/consensus/diffs_test.go
@@ -3,10 +3,10 @@ package consensus
 import (
 	"testing"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // TestCommitDelayedSiacoinOutputDiffBadMaturity commits a delayed sicoin

--- a/modules/consensus/fork.go
+++ b/modules/consensus/fork.go
@@ -66,7 +66,6 @@ func (cs *ConsensusSet) revertToBlock(tx *bolt.Tx, pb *processedBlock) (reverted
 		} else {
 			cs.maybeCheckConsistency(tx)
 		}
-		refreshDB(tx)
 	}
 	return revertedBlocks
 }
@@ -97,11 +96,6 @@ func (cs *ConsensusSet) applyUntilBlock(tx *bolt.Tx, pb *processedBlock) (applie
 			cs.checkConsistency(tx)
 		} else {
 			cs.maybeCheckConsistency(tx)
-		}
-		// Database refresh is not needed unless multiple blocks are being
-		// applied.
-		if len(newPath[1:]) > 1 {
-			refreshDB(tx)
 		}
 	}
 	return appliedBlocks, nil

--- a/modules/consensus/fork.go
+++ b/modules/consensus/fork.go
@@ -3,10 +3,10 @@ package consensus
 import (
 	"errors"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 var (

--- a/modules/consensus/fork_helpers_test.go
+++ b/modules/consensus/fork_helpers_test.go
@@ -1,7 +1,7 @@
 package consensus
 
 import (
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 // dbBacktrackToCurrentPath is a convenience function to call

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -3,12 +3,12 @@ package consensus
 import (
 	"errors"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 var (

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -4,7 +4,7 @@ package consensus
 import (
 	"testing"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 const (

--- a/modules/consensus/processedblock.go
+++ b/modules/consensus/processedblock.go
@@ -4,13 +4,13 @@ import (
 	"math/big"
 	"sort"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // SurpassThreshold is a percentage that dictates how much heavier a competing

--- a/modules/consensus/processedblock_test.go
+++ b/modules/consensus/processedblock_test.go
@@ -1,7 +1,6 @@
 package consensus
 
 import (
-	// "math/big"
 	"path/filepath"
 	"testing"
 

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -3,11 +3,11 @@ package consensus
 import (
 	"errors"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // A changeEntry records a change to the consensus set that happened, and is

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -1,13 +1,13 @@
 package consensus
 
 import (
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 const (

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // TestSynchronize tests that the consensus set can successfully synchronize

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 var (

--- a/modules/explorer/addblock.go
+++ b/modules/explorer/addblock.go
@@ -10,7 +10,7 @@ import (
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 // A boltTx is a bolt transaction. It implements monadic error handling, such that

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -7,7 +7,8 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
-	"github.com/boltdb/bolt"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 /*

--- a/modules/explorer/hashes.go
+++ b/modules/explorer/hashes.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/boltdb/bolt"
-
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 const (

--- a/persist/boltdb.go
+++ b/persist/boltdb.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/boltdb/bolt"
+	"github.com/NebulousLabs/bolt"
 )
 
 type BoltDatabase struct {


### PR DESCRIPTION
There is a fix in the vendored bolt which allows us to get rid of the database reloading and have a substantially reduced rate of database corruption.