### PR TITLE
Add siac renter commands for listing upload and download queues

### DIFF
--- a/siac/main.go
+++ b/siac/main.go
@@ -18,9 +18,10 @@ import (
 
 // flags
 var (
-	addr         string // override default API address
-	initPassword bool   // supply a custom password when creating a wallet
-	hostVerbose  bool   // display additional host info
+	addr              string // override default API address
+	initPassword      bool   // supply a custom password when creating a wallet
+	hostVerbose       bool   // display additional host info
+	renterShowHistory bool   // Show download history in addition to download queue.
 )
 
 // apiGet wraps a GET request with a status code check, such that if the GET does
@@ -185,9 +186,10 @@ func main() {
 	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)
 
 	root.AddCommand(renterCmd)
-	renterCmd.AddCommand(renterDownloadQueueCmd, renterFilesDeleteCmd, renterFilesDownloadCmd,
+	renterCmd.AddCommand(renterFilesDeleteCmd, renterFilesDownloadCmd, renterDownloadsCmd,
 		renterFilesListCmd, renterFilesLoadCmd, renterFilesLoadASCIICmd, renterFilesRenameCmd,
-		renterFilesShareCmd, renterFilesShareASCIICmd, renterFilesUploadCmd)
+		renterFilesShareCmd, renterFilesShareASCIICmd, renterFilesUploadCmd, renterUploadsCmd)
+	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
 
 	root.AddCommand(gatewayCmd)
 	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayStatusCmd)

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -155,44 +155,40 @@ func renterdownloadscmd() {
 		fmt.Println("Could not get download queue:", err)
 		return
 	}
