### PR TITLE
Host cleanup

### DIFF
--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -185,6 +185,10 @@ type (
 		// current path, false otherwise.
 		InCurrentPath(types.BlockID) bool
 
+		// StorageProofSegment returns the segment to be used in the storage proof for
+		// a given file contract.
+		StorageProofSegment(types.FileContractID) (uint64, error)
+
 		// TryTransactionSet checks whether the transaction set would be valid if
 		// it were added in the next block. A consensus change is returned
 		// detailing the diffs that would result from the application of the

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -142,7 +142,7 @@ func (cs *ConsensusSet) BlockAtHeight(height types.BlockHeight) (block types.Blo
 		exists = true
 		return nil
 	})
-	return
+	return block, exists
 }
 
 // ChildTarget returns the target for the child of a block.
@@ -156,7 +156,7 @@ func (cs *ConsensusSet) ChildTarget(id types.BlockID) (target types.Target, exis
 		exists = true
 		return nil
 	})
-	return
+	return target, exists
 }
 
 // Close safely closes the block database.
@@ -179,7 +179,7 @@ func (cs *ConsensusSet) EarliestChildTimestamp(id types.BlockID) (timestamp type
 		exists = true
 		return nil
 	})
-	return
+	return timestamp, exists
 }
 
 // GenesisBlock returns the genesis block.
@@ -204,7 +204,7 @@ func (cs *ConsensusSet) InCurrentPath(id types.BlockID) (inPath bool) {
 		inPath = pathID == id
 		return nil
 	})
-	return
+	return inPath
 }
 
 // StorageProofSegment returns the segment to be used in the storage proof for
@@ -214,5 +214,5 @@ func (cs *ConsensusSet) StorageProofSegment(fcid types.FileContractID) (index ui
 		index, err = storageProofSegment(tx, fcid)
 		return nil
 	})
-	return
+	return index, err
 }

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -214,5 +214,5 @@ func (cs *ConsensusSet) StorageProofSegment(fcid types.FileContractID) (index ui
 		index, err = storageProofSegment(tx, fcid)
 		return nil
 	})
-	return index, err
+	return
 }

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -142,7 +142,7 @@ func (cs *ConsensusSet) BlockAtHeight(height types.BlockHeight) (block types.Blo
 		exists = true
 		return nil
 	})
-	return block, exists
+	return
 }
 
 // ChildTarget returns the target for the child of a block.
@@ -156,7 +156,7 @@ func (cs *ConsensusSet) ChildTarget(id types.BlockID) (target types.Target, exis
 		exists = true
 		return nil
 	})
-	return target, exists
+	return
 }
 
 // Close safely closes the block database.
@@ -179,7 +179,7 @@ func (cs *ConsensusSet) EarliestChildTimestamp(id types.BlockID) (timestamp type
 		exists = true
 		return nil
 	})
-	return timestamp, exists
+	return
 }
 
 // GenesisBlock returns the genesis block.
@@ -204,7 +204,7 @@ func (cs *ConsensusSet) InCurrentPath(id types.BlockID) (inPath bool) {
 		inPath = pathID == id
 		return nil
 	})
-	return inPath
+	return
 }
 
 // StorageProofSegment returns the segment to be used in the storage proof for

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -32,7 +32,7 @@ func TestAddress(t *testing.T) {
 		t.Fatal("Address does not return g.myAddr")
 	}
 	port := modules.NetAddress(g.listener.Addr().String()).Port()
