### PR TITLE
Define GenesisBlock in types package

### DIFF
--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -60,8 +60,7 @@ func TestIntegrationConsensusBlockGET(t *testing.T) {
 	}
 
 	// Sanity check - BlockAtHeight should be working.
-	gb := st.cs.GenesisBlock()
-	if block1.ParentID != gb.ID() {
+	if block1.ParentID != types.GenesisBlock.ID() {
 		t.Fatal("genesis block and block1 mismatch")
 	}
 }

--- a/api/explorer_test.go
+++ b/api/explorer_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"testing"
+
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // TestIntegrationExplorerGET probes the GET call to /explorer.
@@ -47,7 +49,7 @@ func TestIntegrationExplorerBlockGET(t *testing.T) {
 	if ebg.Block.BlockID != ebg.Block.RawBlock.ID() {
 		t.Error("block id and block do not match up from api call")
 	}
-	if st.server.cs.GenesisBlock().ID() != ebg.Block.BlockID {
+	if ebg.Block.BlockID != types.GenesisBlock.ID() {
 		t.Error("wrong block returned by /explorer/block?height=0")
 	}
 }
@@ -64,7 +66,7 @@ func TestIntegrationExplorerGEThash(t *testing.T) {
 	defer st.server.Close()
 
 	var ehg ExplorerHashGET
-	gb := st.server.cs.GenesisBlock()
+	gb := types.GenesisBlock
 	err = st.getAPI("/explorer/"+gb.ID().String(), &ehg)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -191,9 +191,6 @@ type (
 		// blockchain.
 		CurrentBlock() types.Block
 
-		// GenesisBlock returns the genesis block.
-		GenesisBlock() types.Block
-
 		// Height returns the current height of consensus.
 		Height() types.BlockHeight
 

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -73,20 +73,12 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 		return nil, errNilGateway
 	}
 
-	// Create the genesis block.
-	genesisBlock := types.Block{
-		Timestamp: types.GenesisTimestamp,
-		Transactions: []types.Transaction{
-			{SiafundOutputs: types.GenesisSiafundAllocation},
-		},
-	}
-
 	// Create the ConsensusSet object.
 	cs := &ConsensusSet{
 		gateway: gateway,
 
 		blockRoot: processedBlock{
-			Block:       genesisBlock,
+			Block:       types.GenesisBlock,
 			ChildTarget: types.RootTarget,
 			Depth:       types.RootDepth,
 
@@ -103,8 +95,8 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 	}
 
 	// Create the diffs for the genesis siafund outputs.
-	for i, siafundOutput := range genesisBlock.Transactions[0].SiafundOutputs {
-		sfid := genesisBlock.Transactions[0].SiafundOutputID(uint64(i))
+	for i, siafundOutput := range types.GenesisBlock.Transactions[0].SiafundOutputs {
+		sfid := types.GenesisBlock.Transactions[0].SiafundOutputID(uint64(i))
 		sfod := modules.SiafundOutputDiff{
 			Direction:     modules.DiffApply,
 			ID:            sfid,
@@ -174,15 +166,6 @@ func (cs *ConsensusSet) CurrentBlock() (block types.Block) {
 		return nil
 	})
 	return block
-}
-
-// GenesisBlock returns the genesis block.
-func (cs *ConsensusSet) GenesisBlock() types.Block {
-	// GenesisBlock is called fairly frequently, and should not have to do any
-	// I/O as a lookup.
-	cs.mu.RLock()
-	defer cs.mu.RUnlock()
-	return cs.blockRoot.Block
 }
 
 // Height returns the height of the consensus set.

--- a/modules/explorer/info_test.go
+++ b/modules/explorer/info_test.go
@@ -36,7 +36,7 @@ func TestBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gb := et.cs.GenesisBlock()
+	gb := types.GenesisBlock
 	gbFetch, height, exists := et.explorer.Block(gb.ID())
 	if !exists || height != 0 || gbFetch.ID() != gb.ID() {
 		t.Error("call to 'Block' inside explorer failed")
@@ -53,7 +53,7 @@ func TestBlockFacts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gb := et.cs.GenesisBlock()
+	gb := types.GenesisBlock
 	bf, exists := et.explorer.BlockFacts(0)
 	if !exists || bf.BlockID != gb.ID() || bf.Height != 0 {
 		t.Error("call to 'BlockFacts' inside explorer failed")

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -118,7 +118,7 @@ func (h *Host) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// Checking the height here eliminates the need to initialize the host to
 	// and underflowed types.BlockHeight.
 	oldHeight := h.blockHeight
-	if h.blockHeight != 0 || cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID() != h.cs.GenesisBlock().ID() {
+	if h.blockHeight != 0 || cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID() != types.GenesisBlock.ID() {
 		h.blockHeight -= types.BlockHeight(len(cc.RevertedBlocks))
 		h.blockHeight += types.BlockHeight(len(cc.AppliedBlocks))
 	}

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -19,7 +19,7 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// Checking the height here eliminates the need to initialize the miner to
 	// an underflowed types.BlockHeight, which was deemed the worse of the two
 	// evils.
-	if m.persist.Height != 0 || cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID() != m.cs.GenesisBlock().ID() {
+	if m.persist.Height != 0 || cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID() != types.GenesisBlock.ID() {
 		m.persist.Height -= types.BlockHeight(len(cc.RevertedBlocks))
 		m.persist.Height += types.BlockHeight(len(cc.AppliedBlocks))
 	}

--- a/modules/renter/hostdb/update.go
+++ b/modules/renter/hostdb/update.go
@@ -43,7 +43,7 @@ func (hdb *HostDB) ProcessConsensusChange(cc modules.ConsensusChange) {
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
 
-	if hdb.blockHeight != 0 || cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID() != hdb.cs.GenesisBlock().ID() {
+	if hdb.blockHeight != 0 || cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID() != types.GenesisBlock.ID() {
 		hdb.blockHeight += types.BlockHeight(len(cc.AppliedBlocks))
 		hdb.blockHeight -= types.BlockHeight(len(cc.RevertedBlocks))
 	}

--- a/types/constants.go
+++ b/types/constants.go
@@ -34,6 +34,7 @@ var (
 	MinimumCoinbase  uint64
 
 	GenesisSiafundAllocation []SiafundOutput
+	GenesisBlock             Block
 )
 
 // init checks which build constant is in place and initializes the variables
@@ -359,5 +360,13 @@ func init() {
 				UnlockHash: UnlockHash{125, 12, 68, 247, 102, 78, 45, 52, 229, 62, 253, 224, 102, 26, 111, 98, 142, 201, 38, 71, 133, 174, 142, 60, 215, 201, 115, 232, 209, 144, 195, 201},
 			},
 		}
+	}
+
+	// Create the genesis block.
+	GenesisBlock = Block{
+		Timestamp: GenesisTimestamp,
+		Transactions: []Transaction{
+			{SiafundOutputs: GenesisSiafundAllocation},
+		},
 	}
 }


### PR DESCRIPTION
I opted for the smallest possible diff here, but one alternative would be to define `GenesisBlock` *instead* of `GenesisSiafundAllocation` (and maybe `GenesisTimestamp` as well), since those values can easily be obtained by via `GenesisBlock`.