-	func() {
-		// Filter out files that have been downloaded.
-		var downloading []modules.DownloadInfo
-		for _, file := range queue.Downloads {
-			if file.Received != file.Filesize {
-				downloading = append(downloading, file)
-			}
+	// Filter out files that have been downloaded.
+	var downloading []modules.DownloadInfo
+	for _, file := range queue.Downloads {
+		if file.Received != file.Filesize {
+			downloading = append(downloading, file)
 		}
-		if len(downloading) == 0 {
-			fmt.Println("No files are downloading.")
-			return
-		}
+	}
+	if len(downloading) == 0 {
+		fmt.Println("No files are downloading.")
+	} else {
 		fmt.Println("Downloading", len(downloading), "files:")
 		for _, file := range downloading {
 			fmt.Printf("%s: %5.1f%% %s -> %s\n", file.StartTime.Format("Jan 02 03:04 PM"), 100*float64(file.Received)/float64(file.Filesize), file.SiaPath, file.Destination)
 		}
-	}()
+	}
 	if !renterShowHistory {
 		return
 	}
-	func() {
-		fmt.Println()
-		// Filter out files that are downloading.
-		var downloaded []modules.DownloadInfo
-		for _, file := range queue.Downloads {
-			if file.Received == file.Filesize {
-				downloaded = append(downloaded, file)
-			}
+	fmt.Println()
+	// Filter out files that are downloading.
+	var downloaded []modules.DownloadInfo
+	for _, file := range queue.Downloads {
+		if file.Received == file.Filesize {
+			downloaded = append(downloaded, file)
 		}
-		if len(downloaded) == 0 {
-			fmt.Println("No files downloaded.")
-			return
-		}
+	}
+	if len(downloaded) == 0 {
+		fmt.Println("No files downloaded.")
+	} else {
 		fmt.Println("Downloaded", len(downloaded), "files:")
 		for _, file := range downloaded {
 			fmt.Printf("%s: %s -> %s\n", file.StartTime.Format("Jan 02 03:04 PM"), file.SiaPath, file.Destination)
 		}
-	}()
+	}
 }
 
 func renterfilesdeletecmd(path string) {

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -94,15 +94,15 @@ var (
 
 	renterFilesShareASCIICmd = &cobra.Command{
 		Use:   "shareascii [path]",
-		Short: "Export a file as an ASCII-encoded .sia file",
-		Long:  "Export a file as an ASCII-encoded .sia file.",
+		Short: "Prints an ASCII-encoded .sia file for sharing",
+		Long:  "Prints an ASCII-encoded .sia file for sharing, but does not save the .sia file to disk.",
 		Run:   wrap(renterfilesshareasciicmd),
 	}
 
 	renterFilesUploadCmd = &cobra.Command{
 		Use:   "upload [source] [path]",
 		Short: "Upload a file",
-		Long:  "Upload a file using a given nickname.",
+		Long:  "Upload a file to [path] on the Sia network.",
 		Run:   wrap(renterfilesuploadcmd),
 	}
 )
@@ -118,6 +118,8 @@ func abs(path string) string {
 	return abspath
 }
 
+// renteruploadscmd is the handler for the command `siac renter uploads`.
+// Lists files currently uploading.
 func renteruploadscmd() {
 	var rf api.RenterFiles
 	err := getAPI("/renter/files", &rf)
@@ -148,6 +150,9 @@ func renteruploadscmd() {
 	}
 }
 
+// renterdownloadscmd is the handler for the command `siac renter downloads`.
+// Lists files currently downloading, and optionally previously downloaded
+// files if the -H or --history flag is specified.
 func renterdownloadscmd() {
 	var queue api.RenterDownloadQueue
 	err := getAPI("/renter/downloads", &queue)
@@ -191,6 +196,8 @@ func renterdownloadscmd() {
 	}
 }
 
+// renterfilesdeletecmd is the handler for the command `siac renter delete [path]`.
+// Removes the specified path from the Sia network.
 func renterfilesdeletecmd(path string) {
 	err := post("/renter/delete/"+path, "")
 	if err != nil {
@@ -200,6 +207,8 @@ func renterfilesdeletecmd(path string) {
 	fmt.Println("Deleted", path)
 }
 
+// renterfilesdownloadcmd is the handler for the comand `siac renter download [path] [destination]`.
+// Downloads a path from the Sia network to the local specified destination.
 func renterfilesdownloadcmd(path, destination string) {
 	err := get("/renter/download/" + path + "?destination=" + abs(destination))
 	if err != nil {
@@ -209,6 +218,8 @@ func renterfilesdownloadcmd(path, destination string) {
 	fmt.Printf("Downloaded '%s' to %s.\n", path, abs(destination))
 }
 
+// renterfileslistcmd is the handler for the command `siac renter list`.
+// Lists files known to the renter on the network.
 func renterfileslistcmd() {
 	var rf api.RenterFiles
 	err := getAPI("/renter/files", &rf)
@@ -230,6 +241,8 @@ func renterfileslistcmd() {
 	}
 }
 
+// renterfilesloadcmd is the handler for the command `siac renter load [source]`.
+// Loads a .sia file, adding the file entries contained within.
 func renterfilesloadcmd(source string) {
 	var info api.RenterLoad
 	err := postResp("/renter/load", "source="+abs(source), &info)
@@ -243,6 +256,8 @@ func renterfilesloadcmd(source string) {
 	}
 }
 
+// renterfilesloadasciicmd is the handler for the command `siac renter loadascii [ascii]`.
+// Load an ASCII-encoded .sia file.
 func renterfilesloadasciicmd(ascii string) {
 	var info api.RenterLoad
 	err := postResp("/renter/loadascii", "asciisia="+ascii, &info)
@@ -256,6 +271,8 @@ func renterfilesloadasciicmd(ascii string) {
 	}
 }
 
+// renterfilesrenamecmd is the handler for the command `siac renter rename [path] [newpath]`.
+// Renames a file on the Sia network.
 func renterfilesrenamecmd(path, newpath string) {
 	err := post("/renter/rename/"+path, "newsiapath="+newpath)
 	if err != nil {
@@ -265,6 +282,8 @@ func renterfilesrenamecmd(path, newpath string) {
 	fmt.Printf("Renamed %s to %s\n", path, newpath)
 }
 
+// renterfilessharecmd is the handler for the command `siac renter share [path] [destination]`.
+// Export a file to a .sia for sharing.
 func renterfilessharecmd(path, destination string) {
 	err := get(fmt.Sprintf("/renter/share?siapaths=%s&destination=%s", path, abs(destination)))
 	if err != nil {
@@ -274,6 +293,8 @@ func renterfilessharecmd(path, destination string) {
 	fmt.Printf("Exported %s to %s\n", path, abs(destination))
 }
 
+// renterfilesshareasciicmd is the handler for the command `siac renter shareascii [path]`.
+// Prints an ascii-encoded sia file.
 func renterfilesshareasciicmd(path string) {
 	var data api.RenterShareASCII
 	err := getAPI("/renter/shareascii?siapaths="+path, &data)
@@ -284,6 +305,8 @@ func renterfilesshareasciicmd(path string) {
 	fmt.Println(data.ASCIIsia)
 }
 
+// renterfilesuploadcmd is the handler for the command `siac renter upload [source] [path]`.
+// Uploads the [source] file to [path] on the Sia network.
 func renterfilesuploadcmd(source, path string) {
 	err := post("/renter/upload/"+path, "source="+abs(source))
 	if err != nil {


### PR DESCRIPTION
`siac renter uploads` lists only files that are currently uploading.

`siac renter downloads [--history/-H]` lists only files that are currently downloading. The `--history` flag shows previously downloaded files in addition to the currently downloading files. There is no `--history` flag for `siac renter uploads` because the backend does not yet support this.

I also moved all `command.AddCommand(subCommand)` into `init()` functions in the respective command's file. This way the main function doesn't need to worry about adding all of the subcommands.