### PR TITLE
Db upgrade

### DIFF
--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -63,8 +63,11 @@ func (h *Host) load() error {
 		height := obligation.FileContract.WindowStart + StorageProofReorgDepth
 		h.obligationsByHeight[height] = append(h.obligationsByHeight[height], obligation)
 		h.obligationsByID[obligation.ID] = obligation
+
 		// update spaceRemaining
-		h.spaceRemaining -= int64(obligation.LastRevisionTxn.FileContractRevisions[0].NewFileSize)
+		if len(obligation.LastRevisionTxn.FileContractRevisions) > 0 { // COMPATv0.4.8
+			h.spaceRemaining -= int64(obligation.LastRevisionTxn.FileContractRevisions[0].NewFileSize)
+		}
 	}
 	h.secretKey = sHost.SecretKey
 	h.publicKey = sHost.PublicKey

--- a/persist/boltdb.go
+++ b/persist/boltdb.go
@@ -1,21 +1,17 @@
 package persist
 
 import (
-	"errors"
 	"time"
 
 	"github.com/NebulousLabs/bolt"
 )
 
+// BoltDatabase is a persist-level wrapper for the bolt database, providing
+// extra information such as a version number.
 type BoltDatabase struct {
 	Metadata
 	*bolt.DB
 }
-
-var (
-	ErrNilEntry  = errors.New("entry does not exist")
-	ErrNilBucket = errors.New("bucket does not exist")
-)
 
 // updateDbMetadata will set the contents of the metadata bucket to be
 // what is stored inside the metadata argument
@@ -70,7 +66,7 @@ func (db *BoltDatabase) CloseDatabase() error {
 	return nil
 }
 
-// openDatabase opens a database filename and checks metadata
+// OpenDatabase opens a database filename and checks metadata
 func OpenDatabase(md Metadata, filename string) (*BoltDatabase, error) {
 	// Open the database using a 1 second timeout (without the timeout,
 	// database will potentially hang indefinitely.

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -8,8 +8,13 @@ import (
 )
 
 var (
+	// ErrBadVersion indicates that the version number of the file is not
+	// compatible with the current codebase.
 	ErrBadVersion = errors.New("incompatible version")
-	ErrBadHeader  = errors.New("wrong header")
+
+	// ErrBadHeader indicates that the file opened is not the file that was
+	// expected.
+	ErrBadHeader = errors.New("wrong header")
 )
 
 // Metadata contains the header and version of the data being stored.
@@ -42,6 +47,8 @@ func (sf *safeFile) Commit() error {
 	return os.Rename(sf.finalName+"_temp", sf.finalName)
 }
 
+// NewSafeFile returns a file that can atomically be written to disk,
+// minimizing the risk of corruption.
 func NewSafeFile(filename string) (*safeFile, error) {
 	file, err := os.Create(filename + "_temp")
 	if err != nil {


### PR DESCRIPTION
2 important things happened:

1. database will perform a backup-and-replace if the existing database is out of date, this should help create a seamless upgrade experience for our users.

2. There is a segfault that happens in you are using legacy host files, I wrapped the offending line of code in a compatibility check. @lukechampine  should confirm that it is sufficient to resolve compatibility issues.