### PR TITLE
Hosting integration test

### DIFF
--- a/api/host_test.go
+++ b/api/host_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// TestIntegrationHosting tests that the host correctly receives payment for
+// hosting files.
+func TestIntegrationHosting(t *testing.T) {
+	if testing.Short() {
+		//t.SkipNow()
+	}
+
+	st, err := createServerTester("TestIntegrationHosting")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// announce the host
+	err = st.stdGetAPI("/host/announce?address=" + string(st.host.Address()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// we need to announce twice, or the renter will complain about not having enough hosts
+	loopAddr := "127.0.0.1:" + st.host.Address().Port()
+	err = st.stdGetAPI("/host/announce?address=" + loopAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for announcement to register
+	st.miner.AddBlock()
+	var hosts ActiveHosts
+	st.getAPI("/hostdb/hosts/active", &hosts)
+	if len(hosts.Hosts) == 0 {
+		t.Fatal("host announcement not seen")
+	}
+
+	// create a file
+	path := filepath.Join(build.SiaTestingDir, "api", "TestIntegrationHosting", "test.dat")
+	data, err := crypto.RandBytes(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(path, data, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// upload to host
+	err = st.stdGetAPI("/renter/files/upload?nickname=test&duration=10&source=" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fi []FileInfo
+	for len(fi) != 1 || fi[0].UploadProgress != 100 {
+		st.getAPI("/renter/files/list", &fi)
+		time.Sleep(3 * time.Second)
+	}
+
+	// mine blocks until storage proof is complete
+	for i := 0; i < 20+int(types.MaturityDelay); i++ {
+		st.miner.AddBlock()
+	}
+
+	// check balance
+	var wi WalletGET
+	st.getAPI("/wallet", &wi)
+	withoutProofBal := "7499794770722000000001457682072"
+	if wi.ConfirmedSiacoinBalance.String() == withoutProofBal {
+		t.Fatal("host's balance was not affected")
+	}
+}

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -75,6 +75,6 @@ func TestIntegrationHosting(t *testing.T) {
 	st.getAPI("/wallet", &wi)
 	withoutProofBal := "7499794770722000000001457682072"
 	if wi.ConfirmedSiacoinBalance.String() == withoutProofBal {
-		t.Fatal("host's balance was not affected")
+		t.Fatal("host's balance was not affected: expected %v, got %v", withoutProofBal, wi.ConfirmedSiacoinBalance)
 	}
 }

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -15,7 +15,7 @@ import (
 // hosting files.
 func TestIntegrationHosting(t *testing.T) {
 	if testing.Short() {
-		//t.SkipNow()
+		t.SkipNow()
 	}
 
 	st, err := createServerTester("TestIntegrationHosting")

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -73,8 +73,8 @@ func TestIntegrationHosting(t *testing.T) {
 	// check balance
 	var wi WalletGET
 	st.getAPI("/wallet", &wi)
-	withoutProofBal := "7499794770722000000001457682072"
-	if wi.ConfirmedSiacoinBalance.String() == withoutProofBal {
-		t.Fatal("host's balance was not affected: expected %v, got %v", withoutProofBal, wi.ConfirmedSiacoinBalance)
+	expBal := "7499794999617870000000002429474"
+	if wi.ConfirmedSiacoinBalance.String() != expBal {
+		t.Fatal("host's balance was not affected: expected %v, got %v", expBal, wi.ConfirmedSiacoinBalance)
 	}
 }

--- a/api/renter.go
+++ b/api/renter.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -193,11 +194,19 @@ func (srv *Server) renterStatusHandler(w http.ResponseWriter, req *http.Request)
 
 // renterFilesUploadHandler handles the API call to upload a file.
 func (srv *Server) renterFilesUploadHandler(w http.ResponseWriter, req *http.Request) {
+	var duration types.BlockHeight
+	if req.FormValue("duration") != "" {
+		_, err := fmt.Sscan(req.FormValue("duration"), &duration)
+		if err != nil {
+			writeError(w, "Couldn't parse duration: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
 	err := srv.renter.Upload(modules.FileUploadParams{
 		Filename: req.FormValue("source"),
 		Nickname: req.FormValue("nickname"),
+		Duration: duration,
 		// let the renter decide these values; eventually they will be configurable
-		Duration:    0,
 		ErasureCode: nil,
 		PieceSize:   0,
 	})

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -137,8 +137,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, wallet modules.
 	return h, nil
 }
 
-// SetConfig updates the host's internal HostSettings object. To modify
-// a specific field, use a combination of Info and SetConfig
+// SetConfig updates the host's internal HostSettings object.
 func (h *Host) SetSettings(settings modules.HostSettings) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -149,14 +148,14 @@ func (h *Host) SetSettings(settings modules.HostSettings) {
 
 // Settings returns the settings of a host.
 func (h *Host) Settings() modules.HostSettings {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	h.HostSettings.IPAddress = h.myAddr // needs to be updated manually
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	return h.HostSettings
 }
 
 func (h *Host) Address() modules.NetAddress {
-	// no lock needed; h.myAddr is only set once (in New).
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	return h.myAddr
 }
 

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -286,8 +286,8 @@ func (h *Host) rpcRevise(conn net.Conn) error {
 
 	h.mu.RLock()
 	obligation, exists := h.obligationsByID[fcid]
+	h.mu.RUnlock()
 	if !exists {
-		h.mu.RUnlock()
 		return errors.New("no record of that contract")
 	}
 
@@ -296,9 +296,6 @@ func (h *Host) rpcRevise(conn net.Conn) error {
 	// proofs impossible
 	obligation.mu.Lock()
 	defer obligation.mu.Unlock()
-	// because h.save accesses obligation.mu, we still need to hold the host
-	// readlock until we acquire the obligation lock.
-	h.mu.RUnlock()
 
 	// open the file in append mode
 	file, err := os.OpenFile(obligation.Path, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0660)

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -347,7 +347,8 @@ func (h *Host) rpcRevise(conn net.Conn) error {
 			// read piece
 			// TODO: simultaneously read into tree and file
 			rev := revTxn.FileContractRevisions[0]
-			piece := make([]byte, rev.NewFileSize-obligation.FileContract.FileSize)
+			last := obligation.LastRevisionTxn.FileContractRevisions[0]
+			piece := make([]byte, rev.NewFileSize-last.NewFileSize)
 			_, err = io.ReadFull(conn, piece)
 			if err != nil {
 				return errors.New("couldn't read piece data: " + err.Error())

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -64,7 +64,7 @@ func (h *Host) load() error {
 		h.obligationsByHeight[height] = append(h.obligationsByHeight[height], obligation)
 		h.obligationsByID[obligation.ID] = obligation
 		// update spaceRemaining
-		h.spaceRemaining -= int64(obligation.FileContract.FileSize)
+		h.spaceRemaining -= int64(obligation.LastRevisionTxn.FileContractRevisions[0].NewFileSize)
 	}
 	h.secretKey = sHost.SecretKey
 	h.publicKey = sHost.PublicKey

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -36,8 +36,11 @@ func (h *Host) save() error {
 		SecretKey:      h.secretKey,
 		PublicKey:      h.publicKey,
 	}
-	for _, obligation := range h.obligationsByID {
-		sHost.Obligations = append(sHost.Obligations, *obligation)
+	for _, ob := range h.obligationsByID {
+		// to avoid race conditions involving the obligation's mutex, copy it
+		// manually into a new object
+		obcopy := contractObligation{ID: ob.ID, FileContract: ob.FileContract, LastRevisionTxn: ob.LastRevisionTxn}
+		sHost.Obligations = append(sHost.Obligations, obcopy)
 	}
 
 	return persist.SaveFile(persistMetadata, sHost, filepath.Join(h.persistDir, "settings.json"))

--- a/modules/host/upnp.go
+++ b/modules/host/upnp.go
@@ -56,6 +56,7 @@ func (h *Host) learnHostname() {
 
 	h.mu.Lock()
 	h.myAddr = modules.NetAddress(net.JoinHostPort(host, h.myAddr.Port()))
+	h.HostSettings.IPAddress = h.myAddr
 	h.save()
 	h.mu.Unlock()
 }

--- a/modules/renter/negotiate.go
+++ b/modules/renter/negotiate.go
@@ -225,6 +225,19 @@ func (hu *hostUploader) negotiateContract(filesize uint64, duration types.BlockH
 		IP:          hu.settings.IPAddress,
 		WindowStart: fc.WindowStart,
 	}
+	// create initial revision
+	hu.lastTxn.FileContractRevisions = []types.FileContractRevision{{
+		ParentID:              fcid,
+		UnlockConditions:      hu.unlockConditions,
+		NewRevisionNumber:     fc.RevisionNumber,
+		NewFileSize:           fc.FileSize,
+		NewFileMerkleRoot:     fc.FileMerkleRoot,
+		NewWindowStart:        fc.WindowStart,
+		NewWindowEnd:          fc.WindowEnd,
+		NewValidProofOutputs:  []types.SiacoinOutput{fc.ValidProofOutputs[0], fc.ValidProofOutputs[1]},
+		NewMissedProofOutputs: []types.SiacoinOutput{fc.MissedProofOutputs[0], fc.MissedProofOutputs[1]},
+		NewUnlockHash:         fc.UnlockHash,
+	}}
 
 	lockID = hu.renter.mu.Lock()
 	hu.renter.contracts[fcid] = fc
@@ -257,7 +270,7 @@ func (hu *hostUploader) addPiece(p uploadPiece) error {
 	}
 
 	// revise the file contract
-	err = hu.revise(fc, encPiece, height)
+	err = hu.revise(hu.lastTxn.FileContractRevisions[0], encPiece, height)
 	if err != nil {
 		return err
 	}
@@ -280,10 +293,10 @@ func (hu *hostUploader) addPiece(p uploadPiece) error {
 	return nil
 }
 
-// revise revises fc to cover piece and uploads both the revision and the
-// piece data to the host.
-func (hu *hostUploader) revise(fc types.FileContract, piece []byte, height types.BlockHeight) error {
-	hu.conn.SetDeadline(time.Now().Add(5 * time.Minute)) // sufficient to transfer 4 MB over 100 kbps
+// revise revises the previous revision to cover piece and uploads both the
+// revision and the piece data to the host.
+func (hu *hostUploader) revise(rev types.FileContractRevision, piece []byte, height types.BlockHeight) error {
+	hu.conn.SetDeadline(time.Now().Add(5 * time.Second)) // sufficient to transfer 4 MB over 100 kbps
 	defer hu.conn.SetDeadline(time.Time{})               // reset timeout after each revision
 
 	// calculate new merkle root
@@ -292,28 +305,19 @@ func (hu *hostUploader) revise(fc types.FileContract, piece []byte, height types
 		return err
 	}
 
-	// create revision
-	rev := types.FileContractRevision{
-		ParentID:          hu.contract.ID,
-		UnlockConditions:  hu.unlockConditions,
-		NewRevisionNumber: fc.RevisionNumber + 1,
-
-		NewFileSize:           fc.FileSize + uint64(len(piece)),
-		NewFileMerkleRoot:     hu.tree.Root(),
-		NewWindowStart:        fc.WindowStart,
-		NewWindowEnd:          fc.WindowEnd,
-		NewValidProofOutputs:  fc.ValidProofOutputs,
-		NewMissedProofOutputs: fc.MissedProofOutputs,
-		NewUnlockHash:         fc.UnlockHash,
-	}
-	// transfer value of piece from renter to host
-	safeDuration := uint64(fc.WindowStart - height + 20) // buffer in case host is behind
+	// calculate piece price
+	safeDuration := uint64(rev.NewWindowStart - height + 20) // buffer in case host is behind
 	piecePrice := types.NewCurrency64(uint64(len(piece))).Mul(types.NewCurrency64(safeDuration)).Mul(hu.settings.Price)
 	// prevent a negative currency panic
-	if piecePrice.Cmp(fc.ValidProofOutputs[0].Value) > 0 {
+	if piecePrice.Cmp(rev.NewValidProofOutputs[0].Value) > 0 {
 		// probably not enough money, but the host might accept it anyway
-		piecePrice = fc.ValidProofOutputs[0].Value
+		piecePrice = rev.NewValidProofOutputs[0].Value
 	}
+
+	// modify revision
+	rev.NewRevisionNumber = rev.NewRevisionNumber + 1
+	rev.NewFileSize = rev.NewFileSize + uint64(len(piece))
+	rev.NewFileMerkleRoot = hu.tree.Root()
 	rev.NewValidProofOutputs[0].Value = rev.NewValidProofOutputs[0].Value.Sub(piecePrice)   // less returned to renter
 	rev.NewValidProofOutputs[1].Value = rev.NewValidProofOutputs[1].Value.Add(piecePrice)   // more given to host
 	rev.NewMissedProofOutputs[0].Value = rev.NewMissedProofOutputs[0].Value.Sub(piecePrice) // less returned to renter

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -89,6 +89,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	if err != nil {
 		return err
 	}
+	// TODO: remove this; default duration should be 0 (indefinite)
 	if up.Duration == 0 {
 		up.Duration = defaultDuration
 	}
@@ -116,7 +117,10 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	// Add file to renter.
 	lockID = r.mu.Lock()
 	r.files[up.Nickname] = f
-	r.repairSet[up.Nickname] = up.Filename
+	r.tracking[up.Nickname] = trackedFile{
+		RepairPath: up.Filename,
+		EndHeight:  r.blockHeight + up.Duration,
+	}
 	r.save()
 	r.mu.Unlock(lockID)
 


### PR DESCRIPTION
And lots of race condition fixes along the way (benign ones, for the most part).
This also required adding a configurable duration to the `/renter/upload` call, which in turn required adding a new field to `renter.json`...more than I would have liked, but compatibility should be ok.
The repair scheme now works like this (in theory): if you manually pass in a duration, the renter will calculate the resulting ending height and use that for all future contracts for that file. So if you specify `duration=10` at height 100, whenever the renter repairs the file, it will create contracts ending at height 110, and remove the file from the repair set after that height has been reached. But if you don't supply a duration (or if `duration=0`), the renter will renew the file indefinitely. Reasonable?