### PR TITLE
Remove status commands from siac

### DIFF
--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -9,21 +9,21 @@ import (
 )
 
 var (
-	consensusStatusCmd = &cobra.Command{
-		Use:   "status",
-		Short: "Print the current state of the daemon",
-		Long:  "Query the daemon for values such as the current difficulty, target, height, peers, transactions, etc.",
-		Run:   wrap(consensusstatuscmd),
+	consensusCmd = &cobra.Command{
+		Use:   "consensus",
+		Short: "Print the current state of consensus",
+		Long:  "Print the current state of consensus such as current block, block height, and target.",
+		Run:   wrap(consensuscmd),
 	}
 )
 
-// consensusstatuscmd is the handler for the command `siac status`.
-// Prints the current state of the daemon.
-func consensusstatuscmd() {
+// consensuscmd is the handler for the command `siac consensus`.
+// Prints the current state of consensus.
+func consensuscmd() {
 	var cg api.ConsensusGET
 	err := getAPI("/consensus", &cg)
 	if err != nil {
-		fmt.Println("Could not get daemon status:", err)
+		fmt.Println("Could not get current consensus state:", err)
 		return
 	}
 	fmt.Printf(`Block:  %v

--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -17,6 +17,8 @@ var (
 	}
 )
 
+// consensusstatuscmd is the handler for the command `siac status`.
+// Prints the current state of the daemon.
 func consensusstatuscmd() {
 	var cg api.ConsensusGET
 	err := getAPI("/consensus", &cg)

--- a/siac/daemoncmd.go
+++ b/siac/daemoncmd.go
@@ -15,6 +15,8 @@ var (
 	}
 )
 
+// stopcmd is the handler for the command `siac stop`.
+// Stops the daemon.
 func stopcmd() {
 	err := get("/daemon/stop")
 	if err != nil {

--- a/siac/gatewaycmd.go
+++ b/siac/gatewaycmd.go
@@ -13,7 +13,7 @@ var (
 		Use:   "gateway",
 		Short: "Perform gateway actions",
 		Long:  "Add or remove a peer, view the current peer list, or synchronize to the network.",
-		Run:   wrap(gatewaylistcmd),
+		Run:   wrap(gatewaycmd),
 	}
 
 	gatewayAddCmd = &cobra.Command{
@@ -28,6 +28,13 @@ var (
 		Short: "Remove a peer",
 		Long:  "Remove a peer from the peer list.",
 		Run:   wrap(gatewayremovecmd),
+	}
+
+	gatewayAddressCmd = &cobra.Command{
+		Use:   "address",
+		Short: "Print the gateway address",
+		Long:  "Print the network address of the gateway.",
+		Run:   wrap(gatewayaddresscmd),
 	}
 
 	gatewayListCmd = &cobra.Command{
@@ -60,6 +67,31 @@ func gatewayremovecmd(addr string) {
 	fmt.Println("Removed", addr, "from peer list.")
 }
 
+// gatewayaddresscmd is the handler for the command `siac gateway address`.
+// Prints the gateway's network address.
+func gatewayaddresscmd() {
+	var info api.GatewayInfo
+	err := getAPI("/gateway", &info)
+	if err != nil {
+		fmt.Println("Could not get gateway address:", err)
+		return
+	}
+	fmt.Println("Address:", info.NetAddress)
+}
+
+// gatewaycmd is the handler for the command `siac gateway`.
+// Prints the gateway's network address and number of peers.
+func gatewaycmd() {
+	var info api.GatewayInfo
+	err := getAPI("/gateway", &info)
+	if err != nil {
+		fmt.Println("Could not get gateway address:", err)
+		return
+	}
+	fmt.Println("Address:", info.NetAddress)
+	fmt.Println("Active peers:", len(info.Peers))
+}
+
 // gatewaylistcmd is the handler for the command `siac gateway list`.
 // Prints a list of all peers.
 func gatewaylistcmd() {
@@ -69,7 +101,6 @@ func gatewaylistcmd() {
 		fmt.Println("Could not get peer list:", err)
 		return
 	}
-	fmt.Println("Address:", info.NetAddress)
 	if len(info.Peers) == 0 {
 		fmt.Println("No peers to show.")
 		return

--- a/siac/gatewaycmd.go
+++ b/siac/gatewaycmd.go
@@ -13,7 +13,7 @@ var (
 		Use:   "gateway",
 		Short: "Perform gateway actions",
 		Long:  "Add or remove a peer, view the current peer list, or synchronize to the network.",
-		Run:   wrap(gatewaystatuscmd),
+		Run:   wrap(gatewaylistcmd),
 	}
 
 	gatewayAddCmd = &cobra.Command{
@@ -30,11 +30,11 @@ var (
 		Run:   wrap(gatewayremovecmd),
 	}
 
-	gatewayStatusCmd = &cobra.Command{
-		Use:   "status",
+	gatewayListCmd = &cobra.Command{
+		Use:   "list",
 		Short: "View a list of peers",
 		Long:  "View the current peer list.",
-		Run:   wrap(gatewaystatuscmd),
+		Run:   wrap(gatewaylistcmd),
 	}
 )
 
@@ -56,11 +56,11 @@ func gatewayremovecmd(addr string) {
 	fmt.Println("Removed", addr, "from peer list.")
 }
 
-func gatewaystatuscmd() {
+func gatewaylistcmd() {
 	var info api.GatewayInfo
 	err := getAPI("/gateway", &info)
 	if err != nil {
-		fmt.Println("Could not get gateway status:", err)
+		fmt.Println("Could not get peer list:", err)
 		return
 	}
 	fmt.Println("Address:", info.NetAddress)

--- a/siac/gatewaycmd.go
+++ b/siac/gatewaycmd.go
@@ -38,6 +38,8 @@ var (
 	}
 )
 
+// gatewayaddcmd is the handler for the command `siac gateway add [address]`.
+// Adds a new peer to the peer list.
 func gatewayaddcmd(addr string) {
 	err := post("/gateway/add/"+addr, "")
 	if err != nil {
@@ -47,6 +49,8 @@ func gatewayaddcmd(addr string) {
 	fmt.Println("Added", addr, "to peer list.")
 }
 
+// gatewayremovecmd is the handler for the command `siac gateway remove [address]`.
+// Removes a peer from the peer list.
 func gatewayremovecmd(addr string) {
 	err := post("/gateway/remove/"+addr, "")
 	if err != nil {
@@ -56,6 +60,8 @@ func gatewayremovecmd(addr string) {
 	fmt.Println("Removed", addr, "from peer list.")
 }
 
+// gatewaylistcmd is the handler for the command `siac gateway list`.
+// Prints a list of all peers.
 func gatewaylistcmd() {
 	var info api.GatewayInfo
 	err := getAPI("/gateway", &info)

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -47,6 +47,8 @@ Doing so will override the standard connectivity checks.`,
 	}
 )
 
+// hostconfigcmd is the handler for the command `siac host config [setting] [value]`.
+// Modifies host settings.
 func hostconfigcmd(param, value string) {
 	switch param {
 	case "price":
@@ -80,6 +82,9 @@ func hostconfigcmd(param, value string) {
 	fmt.Println("Host settings updated.")
 }
 
+// hostannouncecmd is the handler for the command `siac host announce`.
+// Announces yourself as a host to the network. Optionally takes an address to
+// announce as.
 func hostannouncecmd(cmd *cobra.Command, args []string) {
 	var err error
 	switch len(args) {
@@ -98,6 +103,8 @@ func hostannouncecmd(cmd *cobra.Command, args []string) {
 	fmt.Println("Host announcement submitted to network.")
 }
 
+// hostcmd is the handler for the command `siac host`.
+// Prints info about the host.
 func hostcmd() {
 	hg := new(api.HostGET)
 	err := getAPI("/host", &hg)

--- a/siac/main.go
+++ b/siac/main.go
@@ -192,7 +192,7 @@ func main() {
 	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
 
 	root.AddCommand(gatewayCmd)
-	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayListCmd)
+	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayAddressCmd, gatewayListCmd)
 
 	root.AddCommand(consensusCmd)
 

--- a/siac/main.go
+++ b/siac/main.go
@@ -180,7 +180,7 @@ func main() {
 	root.AddCommand(walletCmd)
 	walletCmd.AddCommand(walletAddressCmd, walletAddressesCmd, walletInitCmd,
 		walletLoadCmd, walletLockCmd, walletSeedsCmd, walletSendCmd,
-		walletStatusCmd, walletTransactionsCmd, walletUnlockCmd)
+		walletBalanceCmd, walletTransactionsCmd, walletUnlockCmd)
 	walletInitCmd.Flags().BoolVarP(&initPassword, "password", "p", false, "Prompt for a custom password")
 	walletLoadCmd.AddCommand(walletLoad033xCmd, walletLoadSeedCmd, walletLoadSiagCmd)
 	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)

--- a/siac/main.go
+++ b/siac/main.go
@@ -154,7 +154,7 @@ func main() {
 		Use:   os.Args[0],
 		Short: "Sia Client v" + build.Version,
 		Long:  "Sia Client v" + build.Version,
-		Run:   version,
+		Run:   wrap(consensuscmd),
 	}
 
 	// create command tree
@@ -194,7 +194,7 @@ func main() {
 	root.AddCommand(gatewayCmd)
 	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayListCmd)
 
-	root.AddCommand(consensusStatusCmd)
+	root.AddCommand(consensusCmd)
 
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")

--- a/siac/main.go
+++ b/siac/main.go
@@ -175,7 +175,7 @@ func main() {
 	hostCmd.Flags().BoolVarP(&hostVerbose, "verbose", "v", false, "Display detailed host info")
 
 	root.AddCommand(minerCmd)
-	minerCmd.AddCommand(minerStartCmd, minerStopCmd, minerStatusCmd)
+	minerCmd.AddCommand(minerStartCmd, minerStopCmd)
 
 	root.AddCommand(walletCmd)
 	walletCmd.AddCommand(walletAddressCmd, walletAddressesCmd, walletInitCmd,

--- a/siac/main.go
+++ b/siac/main.go
@@ -192,7 +192,7 @@ func main() {
 	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
 
 	root.AddCommand(gatewayCmd)
-	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayStatusCmd)
+	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayListCmd)
 
 	root.AddCommand(consensusStatusCmd)
 

--- a/siac/minercmd.go
+++ b/siac/minercmd.go
@@ -12,8 +12,8 @@ var (
 	minerCmd = &cobra.Command{
 		Use:   "miner",
 		Short: "Perform miner actions",
-		Long:  "Interact with the miner",
-		Run:   wrap(minerstatuscmd),
+		Long:  "Perform miner actions and view miner status.",
+		Run:   wrap(minercmd),
 	}
 
 	minerStartCmd = &cobra.Command{
@@ -21,13 +21,6 @@ var (
 		Short: "Start cpu mining",
 		Long:  "Start cpu mining, if the miner is already running, this command does nothing",
 		Run:   wrap(minerstartcmd),
-	}
-
-	minerStatusCmd = &cobra.Command{
-		Use:   "status",
-		Short: "View miner status",
-		Long:  "View the current mining status",
-		Run:   wrap(minerstatuscmd),
 	}
 
 	minerStopCmd = &cobra.Command{
@@ -47,7 +40,7 @@ func minerstartcmd() {
 	fmt.Println("CPU Miner is now running.")
 }
 
-func minerstatuscmd() {
+func minercmd() {
 	status := new(api.MinerGET)
 	err := getAPI("/miner", status)
 	if err != nil {

--- a/siac/minercmd.go
+++ b/siac/minercmd.go
@@ -31,6 +31,8 @@ var (
 	}
 )
 
+// minerstartcmd is the handler for the command `siac miner start`.
+// Starts the CPU miner.
 func minerstartcmd() {
 	err := get("/miner/start")
 	if err != nil {
@@ -40,6 +42,8 @@ func minerstartcmd() {
 	fmt.Println("CPU Miner is now running.")
 }
 
+// minercmd is the handler for the command `siac miner`.
+// Prints the status of the miner.
 func minercmd() {
 	status := new(api.MinerGET)
 	err := getAPI("/miner", status)
@@ -59,6 +63,8 @@ Blocks Mined: %d (%d stale)
 `, miningStr, status.CPUHashrate/1000, status.BlocksMined, status.StaleBlocksMined)
 }
 
+// minerstopcmd is the handler for the command `siac miner stop`.
+// Stops the CPU miner.
 func minerstopcmd() {
 	err := get("/miner/stop")
 	if err != nil {


### PR DESCRIPTION
e.g. The command to get the status of the miner is `siac miner` instead of `siac miner status`.

@lukechampine and I discussed this earlier. Status commands are redundant and require more typing.

Also renamed hostdb command to `siac host list`.
And renamed `siac gateway status` to `siac gateway list` (also callable with `siac gateway`).