### PR TITLE
Host Robustness Changes

### DIFF
--- a/modules/host/obligations.go
+++ b/modules/host/obligations.go
@@ -259,6 +259,11 @@ func (h *Host) reviseObligation(revisionTransaction types.Transaction) {
 	// Add the revision to the obligation
 	obligation.RevisionTransaction = revisionTransaction
 	obligation.RevisionConfirmed = false
+
+	err := h.save()
+	if err != nil {
+		h.log.Println("WARN: failed to save host:", err)
+	}
 }
 
 // removeObligation removes a file contract obligation and the corresponding

--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -276,7 +276,7 @@ func (h *Host) managedRPCRevise(conn net.Conn) error {
 	}
 
 	// remove conn deadline while we wait for lock and rebuild the Merkle tree.
-	err := conn.SetDeadline(time.Time{})
+	err := conn.SetDeadline(time.Now().Add(15 * time.Minute))
 	if err != nil {
 		return err
 	}

--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -287,7 +287,6 @@ func (h *Host) managedRPCRevise(conn net.Conn) error {
 	if !exists {
 		return errors.New("no record of that contract")
 	}
-
 	// need to protect against two simultaneous revisions to the same
 	// contract; this can cause inconsistency and data loss, making storage
 	// proofs impossible
@@ -429,7 +428,6 @@ func (h *Host) managedRPCRenew(conn net.Conn) error {
 	if !exists {
 		return errors.New("no record of that contract")
 	}
-
 	// need to protect against simultaneous renewals of the same contract
 	obligation.mu.Lock()
 	defer obligation.mu.Unlock()


### PR DESCRIPTION
host will now save after any revision, minimizing the chance of losing files due to disk corruption.

host now limits time before starting up a revision to 15 minutes.