-	expAddr := modules.NetAddress(net.JoinHostPort("::1", port))
+	expAddr := modules.NetAddress(net.JoinHostPort("::", port))
 	if g.Address() != expAddr {
 		t.Fatalf("Wrong address: expected %v, got %v", expAddr, g.Address())
 	}

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -52,9 +52,9 @@ func (h *Host) announce(addr modules.NetAddress) error {
 func (h *Host) Announce() error {
 	// Get the external IP again; it may have changed.
 	h.learnHostname()
-	lockID := h.mu.RLock()
+	h.mu.RLock()
 	addr := h.myAddr
-	h.mu.RUnlock(lockID)
+	h.mu.RUnlock()
 
 	// Check that the host's ip address is known.
 	if addr.IsLocal() {

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -2,28 +2,11 @@ package host
 
 import (
 	"errors"
-	"net"
-	"time"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
-
-const (
-	pingTimeout = 10 * time.Second
-)
-
-// ping establishes a connection to addr and then immediately closes it. It is
-// used to verify that an address is connectible.
-func ping(addr modules.NetAddress) bool {
-	conn, err := net.DialTimeout("tcp", string(addr), pingTimeout)
-	if err != nil {
-		return false
-	}
-	conn.Close()
-	return true
-}
 
 // announce creates an announcement transaction and submits it to the network.
 func (h *Host) announce(addr modules.NetAddress) error {
@@ -57,6 +40,9 @@ func (h *Host) announce(addr modules.NetAddress) error {
 	if err != nil {
 		return err
 	}
+
+	h.log.Printf("INFO: Successfully announced as %v", addr)
+
 	return nil
 }
 
@@ -70,16 +56,15 @@ func (h *Host) Announce() error {
 	addr := h.myAddr
 	h.mu.RUnlock(lockID)
 
-	// Check that the host's ip address is both known and reachable.
-	if addr.Host() == "::1" {
+	// Check that the host's ip address is known.
+	if addr.IsLocal() {
 		return errors.New("can't announce without knowing external IP")
 	}
 
 	return h.announce(addr)
 }
 
-// ForceAnnounce announces using the provided address, and without performing
-// any connectivity checks.
+// ForceAnnounce announces using the provided address.
 func (h *Host) ForceAnnounce(addr modules.NetAddress) error {
 	return h.announce(addr)
 }

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -28,9 +28,10 @@ var (
 // A contractObligation tracks a file contract that the host is obligated to
 // fulfill.
 type contractObligation struct {
-	ID           types.FileContractID
-	FileContract types.FileContract
-	Path         string // Where on disk the file is stored.
+	ID              types.FileContractID
+	FileContract    types.FileContract
+	LastRevisionTxn types.Transaction
+	Path            string // Where on disk the file is stored.
 
 	// each obligation needs a mutex to prevent simultaneous revisions to the
 	// same obligation

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/modules/consensus"
 	safesync "github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -41,32 +40,35 @@ type contractObligation struct {
 // A Host contains all the fields necessary for storing files for clients and
 // performing the storage proofs on the received files.
 type Host struct {
-	cs          *consensus.ConsensusSet
-	hostdb      modules.HostDB
-	tpool       modules.TransactionPool
-	wallet      modules.Wallet
-	blockHeight types.BlockHeight
+	// modules
+	cs     modules.ConsensusSet
+	hostdb modules.HostDB
+	tpool  modules.TransactionPool
+	wallet modules.Wallet
 
-	myAddr         modules.NetAddress
-	saveDir        string
-	spaceRemaining int64
-	fileCounter    int
-	profit         types.Currency
-
+	// resources
 	listener net.Listener
 
+	// variables
+	blockHeight         types.BlockHeight
 	obligationsByID     map[types.FileContractID]contractObligation
 	obligationsByHeight map[types.BlockHeight][]contractObligation
-	secretKey           crypto.SecretKey
-	publicKey           types.SiaPublicKey
-
+	spaceRemaining      int64
+	fileCounter         int
+	profit              types.Currency
 	modules.HostSettings
+
+	// constants
+	myAddr    modules.NetAddress
+	saveDir   string
+	secretKey crypto.SecretKey
+	publicKey types.SiaPublicKey
 
 	mu *safesync.RWMutex
 }
 
 // New returns an initialized Host.
-func New(cs *consensus.ConsensusSet, hdb modules.HostDB, tpool modules.TransactionPool, wallet modules.Wallet, addr string, saveDir string) (*Host, error) {
+func New(cs modules.ConsensusSet, hdb modules.HostDB, tpool modules.TransactionPool, wallet modules.Wallet, addr string, saveDir string) (*Host, error) {
 	if cs == nil {
 		return nil, errors.New("host cannot use a nil state")
 	}

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -160,6 +160,7 @@ func (h *Host) SetSettings(settings modules.HostSettings) {
 func (h *Host) Settings() modules.HostSettings {
 	lockID := h.mu.RLock()
 	defer h.mu.RUnlock(lockID)
+	h.HostSettings.IPAddress = h.myAddr // needs to be updated manually
 	return h.HostSettings
 }
 
@@ -172,6 +173,7 @@ func (h *Host) Info() modules.HostInfo {
 	lockID := h.mu.RLock()
 	defer h.mu.RUnlock(lockID)
 
+	h.HostSettings.IPAddress = h.myAddr // needs to be updated manually
 	info := modules.HostInfo{
 		HostSettings: h.HostSettings,
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -47,12 +47,11 @@ type Host struct {
 	wallet      modules.Wallet
 	blockHeight types.BlockHeight
 
-	consensusHeight types.BlockHeight
-	myAddr          modules.NetAddress
-	saveDir         string
-	spaceRemaining  int64
-	fileCounter     int
-	profit          types.Currency
+	myAddr         modules.NetAddress
+	saveDir        string
+	spaceRemaining int64
+	fileCounter    int
+	profit         types.Currency
 
 	listener net.Listener
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -133,14 +133,13 @@ func New(cs *consensus.ConsensusSet, hdb modules.HostDB, tpool modules.Transacti
 	if err != nil {
 		return nil, err
 	}
-	_, port, _ := net.SplitHostPort(h.listener.Addr().String())
-	h.myAddr = modules.NetAddress(net.JoinHostPort("::1", port))
+	h.myAddr = modules.NetAddress(h.listener.Addr().String())
+
+	// Forward the hosting port, if possible.
+	go h.forwardPort(h.myAddr.Port())
 
 	// Learn our external IP.
 	go h.learnHostname()
-
-	// Forward the hosting port, if possible.
-	go h.forwardPort(port)
 
 	// spawn listener
 	go h.listen()

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -250,7 +250,7 @@ func (h *Host) rpcUpload(conn net.Conn) error {
 	co := contractObligation{
 		ID:           contractTxn.FileContractID(0),
 		FileContract: contractTxn.FileContracts[0],
-		Path:         filepath.Join(h.saveDir, strconv.Itoa(h.fileCounter)),
+		Path:         filepath.Join(h.persistDir, strconv.Itoa(h.fileCounter)),
 		mu:           new(sync.Mutex),
 	}
 	proofHeight := co.FileContract.WindowStart + StorageProofReorgDepth

--- a/modules/host/net.go
+++ b/modules/host/net.go
@@ -25,20 +25,24 @@ func (h *Host) handleConn(conn net.Conn) {
 
 	var id types.Specifier
 	if err := encoding.ReadObject(conn, &id, 16); err != nil {
-		// log
 		return
 	}
+	var err error
 	switch id {
 	case modules.RPCSettings:
-		h.rpcSettings(conn)
+		err = h.rpcSettings(conn)
 	case modules.RPCUpload:
-		h.rpcUpload(conn)
+		err = h.rpcUpload(conn)
 	case modules.RPCRevise:
-		h.rpcRevise(conn)
+		err = h.rpcRevise(conn)
 	case modules.RPCDownload:
-		h.rpcDownload(conn)
+		err = h.rpcDownload(conn)
 	default:
-		// log
+		h.log.Printf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RemoteAddr(), id)
+		return
+	}
+	if err != nil {
+		h.log.Printf("WARN: incoming RPC \"%v\" failed: %v", id, err)
 	}
 }
 

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -11,8 +11,8 @@ import (
 
 // threadedDeleteObligation deletes a file obligation.
 func (h *Host) threadedDeleteObligation(obligation contractObligation) {
-	lockID := h.mu.Lock()
-	defer h.mu.Unlock(lockID)
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	err := h.deallocate(obligation.Path)
 	if err != nil {
 		fmt.Println("WARN: failed to deallocate %v: %v", obligation.Path, err)
@@ -63,16 +63,16 @@ func (h *Host) threadedCreateStorageProof(obligation contractObligation) {
 	}
 
 	// Storage proof was successful, so increment profit tracking
-	lockID := h.mu.Lock()
+	h.mu.Lock()
 	h.profit = h.profit.Add(obligation.FileContract.Payout)
-	h.mu.Unlock(lockID)
+	h.mu.Unlock()
 }
 
 // ProcessConsensusChange will be called by the consensus set every time there
 // is a change to the blockchain.
 func (h *Host) ProcessConsensusChange(cc modules.ConsensusChange) {
-	lockID := h.mu.Lock()
-	defer h.mu.Unlock(lockID)
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	h.blockHeight += types.BlockHeight(len(cc.AppliedBlocks))
 	h.blockHeight -= types.BlockHeight(len(cc.RevertedBlocks))

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -74,12 +74,12 @@ func (h *Host) ProcessConsensusChange(cc modules.ConsensusChange) {
 	lockID := h.mu.Lock()
 	defer h.mu.Unlock(lockID)
 
+	h.blockHeight += types.BlockHeight(len(cc.AppliedBlocks))
 	h.blockHeight -= types.BlockHeight(len(cc.RevertedBlocks))
 
 	// Check the applied blocks and see if any of the contracts we have are
 	// ready for storage proofs.
 	for _ = range cc.AppliedBlocks {
-		h.blockHeight++
 		for _, obligation := range h.obligationsByHeight[h.blockHeight] {
 			go h.threadedCreateStorageProof(obligation)
 		}
@@ -87,6 +87,4 @@ func (h *Host) ProcessConsensusChange(cc modules.ConsensusChange) {
 		// created, those files will never get cleared from the host.
 		delete(h.obligationsByHeight, h.blockHeight)
 	}
-	h.consensusHeight -= types.BlockHeight(len(cc.RevertedBlocks))
-	h.consensusHeight += types.BlockHeight(len(cc.AppliedBlocks))
 }

--- a/modules/host/update_test.go
+++ b/modules/host/update_test.go
@@ -46,7 +46,7 @@ func TestStorageProof(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(filepath.Join(ht.host.saveDir, "foo"), data, 0777)
+	ioutil.WriteFile(filepath.Join(ht.host.persistDir, "foo"), data, 0777)
 
 	// create revision
 	rev := types.FileContractRevision{
@@ -68,7 +68,7 @@ func TestStorageProof(t *testing.T) {
 	obligation := contractObligation{
 		ID:           fcid,
 		FileContract: fc,
-		Path:         filepath.Join(ht.host.saveDir, "foo"),
+		Path:         filepath.Join(ht.host.persistDir, "foo"),
 	}
 	ht.host.obligationsByID[fcid] = obligation
 	ht.host.obligationsByHeight[fc.WindowStart+1] = []contractObligation{obligation}

--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -33,7 +33,7 @@ func (h *Host) rpcRetrieve(conn net.Conn) error {
 		h.mu.RUnlock(lockID)
 		return errors.New("no record of that file")
 	}
-	path := filepath.Join(h.saveDir, contractObligation.Path)
+	path := filepath.Join(h.persistDir, contractObligation.Path)
 	h.mu.RUnlock(lockID)
 
 	// Open the file.

--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -27,14 +27,14 @@ func (h *Host) rpcRetrieve(conn net.Conn) error {
 	}
 
 	// Verify the file exists, using a mutex while reading the host.
-	lockID := h.mu.RLock()
+	h.mu.RLock()
 	contractObligation, exists := h.obligationsByID[contractID]
 	if !exists {
-		h.mu.RUnlock(lockID)
+		h.mu.RUnlock()
 		return errors.New("no record of that file")
 	}
 	path := filepath.Join(h.persistDir, contractObligation.Path)
-	h.mu.RUnlock(lockID)
+	h.mu.RUnlock()
 
 	// Open the file.
 	file, err := os.Open(path)
@@ -64,13 +64,13 @@ func (h *Host) rpcDownload(conn net.Conn) error {
 	}
 
 	// Verify the file exists, using a mutex while reading the host.
-	lockID := h.mu.RLock()
+	h.mu.RLock()
 	co, exists := h.obligationsByID[contractID]
 	if !exists {
-		h.mu.RUnlock(lockID)
+		h.mu.RUnlock()
 		return errors.New("no record of that file")
 	}
-	h.mu.RUnlock(lockID)
+	h.mu.RUnlock()
 
 	// Open the file.
 	file, err := os.Open(co.Path)

--- a/modules/host/upnp.go
+++ b/modules/host/upnp.go
@@ -50,7 +50,7 @@ func (h *Host) learnHostname() {
 		host, err = myExternalIP()
 	}
 	if err != nil {
-		//g.log.Println("WARN: failed to discover external IP")
+		h.log.Println("WARN: failed to discover external IP")
 		return
 	}
 
@@ -68,18 +68,18 @@ func (h *Host) forwardPort(port string) {
 
 	d, err := upnp.Discover()
 	if err != nil {
-		//g.log.Printf("WARN: could not automatically forward port %s: no UPnP-enabled devices found", port)
+		h.log.Printf("WARN: could not automatically forward port %s: no UPnP-enabled devices found", port)
 		return
 	}
 
 	portInt, _ := strconv.Atoi(port)
 	err = d.Forward(uint16(portInt), "Sia Host")
 	if err != nil {
-		//g.log.Printf("WARN: could not automatically forward port %s: %v", port, err)
+		h.log.Printf("WARN: could not automatically forward port %s: %v", port, err)
 		return
 	}
 
-	//g.log.Println("INFO: successfully forwarded port", port)
+	h.log.Println("INFO: successfully forwarded port", port)
 }
 
 // clearPort removes a port mapping from the router.
@@ -96,9 +96,9 @@ func (h *Host) clearPort(port string) {
 	portInt, _ := strconv.Atoi(port)
 	err = d.Clear(uint16(portInt))
 	if err != nil {
-		//g.log.Printf("WARN: could not automatically unforward port %s: %v", port, err)
+		h.log.Printf("WARN: could not automatically unforward port %s: %v", port, err)
 		return
 	}
 
-	//g.log.Println("INFO: successfully unforwarded port", port)
+	h.log.Println("INFO: successfully unforwarded port", port)
 }

--- a/modules/host/upnp.go
+++ b/modules/host/upnp.go
@@ -54,10 +54,10 @@ func (h *Host) learnHostname() {
 		return
 	}
 
-	id := h.mu.Lock()
+	h.mu.Lock()
 	h.myAddr = modules.NetAddress(net.JoinHostPort(host, h.myAddr.Port()))
 	h.save()
-	h.mu.Unlock(id)
+	h.mu.Unlock()
 }
 
 // forwardPort adds a port mapping to the router.

--- a/modules/netaddress.go
+++ b/modules/netaddress.go
@@ -39,7 +39,7 @@ func (na NetAddress) IsLocal() bool {
 	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 		return true
 	}
-	if host == "localhost" || host == "0.0.0.0" {
+	if host == "localhost" || host == "::" || host == "0.0.0.0" {
 		return true
 	}
 	return false

--- a/modules/netaddress_test.go
+++ b/modules/netaddress_test.go
@@ -46,6 +46,7 @@ func TestIsLocal(t *testing.T) {
 		{"127.0.0.1", false},
 		{"127.0.0.1:6723", true},
 		{"0.0.0.0:1234", true},
+		{"[::]:1234", true},
 		{"::1", false},
 		{"[::1]:7124", true},
 


### PR DESCRIPTION
Added a logger and various minor improvements. Notably, the host now saves the full revision transaction, instead of just modifying the original file contract object.
I'm 90% sure this won't cause compatibility problems, but I'm running this code on my local hosting node for a while to make sure. (Host could use a lot more tests...)