### PR TITLE
more strict method handling in the api

### DIFF
--- a/api/consensus.go
+++ b/api/consensus.go
@@ -38,9 +38,9 @@ func (srv *Server) consensusHandlerGET(w http.ResponseWriter, req *http.Request)
 func (srv *Server) consensusHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.consensusHandlerGET(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /consensus", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /consensus", http.StatusBadRequest)
 }
 
 // consensusBlockHandlerGET handles a GET request to /consensus/block.
@@ -65,7 +65,7 @@ func (srv *Server) consensusBlockHandlerGET(w http.ResponseWriter, req *http.Req
 func (srv *Server) consensusBlockHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.consensusBlockHandlerGET(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /consensus/block", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /consensus/block", http.StatusBadRequest)
 }

--- a/api/miner.go
+++ b/api/miner.go
@@ -35,9 +35,9 @@ func (srv *Server) minerHandlerGET(w http.ResponseWriter, req *http.Request) {
 func (srv *Server) minerHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.minerHandlerGET(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /miner", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /miner", http.StatusBadRequest)
 }
 
 // minerStartHandler handles the API call that starts the miner.
@@ -45,9 +45,9 @@ func (srv *Server) minerStartHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		srv.miner.StartCPUMining()
 		writeSuccess(w)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /miner/start", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /miner/start", http.StatusBadRequest)
 }
 
 // minerStopHandler handles the API call to stop the miner.
@@ -55,9 +55,9 @@ func (srv *Server) minerStopHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		srv.miner.StopCPUMining()
 		writeSuccess(w)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /miner/stop", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /miner/stop", http.StatusBadRequest)
 }
 
 // minerHeaderforworkHandler handles the API call that retrieves a block header
