### PR TITLE
Host compatibility

### DIFF
--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -242,19 +242,19 @@ func TestSetAndGetSettings(t *testing.T) {
 	// Check the default settings get returned at first call.
 	settings := ht.host.Settings()
 	if settings.TotalStorage != defaultTotalStorage {
-		t.Error("settings GET did not return default value:", settings.TotalStorage, defaultTotalStorage)
+		t.Error("settings retrieval did not return default value:", settings.TotalStorage, defaultTotalStorage)
 	}
 	if settings.MaxDuration != defaultMaxDuration {
-		t.Error("settings GET did not return default value")
+		t.Error("settings retrieval did not return default value")
 	}
 	if settings.WindowSize != defaultWindowSize {
-		t.Error("settings GET did not return default value")
+		t.Error("settings retrieval did not return default value")
 	}
 	if settings.Price.Cmp(defaultPrice) != 0 {
-		t.Error("settings GET did not return default value")
+		t.Error("settings retrieval did not return default value")
 	}
 	if settings.Collateral.Cmp(defaultCollateral) != 0 {
-		t.Error("settings GET did not return default value")
+		t.Error("settings retrieval did not return default value")
 	}
 
 	// Submit updated settings and check that the changes stuck.
@@ -269,19 +269,19 @@ func TestSetAndGetSettings(t *testing.T) {
 	}
 	newSettings := ht.host.Settings()
 	if settings.TotalStorage != newSettings.TotalStorage {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.MaxDuration != newSettings.MaxDuration {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.WindowSize != newSettings.WindowSize {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.Price.Cmp(newSettings.Price) != 0 {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.Collateral.Cmp(newSettings.Collateral) != 0 {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 
 	// Reload the host and verify that the altered settings persisted.
@@ -295,19 +295,19 @@ func TestSetAndGetSettings(t *testing.T) {
 	}
 	rebootSettings := rebootHost.Settings()
 	if settings.TotalStorage != rebootSettings.TotalStorage {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.MaxDuration != rebootSettings.MaxDuration {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.WindowSize != rebootSettings.WindowSize {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.Price.Cmp(rebootSettings.Price) != 0 {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.Collateral.Cmp(rebootSettings.Collateral) != 0 {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 }
 
@@ -365,18 +365,18 @@ func TestPersistentSettings(t *testing.T) {
 	}
 	newSettings := h.Settings()
 	if settings.TotalStorage != newSettings.TotalStorage {
-		t.Error("settings GET did not return updated value:", settings.TotalStorage, "vs", newSettings.TotalStorage)
+		t.Error("settings retrieval did not return updated value:", settings.TotalStorage, "vs", newSettings.TotalStorage)
 	}
 	if settings.MaxDuration != newSettings.MaxDuration {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.WindowSize != newSettings.WindowSize {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.Price.Cmp(newSettings.Price) != 0 {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 	if settings.Collateral.Cmp(newSettings.Collateral) != 0 {
-		t.Error("settings GET did not return updated value")
+		t.Error("settings retrieval did not return updated value")
 	}
 }

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -157,7 +157,10 @@ func (h *Host) establishDefaults() error {
 func (h *Host) load() error {
 	p := new(persistence)
 	err := persist.LoadFile(persistMetadata, p, filepath.Join(h.persistDir, "settings.json"))
-	if os.IsNotExist(err) {
+	if err == persist.ErrBadVersion {
+		// COMPATv0.4.8 - try the compatibility loader.
+		return h.compatibilityLoad()
+	} else if os.IsNotExist(err) {
 		// This is the host's first run, set up the default values.
 		return h.establishDefaults()
 	} else if err != nil {

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -17,7 +17,7 @@ const (
 )
 
 // persistMetadata is the header that gets written to the persist file, and is
-// used to recognize other persisit files.
+// used to recognize other persist files.
 var persistMetadata = persist.Metadata{
 	Header:  "Sia Host",
 	Version: "0.5",

--- a/modules/host/persist_compat.go
+++ b/modules/host/persist_compat.go
@@ -1,0 +1,142 @@
+package host
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// compat04Metadata is the header used by 0.4.x versions of the host.
+var compat04Metadata = persist.Metadata{
+	Header:  "Sia Host",
+	Version: "0.4",
+}
+
+// compat04Obligation contains the fields that were used by the 0.4.x to
+// represent contract obligations.
+type compat04Obligation struct {
+	ID           types.FileContractID
+	FileContract types.FileContract
+	Path         string
+}
+
+// compat04Host contains the fields that were saved to disk by 0.4.x hosts.
+type compat04Host struct {
+	SpaceRemaining int64
+	FileCounter    int
+	Profit         types.Currency
+	HostSettings   modules.HostSettings
+	Obligations    []compat04Obligation
+	SecretKey      crypto.SecretKey
+	PublicKey      types.SiaPublicKey
+}
+
+// loadCompat04Obligations loads all of the file contract obligations found by
+func (h *Host) loadCompat04Obligations(c04os []compat04Obligation) []*contractObligation {
+	cos := make([]*contractObligation, 0, len(c04os))
+	for _, c04o := range c04os {
+		// Create an upgraded contract obligation out of the compatibility
+		// obligation and add it to the set of upgraded obligations.
+		co := &contractObligation{
+			ID: c04o.ID,
+			OriginTransaction: types.Transaction{
+				FileContracts: []types.FileContract{
+					c04o.FileContract,
+				},
+			},
+
+			Path: c04o.Path,
+		}
+
+		// Update the statistics of the obligation, but do not add any action
+		// items for the obligation. Action items will be added after the
+		// consensus set has been scanned. Scanning the consensus set will
+		// reveal which obligations have transactions on the blockchain, all
+		// other obligations will be discarded.
+		h.obligationsByID[co.ID] = co
+		h.spaceRemaining -= int64(co.fileSize())
+		h.anticipatedRevenue = h.anticipatedRevenue.Add(co.value())
+		cos = append(cos, co)
+	}
+	return cos
+}
+
+// compatibilityLoad tries to load the file as a compatible version.
+func (h *Host) compatibilityLoad() error {
+	// Try loading the file as a 0.4 file.
+	c04h := new(compat04Host)
+	err := persist.LoadFile(compat04Metadata, c04h, filepath.Join(h.persistDir, "settings.json"))
+	if err != nil {
+		// 0.4.x is the only backwards compatibility provided. File could not
+		// be loaded.
+		return err
+	}
+
+	// Copy over host identity.
+	h.publicKey = c04h.PublicKey
+	h.secretKey = c04h.SecretKey
+
+	// Copy file management, including providing compatibility for old
+	// obligations.
+	h.fileCounter = int64(c04h.FileCounter)
+	h.spaceRemaining = c04h.HostSettings.TotalStorage
+	upgradedObligations := h.loadCompat04Obligations(c04h.Obligations)
+
+	// Copy over statistics.
+	h.revenue = c04h.Profit
+
+	// Copy over utilities.
+	h.settings = c04h.HostSettings
+
+	// Subscribe to the consensus set.
+	if build.DEBUG && h.recentChange != (modules.ConsensusChangeID{}) {
+		panic("compatibility loading is not starting from blank consensus?")
+	}
+	err = h.initConsensusSubscription()
+	if err != nil {
+		return err
+	}
+
+	// Remove all obligations that have not had their origin transactions
+	// confirmed on the blockchain, and add action items for the rest.
+	for _, uo := range upgradedObligations {
+		if !uo.OriginConfirmed {
+			// Because there is no transaction on the blockchain, and because
+			// the old host did not keep the transaction, it's highly unlikely
+			// that a transaction will appear - the obligation should be
+			// removed.
+			h.removeObligation(uo, obligationFailed)
+			continue
+		}
+		// Check that the file Merkle root matches the Merkle root found in the
+		// blockchain.
+		file, err := os.Open(uo.Path)
+		if err != nil {
+			h.log.Println("Compatibility contract file could not be opened.")
+			h.removeObligation(uo, obligationFailed)
+			continue
+		}
+		merkleRoot, err := crypto.ReaderMerkleRoot(file)
+		file.Close() // Close the file after use, to prevent buildup if the loop iterates many times.
+		if err != nil {
+			h.log.Println("Compatibility contract file could not be checksummed")
+			h.removeObligation(uo, obligationFailed)
+			continue
+		}
+		if merkleRoot != uo.merkleRoot() {
+			h.log.Println("Compatibility contract file has the wrong merkle root")
+			h.removeObligation(uo, obligationFailed)
+			continue
+		}
+
+		// No action items have been created for this contract yet, create
+		// them now.
+		h.handleActionItem(uo)
+	}
+	return nil
+}

--- a/modules/host/persist_compat.go
+++ b/modules/host/persist_compat.go
@@ -97,6 +97,9 @@ func (h *Host) compatibilityLoad() error {
 	if build.DEBUG && h.recentChange != (modules.ConsensusChangeID{}) {
 		panic("compatibility loading is not starting from blank consensus?")
 	}
+	// initConsensusSubscription will scan through the consensus set and set
+	// 'OriginConfirmed' and 'RevisionConfirmed' when the accociated file
+	// contract and file contract revisions are found.
 	err = h.initConsensusSubscription()
 	if err != nil {
 		return err


### PR DESCRIPTION
Plus some typo corrections from previous PRs. Minimal changes were needed to the actual logic to get compatibility working, but the compatibility file itself is kind of long. Some logic is required to allow the host to scan the consensus set and look for contracts and revisions before moving on.