### PR TITLE
Proper offline checking in HostDB

### DIFF
--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -31,13 +31,16 @@ func (hdb *HostDB) insertHost(host modules.HostSettings) {
 		return
 	}
 
-	// Add the host to the scan queue. After scanning, it will be placed in
-	// allHosts. If the scan is successful, it will also be placed in
-	// activeHosts.
-	hdb.scanHostEntry(&hostEntry{
+	// Create hostEntry and add to allHosts.
+	h := &hostEntry{
 		HostSettings: host,
 		reliability:  DefaultReliability,
-	})
+	}
+	hdb.allHosts[host.NetAddress] = h
+
+	// Add the host to the scan queue. If the scan is successful, the host
+	// will be placed in activeHosts.
+	hdb.scanHostEntry(h)
 }
 
 // Remove deletes an entry from the hostdb.

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -11,6 +11,7 @@ type hostEntry struct {
 	modules.HostSettings
 	weight      types.Currency
 	reliability types.Currency
+	online      bool
 }
 
 // insert adds a host entry to the state. The host will be inserted into the
@@ -94,4 +95,19 @@ func (hdb *HostDB) AveragePrice() types.Currency {
 		totalPrice = totalPrice.Add(host.Price)
 	}
 	return totalPrice.Div(types.NewCurrency64(uint64(len(hosts))))
+}
+
+// IsOffline reports whether a host is offline. If the HostDB has no record of
+// the host, IsOffline will return false and spawn a goroutine to the scan the
+// host.
+func (hdb *HostDB) IsOffline(addr modules.NetAddress) bool {
+	if _, ok := hdb.activeHosts[addr]; ok {
+		return false
+	}
+	if h, ok := hdb.allHosts[addr]; ok {
+		return !h.online
+	}
+	// no record of the host; add it to the HostDB
+	hdb.insertHost(modules.HostSettings{NetAddress: addr})
+	return false
 }

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -74,6 +74,7 @@ func (hdb *HostDB) decrementReliability(addr modules.NetAddress, penalty types.C
 		return
 	}
 	entry.reliability = entry.reliability.Sub(penalty)
+	entry.online = false
 
 	// If the entry is in the active database, remove it from the active
 	// database.
