### PR TITLE
Add tests for safeFiles

### DIFF
--- a/persist/persist.go
+++ b/persist/persist.go
@@ -49,8 +49,17 @@ type safeFile struct {
 	finalName string
 }
 
-// Commit renames the file to the intended final filename.
+// Commit syncs the file and then renames it to the intended final filename.
+// Writing to the file after calling Commit will succeed but will write to the
+// final file location (sf.Name() will deceptively still point to the old file
+// location).  Therefore it is recommended that the file handle be closed
+// immediately after calling Commit. Note that the file must not be closed
+// before calling commit as this will cause the sync to fail.
 func (sf *safeFile) Commit() error {
+	err := sf.Sync()
+	if err != nil {
+		return err
+	}
 	return os.Rename(sf.finalName+"_temp", sf.finalName)
 }
 

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base32"
 	"errors"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -60,5 +61,14 @@ func NewSafeFile(filename string) (*safeFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &safeFile{file, filename}, nil
+
+	// Get the absolute path of the filename so that calling os.Chdir in
+	// between calling NewSafeFile and calling safeFile.Commit does not change
+	// the final file path.
+	absFilename, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return &safeFile{file, absFilename}, nil
 }

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -26,3 +26,69 @@ func TestIntegrationRandomSuffix(t *testing.T) {
 		file.Close()
 	}
 }
+
+// TestUnitNewSafeFile checks that a new file is created and that its name is
+// different than the finalName of the new safeFile.
+func TestUnitNewSafeFile(t *testing.T) {
+	// Create safe file.
+	sf, err := NewSafeFile("NewSafeFile test file" + RandomSuffix())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(sf.Name())
+	defer sf.Close()
+
+	// Check that the name of the file is not equal to the final name of the
+	// file.
+	if sf.Name() == sf.finalName {
+		t.Errorf("safeFile temporary filename and finalName are equivalent: %s\n", sf.Name())
+	}
+}
+
+// testSafeFileWithPath tests creating and committing safe files with a
+// specified path.
+func testSafeFileWithPath(filename string, t *testing.T) {
+	// Create safe file.
+	sf, err := NewSafeFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// These two defers seem redundant but are not. If sf.Commit() fails to
+	// move the file then the first defer is necessary. Otherwise the second
+	// defer is necessary.
+	defer os.Remove(sf.Name())
+	defer os.Remove(sf.finalName)
+
+	// Check that the name of the file is not equal to the final name of the
+	// file.
+	if sf.Name() == sf.finalName {
+		t.Errorf("safeFile temporary filename and finalName are equivalent: %s\n", sf.Name())
+	}
+
+	sf.Close()
+	err = sf.Commit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that commiting moved the file to the originally specified path.
+	_, err = os.Stat(filename)
+	if err != nil {
+		t.Fatal("safeFile not committed correctly.")
+	}
+}
+
+// TestAbsolutePathSafeFile tests that safe files created with an absolute path
+// are created and committed correctly.
+func TestAbsolutePathSafeFile(t *testing.T) {
+	filename := filepath.Join(os.TempDir(), "NewSafeFile test file"+RandomSuffix())
+	absFilename, _ := filepath.Abs(filename)
+	testSafeFileWithPath(absFilename, t)
+}
+
+// TestRelativePathSafeFile tests that safe files created with a relative path
+// are created and committed correctly.
+func TestRelativePathSafeFile(t *testing.T) {
+	filename := filepath.Join(os.TempDir(), "NewSafeFile test file"+RandomSuffix())
+	testSafeFileWithPath(filename, t)
+}

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -3,6 +3,7 @@ package persist
 import (
 	"bytes"
 	"crypto/rand"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -65,17 +66,10 @@ func TestAbsolutePathSafeFile(t *testing.T) {
 	}
 
 	// Check that the file exists and has same data that was written to it.
-	f, err := os.Open(absPath)
-	defer f.Close()
+	dataRead, err := ioutil.ReadFile(absPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dataRead := make([]byte, 11)
-	n, err := f.Read(dataRead)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dataRead = dataRead[:n]
 	if !bytes.Equal(data, dataRead) {
 		t.Fatalf("Committed file has different data than was written to it: expected %v, got %v\n", data, dataRead)
 	}
@@ -133,17 +127,10 @@ func TestRelativePathSafeFile(t *testing.T) {
 	}
 
 	// Check that the file exists and has same data that was written to it.
-	f, err := os.Open(absPath)
-	defer f.Close()
+	dataRead, err := ioutil.ReadFile(absPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dataRead := make([]byte, 11)
-	n, err := f.Read(dataRead)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dataRead = dataRead[:n]
 	if !bytes.Equal(data, dataRead) {
 		t.Fatalf("Committed file has different data than was written to it: expected %v, got %v\n", data, dataRead)
 	}

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -81,11 +81,11 @@ func TestSafeFile(t *testing.T) {
 		}
 
 		// Check that committing doesn't return an error.
-		sf.Close()
 		err = sf.Commit()
 		if err != nil {
 			t.Fatal(err)
 		}
+		sf.Close()
 
 		// Check that commiting moved the file to the originally specified path.
 		_, err = os.Stat(filename)


### PR DESCRIPTION
~~Use `ioutil.TempFile` instead of adding a "_temp" suffix when creating a new `safeFile`.~~

Added tests as well.