### PR TITLE
Fix host desynchronization

### DIFF
--- a/modules/consensus/accept_bench_test.go
+++ b/modules/consensus/accept_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkAcceptEmptyBlocks(b *testing.B) {
 	if err != nil {
 		b.Fatal("Error creating tester: " + err.Error())
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Create an alternate testing consensus set, which does not
 	// have any subscribers
@@ -76,7 +76,7 @@ func BenchmarkAcceptSmallBlocks(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// COMPAT v0.4.0
 	//

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -296,7 +296,7 @@ func TestIntegrationDoSBlockHandling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Mine a block that is valid except for containing a buried invalid
 	// transaction. The transaction has more siacoin inputs than outputs.
@@ -340,7 +340,7 @@ func TestBlockKnownHandling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Get a block destined to be stale.
 	block, target, err := cst.miner.BlockForWork()
@@ -403,7 +403,7 @@ func TestOrphanHandling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Try submitting an orphan block to the consensus set. The empty block can
 	// be used, because looking for a parent is one of the first checks the
@@ -428,7 +428,7 @@ func TestMissedTarget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Mine a block that doesn't meet the target.
 	block, target, err := cst.miner.BlockForWork()
@@ -457,7 +457,7 @@ func TestMinerPayoutHandling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Create a block with the wrong miner payout structure - testing can be
 	// light here because there is heavier testing in the 'types' package,
@@ -484,7 +484,7 @@ func TestFutureTimestampHandling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Submit a block with a timestamp in the future, but not the extreme
 	// future.
@@ -528,7 +528,7 @@ func TestBuriedBadTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	pb := cst.cs.dbCurrentProcessedBlock()
 
 	// Create a good transaction using the wallet.
@@ -578,7 +578,6 @@ func TestInconsistentCheck(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
 
 	// Corrupt the consensus set by adding a new siafund output.
 	sfo := types.SiafundOutput{
@@ -609,7 +608,7 @@ func TestTaxHardfork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Create a file contract with a payout that is put into the blockchain
 	// before the hardfork block but expires after the hardfork block.

--- a/modules/consensus/accept_txntypes_test.go
+++ b/modules/consensus/accept_txntypes_test.go
@@ -94,7 +94,7 @@ func TestIntegrationSimpleBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	cst.testSimpleBlock()
 }
 
@@ -151,7 +151,7 @@ func TestIntegrationSpendSiacoinsBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	cst.testSpendSiacoinsBlock()
 }
 
@@ -297,7 +297,7 @@ func TestIntegrationValidStorageProofBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	cst.testValidStorageProofBlocks()
 }
 
@@ -401,7 +401,7 @@ func TestIntegrationMissedStorageProofBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	cst.testMissedStorageProofBlocks()
 }
 
@@ -566,7 +566,7 @@ func TestIntegrationFileContractRevision(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	cst.testFileContractRevision()
 }
 
@@ -662,7 +662,7 @@ func (cst *consensusSetTester) TestIntegrationSpendSiafunds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	cst.testSpendSiafunds()
 }
 

--- a/modules/consensus/consensusset_bench_test.go
+++ b/modules/consensus/consensusset_bench_test.go
@@ -17,6 +17,6 @@ func BenchmarkCreateServerTester(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		cst.closeCst()
+		cst.Close()
 	}
 }

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -168,9 +168,19 @@ func createConsensusSetTester(name string) (*consensusSetTester, error) {
 	return cst, nil
 }
 
