### PR TITLE
protect daemon calls if explorer is built

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -55,11 +55,13 @@ func (srv *Server) initAPI() {
 	srv.handleHTTPRequest(mux, "/", srv.unrecognizedCallHandler)
 
 	// Daemon API Calls - Unfinished
-	srv.handleHTTPRequest(mux, "/daemon/constants", srv.daemonConstantsHandler)
-	srv.handleHTTPRequest(mux, "/daemon/stop", srv.daemonStopHandler)
-	srv.handleHTTPRequest(mux, "/daemon/version", srv.daemonVersionHandler)
-	srv.handleHTTPRequest(mux, "/daemon/updates/apply", srv.daemonUpdatesApplyHandler)
-	srv.handleHTTPRequest(mux, "/daemon/updates/check", srv.daemonUpdatesCheckHandler)
+	if srv.explorer != nil && srv.wallet == nil {
+		srv.handleHTTPRequest(mux, "/daemon/constants", srv.daemonConstantsHandler)
+		srv.handleHTTPRequest(mux, "/daemon/stop", srv.daemonStopHandler)
+		srv.handleHTTPRequest(mux, "/daemon/version", srv.daemonVersionHandler)
+		srv.handleHTTPRequest(mux, "/daemon/updates/apply", srv.daemonUpdatesApplyHandler)
+		srv.handleHTTPRequest(mux, "/daemon/updates/check", srv.daemonUpdatesCheckHandler)
+	}
 
 	// Consensus API Calls
 	if srv.cs != nil {


### PR DESCRIPTION
This is a dirty hack that protects the daemon calls from being exposed if there is an explorer, that allows the API to be exposed to the web without needing to worry about someone hitting the `/daemon/stop` button.

The protection is only in place when there is no wallet.