### PR TITLE
Add preprocessing for the configuration to Siad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ run = Test
 pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/consensus \
        ./modules/explorer ./modules/gateway ./modules/host ./modules/renter/hostdb \
        ./modules/miner ./modules/renter ./modules/transactionpool ./modules/wallet \
-       ./persist ./siac ./sync ./types
+       ./persist ./siac ./siad ./sync ./types
 
 # fmt calls go fmt on all packages.
 fmt:

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/NebulousLabs/Sia/api"
@@ -22,6 +23,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// preprocessConfig checks the configuration values and performs cleanup on
+// incorrect-but-allowed values.
+func preprocessConfig() {
+	// If the port numbers decode as an integer, prepend ":".
+	_, err := strconv.Atoi(config.Siad.RPCaddr)
+	if err == nil {
+		config.Siad.RPCaddr = ":" + config.Siad.RPCaddr
+	}
+	_, err = strconv.Atoi(config.Siad.HostAddr)
+	if err == nil {
+		config.Siad.HostAddr = ":" + config.Siad.HostAddr
+	}
+}
+
 // startDaemonCmd uses the config parameters to start siad.
 func startDaemon() error {
 	// Establish multithreading.
@@ -33,6 +48,9 @@ func startDaemon() error {
 	// second.
 	fmt.Println("Loading...")
 	loadStart := time.Now()
+
+	// Clean up the configuration input.
+	preprocessConfig()
 
 	// Create all of the modules.
 	gateway, err := gateway.New(config.Siad.RPCaddr, filepath.Join(config.Siad.SiaDir, modules.GatewayDir))

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -4,6 +4,23 @@ import (
 	"testing"
 )
 
+// TestUnitProcessNetAddr probes the 'processNetAddr' function.
+func TestUnitProcessNetAddr(t *testing.T) {
+	testVals := struct {
+		inputs          []string
+		expectedOutputs []string
+	}{
+		inputs:          []string{"9980", ":9980", "localhost:9980", "test.com:9980", "192.168.14.92:9980"},
+		expectedOutputs: []string{":9980", ":9980", "localhost:9980", "test.com:9980", "192.168.14.92:9980"},
+	}
+	for i, input := range testVals.inputs {
+		output := processNetAddr(input)
+		if output != testVals.expectedOutputs[i] {
+			t.Error("unexpected result", i)
+		}
+	}
+}
+
 // TestUnitProcessConfig probes the 'processConfig' function.
 func TestUnitProcessConfig(t *testing.T) {
 	testVals := struct {
@@ -13,25 +30,26 @@ func TestUnitProcessConfig(t *testing.T) {
 		inputs: [][]string{
 			[]string{"9980", "9981", "9982"},
 			[]string{":9980", ":9981", ":9982"},
-			[]string{"localhost:9980", "localhost:9981", "localhost:9982"},
-			[]string{"localhost:9980", ":9981", "9982"},
 		},
 		expectedOutputs: [][]string{
 			[]string{":9980", ":9981", ":9982"},
 			[]string{":9980", ":9981", ":9982"},
-			[]string{"localhost:9980", "localhost:9981", "localhost:9982"},
-			[]string{"localhost:9980", ":9981", ":9982"},
 		},
 	}
+	var config Config
 	for i := range testVals.inputs {
-		config.Siad.RPCaddr = testVals.inputs[i][0]
-		config.Siad.HostAddr = testVals.inputs[i][1]
-		processConfig()
-		if config.Siad.RPCaddr != testVals.expectedOutputs[i][0] {
+		config.Siad.APIaddr = testVals.inputs[i][0]
+		config.Siad.RPCaddr = testVals.inputs[i][1]
+		config.Siad.HostAddr = testVals.inputs[i][2]
+		config = processConfig(config)
+		if config.Siad.APIaddr != testVals.expectedOutputs[i][0] {
 			t.Error("processing failure at check", i, 0)
 		}
-		if config.Siad.HostAddr != testVals.expectedOutputs[i][1] {
+		if config.Siad.RPCaddr != testVals.expectedOutputs[i][1] {
 			t.Error("processing failure at check", i, 1)
+		}
+		if config.Siad.HostAddr != testVals.expectedOutputs[i][2] {
+			t.Error("processing failure at check", i, 2)
 		}
 	}
 }

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -4,32 +4,34 @@ import (
 	"testing"
 )
 
-// TestUnitPreprocessConfig probes the 'preprocessConfig' function.
-func TestUnitPreprocessConfig(t *testing.T) {
+// TestUnitProcessConfig probes the 'processConfig' function.
+func TestUnitProcessConfig(t *testing.T) {
 	testVals := struct {
 		inputs          [][]string
 		expectedOutputs [][]string
 	}{
 		inputs: [][]string{
-			[]string{"9981", "9982"},
-			[]string{":9981", ":9982"},
-			[]string{":9981", "9982"},
+			[]string{"9980", "9981", "9982"},
+			[]string{":9980", ":9981", ":9982"},
+			[]string{"localhost:9980", "localhost:9981", "localhost:9982"},
+			[]string{"localhost:9980", ":9981", "9982"},
 		},
 		expectedOutputs: [][]string{
-			[]string{":9981", ":9982"},
-			[]string{":9981", ":9982"},
-			[]string{":9981", ":9982"},
+			[]string{":9980", ":9981", ":9982"},
+			[]string{":9980", ":9981", ":9982"},
+			[]string{"localhost:9980", "localhost:9981", "localhost:9982"},
+			[]string{"localhost:9980", ":9981", ":9982"},
 		},
 	}
 	for i := range testVals.inputs {
 		config.Siad.RPCaddr = testVals.inputs[i][0]
 		config.Siad.HostAddr = testVals.inputs[i][1]
-		preprocessConfig()
+		processConfig()
 		if config.Siad.RPCaddr != testVals.expectedOutputs[i][0] {
-			t.Error("preprocessing failure at check", i, 0)
+			t.Error("processing failure at check", i, 0)
 		}
 		if config.Siad.HostAddr != testVals.expectedOutputs[i][1] {
-			t.Error("preprocessing failure at check", i, 1)
+			t.Error("processing failure at check", i, 1)
 		}
 	}
 }

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestUnitPreprocessConfig probes the 'preprocessConfig' function.
+func TestUnitPreprocessConfig(t *testing.T) {
+	testVals := struct {
+		inputs          [][]string
+		expectedOutputs [][]string
+	}{
+		inputs: [][]string{
+			[]string{"9981", "9982"},
+			[]string{":9981", ":9982"},
+			[]string{":9981", "9982"},
+		},
+		expectedOutputs: [][]string{
+			[]string{":9981", ":9982"},
+			[]string{":9981", ":9982"},
+			[]string{":9981", ":9982"},
+		},
+	}
+	for i := range testVals.inputs {
+		config.Siad.RPCaddr = testVals.inputs[i][0]
+		config.Siad.HostAddr = testVals.inputs[i][1]
+		preprocessConfig()
+		if config.Siad.RPCaddr != testVals.expectedOutputs[i][0] {
+			t.Error("preprocessing failure at check", i, 0)
+		}
+		if config.Siad.HostAddr != testVals.expectedOutputs[i][1] {
+			t.Error("preprocessing failure at check", i, 1)
+		}
+	}
+}

--- a/siad/main.go
+++ b/siad/main.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	// A global config variable is needed to work with cobra's flag system.
-	config Config
+	// globalConfig is used by the cobra package to fill out the configuration
+	// variables.
+	globalConfig Config
 )
 
 // The Config struct contains all configurable variables for siad. It is
@@ -55,16 +56,16 @@ func main() {
 	})
 
 	// Set default values, which have the lowest priority.
-	root.PersistentFlags().StringVarP(&config.Siad.RequiredUserAgent, "agent", "A", "Sia-Agent", "required substring for the user agent")
-	root.PersistentFlags().BoolVarP(&config.Siad.Explorer, "explorer", "E", false, "whether or not to run an explorer in the daemon")
-	root.PersistentFlags().StringVarP(&config.Siad.HostAddr, "host-addr", "H", ":9982", "which port the host listens on")
-	root.PersistentFlags().BoolVarP(&config.Siad.LimitedAPI, "limited-api", "L", false, "whether or not private information is provided through the api")
-	root.PersistentFlags().StringVarP(&config.Siad.ProfileDir, "profile-directory", "P", "profiles", "location of the profiling directory")
-	root.PersistentFlags().StringVarP(&config.Siad.APIaddr, "api-addr", "a", "localhost:9980", "which host:port the API server listens on")
-	root.PersistentFlags().StringVarP(&config.Siad.SiaDir, "sia-directory", "d", "", "location of the sia directory")
-	root.PersistentFlags().BoolVarP(&config.Siad.NoBootstrap, "no-bootstrap", "n", false, "disable bootstrapping on this run")
-	root.PersistentFlags().BoolVarP(&config.Siad.Profile, "profile", "p", false, "enable profiling")
-	root.PersistentFlags().StringVarP(&config.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
+	root.PersistentFlags().StringVarP(&globalConfig.Siad.RequiredUserAgent, "agent", "A", "Sia-Agent", "required substring for the user agent")
+	root.PersistentFlags().BoolVarP(&globalConfig.Siad.Explorer, "explorer", "E", false, "whether or not to run an explorer in the daemon")
+	root.PersistentFlags().StringVarP(&globalConfig.Siad.HostAddr, "host-addr", "H", ":9982", "which port the host listens on")
+	root.PersistentFlags().BoolVarP(&globalConfig.Siad.LimitedAPI, "limited-api", "L", false, "whether or not private information is provided through the api")
+	root.PersistentFlags().StringVarP(&globalConfig.Siad.ProfileDir, "profile-directory", "P", "profiles", "location of the profiling directory")
+	root.PersistentFlags().StringVarP(&globalConfig.Siad.APIaddr, "api-addr", "a", "localhost:9980", "which host:port the API server listens on")
+	root.PersistentFlags().StringVarP(&globalConfig.Siad.SiaDir, "sia-directory", "d", "", "location of the sia directory")
+	root.PersistentFlags().BoolVarP(&globalConfig.Siad.NoBootstrap, "no-bootstrap", "n", false, "disable bootstrapping on this run")
+	root.PersistentFlags().BoolVarP(&globalConfig.Siad.Profile, "profile", "p", false, "enable profiling")
+	root.PersistentFlags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
 
 	// Parse cmdline flags, overwriting both the default values and the config
 	// file values.


### PR DESCRIPTION
Specifically, preprocessing was added for portnumbers in siad.
Previously, a port number provided as an integer resulted as an error, a
prefixed ":" was required. Now, it is okay to provide just an integer as
the preprocesser will clean up the number.

This was done by adding a function `preprocessConfig` which can be
extended to clean up other configuration values in the future.

fixes #650

---

'siad' previously had no testing. In this commit, a test package was
added for 'siad' so that `preprocessConfig` could be unit tested.