### PR TITLE
Remove unused api.Server.daemonExposed field

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -24,7 +24,6 @@ type Server struct {
 	wallet   modules.Wallet
 
 	apiServer         *http.Server
-	daemonExposed     bool
 	listener          net.Listener
 	requiredUserAgent string
 }


### PR DESCRIPTION
`grep -r "daemonExposed" .` shows it isn't used anywhere.