### PR TITLE
HostDB mocking

### DIFF
--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -59,16 +59,21 @@ type hdbWalletShim struct {
 func (ws *hdbWalletShim) NextAddress() (types.UnlockConditions, error) { return ws.w.NextAddress() }
 func (ws *hdbWalletShim) StartTransaction() hdbTransactionBuilder      { return ws.w.StartTransaction() }
 
+// stdDialer implements the hdbDialer interface via net.DialTimeout.
 type stdDialer struct{}
 
 func (d stdDialer) DialTimeout(addr modules.NetAddress, timeout time.Duration) (net.Conn, error) {
 	return net.DialTimeout("tcp", string(addr), timeout)
 }
 
+// stdSleeper implements the hdbSleeper interface via time.Sleep.
 type stdSleeper struct{}
 
 func (s stdSleeper) Sleep(d time.Duration) { time.Sleep(d) }
 
+// stdPersist implements the hdbPersister interface via persist.SaveFile and
+// persist.LoadFile. The metadata and filename required by these functions is
+// internal to stdPersist.
 type stdPersist struct {
 	meta     persist.Metadata
 	filename string
@@ -92,6 +97,7 @@ func newPersist(dir string) *stdPersist {
 	}
 }
 
+// newLogger creates a persist.Logger with the standard filename.
 func newLogger(dir string) (*persist.Logger, error) {
 	return persist.NewLogger(filepath.Join(dir, "hostdb.log"))
 }

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -1,0 +1,51 @@
+package hostdb
+
+import (
+	"net"
+	"time"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// These interfaces define the HostDB's dependencies. Using the smallest
+// interface possible makes it easier to mock these dependencies in testing.
+type (
+	hdbConsensusSet interface {
+		ConsensusSetSubscribe(modules.ConsensusSetSubscriber)
+	}
+	hdbTransactionBuilder interface {
+		AddArbitraryData([]byte) uint64
+		AddFileContract(types.FileContract) uint64
+		Drop()
+		FundSiacoins(types.Currency) error
+		Sign(bool) ([]types.Transaction, error)
+		View() (types.Transaction, []types.Transaction)
+	}
+	hdbWallet interface {
+		NextAddress() (types.UnlockConditions, error)
+		StartTransaction() hdbTransactionBuilder
+	}
+	hdbTransactionPool interface {
+		AcceptTransactionSet([]types.Transaction) error
+	}
+
+	hdbDialer interface {
+		DialTimeout(modules.NetAddress, time.Duration) (net.Conn, error)
+	}
+)
+
+// because hdbWallet is not directly compatible with modules.Wallet (wrong
+// type signature for StartTransaction), we must provide a shim type.
+type hdbWalletShim struct {
+	w modules.Wallet
+}
+
+func (ws *hdbWalletShim) NextAddress() (types.UnlockConditions, error) { return ws.w.NextAddress() }
+func (ws *hdbWalletShim) StartTransaction() hdbTransactionBuilder      { return ws.w.StartTransaction() }
+
+type stdDialer struct{}
+
+func (d stdDialer) DialTimeout(addr modules.NetAddress, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("tcp", string(addr), timeout)
+}

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -33,6 +33,10 @@ type (
 	hdbDialer interface {
 		DialTimeout(modules.NetAddress, time.Duration) (net.Conn, error)
 	}
+
+	hdbSleeper interface {
+		Sleep(time.Duration)
+	}
 )
 
 // because hdbWallet is not directly compatible with modules.Wallet (wrong
@@ -49,3 +53,7 @@ type stdDialer struct{}
 func (d stdDialer) DialTimeout(addr modules.NetAddress, timeout time.Duration) (net.Conn, error) {
 	return net.DialTimeout("tcp", string(addr), timeout)
 }
+
+type stdSleeper struct{}
+
+func (s stdSleeper) Sleep(d time.Duration) { time.Sleep(d) }

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -44,6 +44,10 @@ type (
 		save(hdbPersist) error
 		load(*hdbPersist) error
 	}
+
+	hdbLogger interface {
+		Println(...interface{})
+	}
 )
 
 // because hdbWallet is not directly compatible with modules.Wallet (wrong
@@ -86,4 +90,8 @@ func newPersist(dir string) *stdPersist {
 		},
 		filename: filepath.Join(dir, "hostdb.json"),
 	}
+}
+
+func newLogger(dir string) (*persist.Logger, error) {
+	return persist.NewLogger(filepath.Join(dir, "hostdb.log"))
 }

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -27,45 +27,14 @@ var (
 	errNilTpool  = errors.New("cannot create hostdb with nil transaction pool")
 )
 
