### PR TITLE
Crypto errcheck

### DIFF
--- a/crypto/encrypt.go
+++ b/crypto/encrypt.go
@@ -36,6 +36,7 @@ func GenerateTwofishKey() (key TwofishKey, err error) {
 // NewCipher creates a new Twofish cipher from the key.
 func (key TwofishKey) NewCipher() cipher.Block {
 	// NOTE: NewCipher only returns an error if len(key) != 16, 24, or 32.
+	//       Assumption tested in TestTwofishNewCipherAssumption.
 	cipher, _ := twofish.NewCipher(key[:])
 	return cipher
 }
@@ -45,6 +46,7 @@ func (key TwofishKey) NewCipher() cipher.Block {
 func (key TwofishKey) EncryptBytes(plaintext []byte) (Ciphertext, error) {
 	// Create the cipher.
 	// NOTE: NewGCM only returns an error if twofishCipher.BlockSize != 16.
+	//       Assumption tested in TestCipherNewGCMAssumption.
 	aead, _ := cipher.NewGCM(key.NewCipher())
 
 	// Create the nonce.
@@ -63,6 +65,7 @@ func (key TwofishKey) EncryptBytes(plaintext []byte) (Ciphertext, error) {
 func (key TwofishKey) DecryptBytes(ct Ciphertext) ([]byte, error) {
 	// Create the cipher.
 	// NOTE: NewGCM only returns an error if twofishCipher.BlockSize != 16.
+	//       Assumption tested in TestCipherNewGCMAssumption.
 	aead, _ := cipher.NewGCM(key.NewCipher())
 
 	// Check for a nonce.

--- a/crypto/encrypt.go
+++ b/crypto/encrypt.go
@@ -36,7 +36,6 @@ func GenerateTwofishKey() (key TwofishKey, err error) {
 // NewCipher creates a new Twofish cipher from the key.
 func (key TwofishKey) NewCipher() cipher.Block {
 	// NOTE: NewCipher only returns an error if len(key) != 16, 24, or 32.
-	//       Assumption tested in TestTwofishNewCipherAssumption.
 	cipher, _ := twofish.NewCipher(key[:])
 	return cipher
 }
@@ -46,7 +45,6 @@ func (key TwofishKey) NewCipher() cipher.Block {
 func (key TwofishKey) EncryptBytes(plaintext []byte) (Ciphertext, error) {
 	// Create the cipher.
 	// NOTE: NewGCM only returns an error if twofishCipher.BlockSize != 16.
-	//       Assumption tested in TestCipherNewGCMAssumption.
 	aead, _ := cipher.NewGCM(key.NewCipher())
 
 	// Create the nonce.
@@ -65,7 +63,6 @@ func (key TwofishKey) EncryptBytes(plaintext []byte) (Ciphertext, error) {
 func (key TwofishKey) DecryptBytes(ct Ciphertext) ([]byte, error) {
 	// Create the cipher.
 	// NOTE: NewGCM only returns an error if twofishCipher.BlockSize != 16.
-	//       Assumption tested in TestCipherNewGCMAssumption.
 	aead, _ := cipher.NewGCM(key.NewCipher())
 
 	// Check for a nonce.

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -229,9 +229,9 @@ func TestTwofishNewCipherAssumption(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Test key length.
-	len := len(key)
-	if len != 16 && len != 24 && len != 32 {
-		t.Errorf("TwofishKey must have length 16, 24, or 32, but generated key has length %d\n", len)
+	keyLen := len(key)
+	if keyLen != 16 && keyLen != 24 && keyLen != 32 {
+		t.Errorf("TwofishKey must have length 16, 24, or 32, but generated key has length %d\n", keyLen)
 	}
 }
 

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -69,9 +69,15 @@ func TestTwofishEncryption(t *testing.T) {
 		t.Error("Expecting ErrInsufficientLen:", err)
 	}
 
-	// Try to trigger a panic with nil values.
-	key.EncryptBytes(nil)
-	key.DecryptBytes(nil)
+	// Try to trigger a panic or error with nil values.
+	_, err = key.EncryptBytes(nil)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = key.DecryptBytes(nil)
+	if err != ErrInsufficientLen {
+		t.Error("Expecting ErrInsufficientLen:", err)
+	}
 }
 
 // TestReaderWriter probes the NewReader and NewWriter methods of the key type.

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -218,3 +218,31 @@ func TestCiphertextMarshalling(t *testing.T) {
 		}
 	}
 }
+
+func TestTwofishNewCipherAssumption(t *testing.T) {
+	// Generate key.
+	key, err := GenerateTwofishKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Test that len(key) is 16, 24, or 32 as these are the only cases
+	// where twofish.NewCipher(key[:]) doesn't return an error.
+	len := len(key)
+	if len != 16 && len != 24 && len != 32 {
+		t.Errorf("TwofishKey must have length 16, 24, or 32, but generated key has length %d\n", len)
+	}
+}
+
+func TestCipherNewGCMAssumption(t *testing.T) {
+	// Generate a key and cipher block.
+	key, err := GenerateTwofishKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := key.NewCipher()
+	// Test that block.BlockSize() is 16, as this is the only case where
+	// cipher.NewGCM(block) doesn't return an error.
+	if block.BlockSize() != 16 {
+		t.Errorf("cipher must have BlockSize 16, but generated cipher has BlockSize %d\n", block.BlockSize())
+	}
+}

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -219,29 +219,32 @@ func TestCiphertextMarshalling(t *testing.T) {
 	}
 }
 
+// TestTwofishNewCipherAssumption tests that the length of a TwofishKey is 16,
+// 24, or 32 as these are the only cases where twofish.NewCipher(key[:])
+// doesn't return an error.
 func TestTwofishNewCipherAssumption(t *testing.T) {
 	// Generate key.
 	key, err := GenerateTwofishKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Test that len(key) is 16, 24, or 32 as these are the only cases
-	// where twofish.NewCipher(key[:]) doesn't return an error.
+	// Test key length.
 	len := len(key)
 	if len != 16 && len != 24 && len != 32 {
 		t.Errorf("TwofishKey must have length 16, 24, or 32, but generated key has length %d\n", len)
 	}
 }
 
+// TestCipherNewGCMAssumption tests that the BlockSize of a cipher block is 16,
+// as this is the only case where cipher.NewGCM(block) doesn't return an error.
 func TestCipherNewGCMAssumption(t *testing.T) {
-	// Generate a key and cipher block.
+	// Generate a key and then cipher block from key.
 	key, err := GenerateTwofishKey()
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Test block size.
 	block := key.NewCipher()
-	// Test that block.BlockSize() is 16, as this is the only case where
-	// cipher.NewGCM(block) doesn't return an error.
 	if block.BlockSize() != 16 {
 		t.Errorf("cipher must have BlockSize 16, but generated cipher has BlockSize %d\n", block.BlockSize())
 	}

--- a/crypto/rand.go
+++ b/crypto/rand.go
@@ -21,12 +21,16 @@ func RandIntn(n int) (int, error) {
 
 // Perm returns, as a slice of n ints, a random permutation of the integers
 // [0,n).
-func Perm(n int) []int {
+func Perm(n int) ([]int, error) {
 	m := make([]int, n)
 	for i := 0; i < n; i++ {
-		j, _ := RandIntn(i + 1)
+		j, err := RandIntn(i + 1)
+		if err != nil {
+			return nil, err
+		}
+
 		m[i] = m[j]
 		m[j] = i
 	}
-	return m
+	return m, nil
 }

--- a/crypto/rand_test.go
+++ b/crypto/rand_test.go
@@ -11,6 +11,14 @@ func TestRandIntnPanics(t *testing.T) {
 			t.Error("expected panic for n <= 0")
 		}
 	}()
-	RandIntn(0)
-	RandIntn(-1)
+
+	_, err := RandIntn(0)
+	if err != nil {
+		t.Error("expected panic on n <= 0, not error")
+	}
+
+	_, err = RandIntn(-1)
+	if err != nil {
+		t.Error("expected panic on n <= 0, not error")
+	}
 }

--- a/crypto/rand_test.go
+++ b/crypto/rand_test.go
@@ -4,21 +4,24 @@ import (
 	"testing"
 )
 
+// panics returns true if the function fn panicked.
+func panics(fn func()) (panicked bool) {
+	defer func() {
+		panicked = (recover() != nil)
+	}()
+	fn()
+	return
+}
+
 // TestRandIntnPanics tests that RandIntn panics if n <= 0.
 func TestRandIntnPanics(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for n <= 0")
-		}
-	}()
-
-	_, err := RandIntn(0)
-	if err != nil {
-		t.Error("expected panic on n <= 0, not error")
+	// Test n = 0.
+	if !panics(func() { RandIntn(0) }) {
+		t.Error("expected panic for n <= 0")
 	}
 
-	_, err = RandIntn(-1)
-	if err != nil {
-		t.Error("expected panic on n <= 0, not error")
+	// Test n < 0.
+	if !panics(func() { RandIntn(-1) }) {
+		t.Error("expected panic for n <= 0")
 	}
 }

--- a/modules/miner/blockmanager_test.go
+++ b/modules/miner/blockmanager_test.go
@@ -120,7 +120,10 @@ func TestIntegrationManyHeaders(t *testing.T) {
 	}
 
 	// Submit the headers randomly and make sure they are all considered valid.
-	selectionOrder := crypto.Perm(len(solvedHeaders))
+	selectionOrder, err := crypto.Perm(len(solvedHeaders))
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, selection := range selectionOrder {
 		err = mt.miner.SubmitHeader(solvedHeaders[selection])
 		if err != nil && err != modules.ErrNonExtendingBlock {

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -170,7 +170,11 @@ func (d *download) run(w io.Writer) error {
 		chunk := make([][]byte, d.erasureCode.NumPieces())
 		left := d.erasureCode.MinPieces()
 		// pick hosts at random
-		for _, j := range crypto.Perm(len(chunk)) {
+		chunkOrder, err := crypto.Perm(len(chunk))
+		if err != nil {
+			return err
+		}
+		for _, j := range chunkOrder {
 			chunk[j] = d.getPiece(i, uint64(j))
 			if chunk[j] != nil {
 				left--
@@ -189,7 +193,7 @@ func (d *download) run(w io.Writer) error {
 		if n > d.fileSize-received {
 			n = d.fileSize - received
 		}
-		err := d.erasureCode.Recover(chunk, uint64(n), w)
+		err = d.erasureCode.Recover(chunk, uint64(n), w)
 		if err != nil {
 			return err
 		}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -102,7 +102,10 @@ func startDaemon(config Config) error {
 	// Bootstrap to the network.
 	if !config.Siad.NoBootstrap {
 		// connect to 3 random bootstrap nodes
-		perm := crypto.Perm(len(modules.BootstrapPeers))
+		perm, err := crypto.Perm(len(modules.BootstrapPeers))
+		if err != nil {
+			return err
+		}
 		for _, i := range perm[:3] {
 			go gateway.Connect(modules.BootstrapPeers[i])
 		}


### PR DESCRIPTION
Used `errcheck -blank github.com/NebulousLabs/Sia/crypto/...` to find places where errors weren't being checked, and checked them.

The remaining unchecked errors are listed below. Other than the first three, all of the remaining unchecked errors are in tests and are calls to standard library packages that we can assume return `nil` on a working system, so they can be ignored.

The first three unchecked errors below assume that an error can not occur. See issue #883. For these cases tests were added to verify these assumptions.

```
/Users/jordan/Projects/Sia/crypto/encrypt.go:40:10	cipher, _ := twofish.NewCipher(key[:])
/Users/jordan/Projects/Sia/crypto/encrypt.go:50:8	aead, _ := cipher.NewGCM(key.NewCipher())
/Users/jordan/Projects/Sia/crypto/encrypt.go:69:8	aead, _ := cipher.NewGCM(key.NewCipher())
/Users/jordan/Projects/Sia/crypto/encrypt_test.go:101:26	key.NewWriter(buf).Write(plaintext)
/Users/jordan/Projects/Sia/crypto/encrypt_test.go:110:25	key.NewReader(buf).Read(decrypted)
/Users/jordan/Projects/Sia/crypto/encrypt_test.go:145:11	zip.Close()
/Users/jordan/Projects/Sia/crypto/hash_test.go:54:11	rand.Read(data)
/Users/jordan/Projects/Sia/crypto/merkle_test.go:50:11	rand.Read(data)
/Users/jordan/Projects/Sia/crypto/merkle_test.go:83:11	rand.Read(data)
/Users/jordan/Projects/Sia/crypto/merkle_test.go:105:11	rand.Read(data)
/Users/jordan/Projects/Sia/crypto/merkle_test.go:136:11	rand.Read(data)
/Users/jordan/Projects/Sia/crypto/signatures_test.go:156:11	rand.Read(signedData[:])
/Users/jordan/Projects/Sia/crypto/signatures_test.go:197:12	rand.Read(randData[:])
```