### PR TITLE
Add filesize and duration arguments to NewPool

### DIFF
--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -170,7 +170,7 @@ func negotiateContract(addr modules.NetAddress, fc types.FileContract, txnBuilde
 
 // newContract negotiates an initial file contract with the specified host
 // and returns a hostContract. The contract is also saved by the HostDB.
-func (hdb *HostDB) newContract(host modules.HostSettings) (hostContract, error) {
+func (hdb *HostDB) newContract(host modules.HostSettings, filesize uint64, duration types.BlockHeight) (hostContract, error) {
 	// reject hosts that are too expensive
 	if host.Price.Cmp(maxPrice) > 0 {
 		return hostContract{}, errTooExpensive
@@ -190,9 +190,7 @@ func (hdb *HostDB) newContract(host modules.HostSettings) (hostContract, error) 
 	hdb.mu.Unlock()
 
 	// create file contract
-	const filesize = 1e9  // 1 GB
-	const duration = 4320 // 30 days
-	renterCost := host.Price.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(duration))
+	renterCost := host.Price.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration)))
 	renterCost = renterCost.MulFloat(1.05) // extra buffer to guarantee we won't run out of money during revision
 	payout := renterCost                   // no collateral
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -22,8 +22,10 @@ type hostDB interface {
 	// AveragePrice returns the average price of a host.
 	AveragePrice() types.Currency
 
-	// NewPool returns a new HostPool.
-	NewPool() (hostdb.HostPool, error)
+	// NewPool returns a new HostPool, which can negotiate contracts with
+	// hosts. The size and duration of these contracts are supplied as
+	// arguments.
+	NewPool(filesize uint64, duration types.BlockHeight) (hostdb.HostPool, error)
 }
 
 // A trackedFile contains metadata about files being tracked by the Renter.

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -192,7 +192,8 @@ func (r *Renter) threadedRepairFile(name string, meta trackedFile) {
 	r.log.Printf("repairing %v chunks of %v", len(badChunks), name)
 
 	// create host pool
-	pool, err := r.hostDB.NewPool()
+	contractSize := f.pieceSize * f.numChunks() // each host gets one piece of each chunk
+	pool, err := r.hostDB.NewPool(contractSize, defaultDuration)
 	if err != nil {
 		r.log.Printf("failed to repair %v: %v", name, err)
 		return


### PR DESCRIPTION
The pool will now form new contracts according to these values, instead of using the same size and duration for all contracts.