### PR TITLE
Implement Renew RPC and add renew logic

### DIFF
--- a/modules/host.go
+++ b/modules/host.go
@@ -19,6 +19,9 @@ var (
 	// RPCUpload is the specifier for initiating an upload with the host.
 	RPCUpload = types.Specifier{'U', 'p', 'l', 'o', 'a', 'd'}
 
+	// RPCRenew is the specifier to renewing an existing contract.
+	RPCRenew = types.Specifier{'R', 'e', 'n', 'e', 'w'}
+
 	// RPCRevise is the specifier for revising an existing file contract.
 	RPCRevise = types.Specifier{'R', 'e', 'v', 'i', 's', 'e'}
 

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -77,9 +77,6 @@ func (h *Host) considerContract(txn types.Transaction, renterKey types.SiaPublic
 	case len(fc.MissedProofOutputs) != 2:
 		return errors.New("bad file contract missed proof outputs")
 
-	case !fc.ValidProofOutputs[1].Value.IsZero(), !fc.MissedProofOutputs[1].Value.IsZero():
-		return errors.New("file contract collateral is not zero")
-
 	case fc.ValidProofOutputs[1].UnlockHash != h.UnlockHash:
 		return errors.New("file contract valid proof output not sent to host")
 	case fc.MissedProofOutputs[1].UnlockHash != voidAddress:

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -272,7 +272,7 @@ func (h *Host) negotiateContract(conn net.Conn, merkleRoot crypto.Hash, filename
 func (h *Host) rpcUpload(conn net.Conn) error {
 	// Check that the host has grabbed an address from the wallet.
 	if h.UnlockHash == (types.UnlockHash{}) {
-		return errors.New("host needs an address; have you properly announced?")
+		return errors.New("couldn't negotiate contract: host does not have an address")
 	}
 
 	h.mu.RLock()

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -156,7 +156,7 @@ func (h *Host) considerRevision(txn types.Transaction, obligation contractObliga
 		return errors.New("revision outputs do not sum to original payout")
 
 	// outputs should have been adjusted proportional to the new filesize
-	case rev.NewValidProofOutputs[1].Value.Cmp(minHostPrice) <= 0:
+	case rev.NewValidProofOutputs[1].Value.Cmp(minHostPrice) < 0:
 		return errors.New("revision price is too small")
 	case rev.NewMissedProofOutputs[0].Value.Cmp(rev.NewValidProofOutputs[0].Value) != 0:
 		return errors.New("revision missed renter payout does not match valid payout")

--- a/modules/host/net.go
+++ b/modules/host/net.go
@@ -37,6 +37,8 @@ func (h *Host) handleConn(conn net.Conn) {
 		err = h.rpcSettings(conn)
 	case modules.RPCUpload:
 		err = h.rpcUpload(conn)
+	case modules.RPCRenew:
+		err = h.rpcRenew(conn)
 	case modules.RPCRevise:
 		err = h.rpcRevise(conn)
 	case modules.RPCDownload:

--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -319,7 +319,7 @@ func (hdb *HostDB) Renew(fcid types.FileContractID, newEndHeight types.BlockHeig
 	hdb.mu.RLock()
 	height := hdb.blockHeight
 	hc, ok := hdb.contracts[fcid]
-	host, eok := hdb.allHosts[hc.IP] // or activeHosts?
+	host, eok := hdb.allHosts[hc.IP]
 	hdb.mu.RUnlock()
 	if !ok {
 		return types.FileContractID{}, errors.New("no record of that contract")
@@ -373,8 +373,11 @@ func (hdb *HostDB) Renew(fcid types.FileContractID, newEndHeight types.BlockHeig
 	// update host contract
 	hdb.mu.Lock()
 	hdb.contracts[newContract.ID] = newContract
-	hdb.save()
+	err = hdb.save()
 	hdb.mu.Unlock()
+	if err != nil {
+		hdb.log.Println("WARN: failed to save the hostdb:", err)
+	}
 
 	return newContract.ID, nil
 }

--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -295,7 +295,6 @@ func newRevision(rev types.FileContractRevision, pieceLen uint64, merkleRoot cry
 		// probably not enough money, but the host might accept it anyway
 		piecePrice = rev.NewValidProofOutputs[0].Value
 	}
-
 	return types.FileContractRevision{
 		ParentID:          rev.ParentID,
 		UnlockConditions:  rev.UnlockConditions,
@@ -318,4 +317,188 @@ func newRevision(rev types.FileContractRevision, pieceLen uint64, merkleRoot cry
 		},
 		NewUnlockHash: rev.NewUnlockHash,
 	}
+}
+
+// Renew negotiates a new contract for data already stored with a host. It
+// returns the ID of the new contract. This is a blocking call that performs
+// network I/O.
+func (hdb *HostDB) Renew(fcid types.FileContractID, newEndHeight types.BlockHeight) (types.FileContractID, error) {
+	hdb.mu.RLock()
+	height := hdb.blockHeight
+	hc, ok := hdb.contracts[fcid]
+	host, eok := hdb.allHosts[hc.IP] // or activeHosts?
+	hdb.mu.RUnlock()
+	if !ok {
+		return types.FileContractID{}, errors.New("no record of that contract")
+	} else if !eok {
+		return types.FileContractID{}, errors.New("no record of that host")
+	} else if newEndHeight < height {
+		return types.FileContractID{}, errors.New("cannot renew below current height")
+	}
+
+	conn, err := net.DialTimeout("tcp", string(hc.IP), 15*time.Second)
+	if err != nil {
+		return types.FileContractID{}, err
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(30 * time.Second))
+
+	// write rpcID
+	if err := encoding.WriteObject(conn, modules.RPCRenew); err != nil {
+		return types.FileContractID{}, errors.New("couldn't initiate RPC: " + err.Error())
+	}
+
+	// write fcid
+	if err := encoding.WriteObject(conn, fcid); err != nil {
+		return types.FileContractID{}, errors.New("couldn't send contract ID: " + err.Error())
+	}
+
+	// rest of protocol is identical to negotiateContract
+	renterCost := host.Price.Mul(types.NewCurrency64(hc.LastRevision.NewFileSize)).Mul(types.NewCurrency64(uint64(newEndHeight - height)))
+	renterCost = renterCost.MulFloat(1.05) // extra buffer to guarantee we won't run out of money during revision
+	payout := renterCost                   // no collateral
+
+	// read host key
+	var hostPublicKey types.SiaPublicKey
+	if err := encoding.ReadObject(conn, &hostPublicKey, 256); err != nil {
+		return types.FileContractID{}, errors.New("couldn't read host's public key: " + err.Error())
+	}
+
+	// create our key
+	ourSK, ourPK, err := crypto.StdKeyGen.Generate()
+	if err != nil {
+		return types.FileContractID{}, errors.New("failed to generate keypair: " + err.Error())
+	}
+	ourPublicKey := types.SiaPublicKey{
+		Algorithm: types.SignatureEd25519,
+		Key:       ourPK[:],
+	}
+
+	// send our public key
+	if err := encoding.WriteObject(conn, ourPublicKey); err != nil {
+		return types.FileContractID{}, errors.New("couldn't send our public key: " + err.Error())
+	}
+
+	// create unlock conditions
+	uc := types.UnlockConditions{
+		PublicKeys:         []types.SiaPublicKey{ourPublicKey, hostPublicKey},
+		SignaturesRequired: 2,
+	}
+
+	// create file contract
+	fc := types.FileContract{
+		FileSize:       hc.LastRevision.NewFileSize,
+		FileMerkleRoot: hc.LastRevision.NewFileMerkleRoot,
+		WindowStart:    newEndHeight,
+		WindowEnd:      newEndHeight + host.WindowSize,
+		Payout:         payout,
+		UnlockHash:     uc.UnlockHash(),
+		// TODO: are these correct?
+		RevisionNumber:     0,
+		ValidProofOutputs:  hc.LastRevision.NewValidProofOutputs,
+		MissedProofOutputs: hc.LastRevision.NewMissedProofOutputs,
+	}
+
+	// build transaction containing fc
+	txnBuilder := hdb.wallet.StartTransaction()
+	err = txnBuilder.FundSiacoins(fc.Payout)
+	if err != nil {
+		return types.FileContractID{}, err
+	}
+	txnBuilder.AddFileContract(fc)
+	txn, parents := txnBuilder.View()
+	txnSet := append(parents, txn)
+
+	// calculate new contract ID
+	newContractID := txn.FileContractID(0)
+
+	// if an error occurs at any point here, we need to drop the txn
+	err = func() error {
+		// send txn
+		if err := encoding.WriteObject(conn, txnSet); err != nil {
+			return errors.New("couldn't send our proposed contract: " + err.Error())
+		}
+
+		// read back acceptance
+		var response string
+		if err := encoding.ReadObject(conn, &response, 128); err != nil {
+			return errors.New("couldn't read the host's response to our proposed contract: " + err.Error())
+		}
+		if response != modules.AcceptResponse {
+			return errors.New("host rejected proposed contract: " + response)
+		}
+
+		// read back txn with host collateral.
+		var hostTxnSet []types.Transaction
+		if err := encoding.ReadObject(conn, &hostTxnSet, types.BlockSizeLimit); err != nil {
+			return errors.New("couldn't read the host's updated contract: " + err.Error())
+		}
+
+		// check that txn is okay. For now, no collateral will be added, so the
+		// transaction sets should be identical.
+		if len(hostTxnSet) != len(txnSet) {
+			return errors.New("host sent bad collateral transaction")
+		}
+		for i := range hostTxnSet {
+			if hostTxnSet[i].ID() != txnSet[i].ID() {
+				return errors.New("host sent bad collateral transaction")
+			}
+		}
+
+		// sign the txn and resend
+		// NOTE: for now, we are assuming that the transaction has not changed
+		// since we sent it. Otherwise, the txnBuilder would have to be updated
+		// with whatever fields were added by the host.
+		signedTxnSet, err := txnBuilder.Sign(true)
+		if err != nil {
+			return err
+		}
+		if err := encoding.WriteObject(conn, signedTxnSet); err != nil {
+			return errors.New("couldn't send the contract signed by us: " + err.Error())
+		}
+
+		// read signed txn from host
+		var signedHostTxnSet []types.Transaction
+		if err := encoding.ReadObject(conn, &signedHostTxnSet, types.BlockSizeLimit); err != nil {
+			return errors.New("couldn't read the contract signed by the host: " + err.Error())
+		}
+
+		// submit to blockchain
+		err = hdb.tpool.AcceptTransactionSet(signedHostTxnSet)
+		if err == modules.ErrDuplicateTransactionSet {
+			// this can happen if the renter is uploading to itself
+			err = nil
+		}
+		return err
+	}()
+	if err != nil {
+		txnBuilder.Drop()
+		return types.FileContractID{}, err
+	}
+
+	// update host contract
+	hdb.mu.Lock()
+	hdb.contracts[fcid] = hostContract{
+		IP: hc.IP,
+		ID: newContractID,
+		LastRevision: types.FileContractRevision{
+			ParentID:              newContractID,
+			UnlockConditions:      uc,
+			NewRevisionNumber:     fc.RevisionNumber,
+			NewFileSize:           fc.FileSize,
+			NewFileMerkleRoot:     fc.FileMerkleRoot,
+			NewWindowStart:        fc.WindowStart,
+			NewWindowEnd:          fc.WindowEnd,
+			NewValidProofOutputs:  []types.SiacoinOutput{fc.ValidProofOutputs[0], fc.ValidProofOutputs[1]},
+			NewMissedProofOutputs: []types.SiacoinOutput{fc.MissedProofOutputs[0], fc.MissedProofOutputs[1]},
+			NewUnlockHash:         fc.UnlockHash,
+		},
+		LastRevisionTxn: types.Transaction{},
+		SecretKey:       ourSK,
+	}
+	hdb.save()
+	hdb.mu.Unlock()
+
+	return newContractID, nil
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -26,6 +26,9 @@ type hostDB interface {
 	// hosts. The size and duration of these contracts are supplied as
 	// arguments.
 	NewPool(filesize uint64, duration types.BlockHeight) (hostdb.HostPool, error)
+
+	// Renew renews a file contract, returning the new contract ID.
+	Renew(id types.FileContractID, newHeight types.BlockHeight) (types.FileContractID, error)
 }
 
 // A trackedFile contains metadata about files being tracked by the Renter.

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -209,7 +209,11 @@ func (r *Renter) threadedRepairFile(name string, meta trackedFile) {
 
 	// create host pool
 	contractSize := f.pieceSize * f.numChunks() // each host gets one piece of each chunk
-	pool, err := r.hostDB.NewPool(contractSize, defaultDuration)
+	var duration types.BlockHeight = defaultDuration
+	if meta.EndHeight != 0 {
+		duration = meta.EndHeight - height
+	}
+	pool, err := r.hostDB.NewPool(contractSize, duration)
 	if err != nil {
 		r.log.Printf("failed to repair %v: %v", name, err)
 		return

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -111,12 +111,7 @@ func (fcid FileContractID) StorageProofOutputID(proofStatus ProofStatus, i uint6
 // PostTax returns the amount of currency remaining in a file contract payout
 // after tax.
 func PostTax(height BlockHeight, payout Currency) Currency {
-	// COMPATv0.4.0 - until the first 20,000 blocks have been archived, they
-	// will need to be handled in a special way.
-	if (height < 21e3 && build.Release == "standard") || (height < 10 && build.Release == "testing") {
-		return payout.Sub(payout.MulFloat(0.039).RoundDown(SiafundCount))
-	}
-	return payout.Sub(payout.MulTax().RoundDown(SiafundCount))
+	return payout.Sub(Tax(height, payout))
 }
 
 // Tax returns the amount of Currency that will be taxed from fc.


### PR DESCRIPTION
`RPCRenew` is a new host RPC that allows a renter to renew a contract without reuploading. The renter now makes use of this RPC to renew files that are within 2000 blocks of expiring.

The `negotiateContract` functions for both the host and renter have been refactored so that they can be used for renewing as well as the initial negotiation process. It's not a perfect fit, but it saves a lot of duplicated code. This may not be possible if the `RPCRenew` protocol is changed in the future.