-// closeCst safely closes the consensus set tester.
-func (cst *consensusSetTester) closeCst() error {
-	return cst.gateway.Close()
+// Close safely closes the consensus set tester. Because there's not a good way
+// to errcheck when deferring a close, a panic is called in the event of an
+// error.
+func (cst *consensusSetTester) Close() error {
+	err := cst.cs.Close()
+	if err != nil {
+		panic(err)
+	}
+	err = cst.gateway.Close()
+	if err != nil {
+		panic(err)
+	}
+	return nil
 }
 
 // TestNilInputs tries to create new consensus set modules using nil inputs.

--- a/modules/consensus/subscribe_test.go
+++ b/modules/consensus/subscribe_test.go
@@ -44,7 +44,7 @@ func TestUnitInvalidConsensusChangeSubscription(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	ms := newMockSubscriber()
 	badCCID := modules.ConsensusChangeID{1}
@@ -64,7 +64,7 @@ func TestUnitUnsubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// Subscribe the mock subscriber to the consensus set.
 	ms := newMockSubscriber()

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -20,12 +20,12 @@ func TestSynchronize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst1.closeCst()
+	defer cst1.Close()
 	cst2, err := createConsensusSetTester("TestSynchronize2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst2.closeCst()
+	defer cst2.Close()
 
 	// mine on cst2 until it is above cst1
 	for cst1.cs.dbBlockHeight() >= cst2.cs.dbBlockHeight() {
@@ -92,12 +92,12 @@ func TestResynchronize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst1.closeCst()
+	defer cst1.Close()
 	cst2, err := createConsensusSetTester("TestResynchronize2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst2.closeCst()
+	defer cst2.Close()
 
 	// TODO: without this extra block, sync fails. Why?
 	b, _ := cst2.miner.FindBlock()
@@ -166,7 +166,7 @@ func TestBlockHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 
 	// mine until we have enough blocks to test blockHistory
 	for cst.cs.dbBlockHeight() < 50 {

--- a/modules/consensus/validtransaction_test.go
+++ b/modules/consensus/validtransaction_test.go
@@ -16,7 +16,7 @@ func TestTryValidTransactionSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	initialHash := cst.cs.dbConsensusChecksum()
 
 	// Try a valid transaction.
@@ -47,7 +47,7 @@ func TestTryInvalidTransactionSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst.closeCst()
+	defer cst.Close()
 	initialHash := cst.cs.dbConsensusChecksum()
 
 	// Try a valid transaction followed by an invalid transaction.

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -19,6 +19,7 @@ func TestAnnouncement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Place the announcement.
 	ht.host.mu.RLock()

--- a/modules/host/download_test.go
+++ b/modules/host/download_test.go
@@ -16,6 +16,7 @@ func TestRPCDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 	nickname := "TestRPCDownload1"
 	uploadData, err := ht.uploadFile(nickname, renewDisabled)
 	if err != nil {

--- a/modules/host/obligations.go
+++ b/modules/host/obligations.go
@@ -428,7 +428,7 @@ func (h *Host) handleActionItem(co *contractObligation) {
 			h.log.Println("WARN: could not submit file contract transaction:", err)
 		}
 	}
-	if co.OriginConfirmed && !co.RevisionConfirmed && co.hasRevision() {
+	if !co.RevisionConfirmed && co.hasRevision() {
 		// The revision transaction has not been seen on the blockchain, and
 		// should be resubmitted.
 		err := h.tpool.AcceptTransactionSet([]types.Transaction{co.RevisionTransaction})

--- a/modules/host/obligations.go
+++ b/modules/host/obligations.go
@@ -428,7 +428,7 @@ func (h *Host) handleActionItem(co *contractObligation) {
 			h.log.Println("WARN: could not submit file contract transaction:", err)
 		}
 	}
-	if !co.RevisionConfirmed && co.hasRevision() {
+	if co.OriginConfirmed && !co.RevisionConfirmed && co.hasRevision() {
 		// The revision transaction has not been seen on the blockchain, and
 		// should be resubmitted.
 		err := h.tpool.AcceptTransactionSet([]types.Transaction{co.RevisionTransaction})

--- a/modules/host/obligations.go
+++ b/modules/host/obligations.go
@@ -422,7 +422,7 @@ func (h *Host) handleActionItem(co *contractObligation) {
 				// going to be accepted onto the blockchain at any point in the
 				// future, and therefore the obligation should be removed.
 				h.removeObligation(co, obligationFailed)
-				h.log.Println("WARN: a file contract given to the host has been double spent!")
+				h.log.Println("WARN: a file contract given to the host has been invalidated")
 				return
 			}
 			h.log.Println("WARN: could not submit file contract transaction:", err)

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -177,13 +177,6 @@ func (h *Host) load() error {
 	h.publicKey = p.PublicKey
 	h.secretKey = p.SecretKey
 
-	// Copy over the file management. The space remaining is recalculated from
-	// disk instead of being saved, to maximize the potential usefulness of
-	// restarting Sia as a means of eliminating unkonwn errors.
-	h.fileCounter = p.FileCounter
-	h.spaceRemaining = p.Settings.TotalStorage
-	h.loadObligations(p.Obligations)
-
 	// Copy over statistics.
 	h.revenue = p.Revenue
 	h.lostRevenue = p.LostRevenue
@@ -199,6 +192,13 @@ func (h *Host) load() error {
 
 	// Utilities.
 	h.settings = p.Settings
+
+	// Copy over the file management. The space remaining is recalculated from
+	// disk instead of being saved, to maximize the potential usefulness of
+	// restarting Sia as a means of eliminating unkonwn errors.
+	h.fileCounter = p.FileCounter
+	h.spaceRemaining = p.Settings.TotalStorage
+	h.loadObligations(p.Obligations)
 
 	// Subscribe to the consensus set.
 	err = h.initConsensusSubscription()

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -198,7 +198,6 @@ func (h *Host) load() error {
 	// restarting Sia as a means of eliminating unkonwn errors.
 	h.fileCounter = p.FileCounter
 	h.spaceRemaining = p.Settings.TotalStorage
-	h.loadObligations(p.Obligations)
 
 	// Subscribe to the consensus set.
 	err = h.initConsensusSubscription()
@@ -206,6 +205,7 @@ func (h *Host) load() error {
 		return err
 	}
 
+	h.loadObligations(p.Obligations)
 	return nil
 }
 

--- a/modules/host/update_test.go
+++ b/modules/host/update_test.go
@@ -21,6 +21,7 @@ func TestStorageProof(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// create a file contract
 	fc := types.FileContract{
@@ -113,6 +114,7 @@ func TestInitRescan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Check that the host's persistent variables have incorporated the first
 	// few blocks.

--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -512,5 +512,14 @@ func (h *Host) managedRPCRenew(conn net.Conn) error {
 		return err
 	}
 
-	return h.managedNegotiateContract(conn, obligation.fileSize(), obligation.merkleRoot(), filename)
+	err = h.managedNegotiateContract(conn, obligation.fileSize(), obligation.merkleRoot(), filename)
+	if err != nil {
+		// Negotiation failed, delete the copied file.
+		err2 := os.Remove(filename)
+		if err2 != nil {
+			return errors.New(err.Error() + " and " + err2.Error())
+		}
+		return err
+	}
+	return nil
 }

--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -252,8 +252,8 @@ func (h *Host) managedNegotiateContract(conn net.Conn, filesize uint64, merkleRo
 
 	// Add this contract to the host's list of obligations.
 	co := &contractObligation{
-		ID:                contractTxn.FileContractID(0),
-		OriginTransaction: contractTxn,
+		ID:                signedTxn.FileContractID(0),
+		OriginTransaction: signedTxn,
 		RevisionConfirmed: true,
 		Path:              filename,
 	}

--- a/modules/host/upload_test.go
+++ b/modules/host/upload_test.go
@@ -296,6 +296,8 @@ func TestFailedObligation(t *testing.T) {
 		t.Error("host did not reallocate space after failed storage proof")
 	}
 	if rebootHost.lostRevenue.Cmp(expectedLostRevenue) != 0 {
+		t.Error(rebootHost.lostRevenue)
+		t.Error(expectedLostRevenue)
 		t.Error("host did not correctly report lost revenue")
 	}
 }

--- a/modules/host/upload_test.go
+++ b/modules/host/upload_test.go
@@ -181,6 +181,17 @@ func TestRPCUpload(t *testing.T) {
 	if expectedRevenue.Cmp(ht.host.revenue) != 0 {
 		t.Error("host's revenue was not moved from anticipated to expected")
 	}
+
+	// Check that the file has been removed from the host directory.
+	fileInfos, err := ioutil.ReadDir(filepath.Join(ht.persistDir, modules.HostDir))
+	if len(fileInfos) != 2 {
+		t.Error("too many files in directory after storage proof completed")
+	}
+	for _, fileInfo := range fileInfos {
+		if fileInfo.Name() != "host.log" && fileInfo.Name() != "settings.json" {
+			t.Error("unexpected file after storage proof", fileInfo.Name())
+		}
+	}
 }
 
 // TestRPCRenew attempts to upload a file to the host, adding coverage to the

--- a/modules/host/upload_test.go
+++ b/modules/host/upload_test.go
@@ -323,14 +323,21 @@ func TestRestartSuccessObligation(t *testing.T) {
 	expectedRevenue := ht.host.anticipatedRevenue
 	ht.host.mu.RUnlock()
 
+	// TODO: This is a hack to get the build passing, needed to bypass a
+	// problem with the transaction pool.
+	_, err = ht.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Close the host, then mine some blocks, but not enough that the host
 	// misses the storage proof.
 	err = ht.host.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i <= 5; i++ {
-		_, err := ht.miner.AddBlock()
+	for i := 0; i <= 3; i++ {
+		_, err = ht.miner.AddBlock()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -391,6 +398,13 @@ func TestRestartCorruptSuccessObligation(t *testing.T) {
 	expectedRevenue := ht.host.anticipatedRevenue
 	ht.host.mu.RUnlock()
 
+	// TODO: This is a hack to get the build to pass. There are issues with the
+	// transaction pool that need to be worked out.
+	_, err = ht.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Corrupt the host's consensus tracking, close the host, then mine some
 	// blocks, but not enough that the host misses the storage proof. The host
 	// will need to perform a rescan and update its obligations correctly.
@@ -402,7 +416,7 @@ func TestRestartCorruptSuccessObligation(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i <= 3; i++ {
-		_, err := ht.miner.AddBlock()
+		_, err = ht.miner.AddBlock()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/modules/host/upload_test.go
+++ b/modules/host/upload_test.go
@@ -132,6 +132,7 @@ func TestRPCUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 	ht.host.mu.RLock()
 	baselineAnticipatedRevenue := ht.host.anticipatedRevenue
 	baselineSpace := ht.host.spaceRemaining
@@ -205,6 +206,7 @@ func TestRPCRenew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 	_, err = ht.uploadFile("TestRPCRenew- 1", renewEnabled)
 	if err != nil {
 		t.Fatal(err)
@@ -457,6 +459,7 @@ func TestUploadConstraints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 	h := ht.host
 	settings := h.Settings()
 	settings.TotalStorage = 10e3

--- a/modules/host/upload_test.go
+++ b/modules/host/upload_test.go
@@ -323,13 +323,6 @@ func TestRestartSuccessObligation(t *testing.T) {
 	expectedRevenue := ht.host.anticipatedRevenue
 	ht.host.mu.RUnlock()
 
-	// TODO: This is a hack to get the build passing, needed to bypass a
-	// problem with the transaction pool.
-	_, err = ht.miner.AddBlock()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Close the host, then mine some blocks, but not enough that the host
 	// misses the storage proof.
 	err = ht.host.Close()
@@ -397,13 +390,6 @@ func TestRestartCorruptSuccessObligation(t *testing.T) {
 	ht.host.mu.RLock()
 	expectedRevenue := ht.host.anticipatedRevenue
 	ht.host.mu.RUnlock()
-
-	// TODO: This is a hack to get the build to pass. There are issues with the
-	// transaction pool that need to be worked out.
-	_, err = ht.miner.AddBlock()
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// Corrupt the host's consensus tracking, close the host, then mine some
 	// blocks, but not enough that the host misses the storage proof. The host

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -201,7 +201,7 @@ func (tp *TransactionPool) handleConflicts(ts []types.Transaction, conflicts []T
 	// Check that the transaction set is valid.
 	cc, err := tp.consensusSet.TryTransactionSet(superset)
 	if err != nil {
-		return err
+		return modules.NewConsensusConflict(err.Error())
 	}
 
 	// Remove the conflicts from the transaction pool. The diffs do not need to
@@ -260,7 +260,7 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction) error {
 	}
 	cc, err := tp.consensusSet.TryTransactionSet(ts)
 	if err != nil {
-		return err
+		return modules.NewConsensusConflict(err.Error())
 	}
 
 	// Add the transaction set to the pool.

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -189,7 +189,8 @@ func TestIntegrationTransactionSuperset(t *testing.T) {
 		t.Fatal("transaction set must have dependent transactions")
 	}
 
-	// Submit the first transaction in the set to the transaction pool.
+	// Submit the first transaction in the set to the transaction pool, and
+	// then the superset.
 	err = tpt.tpool.AcceptTransactionSet(txnSet[:1])
 	if err != nil {
 		t.Fatal("first transaction in the transaction set was not valid?")
@@ -208,6 +209,52 @@ func TestIntegrationTransactionSuperset(t *testing.T) {
 	err = tpt.tpool.AcceptTransactionSet(txnSet)
 	if err != modules.ErrDuplicateTransactionSet {
 		t.Fatal("super setting is not working:", err)
+	}
+}
+
+// TestTransactionSubset submits a transaction set to the network, followed by
+// just a subset, expectint ErrDuplicateTransactionSet as a response.
+func TestIntegrationTransactionSubset(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	// Create a transaction pool tester.
+	tpt, err := createTpoolTester("TestTransactionSubset")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fund a partial transaction.
+	fund := types.NewCurrency64(30e6)
+	txnBuilder := tpt.wallet.StartTransaction()
+	err = txnBuilder.FundSiacoins(fund)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txnBuilder.AddMinerFee(fund)
+	// wholeTransaction is set to false so that we can use the same signature
+	// to create a double spend.
+	txnSet, err := txnBuilder.Sign(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(txnSet) <= 1 {
+		t.Fatal("test is invalid unless the transaction set has two or more transactions")
+	}
+	// Check that the second transaction is dependent on the first.
+	err = tpt.tpool.AcceptTransactionSet(txnSet[1:])
+	if err == nil {
+		t.Fatal("transaction set must have dependent transactions")
+	}
+
+	// Submit the set to the pool, followed by just the transaction.
+	err = tpt.tpool.AcceptTransactionSet(txnSet)
+	if err != nil {
+		t.Fatal("super setting is not working:", err)
+	}
+	err = tpt.tpool.AcceptTransactionSet(txnSet[:1])
+	if err != modules.ErrDuplicateTransactionSet {
+		t.Fatal(err)
 	}
 }
 

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -198,6 +198,17 @@ func TestIntegrationTransactionSuperset(t *testing.T) {
 	if err != nil {
 		t.Fatal("super setting is not working:", err)
 	}
+
+	// Try resubmitting the individual transaction and the superset, a
+	// duplication error should be returned for each case.
+	err = tpt.tpool.AcceptTransactionSet(txnSet[:1])
+	if err != modules.ErrDuplicateTransactionSet {
+		t.Fatal(err)
+	}
+	err = tpt.tpool.AcceptTransactionSet(txnSet)
+	if err != modules.ErrDuplicateTransactionSet {
+		t.Fatal("super setting is not working:", err)
+	}
 }
 
 // TestIntegrationTransactionChild submits a single transaction to the network,


### PR DESCRIPTION
Most of the major logging errors we've been seeing in the host should be resolved now. Additionally, the host has been altered so that the log does not grow as quickly, with the slowdown being a factor of 200x. We can continue to experiment with loggings as we move forward. Some type of proper aggregation would be nice, but we need to make sure that the logs are reasonable in size under all circumstances.

The transaction pool will return a new type of error if the transaction is rejected on consensus-incompatibility grounds. I do believe that there is an error here, but I haven't had enough time to investigate.

When attempting a renew, the host used to not delete the copy it made if the negotiation failed for some reason. It's not tested, but the host should not correctly delete the file. It will be difficult to test while the renter renewal uses time-based renewing instead of push-based renewing (for example, checking every time there's a new block). I will try to write a test today though, this isn't behavior that I want to release untested.

There's some unfortunate stuff here, I'm trying to fix it, but this PR as-is should be safe enough for release.