@@ -97,9 +97,9 @@ func (srv *Server) minerSubmitheaderHandler(w http.ResponseWriter, req *http.Req
 func (srv *Server) minerHeaderHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.minerHeaderforworkHandler(w, req)
-		return
 	} else if req.Method == "POST" {
 		srv.minerSubmitheaderHandler(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /miner/header", http.StatusBadRequest)
 	}
 }

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -129,9 +129,9 @@ func (srv *Server) walletHandlerGET(w http.ResponseWriter, req *http.Request) {
 func (srv *Server) walletHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.walletHandlerGET(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet", http.StatusBadRequest)
 }
 
 // walletAddressHandlerGET handles a GET request to /wallet/address.
@@ -150,9 +150,9 @@ func (srv *Server) walletAddressHandlerGET(w http.ResponseWriter, req *http.Requ
 func (srv *Server) walletAddressHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.walletAddressHandlerGET(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/address", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/address", http.StatusBadRequest)
 }
 
 // walletAddressesHandlerGET handles a GET request to /wallet/addresses.
@@ -174,9 +174,9 @@ func (srv *Server) walletAddressesHandlerGET(w http.ResponseWriter, req *http.Re
 func (srv *Server) walletAddressesHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.walletAddressesHandlerGET(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/addresses", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/addresses", http.StatusBadRequest)
 }
 
 // walletBackupHandlerPOST handles a POST call to /wallet/backup
@@ -193,9 +193,9 @@ func (srv *Server) walletBackupHandlerPOST(w http.ResponseWriter, req *http.Requ
 func (srv *Server) walletBackupHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "" || req.Method == "GET" {
 		srv.walletBackupHandlerPOST(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/backup", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/backup", http.StatusBadRequest)
 }
 
 // walletInitHandlerPOST handles a POST call to /wallet/init.
@@ -228,9 +228,9 @@ func (srv *Server) walletInitHandlerPOST(w http.ResponseWriter, req *http.Reques
 func (srv *Server) walletInitHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		srv.walletInitHandlerPOST(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/init", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/init", http.StatusBadRequest)
 }
 
 // walletEncryptHandler is a legacy alias for walletInitHandler.
@@ -266,9 +266,9 @@ func (srv *Server) walletLoad033xHandlerPOST(w http.ResponseWriter, req *http.Re
 func (srv *Server) walletLoad033xHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		srv.walletLoad033xHandlerPOST(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/load/033x", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/load/033x", http.StatusBadRequest)
 }
 
 // walletLoadSeedHandlerPOST handles a POST request to /wallet/load/seed.
@@ -298,10 +298,9 @@ func (srv *Server) walletLoadSeedHandlerPOST(w http.ResponseWriter, req *http.Re
 
 // walletLoadSeedHandler handles API calls to /wallet/load/seed.
 func (srv *Server) walletLoadSeedHandler(w http.ResponseWriter, req *http.Request) {
-	switch req.Method {
-	case "POST":
+	if req.Method == "POST" {
 		srv.walletLoadSeedHandlerPOST(w, req)
-	default:
+	} else {
 		writeError(w, "unrecognized method when calling /wallet/load/seed", http.StatusBadRequest)
 	}
 }
@@ -327,10 +326,9 @@ func (srv *Server) walletLoadSiagHandlerPOST(w http.ResponseWriter, req *http.Re
 
 // walletLoadSiagHandler handles API calls to /wallet/load/seed.
 func (srv *Server) walletLoadSiagHandler(w http.ResponseWriter, req *http.Request) {
-	switch req.Method {
-	case "POST":
+	if req.Method == "POST" {
 		srv.walletLoadSiagHandlerPOST(w, req)
-	default:
+	} else {
 		writeError(w, "unrecognized method when calling /wallet/load/siag", http.StatusBadRequest)
 	}
 }
@@ -349,9 +347,9 @@ func (srv *Server) walletLockHandlerPOST(w http.ResponseWriter, req *http.Reques
 func (srv *Server) walletLockHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		srv.walletLockHandlerPOST(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/lock", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/lock", http.StatusBadRequest)
 }
 
 // walletSeedsHandlerGET handles a GET request to /wallet/seeds.
@@ -397,10 +395,9 @@ func (srv *Server) walletSeedsHandlerGET(w http.ResponseWriter, req *http.Reques
 
 // walletSeedHandler handles API calls to /wallet/seed.
 func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request) {
-	switch req.Method {
-	case "GET", "":
+	if req.Method == "" || req.Method == "GET" {
 		srv.walletSeedsHandlerGET(w, req)
-	default:
+	} else {
 		writeError(w, "unrecognized method when calling /wallet/seeds", http.StatusBadRequest)
 	}
 }
@@ -436,9 +433,9 @@ func (srv *Server) walletSiacoinsHandlerPOST(w http.ResponseWriter, req *http.Re
 func (srv *Server) walletSiacoinsHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		srv.walletSiacoinsHandlerPOST(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/siacoins", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/siacoins", http.StatusBadRequest)
 }
 
 // walletSiafundsHandlerPOST handles a POST request to /wallet/siafunds.
@@ -479,7 +476,16 @@ func (srv *Server) walletSiafundsHandler(w http.ResponseWriter, req *http.Reques
 
 // walletTransactionHandlerGETid handles a GET call to
 // /wallet/transaction/$(id).
-func (srv *Server) walletTransactionHandlerGETid(w http.ResponseWriter, req *http.Request, id types.TransactionID) {
+func (srv *Server) walletTransactionHandlerGETid(w http.ResponseWriter, req *http.Request) {
+	// Parse the id from the url.
+	var id types.TransactionID
+	jsonID := "\"" + strings.TrimPrefix(req.URL.Path, "/wallet/transaction/") + "\""
+	err := id.UnmarshalJSON([]byte(jsonID))
+	if err != nil {
+		writeError(w, "error after call to /wallet/history: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	txn, ok := srv.wallet.Transaction(id)
 	if !ok {
 		writeError(w, "error when calling /wallet/transaction/$(id): transaction not found", http.StatusBadRequest)
@@ -492,21 +498,11 @@ func (srv *Server) walletTransactionHandlerGETid(w http.ResponseWriter, req *htt
 
 // walletTransactionHandler handles API calls to /wallet/transaction.
 func (srv *Server) walletTransactionHandler(w http.ResponseWriter, req *http.Request) {
-	// GET is the only supported method.
-	if req.Method != "" && req.Method != "GET" {
+	if strings.HasPrefix(req.URL.Path, "/wallet/transaction/") && (req.Method == "" || req.Method == "GET") {
+		srv.walletTransactionHandlerGETid(w, req)
+	} else {
 		writeError(w, "unrecognized method when calling /wallet/transaction", http.StatusBadRequest)
-		return
 	}
-
-	// Parse the id from the url.
-	var id types.TransactionID
-	jsonID := "\"" + strings.TrimPrefix(req.URL.Path, "/wallet/transaction/") + "\""
-	err := id.UnmarshalJSON([]byte(jsonID))
-	if err != nil {
-		writeError(w, "error after call to /wallet/history: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	srv.walletTransactionHandlerGETid(w, req, id)
 }
 
 // walletTransactionsHandlerGET handles a GET call to /wallet/transactions.
@@ -537,7 +533,16 @@ func (srv *Server) walletTransactionsHandlerGET(w http.ResponseWriter, req *http
 
 // walletTransactionsHandlerGETaddr handles a GET request to
 // /wallet/transactions/$(addr).
-func (srv *Server) walletTransactionsHandlerGETaddr(w http.ResponseWriter, req *http.Request, addr types.UnlockHash) {
+func (srv *Server) walletTransactionsHandlerGETaddr(w http.ResponseWriter, req *http.Request) {
+	// Parse the address being input.
+	jsonAddr := "\"" + strings.TrimPrefix(req.URL.Path, "/wallet/transactions/") + "\""
+	var addr types.UnlockHash
+	err := addr.UnmarshalJSON([]byte(jsonAddr))
+	if err != nil {
+		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	confirmedATs := srv.wallet.AddressTransactions(addr)
 	unconfirmedATs := srv.wallet.AddressUnconfirmedTransactions(addr)
 	writeJSON(w, WalletTransactionsGETaddr{
@@ -550,25 +555,11 @@ func (srv *Server) walletTransactionsHandlerGETaddr(w http.ResponseWriter, req *
 func (srv *Server) walletTransactionsHandler(w http.ResponseWriter, req *http.Request) {
 	if req.URL.Path == "/wallet/transactions" && (req.Method == "" || req.Method == "GET") {
 		srv.walletTransactionsHandlerGET(w, req)
-		return
-	}
-
-	// Only a GET call is allowed at this point.
-	if req.Method != "" && req.Method != "GET" {
+	} else if strings.HasPrefix(req.URL.Path, "/wallet/transactions/") && (req.Method == "" || req.Method == "GET") {
+		srv.walletTransactionsHandlerGETaddr(w, req)
+	} else {
 		writeError(w, "unrecognized method call to /wallet/transactions", http.StatusBadRequest)
-		return
 	}
-
-	// The only call remaining is /wallet/transactions/$(addr) - parse the
-	// address.
-	jsonAddr := "\"" + strings.TrimPrefix(req.URL.Path, "/wallet/transactions/") + "\""
-	var addr types.UnlockHash
-	err := addr.UnmarshalJSON([]byte(jsonAddr))
-	if err != nil {
-		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	srv.walletTransactionsHandlerGETaddr(w, req, addr)
 }
 
 // walletUnlockHandlerPOST handles a POST call to /wallet/unlock.
@@ -592,7 +583,7 @@ func (srv *Server) walletUnlockHandlerPOST(w http.ResponseWriter, req *http.Requ
 func (srv *Server) walletUnlockHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Method == "POST" {
 		srv.walletUnlockHandlerPOST(w, req)
-		return
+	} else {
+		writeError(w, "unrecognized method when calling /wallet/unlock", http.StatusBadRequest)
 	}
-	writeError(w, "unrecognized method when calling /wallet/unlock", http.StatusBadRequest)
 }


### PR DESCRIPTION
The api now handles methods by using a chain of if-else statements that
have 1-2 lines of code in them, usually to call a more complex function
to handle the request.

This strictness is introduced to minimize errors from not correctly
returning. Previously, one needed to call 'return' after each call to a
different method handler, an action which is not fully intuitive and on
multiple occasions was forgotten, resulting in bugs in production code.

This new paradigm is both more visually pleasing and hopefully less
prone to errors. This style of control-flow handling should mostly be
restricted to the api.