### PR TITLE
Add tests to crypto package

### DIFF
--- a/crypto/discard_test.go
+++ b/crypto/discard_test.go
@@ -1,0 +1,23 @@
+package crypto
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestUnitSecureWipe tests that the SecureWipe function sets all the elements
+// in a byte slice to 0.
+func TestUnitSecureWipe(t *testing.T) {
+	s := []byte{1, 2, 3, 4}
+	SecureWipe(s)
+	if !bytes.Equal(s, make([]byte, len(s))) {
+		t.Error("some bytes not set to 0")
+	}
+}
+
+// TestUnitSecureWipeEdgeCases tests that SecureWipe doesn't panic on nil or
+// empty slices.
+func TestUnitSecureWipeEdgeCases(t *testing.T) {
+	SecureWipe(nil)
+	SecureWipe([]byte{})
+}

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -142,9 +142,9 @@ func TestTwofishEntropy(t *testing.T) {
 	}
 }
 
-// TestUnitCiphertextUnmarshalJSON tests that Ciphertext.UnmarshalJSON
+// TestUnitCiphertextUnmarshalInvalidJSON tests that Ciphertext.UnmarshalJSON
 // correctly fails on invalid JSON marshalled Ciphertext.
-func TestUnitCiphertextUnmarshalJSON(t *testing.T) {
+func TestUnitCiphertextUnmarshalInvalidJSON(t *testing.T) {
 	// Test unmarshalling invalid JSON.
 	invalidJSONBytes := [][]byte{
 		nil,
@@ -164,7 +164,8 @@ func TestUnitCiphertextUnmarshalJSON(t *testing.T) {
 // in the expected JSON. Also tests that marshalling that JSON back to
 // Ciphertext results in the original Ciphertext.
 func TestCiphertextMarshalling(t *testing.T) {
-	// Ciphertexts and corresponding JSONs to test marshalling and unmarshalling.
+	// Ciphertexts and corresponding JSONs to test marshalling and
+	// unmarshalling.
 	ciphertextMarshallingTests := []struct {
 		ct        Ciphertext
 		jsonBytes []byte
@@ -187,12 +188,14 @@ func TestCiphertextMarshalling(t *testing.T) {
 			copy(ct, expectedCt)
 		}
 
-		// Marshal ct to JSON.
+		// Marshal Ciphertext to JSON.
 		jsonBytes, err := ct.MarshalJSON()
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !bytes.Equal(jsonBytes, expectedJSONBytes) {
+			// Use %#v instead of %v because %v prints Ciphertexts constructed
+			// with nil and []byte{} identically.
 			t.Fatalf("Ciphertext %#v marshalled incorrectly: expected %q, got %q\n", ct, expectedJSONBytes, jsonBytes)
 		}
 
@@ -201,8 +204,10 @@ func TestCiphertextMarshalling(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Compare original Ciphertext (expectedCt) with resulting Ciphertext (ct).
+		// Compare resulting Ciphertext with expected Ciphertext.
 		if expectedCt == nil && ct != nil || expectedCt != nil && ct == nil || !bytes.Equal(expectedCt, ct) {
+			// Use %#v instead of %v because %v prints Ciphertexts constructed
+			// with nil and []byte{} identically.
 			t.Errorf("Ciphertext %#v unmarshalled incorrectly: got %#v\n", expectedCt, ct)
 		}
 	}

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+var (
+	ciphertextMarshallingTests = []struct {
+		ct        Ciphertext
+		jsonBytes []byte
+	}{
+		{ct: Ciphertext(nil), jsonBytes: []byte("null")},
+		{ct: Ciphertext(""), jsonBytes: []byte(`""`)},
+		{ct: Ciphertext("a ciphertext"), jsonBytes: []byte(`"YSBjaXBoZXJ0ZXh0"`) /* base64 encoding of the Ciphertext */},
+	}
+)
+
 // TestTwofishEncryption checks that encryption and decryption works correctly.
 func TestTwofishEncryption(t *testing.T) {
 	// Get a key for encryption.
@@ -139,5 +150,89 @@ func TestTwofishEntropy(t *testing.T) {
 	zip.Close()
 	if b.Len() < cipherSize {
 		t.Error("supposedly high entropy ciphertext has been compressed!")
+	}
+}
+
+// TestUnitCiphertextMarshalJSON tests that Ciphertext.MarshalJSON never fails,
+// because json.Marshal should nevef fail to encode a byte slice.
+func TestUnitCiphertextMarshalJSON(t *testing.T) {
+	for _, test := range ciphertextMarshallingTests {
+		ct := test.ct
+		expectedJSONBytes := test.jsonBytes
+
+		jsonBytes, err := ct.MarshalJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(jsonBytes, expectedJSONBytes) {
+			t.Errorf("cipher text %#v encoded incorrectly: expected %q, got %q\n", ct, expectedJSONBytes, jsonBytes)
+		}
+	}
+}
+
+// TestUnitCiphertextUnmarshalJSON tests that Ciphertext.UnmarshalJSON correctly
+// fails on invalid JSON marshalled Ciphertext and doesn't fail on valid JSON
+// marshalled Ciphertext. Also tests that valid JSON marshalled Ciphertext
+// decodes to the correct JSON.
+func TestUnitCiphertextUnmarshalJSON(t *testing.T) {
+	// Test unmarshalling invalid JSON.
+	invalidJSONBytes := [][]byte{
+		nil,
+		[]byte{},
+		[]byte("\""),
+	}
+	for _, jsonBytes := range invalidJSONBytes {
+		var ct Ciphertext
+		err := ct.UnmarshalJSON(jsonBytes)
+		if err == nil {
+			t.Errorf("expected unmarshall to fail on the invalid JSON: %q\n", jsonBytes)
+		}
+	}
+
+	// Test unmarshalling valid JSON.
+	for _, test := range ciphertextMarshallingTests {
+		expectedCt := test.ct
+		jsonBytes := test.jsonBytes
+
+		var ct Ciphertext
+		err := ct.UnmarshalJSON(jsonBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if expectedCt == nil && ct != nil || expectedCt != nil && ct == nil || !bytes.Equal(expectedCt, ct) {
+			t.Errorf("JSON %q decoded incorrectly: expected %#v, got %#v\n", jsonBytes, expectedCt, ct)
+		}
+	}
+}
+
+// TestCiphertextMarshalling tests that marshalling Ciphertexts to JSON and
+// back results in the same Ciphertext.
+func TestCiphertextMarshalling(t *testing.T) {
+	for _, test := range ciphertextMarshallingTests {
+		expectedCt := test.ct
+		// Create a copy of expectedCt so Unmarshalling does not modify
+		// it (we need it later for comparison).
+		var ct Ciphertext
+		if expectedCt == nil {
+			ct = nil
+		} else {
+			ct = make(Ciphertext, len(expectedCt))
+			copy(ct, expectedCt)
+		}
+
+		// Marshal ct to JSON.
+		jsonBytes, err := ct.MarshalJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// And then back to Ciphertext.
+		err = ct.UnmarshalJSON(jsonBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Compare original Ciphertext (expectedCt) with resulting Ciphertext (ct).
+		if expectedCt == nil && ct != nil || expectedCt != nil && ct == nil || !bytes.Equal(expectedCt, ct) {
+			t.Errorf("Ciphertext %#v marshalled incorrectly: got %#v\n", expectedCt, ct)
+		}
 	}
 }

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -8,9 +8,9 @@ package crypto
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"hash"
 
 	"github.com/NebulousLabs/Sia/encoding"
@@ -74,19 +74,21 @@ func (h Hash) MarshalJSON() ([]byte, error) {
 
 // String prints the hash in hex.
 func (h Hash) String() string {
-	return fmt.Sprintf("%x", h[:])
+	return hex.EncodeToString(h[:])
 }
 
 // UnmarshalJSON decodes the json hex string of the hash.
 func (h *Hash) UnmarshalJSON(b []byte) error {
+	// *2 because there are 2 hex characters per byte.
+	// +2 because the encoded JSON string has a `"` added at the beginning and end.
 	if len(b) != HashSize*2+2 {
 		return ErrHashWrongLen
 	}
 
-	var hBytes []byte
-	_, err := fmt.Sscanf(string(b[1:len(b)-1]), "%x", &hBytes)
+	// b[1 : len(b)-1] cuts off the leading and trailing `"` in the JSON string.
+	hBytes, err := hex.DecodeString(string(b[1 : len(b)-1]))
 	if err != nil {
-		return errors.New("could not unmarshal crypto.Hash: " + err.Error())
+		return err
 	}
 	copy(h[:], hBytes)
 	return nil

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -88,7 +88,7 @@ func (h *Hash) UnmarshalJSON(b []byte) error {
 	// b[1 : len(b)-1] cuts off the leading and trailing `"` in the JSON string.
 	hBytes, err := hex.DecodeString(string(b[1 : len(b)-1]))
 	if err != nil {
-		return err
+		return errors.New("could not unmarshal crypto.Hash: " + err.Error())
 	}
 	copy(h[:], hBytes)
 	return nil

--- a/crypto/merkle_test.go
+++ b/crypto/merkle_test.go
@@ -16,7 +16,7 @@ func TestTreeBuilder(t *testing.T) {
 	bytes := [][]byte{{1}, {2}}
 	_ = MerkleRoot(bytes)
 
-	// correctness is assumed, as it's tested by the merkletree package. This
+	// Correctness is assumed, as it's tested by the merkletree package. This
 	// function is really for code coverage.
 }
 
@@ -44,7 +44,7 @@ func TestCalculateLeaves(t *testing.T) {
 // TestStorageProof builds a storage proof and checks that it verifies
 // correctly.
 func TestStorageProof(t *testing.T) {
-	// generate proof data
+	// Generate proof data.
 	numSegments := uint64(7)
 	data := make([]byte, numSegments*SegmentSize)
 	rand.Read(data)
@@ -53,7 +53,7 @@ func TestStorageProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// create and verify proofs for all indices
+	// Create and verify proofs for all indices.
 	for i := uint64(0); i < numSegments; i++ {
 		baseSegment, hashSet, err := BuildReaderProof(bytes.NewReader(data), i)
 		if err != nil {
@@ -75,10 +75,10 @@ func TestStorageProof(t *testing.T) {
 	}
 }
 
-// TestPaddedStorageProof builds a storage proof that has padding in the last
-// segment, and then requests a proof on the padded segment.
-func TestPaddedStorageProof(t *testing.T) {
-	// generate proof data
+// TestNonMultipleNumberOfSegmentsStorageProof builds a storage proof that has
+// a last leaf of size less than SegmentSize.
+func TestNonMultipleLeafSizeStorageProof(t *testing.T) {
+	// Generate proof data.
 	data := make([]byte, (2*SegmentSize)+10)
 	rand.Read(data)
 	rootHash, err := ReaderMerkleRoot(bytes.NewReader(data))
@@ -86,7 +86,7 @@ func TestPaddedStorageProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// create and verify a proof for the last index.
+	// Create and verify a proof for the last index.
 	baseSegment, hashSet, err := BuildReaderProof(bytes.NewReader(data), 2)
 	if err != nil {
 		t.Error(err)
@@ -113,24 +113,24 @@ func TestReadSegments(t *testing.T) {
 	}
 	rootHash := m.Root()
 
-	// Generate merkle tree root using ReaderMerkleRoot
+	// Generate merkle tree root using ReaderMerkleRoot.
 	expectedHash, err := ReaderMerkleRoot(bytes.NewReader(data))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Compare roots
+	// Compare roots.
 	if rootHash != expectedHash {
 		t.Errorf("root hashes not consistent: expected %s, got %s\n", expectedHash, rootHash)
 	}
 }
 
-// TestPartialLastLeafReadSegments tests MerkleTree.ReadSements for data that
-// doesn't fit evently into a whole number of leaves. It does so by building a
-// MerkleTree with MerkleTree.ReadSegments and comparing its root with the root
-// returned from ReaderMerkleRoot.
-func TestPartialLastLeafReadSegments(t *testing.T) {
-	// Generate leaf data that doesn't fit evenly into n leaves.
+// TestNonMultipleNumberOfSegmentsReadSegments tests MerkleTree.ReadSements for
+// data that doesn't fit evently into a whole number of leaves. It does so by
+// building a MerkleTree with MerkleTree.ReadSegments and comparing its root
+// with the root returned from ReaderMerkleRoot.
+func TestNonMultipleNumberOfSegmentsReadSegments(t *testing.T) {
+	// Generate leaf data that doesn't fit evenly into leaves.
 	numSegments := 2.5
 	data := make([]byte, int(numSegments*SegmentSize))
 	rand.Read(data)
@@ -144,13 +144,13 @@ func TestPartialLastLeafReadSegments(t *testing.T) {
 	}
 	rootHash := m.Root()
 
-	// Generate merkle tree root using ReaderMerkleRoot
+	// Generate merkle tree root using ReaderMerkleRoot.
 	expectedHash, err := ReaderMerkleRoot(bytes.NewReader(data))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Compare roots
+	// Compare roots.
 	if rootHash != expectedHash {
 		t.Errorf("root hashes not consistent: expected %s, got %s\n", expectedHash, rootHash)
 	}

--- a/crypto/merkle_test.go
+++ b/crypto/merkle_test.go
@@ -95,3 +95,63 @@ func TestPaddedStorageProof(t *testing.T) {
 		t.Error("padded segment proof failed")
 	}
 }
+
+// TestReadSegments tests MerkleTree.ReadSegments by building a MerkleTree and
+// comparing its root with the root returned from ReaderMerkleRoot.
+func TestReadSegments(t *testing.T) {
+	// Generate leaf data.
+	numSegments := 7
+	data := make([]byte, numSegments*SegmentSize)
+	rand.Read(data)
+
+	// Generate merkle tree root using MerkleTree.ReadSegments and
+	// MerkleTree.Root.
+	m := NewTree()
+	err := m.ReadSegments(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootHash := m.Root()
+
+	// Generate merkle tree root using ReaderMerkleRoot
+	expectedHash, err := ReaderMerkleRoot(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare roots
+	if rootHash != expectedHash {
+		t.Errorf("root hashes not consistent: expected %s, got %s\n", expectedHash, rootHash)
+	}
+}
+
+// TestPartialLastLeafReadSegments tests MerkleTree.ReadSements for data that
+// doesn't fit evently into a whole number of leaves. It does so by building a
+// MerkleTree with MerkleTree.ReadSegments and comparing its root with the root
+// returned from ReaderMerkleRoot.
+func TestPartialLastLeafReadSegments(t *testing.T) {
+	// Generate leaf data that doesn't fit evenly into n leaves.
+	numSegments := 2.5
+	data := make([]byte, int(numSegments*SegmentSize))
+	rand.Read(data)
+
+	// Generate merkle tree root using MerkleTree.ReadSegments and
+	// MerkleTree.Root.
+	m := NewTree()
+	err := m.ReadSegments(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootHash := m.Root()
+
+	// Generate merkle tree root using ReaderMerkleRoot
+	expectedHash, err := ReaderMerkleRoot(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare roots
+	if rootHash != expectedHash {
+		t.Errorf("root hashes not consistent: expected %s, got %s\n", expectedHash, rootHash)
+	}
+}

--- a/crypto/rand.go
+++ b/crypto/rand.go
@@ -12,8 +12,8 @@ func RandBytes(n int) ([]byte, error) {
 	return b, err
 }
 
-// RandIntn returns a non-negative random integer in the range [0,n). It
-// panics if n <= 0.
+// RandIntn returns a non-negative random integer in the range [0,n). It panics
+// if n <= 0.
 func RandIntn(n int) (int, error) {
 	r, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
 	return int(r.Int64()), err

--- a/crypto/rand_test.go
+++ b/crypto/rand_test.go
@@ -4,9 +4,7 @@ import (
 	"testing"
 )
 
-// TestRandIntnPanics tests that RandIntn panics if n <= 0. The crypto/rand
-// package guarantees that rand.Int will panic if n <= 0, but other random
-// packages might not.
+// TestRandIntnPanics tests that RandIntn panics if n <= 0.
 func TestRandIntnPanics(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {

--- a/crypto/rand_test.go
+++ b/crypto/rand_test.go
@@ -1,0 +1,18 @@
+package crypto
+
+import (
+	"testing"
+)
+
+// TestRandIntnPanics tests that RandIntn panics if n <= 0. The crypto/rand
+// package guarantees that rand.Int will panic if n <= 0, but other random
+// packages might not.
+func TestRandIntnPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for n <= 0")
+		}
+	}()
+	RandIntn(0)
+	RandIntn(-1)
+}


### PR DESCRIPTION
Brings tests coverage for the crypto package from 74.2% to 91.6%. No mocking was used in the tests added. The remaining tests necessary to bring the package up to 100% coverage will require mocking.

**NOTE: TestPartialLastLeafReadSegments will fail (as it should) until PR #880 is merged.**

Tests added:
- discard_test.go
  - TestUnitSecureWipe
  - TestUnitSecureWipeEdgeCases
- encrypt_test.go
  - TestUnitCiphertextUnmarshalJSON
  - TestCiphertextMarshalling
- hash_test.go
  - TestUnitHashMarshalJSON
  - TestUnitHashUnmarshalJSON
- merkle_test.go
  - TestReadSegments
  - TestPartialLastLeafReadSegments
- rand_test.go
  - TestRandIntnPanics

Besides tests, `Hash.String` and `Hash.UnmarshalJSON` were modified to encode / decode hashes to / from strings using `hex.EncodeToString` and `hex.DecodeString`, respectively. The previous implementation used `fmt.Printf` and `fmt.Scanf`. Unlike the fmt package, the hex package does not use reflection. The intent of the code is also more clear with the hex package.