### PR TITLE
upgrade travis to go1.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 go:
-  - 1.5.2
+  - 1.5.3
 
 install:
   - make dependencies


### PR DESCRIPTION
I think this is causing build failures. Additionally, go1.5.2 has security holes. We should test software where the security holes have been patched.