### PR TITLE
Rename renter file commands

### DIFF
--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -44,10 +44,11 @@ var (
 	}
 
 	renterFilesDeleteCmd = &cobra.Command{
-		Use:   "delete [path]",
-		Short: "Delete a file",
-		Long:  "Delete a file. Does not delete the file on disk.",
-		Run:   wrap(renterfilesdeletecmd),
+		Use:     "delete [path]",
+		Aliases: []string{"rm"},
+		Short:   "Delete a file",
+		Long:    "Delete a file. Does not delete the file on disk.",
+		Run:     wrap(renterfilesdeletecmd),
 	}
 
 	renterFilesDownloadCmd = &cobra.Command{
@@ -58,10 +59,11 @@ var (
 	}
 
 	renterFilesListCmd = &cobra.Command{
-		Use:   "list",
-		Short: "List the status of all files",
-		Long:  "List the status of all files known to the renter on the Sia network.",
-		Run:   wrap(renterfileslistcmd),
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List the status of all files",
+		Long:    "List the status of all files known to the renter on the Sia network.",
+		Run:     wrap(renterfileslistcmd),
 	}
 
 	renterFilesLoadCmd = &cobra.Command{
@@ -79,10 +81,11 @@ var (
 	}
 
 	renterFilesRenameCmd = &cobra.Command{
-		Use:   "rename [path] [newpath]",
-		Short: "Rename a file",
-		Long:  "Rename a file.",
-		Run:   wrap(renterfilesrenamecmd),
+		Use:     "rename [path] [newpath]",
+		Aliases: []string{"mv"},
+		Short:   "Rename a file",
+		Long:    "Rename a file.",
+		Run:     wrap(renterfilesrenamecmd),
 	}
 
 	renterFilesShareCmd = &cobra.Command{


### PR DESCRIPTION
delete -> rm
rename -> mv
list -> ls

Most people using siac will be familiar with these commands. It would also be nice to add more features to make these commands to more closely mimic their unix equivalents, such as `ls`ing a specific directory.