-// These interfaces define the HostDB's dependencies. Using the smallest
-// interface possible makes it easier to mock these dependencies in testing.
-type (
-	hdbConsensusSet interface {
-		ConsensusSetSubscribe(modules.ConsensusSetSubscriber)
-	}
-	hdbTransactionBuilder interface {
-		AddArbitraryData([]byte) uint64
-		AddFileContract(types.FileContract) uint64
-		Drop()
-		FundSiacoins(types.Currency) error
-		Sign(bool) ([]types.Transaction, error)
-		View() (types.Transaction, []types.Transaction)
-	}
-	hdbWallet interface {
-		NextAddress() (types.UnlockConditions, error)
-		StartTransaction() hdbTransactionBuilder
-	}
-	hdbTransactionPool interface {
-		AcceptTransactionSet([]types.Transaction) error
-	}
-)
-
-// because hdbWallet is not directly compatible with modules.Wallet (differing
-// type signatures for StartTransaction), we must provide a shim type.
-type hdbWalletShim struct {
-	w modules.Wallet
-}
-
-func (ws *hdbWalletShim) NextAddress() (types.UnlockConditions, error) { return ws.w.NextAddress() }
-func (ws *hdbWalletShim) StartTransaction() hdbTransactionBuilder      { return ws.w.StartTransaction() }
-
 // The HostDB is a database of potential hosts. It assigns a weight to each
 // host based on their hosting parameters, and then can select hosts at random
 // for uploading files.
 type HostDB struct {
-	// modules
+	// dependencies
 	wallet hdbWallet
 	tpool  hdbTransactionPool
+	dialer hdbDialer
 
 	// The hostTree is the root node of the tree that organizes hosts by
 	// weight. The tree is necessary for selecting weighted hosts at
@@ -119,7 +88,7 @@ func New(cs hdbConsensusSet, wallet modules.Wallet, tpool hdbTransactionPool, pe
 		return nil, errNilTpool
 	}
 
-	hdb, err := newHostDB(&hdbWalletShim{w: wallet}, tpool, persistDir)
+	hdb, err := newHostDB(&hdbWalletShim{w: wallet}, tpool, stdDialer{}, persistDir)
 	if err != nil {
 		return nil, err
 	}
@@ -142,10 +111,11 @@ func New(cs hdbConsensusSet, wallet modules.Wallet, tpool hdbTransactionPool, pe
 // newHostDB creates a HostDB using the provided dependencies. It does not
 // have any side effects (i.e. it does not spawn background threads, perform
 // I/O, or call stateful methods of its dependencies.)
-func newHostDB(wallet hdbWallet, tpool hdbTransactionPool, persistDir string) (*HostDB, error) {
+func newHostDB(w hdbWallet, tpool hdbTransactionPool, d hdbDialer, persistDir string) (*HostDB, error) {
 	hdb := &HostDB{
-		wallet: wallet,
+		wallet: w,
 		tpool:  tpool,
+		dialer: d,
 
 		contracts:   make(map[types.FileContractID]hostContract),
 		activeHosts: make(map[modules.NetAddress]*hostNode),

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -77,7 +77,7 @@ type hostContract struct {
 
 // New creates and starts up a hostdb. The hostdb that gets returned will not
 // have finished scanning the network or blockchain.
-func New(cs hdbConsensusSet, wallet modules.Wallet, tpool hdbTransactionPool, persistDir string) (*HostDB, error) {
+func New(cs hdbConsensusSet, wallet hdbWalletShim, tpool hdbTransactionPool, persistDir string) (*HostDB, error) {
 	if cs == nil {
 		return nil, errNilCS
 	}
@@ -101,7 +101,7 @@ func New(cs hdbConsensusSet, wallet modules.Wallet, tpool hdbTransactionPool, pe
 
 	// Create the HostDB using the supplied modules and standard
 	// implementations of each dependency.
-	hdb := newHostDB(&hdbWalletShim{w: wallet}, tpool, stdDialer{}, stdSleeper{}, newPersist(persistDir), logger)
+	hdb := newHostDB(&hdbWalletBridge{w: wallet}, tpool, stdDialer{}, stdSleeper{}, newPersist(persistDir), logger)
 
 	// Load the prior persistance structures.
 	err = hdb.load()

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -32,12 +32,12 @@ var (
 // for uploading files.
 type HostDB struct {
 	// dependencies
-	wallet  wallet
-	tpool   transactionPool
 	dialer  dialer
-	sleeper sleeper
-	persist persister
 	log     logger
+	persist persister
+	sleeper sleeper
+	tpool   transactionPool
+	wallet  wallet
 
 	// The hostTree is the root node of the tree that organizes hosts by
 	// weight. The tree is necessary for selecting weighted hosts at

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -32,12 +32,12 @@ var (
 // for uploading files.
 type HostDB struct {
 	// dependencies
-	wallet  hdbWallet
-	tpool   hdbTransactionPool
-	dialer  hdbDialer
-	sleeper hdbSleeper
-	persist hdbPersister
-	log     hdbLogger
+	wallet  wallet
+	tpool   transactionPool
+	dialer  dialer
+	sleeper sleeper
+	persist persister
+	log     logger
 
 	// The hostTree is the root node of the tree that organizes hosts by
 	// weight. The tree is necessary for selecting weighted hosts at
@@ -77,7 +77,7 @@ type hostContract struct {
 
 // New creates and starts up a hostdb. The hostdb that gets returned will not
 // have finished scanning the network or blockchain.
-func New(cs hdbConsensusSet, wallet hdbWalletShim, tpool hdbTransactionPool, persistDir string) (*HostDB, error) {
+func New(cs consensusSet, wallet walletShim, tpool transactionPool, persistDir string) (*HostDB, error) {
 	if cs == nil {
 		return nil, errNilCS
 	}
@@ -101,7 +101,7 @@ func New(cs hdbConsensusSet, wallet hdbWalletShim, tpool hdbTransactionPool, per
 
 	// Create the HostDB using the supplied modules and standard
 	// implementations of each dependency.
-	hdb := newHostDB(&hdbWalletBridge{w: wallet}, tpool, stdDialer{}, stdSleeper{}, newPersist(persistDir), logger)
+	hdb := newHostDB(&walletBridge{w: wallet}, tpool, stdDialer{}, stdSleeper{}, newPersist(persistDir), logger)
 
 	// Load the prior persistance structures.
 	err = hdb.load()
@@ -123,7 +123,7 @@ func New(cs hdbConsensusSet, wallet hdbWalletShim, tpool hdbTransactionPool, per
 // newHostDB creates a HostDB using the provided dependencies. Unlike New, it
 // does not have any side effects (i.e. it does not spawn background threads,
 // perform I/O, or call stateful methods of its dependencies.)
-func newHostDB(w hdbWallet, tp hdbTransactionPool, d hdbDialer, s hdbSleeper, p hdbPersister, l hdbLogger) *HostDB {
+func newHostDB(w wallet, tp transactionPool, d dialer, s sleeper, p persister, l logger) *HostDB {
 	return &HostDB{
 		wallet:  w,
 		tpool:   tp,

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -32,9 +32,10 @@ var (
 // for uploading files.
 type HostDB struct {
 	// dependencies
-	wallet hdbWallet
-	tpool  hdbTransactionPool
-	dialer hdbDialer
+	wallet  hdbWallet
+	tpool   hdbTransactionPool
+	dialer  hdbDialer
+	sleeper hdbSleeper
 
 	// The hostTree is the root node of the tree that organizes hosts by
 	// weight. The tree is necessary for selecting weighted hosts at
@@ -88,7 +89,7 @@ func New(cs hdbConsensusSet, wallet modules.Wallet, tpool hdbTransactionPool, pe
 		return nil, errNilTpool
 	}
 
-	hdb, err := newHostDB(&hdbWalletShim{w: wallet}, tpool, stdDialer{}, persistDir)
+	hdb, err := newHostDB(&hdbWalletShim{w: wallet}, tpool, stdDialer{}, stdSleeper{}, persistDir)
 	if err != nil {
 		return nil, err
 	}
@@ -111,11 +112,12 @@ func New(cs hdbConsensusSet, wallet modules.Wallet, tpool hdbTransactionPool, pe
 // newHostDB creates a HostDB using the provided dependencies. It does not
 // have any side effects (i.e. it does not spawn background threads, perform
 // I/O, or call stateful methods of its dependencies.)
-func newHostDB(w hdbWallet, tpool hdbTransactionPool, d hdbDialer, persistDir string) (*HostDB, error) {
+func newHostDB(w hdbWallet, tpool hdbTransactionPool, d hdbDialer, s hdbSleeper, persistDir string) (*HostDB, error) {
 	hdb := &HostDB{
-		wallet: w,
-		tpool:  tpool,
-		dialer: d,
+		wallet:  w,
+		tpool:   tpool,
+		dialer:  d,
+		sleeper: s,
 
 		contracts:   make(map[types.FileContractID]hostContract),
 		activeHosts: make(map[modules.NetAddress]*hostNode),

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// bareHostDB returns a HostDB with its fields initialized, but without any
+// dependencies or scanning threads. It is only intended for use in unit tests.
+func bareHostDB() *HostDB {
+	return &HostDB{
+		contracts:   make(map[types.FileContractID]hostContract),
+		activeHosts: make(map[modules.NetAddress]*hostNode),
+		allHosts:    make(map[modules.NetAddress]*hostEntry),
+		scanPool:    make(chan *hostEntry, scanPoolSize),
+	}
+}
+
 // newStub is used to test the New function. It implements all of the hostdb's
 // dependencies.
 type newStub struct{}

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -1,0 +1,83 @@
+package hostdb
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// newStub is used to test the New function. It implements all of the hostdb's
+// dependencies.
+type newStub struct{}
+
+// consensus set stubs
+func (newStub) ConsensusSetSubscribe(modules.ConsensusSetSubscriber) {}
+
+// wallet stubs
+func (newStub) NextAddress() (uc types.UnlockConditions, err error) { return }
+func (newStub) StartTransaction() modules.TransactionBuilder        { return nil }
+
+// transaction pool stubs
+func (newStub) AcceptTransactionSet([]types.Transaction) error { return nil }
+
+// TestNew tests the New function.
+func TestNew(t *testing.T) {
+	// Using a stub implementation of the dependencies is fine, as long as its
+	// non-nil.
+	var stub newStub
+	dir := build.TempDir("hostdb", "TestNew")
+
+	// Sane values.
+	_, err := New(stub, stub, stub, dir)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	// Nil consensus set.
+	_, err = New(nil, stub, stub, dir)
+	if err != errNilCS {
+		t.Fatalf("expected %v, got %v", errNilCS, err)
+	}
+
+	// Nil wallet.
+	_, err = New(stub, nil, stub, dir)
+	if err != errNilWallet {
+		t.Fatalf("expected %v, got %v", errNilWallet, err)
+	}
+
+	// Nil transaction pool.
+	_, err = New(stub, stub, nil, dir)
+	if err != errNilTpool {
+		t.Fatalf("expected %v, got %v", errNilTpool, err)
+	}
+
+	// Bad persistDir.
+	_, err = New(stub, stub, stub, "")
+	if err == nil {
+		t.Fatal("expected invalid directory, got nil")
+	}
+
+	// Corrupted persist file.
+	ioutil.WriteFile(filepath.Join(dir, "hostdb.json"), []byte{1, 2, 3}, 0666)
+	_, err = New(stub, stub, stub, dir)
+	if err == nil {
+		t.Fatalf("expected invalid json, got nil")
+	}
+
+	// Corrupted logfile.
+	os.RemoveAll(filepath.Join(dir, "hostdb.log"))
+	f, err := os.OpenFile(filepath.Join(dir, "hostdb.log"), os.O_CREATE, 0000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, err = New(stub, stub, stub, dir)
+	if err == nil {
+		t.Fatal("expected permissions error, got nil")
+	}
+}

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -1,6 +1,7 @@
 package hostdb
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -69,15 +70,15 @@ func TestNew(t *testing.T) {
 
 	// Bad persistDir.
 	_, err = New(stub, stub, stub, "")
-	if err == nil {
-		t.Fatal("expected invalid directory, got nil")
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected invalid directory, got %v", err)
 	}
 
 	// Corrupted persist file.
 	ioutil.WriteFile(filepath.Join(dir, "hostdb.json"), []byte{1, 2, 3}, 0666)
 	_, err = New(stub, stub, stub, dir)
-	if err == nil {
-		t.Fatalf("expected invalid json, got nil")
+	if _, ok := err.(*json.SyntaxError); !ok {
+		t.Fatalf("expected invalid json, got %v", err)
 	}
 
 	// Corrupted logfile.
@@ -88,8 +89,8 @@ func TestNew(t *testing.T) {
 	}
 	defer f.Close()
 	_, err = New(stub, stub, stub, dir)
-	if err == nil {
-		t.Fatal("expected permissions error, got nil")
+	if !os.IsPermission(err) {
+		t.Fatalf("expected permissions error, got %v", err)
 	}
 }
 

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -92,3 +92,34 @@ func TestNew(t *testing.T) {
 		t.Fatal("expected permissions error, got nil")
 	}
 }
+
+// testWalletShim is used to test the walletBridge type.
+type testWalletShim struct {
+	nextAddressCalled bool
+	startTxnCalled    bool
+}
+
+// These stub implementations for the walletShim interface set their respective
+// booleans to true, allowing tests to verify that they have been called.
+func (ws *testWalletShim) NextAddress() (types.UnlockConditions, error) {
+	ws.nextAddressCalled = true
+	return types.UnlockConditions{}, nil
+}
+func (ws *testWalletShim) StartTransaction() modules.TransactionBuilder {
+	ws.startTxnCalled = true
+	return nil
+}
+
+// TestWalletBridge tests the walletBridge type.
+func TestWalletBridge(t *testing.T) {
+	shim := new(testWalletShim)
+	bridge := walletBridge{shim}
+	bridge.NextAddress()
+	if !shim.nextAddressCalled {
+		t.Error("NextAddress was not called on the shim")
+	}
+	bridge.StartTransaction()
+	if !shim.startTxnCalled {
+		t.Error("StartTransaction was not called on the shim")
+	}
+}

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -1,0 +1,115 @@
+package hostdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// TestInsertHost tests the insertHost method.
+func TestInsertHost(t *testing.T) {
+	// no dependencies necessary
+	hdb := newHostDB(nil, nil, nil, nil, nil, nil)
+
+	// invalid host should not be added
+	hdb.insertHost(modules.HostSettings{NetAddress: "foo"})
+	if _, exists := hdb.allHosts["foo"]; exists {
+		t.Error("host with invalid NetAddress was inserted")
+	}
+
+	// valid host should be added
+	hdb.insertHost(modules.HostSettings{NetAddress: "foo:1234"})
+	if _, exists := hdb.allHosts["foo:1234"]; !exists {
+		t.Error("host with valid NetAddress was not inserted")
+	}
+	// host should be scanned
+	select {
+	case <-hdb.scanPool:
+	case <-time.After(10 * time.Millisecond):
+		t.Error("host was not scanned")
+	}
+
+	// duplicate host should not be added
+	hdb.insertHost(modules.HostSettings{NetAddress: "foo:1234"})
+	if len(hdb.allHosts) != 1 {
+		t.Error("duplicate host was added:", hdb.allHosts)
+	}
+	// no scan should occur
+	select {
+	case <-hdb.scanPool:
+		t.Error("duplicate host was added to scan pool")
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+// TestActiveHosts tests the ActiveHosts method.
+func TestActiveHosts(t *testing.T) {
+	// no dependencies necessary
+	hdb := newHostDB(nil, nil, nil, nil, nil, nil)
+
+	// empty
+	if hosts := hdb.ActiveHosts(); len(hosts) != 0 {
+		t.Errorf("wrong number of hosts: expected %v, got %v", 0, len(hosts))
+	}
+
+	// with one host
+	h1 := new(hostEntry)
+	h1.NetAddress = "foo"
+	hdb.activeHosts = map[modules.NetAddress]*hostNode{
+		h1.NetAddress: &hostNode{hostEntry: h1},
+	}
+	if hosts := hdb.ActiveHosts(); len(hosts) != 1 {
+		t.Errorf("wrong number of hosts: expected %v, got %v", 1, len(hosts))
+	}
+
+	// with multiple hosts
+	h2 := new(hostEntry)
+	h2.NetAddress = "bar"
+	hdb.activeHosts = map[modules.NetAddress]*hostNode{
+		h1.NetAddress: &hostNode{hostEntry: h1},
+		h2.NetAddress: &hostNode{hostEntry: h2},
+	}
+	if hosts := hdb.ActiveHosts(); len(hosts) != 2 {
+		t.Errorf("wrong number of hosts: expected %v, got %v", 2, len(hosts))
+	}
+}
+
+// TestAveragePrice tests the AveragePrice method, which also depends on the
+// randomHosts function.
+func TestAveragePrice(t *testing.T) {
+	// no dependencies necessary
+	hdb := newHostDB(nil, nil, nil, nil, nil, nil)
+
+	// empty
+	if avg := hdb.AveragePrice(); !avg.IsZero() {
+		t.Error("average of empty hostdb should be zero:", avg)
+	}
+
+	// with one host
+	h1 := new(hostEntry)
+	h1.NetAddress = "foo"
+	h1.Price = types.NewCurrency64(100)
+	h1.weight = baseWeight
+	hdb.insertNode(h1)
+	if len(hdb.activeHosts) != 1 {
+		t.Error("host was not added:", hdb.activeHosts)
+	}
+	if avg := hdb.AveragePrice(); avg.Cmp(h1.Price) != 0 {
+		t.Error("average of one host should be that host's price:", avg)
+	}
+
+	// with two hosts
+	h2 := new(hostEntry)
+	h2.NetAddress = "bar"
+	h2.Price = types.NewCurrency64(300)
+	h2.weight = baseWeight
+	hdb.insertNode(h2)
+	if len(hdb.activeHosts) != 2 {
+		t.Error("host was not added:", hdb.activeHosts)
+	}
+	if avg := hdb.AveragePrice(); avg.Cmp(types.NewCurrency64(200)) != 0 {
+		t.Error("average of two hosts should be their sum/2:", avg)
+	}
+}

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -18,14 +18,14 @@ func TestInsertHost(t *testing.T) {
 	select {
 	case <-hdb.scanPool:
 		t.Error("invalid host was added to scan pool")
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	// valid host should be scanned
 	hdb.insertHost(modules.HostSettings{NetAddress: "foo:1234"})
 	select {
 	case <-hdb.scanPool:
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Error("host was not scanned")
 	}
 
@@ -34,7 +34,7 @@ func TestInsertHost(t *testing.T) {
 	select {
 	case <-hdb.scanPool:
 		t.Error("duplicate host was added to scan pool")
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// TestInsertHost tests the insertHost method.
+// TestInsertHost tests the insertHost method, which also depends on the
+// scanHostEntry method.
 func TestInsertHost(t *testing.T) {
-	// no dependencies necessary
-	hdb := newHostDB(nil, nil, nil, nil, nil, nil)
+	hdb := bareHostDB()
 
 	// invalid host should not be scanned
 	hdb.insertHost(modules.HostSettings{NetAddress: "foo"})
@@ -41,8 +41,7 @@ func TestInsertHost(t *testing.T) {
 
 // TestActiveHosts tests the ActiveHosts method.
 func TestActiveHosts(t *testing.T) {
-	// no dependencies necessary
-	hdb := newHostDB(nil, nil, nil, nil, nil, nil)
+	hdb := bareHostDB()
 
 	// empty
 	if hosts := hdb.ActiveHosts(); len(hosts) != 0 {
@@ -72,10 +71,9 @@ func TestActiveHosts(t *testing.T) {
 }
 
 // TestAveragePrice tests the AveragePrice method, which also depends on the
-// randomHosts function.
+// randomHosts method.
 func TestAveragePrice(t *testing.T) {
-	// no dependencies necessary
-	hdb := newHostDB(nil, nil, nil, nil, nil, nil)
+	hdb := bareHostDB()
 
 	// empty
 	if avg := hdb.AveragePrice(); !avg.IsZero() {
@@ -88,9 +86,6 @@ func TestAveragePrice(t *testing.T) {
 	h1.Price = types.NewCurrency64(100)
 	h1.weight = baseWeight
 	hdb.insertNode(h1)
-	if len(hdb.activeHosts) != 1 {
-		t.Error("host was not added:", hdb.activeHosts)
-	}
 	if avg := hdb.AveragePrice(); avg.Cmp(h1.Price) != 0 {
 		t.Error("average of one host should be that host's price:", avg)
 	}

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -56,6 +56,8 @@ func TestActiveHosts(t *testing.T) {
 	}
 	if hosts := hdb.ActiveHosts(); len(hosts) != 1 {
 		t.Errorf("wrong number of hosts: expected %v, got %v", 1, len(hosts))
+	} else if hosts[0].NetAddress != h1.NetAddress {
+		t.Errorf("ActiveHosts returned wrong host: expected %v, got %v", h1.NetAddress, hosts[0].NetAddress)
 	}
 
 	// with multiple hosts
@@ -67,6 +69,10 @@ func TestActiveHosts(t *testing.T) {
 	}
 	if hosts := hdb.ActiveHosts(); len(hosts) != 2 {
 		t.Errorf("wrong number of hosts: expected %v, got %v", 2, len(hosts))
+	} else if hosts[0].NetAddress != h1.NetAddress && hosts[1].NetAddress != h1.NetAddress {
+		t.Errorf("ActiveHosts did not contain an inserted host: %v (missing %v)", hosts, h1.NetAddress)
+	} else if hosts[0].NetAddress != h2.NetAddress && hosts[1].NetAddress != h2.NetAddress {
+		t.Errorf("ActiveHosts did not contain an inserted host: %v (missing %v)", hosts, h2.NetAddress)
 	}
 }
 

--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -20,7 +20,7 @@ var (
 
 // negotiateContract establishes a connection to a host and negotiates an
 // initial file contract according to the terms of the host.
-func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileContract, txnBuilder modules.TransactionBuilder, tpool modules.TransactionPool) (hostContract, error) {
+func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileContract, txnBuilder hdbTransactionBuilder, tpool hdbTransactionPool) (hostContract, error) {
 	// allow 30 seconds for negotiation
 	conn.SetDeadline(time.Now().Add(30 * time.Second))
 

--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -20,7 +20,7 @@ var (
 
 // negotiateContract establishes a connection to a host and negotiates an
 // initial file contract according to the terms of the host.
-func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileContract, txnBuilder hdbTransactionBuilder, tpool hdbTransactionPool) (hostContract, error) {
+func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileContract, txnBuilder transactionBuilder, tpool transactionPool) (hostContract, error) {
 	// allow 30 seconds for negotiation
 	conn.SetDeadline(time.Now().Add(30 * time.Second))
 

--- a/modules/renter/hostdb/negotiate.go
+++ b/modules/renter/hostdb/negotiate.go
@@ -205,7 +205,7 @@ func (hdb *HostDB) newContract(host modules.HostSettings, filesize uint64, durat
 	txnBuilder := hdb.wallet.StartTransaction()
 
 	// initiate connection
-	conn, err := net.DialTimeout("tcp", string(host.NetAddress), 15*time.Second)
+	conn, err := hdb.dialer.DialTimeout(host.NetAddress, 15*time.Second)
 	if err != nil {
 		return hostContract{}, err
 	}
@@ -373,7 +373,7 @@ func (hdb *HostDB) Renew(fcid types.FileContractID, newEndHeight types.BlockHeig
 	txnBuilder := hdb.wallet.StartTransaction()
 
 	// initiate connection
-	conn, err := net.DialTimeout("tcp", string(hc.IP), 15*time.Second)
+	conn, err := hdb.dialer.DialTimeout(hc.IP, 15*time.Second)
 	if err != nil {
 		return types.FileContractID{}, err
 	}

--- a/modules/renter/hostdb/negotiate_test.go
+++ b/modules/renter/hostdb/negotiate_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules/gateway"
 	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
-	"github.com/NebulousLabs/Sia/modules/wallet"
+	modWallet "github.com/NebulousLabs/Sia/modules/wallet" // name conflicts with type
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -52,7 +52,7 @@ func newHostDBTester(name string) (*hostdbTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	w, err := wallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	w, err := modWallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -1,11 +1,6 @@
 package hostdb
 
-import (
-	"log"
-	"os"
-	"path/filepath"
-)
-
+// hdbPersist defines what HostDB data persists across sessions.
 type hdbPersist struct {
 	Contracts []hostContract
 }
@@ -28,31 +23,6 @@ func (hdb *HostDB) load() error {
 	}
 	for _, hc := range data.Contracts {
 		hdb.contracts[hc.ID] = hc
-	}
-	return nil
-}
-
-// initPersist handles all of the persistence initialization, such as creating
-// the persistance directory and starting the logger.
-func (hdb *HostDB) initPersist(dir string) error {
-	// Create the perist directory if it does not yet exist.
-	err := os.MkdirAll(dir, 0700)
-	if err != nil {
-		return err
-	}
-
-	// Initialize the logger.
-	logFile, err := os.OpenFile(filepath.Join(dir, "hostdb.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
-	if err != nil {
-		return err
-	}
-	hdb.log = log.New(logFile, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
-	hdb.log.Println("STARTUP: HostDB has started logging")
-
-	// Load the prior persistance structures.
-	err = hdb.load()
-	if err != nil && !os.IsNotExist(err) {
-		return err
 	}
 	return nil
 }

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -1,0 +1,65 @@
+package hostdb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// memPersist implements the hdbPersister interface in-memory.
+type memPersist hdbPersist
+
+func (m *memPersist) save(data hdbPersist) error { *m = memPersist(data); return nil }
+func (m memPersist) load(data *hdbPersist) error { *data = hdbPersist(m); return nil }
+
+// TestSaveLoad tests that the hostdb can save and load itself.
+func TestSaveLoad(t *testing.T) {
+	// create hostdb with mocked persist dependency
+	p := new(memPersist)
+	hdb := newHostDB(nil, nil, nil, nil, p, nil)
+	// add some fake contracts
+	hdb.contracts = map[types.FileContractID]hostContract{
+		{0}: {IP: "foo"},
+		{1}: {IP: "bar"},
+		{2}: {IP: "baz"},
+	}
+	// save and reload
+	err := hdb.save()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = hdb.load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check that contracts were restored
+	_, ok0 := hdb.contracts[types.FileContractID{0}]
+	_, ok1 := hdb.contracts[types.FileContractID{1}]
+	_, ok2 := hdb.contracts[types.FileContractID{2}]
+	if !ok0 || !ok1 || !ok2 {
+		t.Fatal("contracts were not restored properly:", hdb.contracts)
+	}
+
+	// use stdPersist instead of mock
+	hdb.persist = newPersist(build.TempDir("hostdb", "TestSaveLoad"))
+	os.MkdirAll(build.TempDir("hostdb", "TestSaveLoad"), 0700)
+
+	// save and reload
+	err = hdb.save()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = hdb.load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check that contracts were restored
+	_, ok0 = hdb.contracts[types.FileContractID{0}]
+	_, ok1 = hdb.contracts[types.FileContractID{1}]
+	_, ok2 = hdb.contracts[types.FileContractID{2}]
+	if !ok0 || !ok1 || !ok2 {
+		t.Fatal("contracts were not restored properly:", hdb.contracts)
+	}
+}

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// memPersist implements the hdbPersister interface in-memory.
+// memPersist implements the persister interface in-memory.
 type memPersist hdbPersist
 
 func (m *memPersist) save(data hdbPersist) error { *m = memPersist(data); return nil }

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -17,8 +17,9 @@ func (m memPersist) load(data *hdbPersist) error { *data = hdbPersist(m); return
 // TestSaveLoad tests that the hostdb can save and load itself.
 func TestSaveLoad(t *testing.T) {
 	// create hostdb with mocked persist dependency
-	p := new(memPersist)
-	hdb := newHostDB(nil, nil, nil, nil, p, nil)
+	hdb := bareHostDB()
+	hdb.persist = new(memPersist)
+
 	// add some fake contracts
 	hdb.contracts = map[types.FileContractID]hostContract{
 		{0}: {IP: "foo"},

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -71,6 +71,7 @@ func (hdb *HostDB) decrementReliability(addr modules.NetAddress, penalty types.C
 	// Look up the entry and decrement the reliability.
 	entry, exists := hdb.allHosts[addr]
 	if !exists {
+		// TODO: should panic here
 		return
 	}
 	entry.reliability = entry.reliability.Sub(penalty)

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -193,12 +193,8 @@ func (hdb *HostDB) threadedScan() {
 				entry2, exists := hdb.activeHosts[entry.NetAddress]
 				if !exists {
 					entries = append(entries, entry)
-				} else {
-					if build.DEBUG {
-						if entry2.hostEntry != entry {
-							panic("allHosts + activeHosts mismatch!")
-						}
-					}
+				} else if entry2.hostEntry != entry {
+					build.Critical("allHosts + activeHosts mismatch!")
 				}
 			}
 
@@ -227,9 +223,7 @@ func (hdb *HostDB) threadedScan() {
 		minBig := big.NewInt(int64(MinScanSleep))
 		randSleep, err := rand.Int(rand.Reader, maxBig.Sub(maxBig, minBig))
 		if err != nil {
-			if build.DEBUG {
-				panic(err)
-			}
+			build.Critical(err)
 			// If there's an error, sleep for the default amount of time.
 			defaultBig := big.NewInt(int64(DefaultScanSleep))
 			randSleep = defaultBig.Sub(defaultBig, minBig)

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -208,13 +208,13 @@ func (hdb *HostDB) threadedScan() {
 			if n > len(entries) {
 				n = len(entries)
 			}
-			perm, err := crypto.Perm(n)
+			hostOrder, err := crypto.Perm(n)
 			if err != nil {
 				hdb.log.Println("ERR: could not generate random permutation:", err)
 			}
 
 			// Scan each host.
-			for _, randIndex := range perm {
+			for _, randIndex := range hostOrder {
 				hdb.scanHostEntry(entries[randIndex])
 			}
 		}()

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -240,12 +240,11 @@ func (hdb *HostDB) threadedScan() {
 		if err != nil {
 			if build.DEBUG {
 				panic(err)
-			} else {
-				// If there's an error, sleep for the default amount of time.
-				defaultBig := big.NewInt(int64(DefaultScanSleep))
-				randSleep = defaultBig.Sub(defaultBig, minBig)
 			}
+			// If there's an error, sleep for the default amount of time.
+			defaultBig := big.NewInt(int64(DefaultScanSleep))
+			randSleep = defaultBig.Sub(defaultBig, minBig)
 		}
-		time.Sleep(time.Duration(randSleep.Int64()) + MinScanSleep) // this means the MaxScanSleep is actual Max+Min.
+		hdb.sleeper.Sleep(time.Duration(randSleep.Int64()) + MinScanSleep) // this means the MaxScanSleep is actual Max+Min.
 	}
 }

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -7,7 +7,6 @@ package hostdb
 import (
 	"crypto/rand"
 	"math/big"
-	"net"
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -99,7 +98,7 @@ func (hdb *HostDB) threadedProbeHosts() {
 		// Request settings from the queued host entry.
 		var settings modules.HostSettings
 		err := func() error {
-			conn, err := net.DialTimeout("tcp", string(hostEntry.NetAddress), hostRequestTimeout)
+			conn, err := hdb.dialer.DialTimeout(hostEntry.NetAddress, hostRequestTimeout)
 			if err != nil {
 				return err
 			}

--- a/modules/renter/hostdb/scan_test.go
+++ b/modules/renter/hostdb/scan_test.go
@@ -1,0 +1,156 @@
+package hostdb
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// TestDecrementReliability tests the decrementReliability method.
+func TestDecrementReliability(t *testing.T) {
+	hdb := bareHostDB()
+
+	// Decrementing a non-existent host should be a no-op.
+	// NOTE: can't check any post-conditions here; only indication of correct
+	// behavior is that the test doesn't panic.
+	hdb.decrementReliability("foo", types.NewCurrency64(0))
+
+	// Add a host to allHosts and activeHosts. Decrementing it should remove it
+	// from activeHosts.
+	h := new(hostEntry)
+	h.NetAddress = "foo"
+	h.reliability = types.NewCurrency64(1)
+	hdb.allHosts[h.NetAddress] = h
+	hdb.activeHosts[h.NetAddress] = &hostNode{hostEntry: h}
+	hdb.decrementReliability(h.NetAddress, types.NewCurrency64(0))
+	if _, ok := hdb.activeHosts[h.NetAddress]; ok {
+		t.Error("decrementing did not remove host from activeHosts")
+	}
+
+	// Decrement reliability to 0. This should remove the host from allHosts.
+	hdb.decrementReliability(h.NetAddress, h.reliability)
+	if _, ok := hdb.allHosts[h.NetAddress]; ok {
+		t.Error("decrementing did not remove host from allHosts")
+	}
+}
+
+// probeDialer is used to test the threadedProbeHosts method. A simple type
+// alias is used so that it can easily be redefined during testing, allowing
+// multiple behaviors to be tested.
+type probeDialer func(modules.NetAddress, time.Duration) (net.Conn, error)
+
+func (dial probeDialer) DialTimeout(addr modules.NetAddress, timeout time.Duration) (net.Conn, error) {
+	return dial(addr, timeout)
+}
+
+// TestThreadedProbeHosts tests the threadedProbeHosts method.
+func TestThreadedProbeHosts(t *testing.T) {
+	hdb := bareHostDB()
+
+	// create a host to send to threadedProbeHosts
+	h := new(hostEntry)
+	h.NetAddress = "foo"
+	h.reliability = baseWeight // enough to withstand a few failures
+
+	// define a helper function for running threadedProbeHosts. We send the
+	// hostEntry, close the channel, and then call threadedProbeHosts.
+	// threadedProbeHosts will receive the host, loop once, and return after
+	// seeing the channel has closed.
+	runProbe := func(h *hostEntry) {
+		hdb.scanPool <- h
+		close(hdb.scanPool)
+		hdb.threadedProbeHosts()
+		// reset hdb.scanPool
+		hdb.scanPool = make(chan *hostEntry, 1)
+	}
+
+	// make the dial fail
+	hdb.dialer = probeDialer(func(modules.NetAddress, time.Duration) (net.Conn, error) {
+		return nil, net.UnknownNetworkError("fail")
+	})
+	runProbe(h)
+	if _, ok := hdb.activeHosts[h.NetAddress]; ok {
+		t.Error("unresponsive host was added")
+	}
+
+	// make the RPC fail
+	hdb.dialer = probeDialer(func(modules.NetAddress, time.Duration) (net.Conn, error) {
+		ourPipe, theirPipe := net.Pipe()
+		ourPipe.Close()
+		return theirPipe, nil
+	})
+	runProbe(h)
+	if _, ok := hdb.activeHosts[h.NetAddress]; ok {
+		t.Error("unresponsive host was added")
+	}
+
+	// normal host
+	hdb.dialer = probeDialer(func(modules.NetAddress, time.Duration) (net.Conn, error) {
+		// create an in-memory conn and spawn a goroutine to handle our half
+		ourConn, theirConn := net.Pipe()
+		go func() {
+			// read the RPC
+			encoding.ReadObject(ourConn, new(types.Specifier), types.SpecifierLen)
+			// write old host settings
+			encoding.WriteObject(ourConn, oldHostSettings{
+				NetAddress: "probed",
+			})
+			ourConn.Close()
+		}()
+		return theirConn, nil
+	})
+	runProbe(h)
+	if _, ok := hdb.activeHosts[h.NetAddress]; !ok {
+		t.Error("host was not added")
+	}
+
+	// TODO: respond with old host settings
+}
+
+// TestThreadedScan tests the threadedScan method.
+func TestThreadedScan(t *testing.T) {
+	hdb := bareHostDB()
+	// use a real sleeper; this will prevent threadedScan from looping too
+	// quickly.
+	hdb.sleeper = stdSleeper{}
+	// use a dummy dialer that always fails
+	hdb.dialer = probeDialer(func(modules.NetAddress, time.Duration) (net.Conn, error) {
+		return nil, net.UnknownNetworkError("fail")
+	})
+
+	// create a host to be scanned
+	h := new(hostEntry)
+	h.NetAddress = "foo"
+	h.reliability = types.NewCurrency64(1)
+	hdb.activeHosts[h.NetAddress] = &hostNode{hostEntry: h}
+
+	// perform one scan
+	go hdb.threadedScan()
+
+	// host should be sent down scanPool
+	select {
+	case <-hdb.scanPool:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("host was not scanned")
+	}
+
+	// remove the host from activeHosts and add it to allHosts
+	hdb.mu.Lock()
+	delete(hdb.activeHosts, h.NetAddress)
+	hdb.allHosts[h.NetAddress] = h
+	hdb.mu.Unlock()
+
+	// perform one scan
+	go hdb.threadedScan()
+
+	// host should be sent down scanPool
+	select {
+	case <-hdb.scanPool:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("host was not scanned")
+	}
+}

--- a/modules/renter/hostdb/scan_test.go
+++ b/modules/renter/hostdb/scan_test.go
@@ -134,7 +134,7 @@ func TestThreadedScan(t *testing.T) {
 	// host should be sent down scanPool
 	select {
 	case <-hdb.scanPool:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Error("host was not scanned")
 	}
 
@@ -150,7 +150,7 @@ func TestThreadedScan(t *testing.T) {
 	// host should be sent down scanPool
 	select {
 	case <-hdb.scanPool:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Error("host was not scanned")
 	}
 }

--- a/modules/renter/hostdb/scan_test.go
+++ b/modules/renter/hostdb/scan_test.go
@@ -27,13 +27,13 @@ func TestDecrementReliability(t *testing.T) {
 	hdb.allHosts[h.NetAddress] = h
 	hdb.activeHosts[h.NetAddress] = &hostNode{hostEntry: h}
 	hdb.decrementReliability(h.NetAddress, types.NewCurrency64(0))
-	if _, ok := hdb.activeHosts[h.NetAddress]; ok {
+	if len(hdb.ActiveHosts()) != 0 {
 		t.Error("decrementing did not remove host from activeHosts")
 	}
 
 	// Decrement reliability to 0. This should remove the host from allHosts.
 	hdb.decrementReliability(h.NetAddress, h.reliability)
-	if _, ok := hdb.allHosts[h.NetAddress]; ok {
+	if len(hdb.AllHosts()) != 0 {
 		t.Error("decrementing did not remove host from allHosts")
 	}
 }
@@ -73,7 +73,7 @@ func TestThreadedProbeHosts(t *testing.T) {
 		return nil, net.UnknownNetworkError("fail")
 	})
 	runProbe(h)
-	if _, ok := hdb.activeHosts[h.NetAddress]; ok {
+	if len(hdb.ActiveHosts()) != 0 {
 		t.Error("unresponsive host was added")
 	}
 
@@ -84,7 +84,7 @@ func TestThreadedProbeHosts(t *testing.T) {
 		return theirPipe, nil
 	})
 	runProbe(h)
-	if _, ok := hdb.activeHosts[h.NetAddress]; ok {
+	if len(hdb.ActiveHosts()) != 0 {
 		t.Error("unresponsive host was added")
 	}
 
@@ -104,7 +104,7 @@ func TestThreadedProbeHosts(t *testing.T) {
 		return theirConn, nil
 	})
 	runProbe(h)
-	if _, ok := hdb.activeHosts[h.NetAddress]; !ok {
+	if len(hdb.ActiveHosts()) != 1 {
 		t.Error("host was not added")
 	}
 

--- a/modules/renter/hostdb/update_test.go
+++ b/modules/renter/hostdb/update_test.go
@@ -2,7 +2,6 @@ package hostdb
 
 import (
 	"testing"
-	"time"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -82,45 +81,5 @@ func TestReceiveConsensusSetUpdate(t *testing.T) {
 	// Check that there is now a host in the hostdb.
 	if len(ht.hostdb.AllHosts()) != 1 {
 		t.Fatal("hostdb should have a host after getting a host announcement transcation")
-	}
-}
-
-// TestIsOffline tests the IsOffline method.
-func TestIsOffline(t *testing.T) {
-	hdb := &HostDB{
-		allHosts: map[modules.NetAddress]*hostEntry{
-			"foo:1234": &hostEntry{online: true},
-			"bar:1234": &hostEntry{online: false},
-			"baz:1234": &hostEntry{online: true},
-		},
-		activeHosts: map[modules.NetAddress]*hostNode{
-			"foo:1234": nil,
-		},
-		scanPool: make(chan *hostEntry),
-	}
-
-	tests := []struct {
-		addr    modules.NetAddress
-		offline bool
-	}{
-		{"foo:1234", false},
-		{"bar:1234", true},
-		{"baz:1234", false},
-		{"quux:1234", false},
-	}
-	for _, test := range tests {
-		if offline := hdb.IsOffline(test.addr); offline != test.offline {
-			t.Errorf("IsOffline(%v) = %v, expected %v", test.addr, offline, test.offline)
-		}
-	}
-
-	// quux should have sent host down scanPool
-	select {
-	case h := <-hdb.scanPool:
-		if h.NetAddress != "quux:1234" {
-			t.Error("wrong host in scan pool:", h.NetAddress)
-		}
-	case <-time.After(time.Second):
-		t.Error("unknown host was not added to scan pool")
 	}
 }

--- a/modules/renter/hostdb/upload.go
+++ b/modules/renter/hostdb/upload.go
@@ -121,7 +121,7 @@ func (hdb *HostDB) newHostUploader(hc hostContract) (*hostUploader, error) {
 	// TODO: check for excessive price again?
 
 	// initiate revision loop
-	conn, err := net.DialTimeout("tcp", string(hc.IP), 15*time.Second)
+	conn, err := hdb.dialer.DialTimeout(hc.IP, 15*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/hostdb/upload.go
+++ b/modules/renter/hostdb/upload.go
@@ -244,7 +244,7 @@ outer:
 	if len(errs) == len(randHosts) && len(errs) > 0 {
 		// Log the last error, since early errors are more likely to be
 		// host-specific.
-		p.hdb.log.Printf("couldn't form any host contracts: %v", errs[len(errs)-1])
+		p.hdb.log.Println("couldn't form any host contracts:", errs[len(errs)-1])
 	}
 	return hosts
 }

--- a/modules/renter/hostdb/upload.go
+++ b/modules/renter/hostdb/upload.go
@@ -211,7 +211,7 @@ outer:
 
 	// Ask the hostdb for random hosts. We always ask for at least 10, to
 	// avoid selecting the same uncooperative hosts over and over.
-	ask := n
+	ask := n * 2
 	if ask < 10 {
 		ask = 10
 	}

--- a/modules/renter/hostdb/weightedlist.go
+++ b/modules/renter/hostdb/weightedlist.go
@@ -119,7 +119,7 @@ func (hn *hostNode) recursiveInsert(entry *hostEntry) (nodesAdded int, newNode *
 
 // insertNode inserts a host entry into the host tree, removing
 // any conflicts. The host settings are assummed to be correct. Though hosts
-// with 0 weight will never be selected, they are accetped into the tree.
+// with 0 weight will never be selected, they are accepted into the tree.
 func (hdb *HostDB) insertNode(entry *hostEntry) {
 	// If there's already a host of the same id, remove that host.
 	priorEntry, exists := hdb.activeHosts[entry.NetAddress]

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -267,8 +267,8 @@ func TestNodeAtWeight(t *testing.T) {
 
 // TestRandomHosts probes the randomHosts function.
 func TestRandomHosts(t *testing.T) {
-	// Create the hostdb (no dependencies needed).
-	hdb := newHostDB(nil, nil, nil, nil, nil, nil)
+	// Create the hostdb.
+	hdb := bareHostDB()
 
 	// Empty.
 	if hosts := hdb.randomHosts(1, nil); len(hosts) != 0 {

--- a/persist/log.go
+++ b/persist/log.go
@@ -28,6 +28,10 @@ func (lfw *logFileWrapper) Close() error {
 	if build.DEBUG && lfw.closed {
 		panic("cannot close the logger after it has been closed")
 	}
+	// Ensure that all data has actually hit the disk.
+	if err := lfw.file.Sync(); err != nil {
+		return err
+	}
 	lfw.closed = true
 	return lfw.file.Close()
 }


### PR DESCRIPTION
This PR serves to showcase what extensive mocking would look like in a module. It's not perfect (comments/naming/organization could be improved), but it's more-or-less how I envisioned it.
Nearly all of the hostdb's dependencies have been mocked. (The exceptions are: `filepath.Join`, `sync.RWMutex`, `os.MkdirAll`, `crypto.Perm`, `rand.Int`, `time.Now`, `types.Currency`, and possibly one or two others that I missed. These are pretty inconsequential, since most do not return errors.)

The `New`/`newHostDB` pattern in particular has made it very easy to unit test the hostdb's methods. Most of our module tests have fully initialize the modules, meaning they spawn goroutines, write to disk, mine blocks, etc., all just to test a fairly simple function. By testing with `newHostDB` (which takes all dependencies as parameters and has no side effects) instead of `New`, it becomes trivial to pass in only the dependencies that will be called and mock them accordingly. See the newly-added tests for examples.


Finally, @VoidingWarranties and I talked in person about modifying this code to reduce duplication of types. The basic premise is to define shared "stub" types for each module in the `modules` package instead defining "restricted interfaces" internal to each module. As an example, the hostdb now defines the following type:
```go
hdbTransactionPool interface {
    AcceptTransactionSet([]types.Transaction) error
}
```
which is a parameter to `newHostDB`. Since `modules.TransactionPool` implements `hdbTransactionPool`, it can be passed to `newHostDB`. And during testing, tests which require `AcceptTransactionSet` must define a type that implements `hdbTransactionPool`.
In Jordan's proposal, we would instead define a stub type for the transaction pool like so:
```go
// in modules/transactionpool.go
type TransactionPoolStub struct{}
func (TransactionPoolStub) AcceptTransactionSet([]types.Transaction) error { return nil }
func (TransactionPoolStub) IsStandardTransaction(types.Transaction) error  { return nil }
func (TransactionPoolStub) PurgeTransactionPool()                          { }
// ... etc
```
then, when testing the hostdb, we would define our testing type like so:
```go
type tpoolTest struct {
    modules.TransactionPoolStub
}
func (tpoolTest) AcceptTransactionSet([]types.Transaction) error {
    // ... test-specific logic ...
}
```
And finally, we would throw away the `hdbTransactionPool` type, and have `newHostDB` take a `modules.TransactionPool` instead. Since `tpoolTest` embeds `modules.TransactionPoolStub`, it inherits its methods and thus implements the full `modules.TransactionPool` interface. We can then override any methods as needed during testing.
Part of the rationale here is that we will likely want to define shared stubs anyway, for dependencies like `time.Sleep` and `net.Dial`.

The code reduction is compelling, but something doesn't sit quite right with me about this approach. I prefer to pass modules the smallest interface they require. Also, embedding types all over the place may also be confusing or error-prone.
I guess my primary objection is that I'm averse to writing generic code until at least two specific cases exist. I feel that we should adopt the pattern in this PR for now, and consider abstracting it only after we've mocked another module to a similar degree. It will be easier to see the parallel and evaluate what makes sense once the code is on the page instead of in our heads.
