### PR TITLE
Fix padding bug in MerkleTree.ReadSegments

### DIFF
--- a/crypto/merkle.go
+++ b/crypto/merkle.go
@@ -33,11 +33,7 @@ func (t MerkleTree) PushObject(obj interface{}) {
 // to the tree.  No error is returned unless err != io.EOF && err !=
 // io.errUnexpectedEOF
 func (t MerkleTree) ReadSegments(r io.Reader) error {
-	err := t.ReadAll(r, SegmentSize)
-	if err != nil {
-		return err
-	}
-	return nil
+	return t.ReadAll(r, SegmentSize)
 }
 
 // Root returns the Merkle root of all the objects pushed to the tree.

--- a/crypto/merkle.go
+++ b/crypto/merkle.go
@@ -29,18 +29,13 @@ func (t MerkleTree) PushObject(obj interface{}) {
 }
 
 // ReadSegments reads segments from r into the tree. If EOF is encountered
-// mid-segment, the zero-padded segment is added to the tree and no error is
-// returned.
+// mid-segment, the leaf is resized to the number of bytes read and then added
+// to the tree.  No error is returned unless err != io.EOF && err !=
+// io.errUnexpectedEOF
 func (t MerkleTree) ReadSegments(r io.Reader) error {
-	buf := make([]byte, SegmentSize)
-	for {
-		_, err := io.ReadFull(r, buf)
-		if err == io.EOF {
-			break
-		} else if err != nil && err != io.ErrUnexpectedEOF {
-			return err
-		}
-		t.Push(buf)
+	err := t.ReadAll(r, SegmentSize)
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Two things were wrong with the method.
1) The method should not have been padding data.
2) The function claimed to be padding with 0s but unless there was only one leaf it was actually padding data with the end of the previous leaf.

The fix was to make the corresponding unexported function in the merkletree repo an exported method. See PR NebulousLabs/merkletree#10. MerkleTree.ReadSegments now wraps this method instead of reimplementing it.