### PR TITLE
Fix documentation for safeFile.Commit()

### DIFF
--- a/persist/persist.go
+++ b/persist/persist.go
@@ -49,12 +49,9 @@ type safeFile struct {
 	finalName string
 }
 
-// Commit syncs the file and then renames it to the intended final filename.
-// Writing to the file after calling Commit will succeed but will write to the
-// final file location (sf.Name() will deceptively still point to the old file
-// location).  Therefore it is recommended that the file handle be closed
-// immediately after calling Commit. Note that the file must not be closed
-// before calling commit as this will cause the sync to fail.
+// Commit syncs the file, closes it, and then renames it to the intended final
+// filename. Commit should not be called from a defer if the function it is
+// being called from can return an error.
 func (sf *safeFile) Commit() error {
 	err := sf.Sync()
 	if err != nil {


### PR DESCRIPTION
The documentation refered to an older behavior of commit where
safeFile.Close() was not called in safeFile.Commit().