### PR TITLE
Change the file contract deletion endpoint to a POST request

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -75,7 +75,7 @@ func (srv *Server) initAPI() {
 		router.GET("/host", srv.hostHandlerGET)
 		router.POST("/host", srv.hostHandlerPOST)
 		router.POST("/host/announce", srv.hostAnnounceHandler)
-		router.GET("/host/delete/:filecontractid", srv.hostDeleteHandler)
+		router.POST("/host/delete/:filecontractid", srv.hostDeleteHandler)
 	}
 
 	// Miner API Calls


### PR DESCRIPTION
This matches the API for deleting a file entry from the renter, which is also a POST request. It is also my opinion that any requests that mutate state should be a POST request, and any non-state-mutating requests should be a GET request.