### PR TITLE
Deprecate instead of remove siac commands

### DIFF
--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -15,6 +15,13 @@ var (
 		Long:  "Print the current state of consensus such as current block, block height, and target.",
 		Run:   wrap(consensuscmd),
 	}
+
+	// DEPRECATED v0.5.0
+	consensusDeprecatedStatusCmd = &cobra.Command{
+		Use:        "status",
+		Deprecated: "use `siac` or `siac consensus` instead.",
+		Run:        wrap(consensuscmd),
+	}
 )
 
 // consensuscmd is the handler for the command `siac consensus`.

--- a/siac/gatewaycmd.go
+++ b/siac/gatewaycmd.go
@@ -16,6 +16,13 @@ var (
 		Run:   wrap(gatewaycmd),
 	}
 
+	// DEPRECATED v0.5.0
+	gatewayDeprecatedStatusCmd = &cobra.Command{
+		Use:        "status",
+		Deprecated: "use `siac gateway` instead. Use `siac gateway list` to view peer list.",
+		Run:        wrap(gatewaycmd),
+	}
+
 	gatewayAddCmd = &cobra.Command{
 		Use:   "add [address]",
 		Short: "Add a peer",

--- a/siac/main.go
+++ b/siac/main.go
@@ -211,6 +211,12 @@ func main() {
 
 	root.AddCommand(consensusCmd)
 
+	// DEPRECATED v0.5.0
+	root.AddCommand(consensusDeprecatedStatusCmd)
+	gatewayCmd.AddCommand(gatewayDeprecatedStatusCmd)
+	minerCmd.AddCommand(minerDeprecatedStatusCmd)
+	walletCmd.AddCommand(walletDeprecatedStatusCmd)
+
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")
 

--- a/siac/main.go
+++ b/siac/main.go
@@ -216,6 +216,7 @@ func main() {
 	gatewayCmd.AddCommand(gatewayDeprecatedStatusCmd)
 	minerCmd.AddCommand(minerDeprecatedStatusCmd)
 	walletCmd.AddCommand(walletDeprecatedStatusCmd)
+	renterCmd.AddCommand(renterDeprecatedDownloadQueueCmd)
 
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")

--- a/siac/minercmd.go
+++ b/siac/minercmd.go
@@ -16,6 +16,13 @@ var (
 		Run:   wrap(minercmd),
 	}
 
+	// DEPRECATED v0.5.0
+	minerDeprecatedStatusCmd = &cobra.Command{
+		Use:        "status",
+		Deprecated: "use `siac miner` instead.",
+		Run:        wrap(minercmd),
+	}
+
 	minerStartCmd = &cobra.Command{
 		Use:   "start",
 		Short: "Start cpu mining",

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -43,6 +43,14 @@ var (
 		Run:   wrap(renterdownloadscmd),
 	}
 
+	// DEPRECATED v0.5.0
+	renterDeprecatedDownloadQueueCmd = &cobra.Command{
+		Use:        "queue",
+		Deprecated: `use "downloads [-H | --history]" instead.`,
+		PreRun:     func(*cobra.Command, []string) { renterShowHistory = true }, // Show completed downloads too.
+		Run:        wrap(renterdownloadscmd),
+	}
+
 	renterFilesDeleteCmd = &cobra.Command{
 		Use:     "delete [path]",
 		Aliases: []string{"rm"},

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -31,6 +31,13 @@ The smallest unit of siacoins is the hasting. One siacoin is 10^24 hastings. Oth
 		Run: wrap(walletbalancecmd),
 	}
 
+	// DEPRECATED v0.5.0
+	walletDeprecatedStatusCmd = &cobra.Command{
+		Use:        "status",
+		Deprecated: "use `siac wallet` or `siac wallet balance` instead.",
+		Run:        wrap(walletbalancecmd),
+	}
+
 	walletAddressCmd = &cobra.Command{
 		Use:   "address",
 		Short: "Get a new wallet address",


### PR DESCRIPTION
The deprecated commands will not appear in help messages, and are only for backwards compatibility. They will still work but will print a message stating they are deprecated, and suggesting an alternative command to use instead.