### PR TITLE
move atomic fields in host

### DIFF
--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -64,6 +64,16 @@ var (
 // A Host contains all the fields necessary for storing files for clients and
 // performing the storage proofs on the received files.
 type Host struct {
+	// RPC Tracking - atomic variables need to be placed at the top to preserve
+	// compatibility with 32bit systems.
+	atomicErroredCalls   uint64
+	atomicMalformedCalls uint64
+	atomicDownloadCalls  uint64
+	atomicRenewCalls     uint64
+	atomicReviseCalls    uint64
+	atomicSettingsCalls  uint64
+	atomicUploadCalls    uint64
+
 	// Module dependencies.
 	cs     modules.ConsensusSet
 	tpool  modules.TransactionPool
@@ -91,15 +101,6 @@ type Host struct {
 	lostRevenue        types.Currency
 	revenue            types.Currency
 	spaceRemaining     int64
-
-	// RPC Tracking
-	atomicErroredCalls   uint64
-	atomicMalformedCalls uint64
-	atomicDownloadCalls  uint64
-	atomicRenewCalls     uint64
-	atomicReviseCalls    uint64
-	atomicSettingsCalls  uint64
-	atomicUploadCalls    uint64
 
 	// The resource lock is held by threaded functions for the duration of
 	// their operation. Functions should grab the resource lock as a read lock


### PR DESCRIPTION
atomic fields need to go at the top of the struct for compatibility with
32bit architectures.