### PR TITLE
Renter Paths

### DIFF
--- a/api/host_test.go
+++ b/api/host_test.go
@@ -1,14 +1,12 @@
 package api
 
 import (
-	"io/ioutil"
 	"net/url"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
-	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -32,11 +30,7 @@ func TestIntegrationHosting(t *testing.T) {
 
 	// create a file
 	path := filepath.Join(build.SiaTestingDir, "api", "TestIntegrationHosting", "test.dat")
-	data, err := crypto.RandBytes(1024)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(path, data, 0600)
+	err = createRandFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,11 +88,7 @@ func TestIntegrationRenewing(t *testing.T) {
 
 	// create a file
 	path := filepath.Join(build.SiaTestingDir, "api", "TestIntegrationRenewing", "test.dat")
-	data, err := crypto.RandBytes(1024)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(path, data, 0600)
+	err = createRandFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -25,20 +25,9 @@ func TestIntegrationHosting(t *testing.T) {
 	defer st.server.Close()
 
 	// Announce the host.
-	announceValues := url.Values{}
-	announceValues.Set("address", string(st.host.NetAddress()))
-	err = st.stdPostAPI("/host/announce", announceValues)
+	err = st.announceHost()
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// mine block and wait for announcement to register
-	st.miner.AddBlock()
-	var hosts ActiveHosts
-	time.Sleep(1 * time.Second)
-	st.getAPI("/renter/hosts/active", &hosts)
-	if len(hosts.Hosts) == 0 {
-		t.Fatal("host announcement not seen")
 	}
 
 	// create a file
@@ -98,20 +87,9 @@ func TestIntegrationRenewing(t *testing.T) {
 	defer st.server.Close()
 
 	// Announce the host.
-	announceValues := url.Values{}
-	announceValues.Set("address", string(st.host.NetAddress()))
-	err = st.stdPostAPI("/host/announce", announceValues)
+	err = st.announceHost()
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// mine block and wait for announcement to register
-	st.miner.AddBlock()
-	var hosts ActiveHosts
-	time.Sleep(1 * time.Second)
-	st.getAPI("/renter/hosts/active", &hosts)
-	if len(hosts.Hosts) == 0 {
-		t.Fatal("host announcement not seen")
 	}
 
 	// create a file

--- a/api/renter.go
+++ b/api/renter.go
@@ -127,7 +127,7 @@ func (srv *Server) renterShareHandler(w http.ResponseWriter, req *http.Request, 
 // renterShareAsciiHandler handles the API call to return a '.sia' file
 // in ascii form.
 func (srv *Server) renterShareAsciiHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	ascii, err := srv.renter.ShareFilesAscii([]string{ps.ByName("path")})
+	ascii, err := srv.renter.ShareFilesAscii(strings.Split(req.FormValue("path"), ","))
 	if err != nil {
 		writeError(w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/renter.go
+++ b/api/renter.go
@@ -92,7 +92,7 @@ func (srv *Server) renterFilesHandler(w http.ResponseWriter, req *http.Request, 
 // renterDeleteHander handles the API call to delete a file entry from the
 // renter.
 func (srv *Server) renterDeleteHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	err := srv.renter.DeleteFile(ps.ByName("path"))
+	err := srv.renter.DeleteFile(strings.TrimPrefix(ps.ByName("path"), "/"))
 	if err != nil {
 		writeError(w, err.Error(), http.StatusBadRequest)
 		return
@@ -103,7 +103,7 @@ func (srv *Server) renterDeleteHandler(w http.ResponseWriter, req *http.Request,
 
 // renterDownloadHandler handles the API call to download a file.
 func (srv *Server) renterDownloadHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	err := srv.renter.Download(ps.ByName("path"), req.FormValue("destination"))
+	err := srv.renter.Download(strings.TrimPrefix(ps.ByName("path"), "/"), req.FormValue("destination"))
 	if err != nil {
 		writeError(w, "Download failed: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -150,7 +150,7 @@ func (srv *Server) renterUploadHandler(w http.ResponseWriter, req *http.Request,
 	renew := req.FormValue("renew") == "true"
 	err := srv.renter.Upload(modules.FileUploadParams{
 		Filename: req.FormValue("source"),
-		Nickname: ps.ByName("path"),
+		Nickname: strings.TrimPrefix(ps.ByName("path"), "/"),
 		Duration: duration,
 		Renew:    renew,
 		// let the renter decide these values; eventually they will be configurable

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -3,13 +3,22 @@ package api
 import (
 	"io/ioutil"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules/renter"
 )
+
+// createRandFile creates a file on disk and fills it with random bytes.
+func createRandFile(path string) error {
+	data, err := crypto.RandBytes(1024)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, data, 0600)
+}
 
 // TestRenterPaths tests that the /renter routes handle path parameters
 // properly.
@@ -30,13 +39,8 @@ func TestRenterPaths(t *testing.T) {
 	}
 
 	// Create a file.
-	stDir := filepath.Join(build.SiaTestingDir, "api", "TestRenterPaths")
-	path := filepath.Join(stDir, "test.dat")
-	data, err := crypto.RandBytes(1024)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(path, data, 0600)
+	path := filepath.Join(build.SiaTestingDir, "api", "TestRenterPaths", "test.dat")
+	err = createRandFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,18 +54,71 @@ func TestRenterPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Renter should have created foo/bar structure.
-	// (See modules/renter/persist_test.go for details on this test)
-	var walkStr string
-	filepath.Walk(stDir, func(path string, _ os.FileInfo, _ error) error {
-		if filepath.Ext(path) == ".sia" {
-			rel, _ := filepath.Rel(stDir, path)
-			walkStr += rel
-		}
-		return nil
-	})
-	expWalkStr := "renter/foo/bar/test.sia"
-	if walkStr != expWalkStr {
-		t.Fatalf("Bad walk string: expected %v, got %v", expWalkStr, walkStr)
+	// File should be listed by the renter.
+	var rf RenterFiles
+	err = st.getAPI("/renter/files", &rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rf.Files) != 1 || rf.Files[0].Nickname != "foo/bar/test" {
+		t.Fatal("/renter/files did not return correct file:", rf)
+	}
+}
+
+// TestRenterConflicts tests that the renter handles naming conflicts properly.
+func TestRenterConflicts(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestRenterConflicts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Announce the host.
+	err = st.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file.
+	path := filepath.Join(build.SiaTestingDir, "api", "TestRenterConflicts", "test.dat")
+	err = createRandFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload to host, using a path designed to cause conflicts. The renter
+	// should automatically create a folder called foo/bar.sia. Later, we'll
+	// exploit this by uploading a file called foo/bar.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	uploadValues.Set("renew", "true")
+	err = st.stdPostAPI("/renter/upload/foo/bar.sia/test", uploadValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// File should be listed by the renter.
+	var rf RenterFiles
+	err = st.getAPI("/renter/files", &rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rf.Files) != 1 || rf.Files[0].Nickname != "foo/bar.sia/test" {
+		t.Fatal("/renter/files did not return correct file:", rf)
+	}
+
+	// Upload using the same nickname.
+	err = st.stdPostAPI("/renter/upload/foo/bar.sia/test", uploadValues)
+	if err == renter.ErrDuplicateNickname {
+		t.Fatalf("expected %v, got %v", renter.ErrDuplicateNickname, err)
+	}
+
+	// Upload using nickname that conflicts with folder.
+	err = st.stdPostAPI("/renter/upload/foo/bar", uploadValues)
+	if err == nil {
+		t.Fatal("expecting conflict error, got nil")
 	}
 }

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+)
+
+// TestRenterPaths tests that the /renter routes handle path parameters
+// properly.
+func TestRenterPaths(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestRenterPaths")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Announce the host.
+	err = st.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file.
+	stDir := filepath.Join(build.SiaTestingDir, "api", "TestRenterPaths")
+	path := filepath.Join(stDir, "test.dat")
+	data, err := crypto.RandBytes(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(path, data, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload to host.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	uploadValues.Set("renew", "true")
+	err = st.stdPostAPI("/renter/upload/foo/bar/test", uploadValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Renter should have created foo/bar structure.
+	// (See modules/renter/persist_test.go for details on this test)
+	var walkStr string
+	filepath.Walk(stDir, func(path string, _ os.FileInfo, _ error) error {
+		if filepath.Ext(path) == ".sia" {
+			rel, _ := filepath.Rel(stDir, path)
+			walkStr += rel
+		}
+		return nil
+	})
+	expWalkStr := "renter/foo/bar/test.sia"
+	if walkStr != expWalkStr {
+		t.Fatalf("Bad walk string: expected %v, got %v", expWalkStr, walkStr)
+	}
+}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -243,9 +243,13 @@ func (st *serverTester) announceHost() error {
 	}
 	// mine block
 	st.miner.AddBlock()
+	// wait for announcement
 	var hosts ActiveHosts
-	time.Sleep(1 * time.Second)
 	st.getAPI("/renter/hosts/active", &hosts)
+	for i := 0; i < 20 && len(hosts.Hosts) == 0; i++ {
+		time.Sleep(100 * time.Millisecond)
+		st.getAPI("/renter/hosts/active", &hosts)
+	}
 	if len(hosts.Hosts) == 0 {
 		return errors.New("host announcement not seen")
 	}

--- a/doc/API.md
+++ b/doc/API.md
@@ -734,7 +734,7 @@ struct {
 	}
 }
 ```
-See /renter/hosts/active for a description of each field.
+See /renter/hosts/all for a description of each field.
 
 #### /renter/hosts/all [GET]
 

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -124,6 +124,9 @@ func newHostTester(name string) (*hostTester, error) {
 // TestHostInitialization checks that the host intializes to sensisble default
 // values.
 func TestHostInitialization(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	// Create a blank host tester and check that the height is zero.
 	bht, err := blankHostTester("TestHostInitialization")
 	if err != nil {

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -63,7 +63,8 @@ func (f *file) chunkSize() uint64 {
 // numChunks returns the number of chunks that f was split into.
 func (f *file) numChunks() uint64 {
 	n := f.size / f.chunkSize()
-	if f.size%f.chunkSize() != 0 {
+	// last chunk may have padding
+	if f.size%f.chunkSize() != 0 || f.size == 0 {
 		n++
 	}
 	return n

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -62,9 +62,13 @@ func (f *file) chunkSize() uint64 {
 
 // numChunks returns the number of chunks that f was split into.
 func (f *file) numChunks() uint64 {
+	// empty files still need at least one chunk
+	if f.size == 0 {
+		return 1
+	}
 	n := f.size / f.chunkSize()
-	// last chunk may have padding
-	if f.size%f.chunkSize() != 0 || f.size == 0 {
+	// last chunk will be padded, unless chunkSize divides file evenly.
+	if f.size%f.chunkSize() != 0 {
 		n++
 	}
 	return n

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// TestFileNumChunks checks the numChunks method of the file type.
+func TestFileNumChunks(t *testing.T) {
+	tests := []struct {
+		size           uint64
+		pieceSize      uint64
+		piecesPerChunk int
+		expNumChunks   uint64
+	}{
+		{100, 10, 1, 10}, // evenly divides
+		{100, 10, 2, 5},  // evenly divides
+
+		{101, 10, 1, 11}, // padded
+		{101, 10, 2, 6},  // padded
+
+		{10, 100, 1, 1}, // larger piece than file
+		{0, 10, 1, 1},   // 0-length
+	}
+
+	for _, test := range tests {
+		rsc, _ := NewRSCode(test.piecesPerChunk, 1) // can't use 0
+		f := &file{size: test.size, erasureCode: rsc, pieceSize: test.pieceSize}
+		if f.numChunks() != test.expNumChunks {
+			t.Errorf("Test %v: expected %v, got %v", test, test.expNumChunks, f.numChunks())
+		}
+	}
+}
+
 // TestFileAvailable probes the available method of the file type.
 func TestFileAvailable(t *testing.T) {
 	rsc, _ := NewRSCode(1, 10)

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -159,6 +159,13 @@ func (f *file) load(r io.Reader) error {
 
 // saveFile saves a file to the renter directory.
 func (r *Renter) saveFile(f *file) error {
+	// Create directory structure specified in nickname.
+	fullPath := filepath.Join(r.persistDir, f.name+ShareExtension)
+	err := os.MkdirAll(filepath.Dir(fullPath), 0700)
+	if err != nil {
+		return err
+	}
+
 	handle, err := persist.NewSafeFile(filepath.Join(r.persistDir, f.name+ShareExtension))
 	if err != nil {
 		return err

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -205,7 +205,8 @@ func (r *Renter) load() error {
 	// Recursively load all files found in renter directory. Errors
 	// encountered during loading are logged, but are not considered fatal.
 	err := filepath.Walk(r.persistDir, func(path string, info os.FileInfo, err error) error {
-		// These errors should be considered fatal.
+		// This error is non-nil if filepath.Walk couldn't stat a file or
+		// folder. This generally indicates a serious error.
 		if err != nil {
 			return err
 		}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -68,11 +68,16 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("file with that nickname already exists")
 	}
 
-	// Fill in any missing upload params with sensible defaults.
+	// Stat the file.
 	fileInfo, err := os.Stat(up.Filename)
 	if err != nil {
 		return err
 	}
+	if fileInfo.Size() == 0 {
+		return errors.New("cannot upload empty file")
+	}
+
+	// Fill in any missing upload params with sensible defaults.
 	if up.Duration == 0 {
 		up.Duration = defaultDuration
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -3,6 +3,7 @@ package renter
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
@@ -62,6 +63,11 @@ func (r *Renter) checkWalletBalance(up modules.FileUploadParams) error {
 // Upload instructs the renter to start tracking a file. The renter will
 // automatically upload and repair tracked files using a background loop.
 func (r *Renter) Upload(up modules.FileUploadParams) error {
+	// Enforce nickname rules.
+	if strings.HasPrefix(up.Nickname, "/") {
+		return errors.New("nicknames cannot begin with /")
+	}
+
 	// Check for a nickname conflict.
 	lockID := r.mu.RLock()
 	_, exists := r.files[up.Nickname]

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -68,16 +68,11 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("file with that nickname already exists")
 	}
 
-	// Stat the file.
+	// Fill in any missing upload params with sensible defaults.
 	fileInfo, err := os.Stat(up.Filename)
 	if err != nil {
 		return err
 	}
-	if fileInfo.Size() == 0 {
-		return errors.New("cannot upload empty file")
-	}
-
-	// Fill in any missing upload params with sensible defaults.
 	if up.Duration == 0 {
 		up.Duration = defaultDuration
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -35,6 +35,8 @@ var defaultDuration = func() types.BlockHeight {
 	}
 }()
 
+var ErrDuplicateNickname = errors.New("file with that nickname already exists")
+
 // checkWalletBalance looks at an upload and determines if there is enough
 // money in the wallet to support such an upload. An error is returned if it is
 // determined that there is not enough money.
@@ -65,7 +67,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	_, exists := r.files[up.Nickname]
 	r.mu.RUnlock(lockID)
 	if exists {
-		return errors.New("file with that nickname already exists")
+		return ErrDuplicateNickname
 	}
 
 	// Fill in any missing upload params with sensible defaults.


### PR DESCRIPTION
As discussed in #894:
- Leading slashes have been removed
- The renter creates the directory structure in its persistence folder.

One possible modification here would be to add a `siaroot` folder to the renter folder, under which the .sia directory structure would be stored. This would prevent confusion stemming from the .sia files living alongside renter.json, renter.log, and hostdb.log.