### PR TITLE
New Upload API semantics

### DIFF
--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -17,6 +17,7 @@ func TestIntegrationConsensusGET(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	var cg ConsensusGET
 	err = st.getAPI("/consensus", &cg)
 	if err != nil {
@@ -44,6 +45,7 @@ func TestIntegrationConsensusBlockGET(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	var cbg ConsensusBlockGET
 	err = st.getAPI("/consensus/block?height=1", &cbg)
 	if err != nil {

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/inconshreveable/go-update"
 	"github.com/kardianos/osext"
@@ -177,8 +176,7 @@ func (srv *Server) daemonStopHandler(w http.ResponseWriter, req *http.Request) {
 	// can't write after we stop the server, so lie a bit.
 	writeSuccess(w)
 
-	// send stop signal
-	srv.apiServer.Stop(time.Second)
+	srv.Close()
 }
 
 // daemonVersionHandler handles the API call that requests the daemon's version.

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -35,6 +35,7 @@ func TestSignedUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	// to test the update process, we need to spoof the update server
 	uh := new(updateHandler)
@@ -81,6 +82,7 @@ func TestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	var version string
 	st.getAPI("/daemon/version", &version)
 	if version != build.Version {

--- a/api/explorer_test.go
+++ b/api/explorer_test.go
@@ -13,6 +13,7 @@ func TestIntegrationExplorerGET(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	var eg ExplorerGET
 	err = st.getAPI("/explorer", &eg)
@@ -36,6 +37,7 @@ func TestIntegrationExplorerBlockGET(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	var ebg ExplorerBlockGET
 	err = st.getAPI("/explorer/block?height=0", &ebg)
@@ -59,6 +61,7 @@ func TestIntegrationExplorerGEThash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	var ehg ExplorerHashGET
 	gb := st.server.cs.GenesisBlock()

--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -7,26 +7,6 @@ import (
 	"github.com/NebulousLabs/Sia/modules/gateway"
 )
 
-// addPeer creates a new serverTester and bootstraps it to st. It returns the
-// new peer.
-func (st *serverTester) addPeer(name string) (*serverTester, error) {
-	_, err := st.miner.AddBlock()
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a new peer and bootstrap it to st.
-	newPeer, err := createServerTester(name)
-	if err != nil {
-		return nil, err
-	}
-	err = newPeer.server.gateway.Connect(st.netAddress())
-	if err != nil {
-		return nil, err
-	}
-	return newPeer, nil
-}
-
 func TestGatewayStatus(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -35,6 +15,7 @@ func TestGatewayStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	var info GatewayInfo
 	st.getAPI("/gateway/status", &info)
 	if len(info.Peers) != 0 {
@@ -50,6 +31,7 @@ func TestGatewayPeerAdd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	peer, err := gateway.New(":0", build.TempDir("api", "TestGatewayPeerAdd", "gateway"))
 	if err != nil {
 		t.Fatal(err)
@@ -71,6 +53,7 @@ func TestGatewayPeerRemove(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	peer, err := gateway.New(":0", build.TempDir("api", "TestGatewayPeerRemove", "gateway"))
 	if err != nil {
 		t.Fatal(err)

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -81,3 +81,74 @@ func TestIntegrationHosting(t *testing.T) {
 		t.Fatalf("host's profit was not affected: expected %v, got %v", expRevenue, hg.Revenue)
 	}
 }
+
+// TestIntegrationRenewing tests that the renter and host manage contract
+// renewals properly.
+func TestIntegrationRenewing(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createServerTester("TestIntegrationRenewing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Announce the host.
+	announceValues := url.Values{}
+	announceValues.Set("address", string(st.host.NetAddress()))
+	err = st.stdPostAPI("/host/announce", announceValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// mine block and wait for announcement to register
+	st.miner.AddBlock()
+	var hosts ActiveHosts
+	time.Sleep(1 * time.Second)
+	st.getAPI("/hostdb/hosts/active", &hosts)
+	if len(hosts.Hosts) == 0 {
+		t.Fatal("host announcement not seen")
+	}
+
+	// create a file
+	path := filepath.Join(build.SiaTestingDir, "api", "TestIntegrationRenewing", "test.dat")
+	data, err := crypto.RandBytes(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(path, data, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// upload to host, specifying that the file should be renewed
+	err = st.stdGetAPI("/renter/files/upload?nickname=test&renew=true&source=" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// only one piece will be uploaded (10% at current redundancy)
+	var fi []FileInfo
+	for len(fi) != 1 || fi[0].UploadProgress != 10 {
+		st.getAPI("/renter/files/list", &fi)
+		time.Sleep(3 * time.Second)
+	}
+	// default expiration is 60 blocks
+	expExpiration := st.cs.Height() + 60
+	if fi[0].Expiration != expExpiration {
+		t.Fatalf("expected expiration of %v, got %v", expExpiration, fi[0].Expiration)
+	}
+
+	// mine blocks until we hit the renew threshold (default 20 blocks)
+	for st.cs.Height() <= expExpiration-20 {
+		st.miner.AddBlock()
+	}
+
+	// renter should now renew the contract for another 60 blocks
+	newExpiration := st.cs.Height() + 60
+	for fi[0].Expiration != newExpiration {
+		st.getAPI("/renter/files/list", &fi)
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -141,7 +141,7 @@ func TestIntegrationRenewing(t *testing.T) {
 	}
 
 	// mine blocks until we hit the renew threshold (default 20 blocks)
-	for st.cs.Height() <= expExpiration-20 {
+	for st.cs.Height() < expExpiration-20 {
 		st.miner.AddBlock()
 	}
 

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -61,8 +61,8 @@ func TestIntegrationHosting(t *testing.T) {
 	// only one piece will be uploaded (10% at current redundancy)
 	var fi []FileInfo
 	for len(fi) != 1 || fi[0].UploadProgress != 10 {
-		time.Sleep(3 * time.Second)
 		st.getAPI("/renter/files/list", &fi)
+		time.Sleep(1 * time.Second)
 	}
 
 	// mine blocks until storage proof is complete
@@ -131,8 +131,8 @@ func TestIntegrationRenewing(t *testing.T) {
 	// only one piece will be uploaded (10% at current redundancy)
 	var fi []FileInfo
 	for len(fi) != 1 || fi[0].UploadProgress != 10 {
+		time.Sleep(1 * time.Second)
 		st.getAPI("/renter/files/list", &fi)
-		time.Sleep(3 * time.Second)
 	}
 	// default expiration is 60 blocks
 	expExpiration := st.cs.Height() + 60
@@ -148,7 +148,7 @@ func TestIntegrationRenewing(t *testing.T) {
 	// renter should now renew the contract for another 60 blocks
 	newExpiration := st.cs.Height() + 60
 	for fi[0].Expiration != newExpiration {
+		time.Sleep(1 * time.Second)
 		st.getAPI("/renter/files/list", &fi)
-		time.Sleep(3 * time.Second)
 	}
 }

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -23,6 +23,7 @@ func TestIntegrationHosting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	// Announce the host.
 	announceValues := url.Values{}

--- a/api/miner_test.go
+++ b/api/miner_test.go
@@ -19,6 +19,7 @@ func TestIntegrationMinerGET(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	// Get the api returned fields of the miner.
 	var mg MinerGET
@@ -53,6 +54,7 @@ func TestIntegrationMinerStartStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	// Start the cpu miner, give time for the first hashrate readings to
 	// appear.
@@ -105,6 +107,7 @@ func TestIntegrationMinerHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	startingHeight := st.cs.Height()
 
 	// Get a header that can be used for mining.

--- a/api/renter.go
+++ b/api/renter.go
@@ -172,10 +172,12 @@ func (srv *Server) renterFilesUploadHandler(w http.ResponseWriter, req *http.Req
 			return
 		}
 	}
+	renew := req.FormValue("renew") == "true"
 	err := srv.renter.Upload(modules.FileUploadParams{
 		Filename: req.FormValue("source"),
 		Nickname: req.FormValue("nickname"),
 		Duration: duration,
+		Renew:    renew,
 		// let the renter decide these values; eventually they will be configurable
 		ErasureCode: nil,
 		PieceSize:   0,

--- a/api/server.go
+++ b/api/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/stretchr/graceful"
 
@@ -77,5 +78,11 @@ func (srv *Server) Serve() error {
 	}
 
 	fmt.Println("\rCaught stop signal, quitting.")
+	return nil
+}
+
+func (srv *Server) Close() error {
+	// give graceful 1 second to shutdown
+	srv.apiServer.Stop(time.Second)
 	return nil
 }

--- a/api/server.go
+++ b/api/server.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -77,7 +76,6 @@ func (srv *Server) Serve() error {
 		srv.wallet.Lock()
 	}
 
-	fmt.Println("\rCaught stop signal, quitting.")
 	return nil
 }
 

--- a/api/server.go
+++ b/api/server.go
@@ -79,6 +79,8 @@ func (srv *Server) Serve() error {
 	return nil
 }
 
+// Close sends the stop signal to the API server, giving it a grace period to
+// shut down cleanly before forcibly terminating it.
 func (srv *Server) Close() error {
 	// give graceful 1 second to shutdown
 	srv.apiServer.Stop(time.Second)

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -14,6 +14,7 @@ func TestExplorerPreset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	// Try calling a legal endpoint without a user agent.
 	err = st.stdGetAPIUA("/explorer", "")
@@ -37,6 +38,7 @@ func TestReloading(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	rst, err := st.reloadedServerTester()
 	if err != nil {
 		t.Fatal(err)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -60,6 +60,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 			t.Fatal("API server quit:", listenErr)
 		}
 	}()
+	defer st.server.Close()
 
 	var wg WalletGET
 	err = st.getAPI("/wallet", &wg)
@@ -117,6 +118,7 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 			panic(listenErr)
 		}
 	}()
+	defer st.server.Close()
 
 	// Make a call to /wallet/encrypt and get the seed. Provide no encryption
 	// key so that the encryption key is the seed that gets returned.
@@ -148,6 +150,7 @@ func TestIntegrationWalletGETSiacoins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	// Check the intial wallet is encrypted, unlocked, and has the siacoins
 	// that got mined.
@@ -241,6 +244,7 @@ func TestIntegrationWalletTransactionGETid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 
 	// Mining blocks should have created transactions for the wallet containing
 	// miner payouts. Get the list of transactions.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -37,8 +37,9 @@ type ErasureCoder interface {
 // file.
 type FileUploadParams struct {
 	Filename    string
-	Duration    types.BlockHeight
 	Nickname    string
+	Duration    types.BlockHeight
+	Renew       bool
 	ErasureCode ErasureCoder
 	PieceSize   uint64
 }

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -238,7 +238,7 @@ func (r *Renter) load() error {
 		// COMPATv0.4.8
 		for nick, path := range data.Repairing {
 			// these files will be renewed indefinitely
-			r.tracking[nick] = trackedFile{RepairPath: path, EndHeight: 0}
+			r.tracking[nick] = trackedFile{RepairPath: path, Renew: true}
 		}
 	}
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -38,9 +38,10 @@ type hostDB interface {
 type trackedFile struct {
 	// location of original file on disk
 	RepairPath string
-	// height at which file contracts should end. If EndHeight is 0, the file's
-	// contracts will be renewed indefinitely.
+	// height at which file contracts should end
 	EndHeight types.BlockHeight
+	// whether the file should be renewed (overrides EndHeight if true)
+	Renew bool
 }
 
 // A Renter is responsible for tracking all of the files that a user has

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -106,7 +106,7 @@ func (r *Renter) Info() (ri modules.RentInfo) {
 
 	// Calculate the average cost of a file.
 	averagePrice := r.hostDB.AveragePrice()
-	estimatedCost := averagePrice.Mul(types.NewCurrency64(defaultDuration)).Mul(types.NewCurrency64(1e9)).Mul(types.NewCurrency64(defaultParityPieces + defaultDataPieces))
+	estimatedCost := averagePrice.Mul(types.NewCurrency64(uint64(defaultDuration))).Mul(types.NewCurrency64(1e9)).Mul(types.NewCurrency64(defaultParityPieces + defaultDataPieces))
 	// this also accounts for the buffering in the contract negotiation
 	bufferedCost := estimatedCost.Mul(types.NewCurrency64(5)).Div(types.NewCurrency64(2))
 	ri.Price = bufferedCost

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -192,7 +192,7 @@ func (r *Renter) threadedRepairFile(name string, meta trackedFile) {
 
 	// check for expiration
 	height := r.cs.Height()
-	if meta.EndHeight != 0 && meta.EndHeight < height {
+	if !meta.Renew && meta.EndHeight < height {
 		logAndRemove("removing %v from repair set: storage period has ended", name)
 		return
 	}

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/hostdb"
@@ -13,12 +14,21 @@ import (
 )
 
 const (
-	// When a file contract is within this many blocks of expiring, the renter
-	// will attempt to renew the contract.
-	renewThreshold = 2000
-
 	hostTimeout = 15 * time.Second
 )
+
+// When a file contract is within 'renewThreshold' blocks of expiring, the renter
+// will attempt to renew the contract.
+var renewThreshold = func() types.BlockHeight {
+	switch build.Release {
+	case "testing":
+		return 20
+	case "dev":
+		return 200
+	default:
+		return 2000
+	}
+}()
 
 // repair attempts to repair a file chunk by uploading its pieces to more
 // hosts.

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -175,7 +175,7 @@ func (f *file) expiringContracts(height types.BlockHeight) []fileContract {
 
 	var expiring []fileContract
 	for _, fc := range f.contracts {
-		if height > fc.WindowStart-renewThreshold {
+		if height >= fc.WindowStart-renewThreshold {
 			expiring = append(expiring, fc)
 		}
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -60,6 +60,10 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	if err != nil {
 		return err
 	}
+	if up.Duration == 0 {
+		up.Duration = defaultDuration
+	}
+	endHeight := r.cs.Height() + up.Duration
 	if up.ErasureCode == nil {
 		up.ErasureCode, _ = NewRSCode(defaultDataPieces, defaultParityPieces)
 	}
@@ -69,15 +73,6 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		} else {
 			up.PieceSize = smallPieceSize
 		}
-	}
-	// calculate end height
-	// TODO: using 0 as a special value is kind of hacky. Should probably have
-	// an explicit "renew" field.
-	var endHeight types.BlockHeight
-	if up.Duration == 0 {
-		endHeight = 0
-	} else {
-		endHeight = r.cs.Height() + up.Duration
 	}
 
 	// Check that we have enough money to finance the upload.
@@ -96,6 +91,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	r.tracking[up.Nickname] = trackedFile{
 		RepairPath: up.Filename,
 		EndHeight:  endHeight,
+		Renew:      up.Renew,
 	}
 	r.save()
 	r.mu.Unlock(lockID)

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -4,15 +4,15 @@ import (
 	"errors"
 	"os"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
 
 const (
-	defaultDuration     = 6000 // Duration that hosts will hold onto the file
-	defaultDataPieces   = 2    // Data pieces per erasure-coded chunk
-	defaultParityPieces = 8    // Parity pieces per erasure-coded chunk
+	defaultDataPieces   = 2 // Data pieces per erasure-coded chunk
+	defaultParityPieces = 8 // Parity pieces per erasure-coded chunk
 
 	// piece sizes
 	// NOTE: The encryption overhead is subtracted so that encrypted piece
@@ -21,6 +21,19 @@ const (
 	defaultPieceSize = 1<<22 - crypto.TwofishOverhead // 4 MiB
 	smallPieceSize   = 1<<16 - crypto.TwofishOverhead // 64 KiB
 )
+
+// defaultDuration is the contract length that the renter will use when the
+// uploader does not specify a duration.
+var defaultDuration = func() types.BlockHeight {
+	switch build.Release {
+	case "testing":
+		return 60
+	case "dev":
+		return 600
+	default:
+		return 6000
+	}
+}()
 
 // checkWalletBalance looks at an upload and determines if there is enough
 // money in the wallet to support such an upload. An error is returned if it is


### PR DESCRIPTION
The upload API now behaves like so:
- if `renew == true`, the file will be renewed indefinitely.
- if `renew != true && duration != 0`, the file will be uploaded for the
  duration specified.
- if `renew != true && duration = 0`, the file will be uploaded for the
  default duration.

Basically, instead of using a magic value to indicate renewal (`duration == 0`), we use an explicit separate field.