### PR TITLE
Close safeFile before Renaming

### DIFF
--- a/persist/persist.go
+++ b/persist/persist.go
@@ -60,6 +60,10 @@ func (sf *safeFile) Commit() error {
 	if err != nil {
 		return err
 	}
+	err = sf.Close()
+	if err != nil {
+		return err
+	}
 	return os.Rename(sf.finalName+"_temp", sf.finalName)
 }
 


### PR DESCRIPTION
Renaming with the handle open causes an error on Windows.
Even though this winds up calling `Close` twice (once in `Commit`, once in `defer Close`), it's ok because a double-close doesn't throw an error.
Actually, it winds up being slightly better, since now the `Close` error is explicitly checked, whereas with `defer Close` it is not.