### PR TITLE
ignore duplicate transaction errors as host

### DIFF
--- a/modules/host/upload.go
+++ b/modules/host/upload.go
@@ -456,7 +456,10 @@ func (h *Host) managedRPCRevise(conn net.Conn) error {
 	}
 
 	err = h.tpool.AcceptTransactionSet([]types.Transaction{obligation.RevisionTransaction})
-	if err != nil {
+	if err != nil && err != modules.ErrDuplicateTransactionSet {
+		// It is safe to ignore the duplicate transaction errors, it means that
+		// either the transaction has not changed or the renter already
+		// successfully propagated the transaction through the network.
 		h.log.Println("WARN: transaction pool rejected revision transaction: " + err.Error())
 	}
 	return revisionErr


### PR DESCRIPTION
Ignore duplicate transaction errors as the host when doing file contract
revision negotiation - sometimes the renter will have already submitted
and propagated the signed transaction, or there will have just been no
changes as the result of a failed revision loop.