### PR TITLE
arbitrary data transactions get cleared correctly

### DIFF
--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -310,11 +310,11 @@ func TestIntegrationNilAccept(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	// Create a transaction pool tester.
 	tpt, err := createTpoolTester("TestTransactionChild")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	err = tpt.tpool.AcceptTransactionSet(nil)
 	if err == nil {
 		t.Error("no error returned when submitting nothing to the transaction pool")

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -1,0 +1,41 @@
+package transactionpool
+
+import (
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// TestArbDataOnly tries submitting a transaction with only aribtrary data to
+// the transaction pool. Then a block is mined, putting the transaction on the
+// blockchain. The arb data transaction should no longer be in the transaction
+// pool.
+func TestArbDataOnly(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	tpt, err := createTpoolTester("TestArbDataOnly")
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn := types.Transaction{
+		ArbitraryData: [][]byte{
+			append(modules.PrefixNonSia[:], []byte("arb-data")...),
+		},
+	}
+	err = tpt.tpool.AcceptTransactionSet([]types.Transaction{txn})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tpt.tpool.TransactionList()) != 1 {
+		t.Error("expecting to see a transaction in the transaction pool")
+	}
+	_, err = tpt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tpt.tpool.TransactionList()) != 0 {
+		t.Error("transaction was not cleared from the transaction pool")
+	}
+}


### PR DESCRIPTION
Previously, arbitrary data transactions added to the transaction pool
would just chill there indefinitely. Now, the arbitrary data
transactions are correctly cleaned from the transaction pool, and there
is a test to confirm the process is correct.