@@ -159,6 +160,7 @@ func (hdb *HostDB) threadedProbeHosts() {
 			hostEntry.HostSettings = settings
 			hostEntry.reliability = MaxReliability
 			hostEntry.weight = calculateHostWeight(*hostEntry)
+			hostEntry.online = true
 
 			// If 'MaxActiveHosts' has not been reached, add the host to the
 			// activeHosts tree.

--- a/modules/renter/hostdb/update_test.go
+++ b/modules/renter/hostdb/update_test.go
@@ -2,6 +2,7 @@ package hostdb
 
 import (
 	"testing"
+	"time"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -81,5 +82,45 @@ func TestReceiveConsensusSetUpdate(t *testing.T) {
 	// Check that there is now a host in the hostdb.
 	if len(ht.hostdb.AllHosts()) != 1 {
 		t.Fatal("hostdb should have a host after getting a host announcement transcation")
+	}
+}
+
+// TestIsOffline tests the IsOffline method.
+func TestIsOffline(t *testing.T) {
+	hdb := &HostDB{
+		allHosts: map[modules.NetAddress]*hostEntry{
+			"foo:1234": &hostEntry{online: true},
+			"bar:1234": &hostEntry{online: false},
+			"baz:1234": &hostEntry{online: true},
+		},
+		activeHosts: map[modules.NetAddress]*hostNode{
+			"foo:1234": nil,
+		},
+		scanPool: make(chan *hostEntry),
+	}
+
+	tests := []struct {
+		addr    modules.NetAddress
+		offline bool
+	}{
+		{"foo:1234", false},
+		{"bar:1234", true},
+		{"baz:1234", false},
+		{"quux:1234", false},
+	}
+	for _, test := range tests {
+		if offline := hdb.IsOffline(test.addr); offline != test.offline {
+			t.Errorf("IsOffline(%v) = %v, expected %v", test.addr, offline, test.offline)
+		}
+	}
+
+	// quux should have sent host down scanPool
+	select {
+	case h := <-hdb.scanPool:
+		if h.NetAddress != "quux:1234" {
+			t.Error("wrong host in scan pool:", h.NetAddress)
+		}
+	case <-time.After(time.Second):
+		t.Error("unknown host was not added to scan pool")
 	}
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -22,6 +22,9 @@ type hostDB interface {
 	// AveragePrice returns the average price of a host.
 	AveragePrice() types.Currency
 
+	// IsOffline reports whether a host is consider offline.
+	IsOffline(modules.NetAddress) bool
+
 	// NewPool returns a new HostPool, which can negotiate contracts with
 	// hosts. The size and duration of these contracts are supplied as
 	// arguments.

--- a/modules/renter/repair_test.go
+++ b/modules/renter/repair_test.go
@@ -152,36 +152,17 @@ func TestRepair(t *testing.T) {
 // where the bool indicates whether the host is active.
 type offlineHostDB map[modules.NetAddress]bool
 
-// ActiveHosts returns the set of hosts marked active in the offlineHostDB.
-func (hdb offlineHostDB) ActiveHosts() (hosts []modules.HostSettings) {
-	for addr, active := range hdb {
-		if active {
-			hosts = append(hosts, modules.HostSettings{NetAddress: addr})
-		}
-	}
-	return
+// IsOffline is a stub implementation of the IsOffline method.
+func (hdb offlineHostDB) IsOffline(addr modules.NetAddress) bool {
+	return !hdb[addr]
 }
 
-// AllHosts returns the entire contents of the offlineHostDB.
-func (hdb offlineHostDB) AllHosts() (hosts []modules.HostSettings) {
-	for addr := range hdb {
-		hosts = append(hosts, modules.HostSettings{NetAddress: addr})
-	}
-	return
-}
-
-// AveragePrice is a stub implementation of the AveragePrice method.
-func (hdb offlineHostDB) AveragePrice() types.Currency {
-	return types.Currency{}
-}
-
-// NewPool is a stub implementation of the NewPool method.
-func (hdb offlineHostDB) NewPool(uint64, types.BlockHeight) (hostdb.HostPool, error) {
-	return nil, nil
-}
-
-// Renew is a stub implementation of the Renew method.
-func (hdb offlineHostDB) Renew(types.FileContractID, types.BlockHeight) (types.FileContractID, error) {
+// Stub implementations of other hostDB methods.
+func (offlineHostDB) NewPool(uint64, types.BlockHeight) (hostdb.HostPool, error) { return nil, nil }
+func (offlineHostDB) ActiveHosts() []modules.HostSettings                        { return nil }
+func (offlineHostDB) AllHosts() []modules.HostSettings                           { return nil }
+func (offlineHostDB) AveragePrice() types.Currency                               { return types.Currency{} }
+func (offlineHostDB) Renew(types.FileContractID, types.BlockHeight) (types.FileContractID, error) {
 	return types.FileContractID{}, nil
 }
 

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -44,6 +44,7 @@ func (uploadHostDB) Close() error                     { return nil }
 func (uploadHostDB) ActiveHosts() []modules.HostSettings { return nil }
 func (uploadHostDB) AllHosts() []modules.HostSettings    { return nil }
 func (uploadHostDB) AveragePrice() types.Currency        { return types.Currency{} }
+func (uploadHostDB) IsOffline(modules.NetAddress) bool   { return true }
 func (uploadHostDB) Renew(types.FileContractID, types.BlockHeight) (types.FileContractID, error) {
 	return types.FileContractID{}, nil
 }


### PR DESCRIPTION
Previously, the renter determined whether a host was offline via the `isOffline` function shown in the diff below, which relied on the `ActiveHosts` and `AllHosts` methods. This function depended upon the assumption that hosts would not be added to `AllHosts` until they had been scanned. To accommodate this assumption, that behavior was implemented in 16479f3.

However, this change came with a hidden cost: 126,000 extra goroutines at startup.
When the HostDB scans the blockchain, it calls `insertHost` on every host announcement seen. If the host is already in `allHosts`, nothing is done; but if not, it is added to the scan pool. And since we want to avoid blocking, this is done in a goroutine, and on a buffered channel (`scanPool`).
But scanning a host is a lot slower than loading the blockchain; many thousands of host announcements might be scanned in the time it takes to scan a single host. So what happened was something like this: the HostDB would see a host announcement, check if it was in `allHosts` (no), and then add it to the scan pool. Then it would process another announcement with the same address, and check `allHosts` again. But the scan on the original announcement would not have completed yet, so it wouldn't be in `allHosts`, and as a result the HostDB would add the new announcement to the scan pool as well. And since `scanPool` was only buffered to 1000 entries, all of those goroutines would be blocked, causing considerable strain on the scheduler.

This PR reverts this behavior, so that we add hosts to `allHosts` prior to the scan. Now that we can perform proper deduplication, we wind up scanning only 700 announcements instead of 126,000. These fit within the buffer of `scanPool`, so there should be no blocked goroutines at all, at least until the network grows to >1000 hosts.

As a result, it was necessary to implement a proper `IsOffline` method on the HostDB, since we could no longer depend on the assumption that hosts in `AllHosts` had been scanned. Fortunately this was a pretty easy fix. It didn't even break any HostDB tests...though this is mostly because the HostDB testing is rather sparse. Some of the new tests in #923 will be broken by this change.