### PR TITLE
Host sanity

### DIFF
--- a/build/critical.go
+++ b/build/critical.go
@@ -1,12 +1,14 @@
 package build
 
 import (
+	"fmt"
 	"os"
 )
 
 // Critical will print a message to os.Stderr unless DEBUG has been set, in
 // which case panic will be called instead.
-func Critical(s string) {
+func Critical(v ...interface{}) {
+	s := fmt.Sprintln(v...)
 	os.Stderr.WriteString(s)
 	if DEBUG {
 		panic(s)

--- a/build/critical.go
+++ b/build/critical.go
@@ -1,0 +1,14 @@
+package build
+
+import (
+	"os"
+)
+
+// Critical will print a message to os.Stderr unless DEBUG has been set, in
+// which case panic will be called instead.
+func Critical(s string) {
+	os.Stderr.WriteString(s)
+	if DEBUG {
+		panic(s)
+	}
+}

--- a/build/critical_test.go
+++ b/build/critical_test.go
@@ -6,6 +6,7 @@ import (
 
 // TestCritical checks that a panic is called in debug mode.
 func TestCritical(t *testing.T) {
+	k0 := "critical test killstring"
 	killstring := "critical test killstring\n"
 	defer func() {
 		r := recover()
@@ -13,5 +14,21 @@ func TestCritical(t *testing.T) {
 			t.Error("panic did not work:", r, killstring)
 		}
 	}()
-	Critical(killstring)
+	Critical(k0)
+}
+
+// TestCriticalVariadic checks that a panic is called in debug mode.
+func TestCriticalVariadic(t *testing.T) {
+	k0 := "variadic"
+	k1 := "critical"
+	k2 := "test"
+	k3 := "killstring"
+	killstring := "variadic critical test killstring\n"
+	defer func() {
+		r := recover()
+		if r != killstring {
+			t.Error("panic did not work:", r, killstring)
+		}
+	}()
+	Critical(k0, k1, k2, k3)
 }

--- a/build/critical_test.go
+++ b/build/critical_test.go
@@ -1,0 +1,17 @@
+package build
+
+import (
+	"testing"
+)
+
+// TestCritical checks that a panic is called in debug mode.
+func TestCritical(t *testing.T) {
+	killstring := "critical test killstring\n"
+	defer func() {
+		r := recover()
+		if r != killstring {
+			t.Error("panic did not work:", r, killstring)
+		}
+	}()
+	Critical(killstring)
+}

--- a/modules/host/obligations.go
+++ b/modules/host/obligations.go
@@ -78,15 +78,15 @@ func (co *contractObligation) isSane() error {
 	// of valid and missed proof outputs.
 	fclen := len(co.OriginTransaction.FileContracts)
 	if fclen != 1 {
-		return errors.New("obligation has bad file contract count: " + strconv.Itoa(fclen))
+		return fmt.Errorf("obligation has bad file contract count: %v", fclen)
 	}
 	fcvpolen := len(co.OriginTransaction.FileContracts[0].ValidProofOutputs)
 	if fcvpolen != 2 {
-		return errors.New("obligation contract has bad valid proof output count: " + strconv.Itoa(fcvpolen))
+		return fmt.Errorf("obligation contract has bad valid proof output count: %v", fcvpolen)
 	}
 	fcmpolen := len(co.OriginTransaction.FileContracts[0].MissedProofOutputs)
 	if fcmpolen != 2 {
-		return errors.New("obligation contract has bad missed proof output count: " + strconv.Itoa(fcmpolen))
+		return fmt.Errorf("obligation contract has bad missed proof output count: %v", fcmpolen)
 	}
 
 	// Check that RevisionConfirmed is set to true if there is no revision.
@@ -103,15 +103,15 @@ func (co *contractObligation) isSane() error {
 	// number number of valid and missed proof outputs.
 	fcrlen := len(co.RevisionTransaction.FileContractRevisions)
 	if fcrlen != 1 {
-		return errors.New("obligation has bad revision count: " + strconv.Itoa(fcrlen))
+		return fmt.Errorf("obligation has bad revision count: %v", fcrlen)
 	}
 	fcrvpolen := len(co.RevisionTransaction.FileContractRevisions[0].NewValidProofOutputs)
 	if fcrvpolen != 2 {
-		return errors.New("obligation has bad revision valid proof output count: " + strconv.Itoa(fcrvpolen))
+		return fmt.Errorf("obligation has bad revision valid proof output count: %v", fcrvpolen)
 	}
 	fcrmpolen := len(co.RevisionTransaction.FileContractRevisions[0].NewMissedProofOutputs)
 	if fcrmpolen != 2 {
-		return errors.New("obligation has bad revision missed proof output count: " + strconv.Itoa(fcrmpolen))
+		return fmt.Errorf("obligation has bad revision missed proof output count: %v", fcrmpolen)
 	}
 	return nil
 }
@@ -294,7 +294,7 @@ func (h *Host) reviseObligation(revisionTransaction types.Transaction) {
 	// and that revision should correspond to a known obligation.
 	fcrlen := len(revisionTransaction.FileContractRevisions)
 	if fcrlen != 1 {
-		h.log.Critical("reviseObligation: revisionTransaction has the wrong number of revisions: " + strconv.Itoa(fcrlen))
+		h.log.Critical("reviseObligation: revisionTransaction has the wrong number of revisions:", fcrlen)
 		return
 	}
 	obligation, exists := h.obligationsByID[revisionTransaction.FileContractRevisions[0].ParentID]

--- a/modules/host/obligations.go
+++ b/modules/host/obligations.go
@@ -2,8 +2,8 @@ package host
 
 import (
 	"errors"
+	"fmt"
 	"os"
-	"strconv"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/build"

--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -231,6 +231,7 @@ func (h *Host) managedNegotiateContract(conn net.Conn, filesize uint64, merkleRo
 	co := &contractObligation{
 		ID:                contractTxn.FileContractID(0),
 		OriginTransaction: contractTxn,
+		RevisionConfirmed: true,
 		Path:              filename,
 	}
 	h.mu.Lock()

--- a/persist/log.go
+++ b/persist/log.go
@@ -1,6 +1,7 @@
 package persist
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -68,8 +69,9 @@ func (l *Logger) Close() error {
 
 // Critical will panic if debug mode is activated, and will log the statement
 // otherwise.
-func (l *Logger) Critical(s string) {
-	os.Stderr.WriteString("Severe Error: " + s + "\n")
+func (l *Logger) Critical(v ...interface{}) {
+	s := fmt.Sprintln(v...)
+	os.Stderr.WriteString("Severe Error: " + s)
 	l.Println("CRITICAL:", s)
 	if build.DEBUG {
 		panic(s)

--- a/persist/log.go
+++ b/persist/log.go
@@ -69,9 +69,9 @@ func (l *Logger) Close() error {
 // Critical will panic if debug mode is activated, and will log the statement
 // otherwise.
 func (l *Logger) Critical(s string) {
+	os.Stderr.WriteString("Severe Error: " + s + "\n")
+	l.Println("CRITICAL:", s)
 	if build.DEBUG {
 		panic(s)
 	}
-	os.Stderr.WriteString("Severe Error: " + s)
-	l.Println("CRITICAL:", s)
 }


### PR DESCRIPTION
The host makes some assumptions about the state and contents of file contract obligations. There are now sanity checks to verify that these assumptions always hold.