### PR TITLE
Host Pools

### DIFF
--- a/api/consensus.go
+++ b/api/consensus.go
@@ -22,9 +22,6 @@ type ConsensusBlockGET struct {
 
 // consensusHandlerGET handles a GET request to /consensus.
 func (srv *Server) consensusHandlerGET(w http.ResponseWriter, req *http.Request) {
-	id := srv.mu.RLock()
-	defer srv.mu.RUnlock(id)
-
 	cbid := srv.cs.CurrentBlock().ID()
 	currentTarget, _ := srv.cs.ChildTarget(cbid)
 	writeJSON(w, ConsensusGET{

--- a/api/server.go
+++ b/api/server.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/graceful"
 
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/sync"
 )
 
 // A Server is essentially a collection of modules and an API server to talk
@@ -27,8 +26,6 @@ type Server struct {
 	daemonExposed     bool
 	listener          net.Listener
 	requiredUserAgent string
-
-	mu *sync.RWMutex
 }
 
 // NewServer creates a new API server from the provided modules.
@@ -50,8 +47,6 @@ func NewServer(APIaddr string, requiredUserAgent string, cs modules.ConsensusSet
 
 		listener:          l,
 		requiredUserAgent: requiredUserAgent,
-
-		mu: sync.New(modules.SafeMutexDelay, 1),
 	}
 
 	// Register API handlers

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -192,9 +192,9 @@ func TestRelayNodes(t *testing.T) {
 	}
 
 	// g2 should have received g3's address from g1
-	time.Sleep(100 * time.Millisecond)
-	id = g2.mu.RLock()
-	defer g2.mu.RUnlock(id)
+	time.Sleep(200 * time.Millisecond)
+	id = g2.mu.Lock()
+	defer g2.mu.Unlock(id)
 	if _, ok := g2.nodes[g3.Address()]; !ok {
 		t.Fatal("node was not relayed:", g2.nodes)
 	}

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -82,7 +82,7 @@ func (hdb *HostDB) AveragePrice() types.Currency {
 	// maybe a more sophisticated way of doing this
 	var totalPrice types.Currency
 	sampleSize := 18
-	hosts := hdb.randomHosts(sampleSize)
+	hosts := hdb.randomHosts(sampleSize, nil)
 	if len(hosts) == 0 {
 		return totalPrice
 	}

--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -313,7 +313,7 @@ func (hu *hostUploader) Upload(data []byte) (uint64, error) {
 // revise revises the previous revision to cover piece and uploads both the
 // revision and the piece data to the host.
 func (hu *hostUploader) revise(rev types.FileContractRevision, piece []byte, height types.BlockHeight) error {
-	hu.conn.SetDeadline(time.Now().Add(5 * time.Second)) // sufficient to transfer 4 MB over 100 kbps
+	hu.conn.SetDeadline(time.Now().Add(5 * time.Minute)) // sufficient to transfer 4 MB over 100 kbps
 	defer hu.conn.SetDeadline(time.Time{})               // reset timeout after each revision
 
 	// calculate new merkle root

--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -503,5 +503,5 @@ func (hdb *HostDB) NewPool() (HostPool, error) {
 	if hdb.isEmpty() {
 		return nil, errors.New("HostDB is empty")
 	}
-	return &pool{}, nil
+	return &pool{hdb: hdb}, nil
 }

--- a/modules/renter/hostdb/negotiate_test.go
+++ b/modules/renter/hostdb/negotiate_test.go
@@ -259,3 +259,34 @@ func TestReviseContract(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestUniqueHosts tests the UniqueHosts method of the pool type.
+// TODO: make pool safer to test, using real or mocked hostdb
+func TestUniqueHosts(t *testing.T) {
+	// create hosts
+	h1, h2, h3 := new(hostUploader), new(hostUploader), new(hostUploader)
+	h1.settings.IPAddress = fakeAddr(1)
+	h2.settings.IPAddress = fakeAddr(2)
+	h3.settings.IPAddress = fakeAddr(3)
+
+	p := &pool{hosts: []*hostUploader{h1, h2, h3}}
+
+	tests := []struct {
+		n      int
+		hosts  []modules.NetAddress
+		expLen int
+	}{
+		{0, nil, 0},
+		{3, nil, 3},
+		{2, []modules.NetAddress{fakeAddr(1)}, 2},
+		// TODO: these tests cause panics
+		//{4, nil, 3},
+		//{1, []modules.NetAddress{fakeAddr(1), fakeAddr(2), fakeAddr(3)}, 0},
+	}
+	for i, test := range tests {
+		hosts := p.UniqueHosts(test.n, test.hosts)
+		if len(hosts) != test.expLen {
+			t.Errorf("test %v failed: expected %v hosts, got %v", i, test.expLen, len(hosts))
+		}
+	}
+}

--- a/modules/renter/hostdb/weightedlist.go
+++ b/modules/renter/hostdb/weightedlist.go
@@ -154,10 +154,11 @@ func (hdb *HostDB) isEmpty() bool {
 	return hdb.hostTree == nil || hdb.hostTree.weight.IsZero()
 }
 
-// randomHosts will pull up to 'n' random hosts from the hostdb. There will
-// be no repeats, but the length of the slice returned may be less than 'n',
-// and may even be 0. The hosts that get returned first have the higher
-// priority. Additionally, hosts specified in 'ignore' will not be considered.
+// randomHosts will pull up to 'n' random hosts from the hostdb. There will be
+// no repeats, but the length of the slice returned may be less than 'n', and
+// may even be 0. The hosts that get returned first have the higher priority.
+// Hosts specified in 'ignore' will not be considered; pass 'nil' if no
+// blacklist is desired.
 func (hdb *HostDB) randomHosts(n int, ignore []modules.NetAddress) (hosts []modules.HostSettings) {
 	if hdb.isEmpty() {
 		return

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -41,7 +41,7 @@ func uniformTreeVerification(hdb *HostDB, numEntries int) error {
 		selectionMap := make(map[modules.NetAddress]int)
 		expected := 100
 		for i := 0; i < expected*numEntries; i++ {
-			entries := hdb.randomHosts(1)
+			entries := hdb.randomHosts(1, nil)
 			if len(entries) == 0 {
 				return errors.New("no hosts!")
 			}
@@ -189,7 +189,7 @@ func TestVariedWeights(t *testing.T) {
 	// time.
 	selectionMap := make(map[string]int)
 	for i := 0; i < selections; i++ {
-		randEntry := hdb.randomHosts(1)
+		randEntry := hdb.randomHosts(1, nil)
 		if len(randEntry) == 0 {
 			t.Fatal("no hosts!")
 		}
@@ -280,7 +280,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 1 random host.
-	randHosts := hdb.randomHosts(1)
+	randHosts := hdb.randomHosts(1, nil)
 	if len(randHosts) != 1 {
 		t.Error("didn't get 1 hosts")
 	}
@@ -292,7 +292,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 2 random hosts.
-	randHosts = hdb.randomHosts(2)
+	randHosts = hdb.randomHosts(2, nil)
 	if len(randHosts) != 2 {
 		t.Error("didn't get 2 hosts")
 	}
@@ -307,7 +307,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 3 random hosts.
-	randHosts = hdb.randomHosts(3)
+	randHosts = hdb.randomHosts(3, nil)
 	if len(randHosts) != 3 {
 		t.Error("didn't get 3 hosts")
 	}
@@ -322,7 +322,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 4 random hosts. 3 should be returned.
-	randHosts = hdb.randomHosts(4)
+	randHosts = hdb.randomHosts(4, nil)
 	if len(randHosts) != 3 {
 		t.Error("didn't get 3 hosts")
 	}
@@ -334,5 +334,16 @@ func TestRandomHosts(t *testing.T) {
 	}
 	if randHosts[0].IPAddress == randHosts[1].IPAddress || randHosts[0].IPAddress == randHosts[2].IPAddress || randHosts[1].IPAddress == randHosts[2].IPAddress {
 		t.Error("doubled up")
+	}
+
+	// Ask for 3 hosts that are not in randHosts. No hosts should be
+	// returned.
+	uniqueHosts := hdb.randomHosts(3, []modules.NetAddress{
+		randHosts[0].IPAddress,
+		randHosts[1].IPAddress,
+		randHosts[2].IPAddress,
+	})
+	if len(uniqueHosts) != 0 {
+		t.Error("didn't get 0 hosts")
 	}
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -83,7 +83,7 @@ func New(cs modules.ConsensusSet, wallet modules.Wallet, tpool modules.Transacti
 		return nil, err
 	}
 
-	go r.threadedRepairUploads()
+	go r.threadedRepairLoop()
 
 	return r, nil
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -22,8 +22,8 @@ type hostDB interface {
 	// AveragePrice returns the average price of a host.
 	AveragePrice() types.Currency
 
-	// UniqueHosts will return up to 'n' unique hosts that are not in 'old'.
-	UniqueHosts(n int, old []hostdb.Uploader) []hostdb.Uploader
+	// NewPool returns a new HostPool.
+	NewPool() (hostdb.HostPool, error)
 }
 
 // A trackedFile contains metadata about files being tracked by the Renter.

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -18,7 +18,8 @@ const (
 	hostTimeout = 15 * time.Second
 )
 
-// repair attempts to repair a chunk of f by uploading its pieces to more hosts.
+// repair attempts to repair a file chunk by uploading its pieces to more
+// hosts.
 func (f *file) repair(chunkIndex uint64, missingPieces []uint64, r io.ReaderAt, hosts []hostdb.Uploader) error {
 	// read chunk data and encode
 	chunk := make([]byte, f.chunkSize())

--- a/modules/renter/repair_test.go
+++ b/modules/renter/repair_test.go
@@ -3,31 +3,12 @@ package renter
 import (
 	"bytes"
 	"crypto/rand"
-	"reflect"
 	"strconv"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/hostdb"
-	"github.com/NebulousLabs/Sia/types"
 )
-
-// mockHostDB mocks the functions of the HostDB.
-// TODO: might be unnecessary if we implement a per-chunk repair fn
-type mockHostDB struct {
-	hosts []*testHost
-}
-
-func (hdb *mockHostDB) ActiveHosts() []modules.HostSettings { return nil }
-func (hdb *mockHostDB) AllHosts() []modules.HostSettings    { return nil }
-func (hdb *mockHostDB) AveragePrice() types.Currency        { return types.NewCurrency64(0) }
-
-func (hdb *mockHostDB) UniqueHosts(n int, old []hostdb.Uploader) (ups []hostdb.Uploader) {
-	for i := 0; i < n && i < len(hdb.hosts); i++ {
-		ups = append(ups, hdb.hosts[i])
-	}
-	return
-}
 
 // TestRepair tests that the repair method can repeatedly improve the
 // redundancy of an unavailable file until it becomes available.
@@ -45,7 +26,7 @@ func TestRepair(t *testing.T) {
 
 	// create hosts
 	const pieceSize = 10
-	hosts := make([]*testHost, rsc.NumPieces())
+	hosts := make([]hostdb.Uploader, rsc.NumPieces())
 	for i := range hosts {
 		hosts[i] = &testHost{
 			ip:       modules.NetAddress(strconv.Itoa(i)),
@@ -53,16 +34,16 @@ func TestRepair(t *testing.T) {
 		}
 	}
 	// make one host always fail
-	hosts[0].failRate = 1
-
-	// create hostdb
-	hdb := &mockHostDB{hosts: hosts}
+	hosts[0].(*testHost).failRate = 1
 
 	// upload data to hosts
 	f := newFile("foo", rsc, pieceSize, dataSize)
-	err = f.repair(bytes.NewReader(data), f.incompleteChunks(), hdb)
-	if err != nil {
-		t.Fatal(err)
+	r := bytes.NewReader(data)
+	for chunk, pieces := range f.incompleteChunks() {
+		err = f.repair(chunk, pieces, r, hosts)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// file should not be available after first pass
@@ -73,9 +54,11 @@ func TestRepair(t *testing.T) {
 	// repair until file becomes available
 	const maxAttempts = 20
 	for i := 0; i < maxAttempts; i++ {
-		err = f.repair(bytes.NewReader(data), f.incompleteChunks(), hdb)
-		if err != nil {
-			t.Fatal(err)
+		for chunk, pieces := range f.incompleteChunks() {
+			err = f.repair(chunk, pieces, r, hosts)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 		if f.available() {
 			break
@@ -83,59 +66,5 @@ func TestRepair(t *testing.T) {
 	}
 	if !f.available() {
 		t.Fatalf("file not repaired to availability after %v attempts: %v", maxAttempts, err)
-	}
-}
-
-// TestSubtractRepairMap tests the subtract method of the repairMap type.
-func TestSubtractRepairMap(t *testing.T) {
-	orig := repairMap{
-		10: {1, 2, 3},
-		12: {4, 5, 6},
-	}
-	sub := repairMap{
-		10: {1, 2},
-		12: {5},
-		13: {7, 8, 9},
-	}
-	exp := repairMap{
-		10: {3},
-		12: {4, 6},
-	}
-	res := orig.subtract(sub)
-	if !reflect.DeepEqual(exp, res) {
-		t.Fatal("maps were merged incorrectly:", exp, res)
-	}
-}
-
-// TestChunksBelow tests the chunksBelow method of the file type.
-func TestChunksBelow(t *testing.T) {
-	var f1, f2, f3, f4 file
-	f1.contracts = map[types.FileContractID]fileContract{
-		{}: {WindowStart: 1, Pieces: []pieceData{{}}},
-	}
-	f2.contracts = map[types.FileContractID]fileContract{
-		{}: {WindowStart: 1, Pieces: []pieceData{{}}},
-	}
-	f3.contracts = map[types.FileContractID]fileContract{
-		{}: {WindowStart: 1, Pieces: []pieceData{{}}},
-	}
-	f4.contracts = map[types.FileContractID]fileContract{
-		{0}: {WindowStart: 1, Pieces: []pieceData{{}}},
-		{1}: {WindowStart: 2, Pieces: []pieceData{{}}},
-	}
-	tests := []struct {
-		f         file
-		endHeight types.BlockHeight
-		expChunks int
-	}{
-		{f1, 0, 0},
-		{f2, 1, 0},
-		{f3, 2, 1},
-		{f4, 2, 0},
-	}
-	for i, test := range tests[3:] {
-		if n := len(test.f.chunksBelow(test.endHeight)); n != test.expChunks {
-			t.Errorf("%d: expected %v expiring chunks, got %v", i, test.expChunks, n)
-		}
 	}
 }


### PR DESCRIPTION
check those lengthy commit messages! woo

This diff is hilariously useless, but the gist of it is that `repair.go` underwent some serious refactoring to make optimization easier. (Note how easy it would be to spawn multiple `r.threadedRepairFile` goroutines.)

Some unused code got tossed out, specifically code related to replacing expiring contracts and checking for offline hosts. We'll be adding a new "refresh contract" RPC to the host soon, so I figure that will be a good time to reevaluate how auto-renewing should be managed. At this stage, the HostDB is still making per-file contracts, so renewing an individual file is pretty straightforward. But this will change once the HostDB migrates to long-term host relationships, so things can get tricky.

Good news: as of this PR, chunks should finally be distributed "properly" across hosts. That is, hosts should never receive more than one piece of each chunk.