### PR TITLE
Siad -M, --modules flag

### DIFF
--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -60,9 +60,11 @@ func startDaemon(config Config) (err error) {
 	loadStart := time.Now()
 
 	// Create all of the modules.
+	i := 0
 	var g modules.Gateway
 	if strings.Contains(config.Siad.Modules, "g") {
-		fmt.Println("Loading gateway...")
+		i++
+		fmt.Printf("(%d/%d) Loading gateway...\n", i, len(config.Siad.Modules))
 		g, err = gateway.New(config.Siad.RPCaddr, filepath.Join(config.Siad.SiaDir, modules.GatewayDir))
 		if err != nil {
 			return err
@@ -70,7 +72,8 @@ func startDaemon(config Config) (err error) {
 	}
 	var cs modules.ConsensusSet
 	if strings.Contains(config.Siad.Modules, "c") {
-		fmt.Println("Loading consensus...")
+		i++
+		fmt.Printf("(%d/%d) Loading consensus...\n", i, len(config.Siad.Modules))
 		cs, err = consensus.New(g, filepath.Join(config.Siad.SiaDir, modules.ConsensusDir))
 		if err != nil {
 			return err
@@ -78,7 +81,8 @@ func startDaemon(config Config) (err error) {
 	}
 	var e modules.Explorer
 	if strings.Contains(config.Siad.Modules, "e") {
-		fmt.Println("Loading explorer...")
+		i++
+		fmt.Printf("(%d/%d) Loading explorer...\n", i, len(config.Siad.Modules))
 		e, err = explorer.New(cs, filepath.Join(config.Siad.SiaDir, modules.ExplorerDir))
 		if err != nil {
 			return err
@@ -86,7 +90,8 @@ func startDaemon(config Config) (err error) {
 	}
 	var tpool modules.TransactionPool
 	if strings.Contains(config.Siad.Modules, "t") {
-		fmt.Println("Loading transaction pool...")
+		i++
+		fmt.Printf("(%d/%d) Loading transaction pool...\n", i, len(config.Siad.Modules))
 		tpool, err = transactionpool.New(cs, g)
 		if err != nil {
 			return err
@@ -94,7 +99,8 @@ func startDaemon(config Config) (err error) {
 	}
 	var w modules.Wallet
 	if strings.Contains(config.Siad.Modules, "w") {
-		fmt.Println("Loading wallet...")
+		i++
+		fmt.Printf("(%d/%d) Loading wallet...\n", i, len(config.Siad.Modules))
 		w, err = wallet.New(cs, tpool, filepath.Join(config.Siad.SiaDir, modules.WalletDir))
 		if err != nil {
 			return err
@@ -102,7 +108,8 @@ func startDaemon(config Config) (err error) {
 	}
 	var m modules.Miner
 	if strings.Contains(config.Siad.Modules, "m") {
-		fmt.Println("Loading miner...")
+		i++
+		fmt.Printf("(%d/%d) Loading miner...\n", i, len(config.Siad.Modules))
 		m, err = miner.New(cs, tpool, w, filepath.Join(config.Siad.SiaDir, modules.MinerDir))
 		if err != nil {
 			return err
@@ -110,7 +117,8 @@ func startDaemon(config Config) (err error) {
 	}
 	var h modules.Host
 	if strings.Contains(config.Siad.Modules, "h") {
-		fmt.Println("Loading host...")
+		i++
+		fmt.Printf("(%d/%d) Loading host...\n", i, len(config.Siad.Modules))
 		h, err = host.New(cs, tpool, w, config.Siad.HostAddr, filepath.Join(config.Siad.SiaDir, modules.HostDir))
 		if err != nil {
 			return err
@@ -118,7 +126,8 @@ func startDaemon(config Config) (err error) {
 	}
 	var r modules.Renter
 	if strings.Contains(config.Siad.Modules, "r") {
-		fmt.Println("Loading renter...")
+		i++
+		fmt.Printf("(%d/%d) Loading renter...\n", i, len(config.Siad.Modules))
 		r, err = renter.New(cs, w, tpool, filepath.Join(config.Siad.SiaDir, modules.RenterDir))
 		if err != nil {
 			return err

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -46,7 +46,7 @@ func processModules(modules string) (string, error) {
 		invalidModules = strings.Replace(invalidModules, string(m), "", 1)
 	}
 	if len(invalidModules) > 0 {
-		return "", errors.New("Unable to parse --modules flag, unrecognized modules: " + invalidModules)
+		return "", errors.New("Unable to parse --modules flag, unrecognized or duplicate modules: " + invalidModules)
 	}
 	return modules, nil
 }

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -35,20 +35,32 @@ func processNetAddr(addr string) string {
 	return addr
 }
 
-// processConfig checks the configuration values and performs cleanup on
-// incorrect-but-allowed values.
-func processConfig(config Config) (Config, error) {
-	config.Siad.APIaddr = processNetAddr(config.Siad.APIaddr)
-	config.Siad.RPCaddr = processNetAddr(config.Siad.RPCaddr)
-	config.Siad.HostAddr = processNetAddr(config.Siad.HostAddr)
-	config.Siad.Modules = strings.ToLower(config.Siad.Modules)
+// processModules makes the modules string lowercase to make checking if a
+// module in the string easier, and returns an error if the string contains an
+// invalid module character.
+func processModules(modules string) (string, error) {
+	modules = strings.ToLower(modules)
 	validModules := "cghmrtwe"
-	invalidModules := config.Siad.Modules
+	invalidModules := modules
 	for _, m := range validModules {
 		invalidModules = strings.Replace(invalidModules, string(m), "", 1)
 	}
 	if len(invalidModules) > 0 {
-		return Config{}, errors.New("Unable to parse --modules flag, unrecognized modules: " + invalidModules)
+		return "", errors.New("Unable to parse --modules flag, unrecognized modules: " + invalidModules)
+	}
+	return modules, nil
+}
+
+// processConfig checks the configuration values and performs cleanup on
+// incorrect-but-allowed values.
+func processConfig(config Config) (Config, error) {
+	var err error
+	config.Siad.APIaddr = processNetAddr(config.Siad.APIaddr)
+	config.Siad.RPCaddr = processNetAddr(config.Siad.RPCaddr)
+	config.Siad.HostAddr = processNetAddr(config.Siad.HostAddr)
+	config.Siad.Modules, err = processModules(config.Siad.Modules)
+	if err != nil {
+		return Config{}, err
 	}
 	return config, nil
 }

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -21,19 +21,67 @@ func TestUnitProcessNetAddr(t *testing.T) {
 	}
 }
 
+// TestUnitProcessModules tests that processModules correctly processes modules
+// passed to the -M / --modules flag.
+func TestUnitProcessModules(t *testing.T) {
+	// Test valid modules.
+	testVals := []struct {
+		in  string
+		out string
+	}{
+		{"cghmrtwe", "cghmrtwe"},
+		{"CGHMRTWE", "cghmrtwe"},
+		{"c", "c"},
+		{"g", "g"},
+		{"h", "h"},
+		{"m", "m"},
+		{"r", "r"},
+		{"t", "t"},
+		{"w", "w"},
+		{"e", "e"},
+		{"C", "c"},
+		{"G", "g"},
+		{"H", "h"},
+		{"M", "m"},
+		{"R", "r"},
+		{"T", "t"},
+		{"W", "w"},
+		{"E", "e"},
+	}
+	for _, testVal := range testVals {
+		out, err := processModules(testVal.in)
+		if err != nil {
+			t.Error("processModules failed with error:", err)
+		}
+		if out != testVal.out {
+			t.Errorf("processModules returned incorrect modules: expected %s, got %s\n", testVal.out, out)
+		}
+	}
+
+	// Test invalid modules.
+	invalidModules := []string{"abdfijklnopqsuvxyz", "cghmrtwez", "cz", "z"}
+	for _, invalidModule := range invalidModules {
+		_, err := processModules(invalidModule)
+		if err == nil {
+			t.Error("processModules didn't error on invalid module:", invalidModule)
+		}
+	}
+}
+
 // TestUnitProcessConfig probes the 'processConfig' function.
 func TestUnitProcessConfig(t *testing.T) {
+	// Test valid configs.
 	testVals := struct {
 		inputs          [][]string
 		expectedOutputs [][]string
 	}{
 		inputs: [][]string{
-			[]string{"9980", "9981", "9982"},
-			[]string{":9980", ":9981", ":9982"},
+			[]string{"9980", "9981", "9982", "cghmrtwe"},
+			[]string{":9980", ":9981", ":9982", "CGHMRTWE"},
 		},
 		expectedOutputs: [][]string{
-			[]string{":9980", ":9981", ":9982"},
-			[]string{":9980", ":9981", ":9982"},
+			[]string{":9980", ":9981", ":9982", "cghmrtwe"},
+			[]string{":9980", ":9981", ":9982", "cghmrtwe"},
 		},
 	}
 	var config Config
@@ -41,7 +89,10 @@ func TestUnitProcessConfig(t *testing.T) {
 		config.Siad.APIaddr = testVals.inputs[i][0]
 		config.Siad.RPCaddr = testVals.inputs[i][1]
 		config.Siad.HostAddr = testVals.inputs[i][2]
-		config = processConfig(config)
+		config, err := processConfig(config)
+		if err != nil {
+			t.Error("processConfig failed with error:", err)
+		}
 		if config.Siad.APIaddr != testVals.expectedOutputs[i][0] {
 			t.Error("processing failure at check", i, 0)
 		}
@@ -51,5 +102,13 @@ func TestUnitProcessConfig(t *testing.T) {
 		if config.Siad.HostAddr != testVals.expectedOutputs[i][2] {
 			t.Error("processing failure at check", i, 2)
 		}
+	}
+
+	// Test invalid configs.
+	invalidModule := "z"
+	config.Siad.Modules = invalidModule
+	_, err := processConfig(config)
+	if err == nil {
+		t.Error("processModules didn't error on invalid module:", invalidModule)
 	}
 }

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -59,7 +59,7 @@ func TestUnitProcessModules(t *testing.T) {
 	}
 
 	// Test invalid modules.
-	invalidModules := []string{"abdfijklnopqsuvxyz", "cghmrtwez", "cz", "z"}
+	invalidModules := []string{"abdfijklnopqsuvxyz", "cghmrtwez", "cz", "z", "cc", "ccz", "ccm", "cmm", "ccmm"}
 	for _, invalidModule := range invalidModules {
 		_, err := processModules(invalidModule)
 		if err == nil {

--- a/siad/main.go
+++ b/siad/main.go
@@ -15,6 +15,13 @@ var (
 	globalConfig Config
 )
 
+// exit codes
+// inspired by sysexits.h
+const (
+	exitCodeGeneral = 1  // Not in sysexits.h, but is standard practice.
+	exitCodeUsage   = 64 // EX_USAGE in sysexits.h
+)
+
 // The Config struct contains all configurable variables for siad. It is
 // compatible with gcfg.
 type Config struct {
@@ -31,6 +38,13 @@ type Config struct {
 		ProfileDir string
 		SiaDir     string
 	}
+}
+
+// die prints its arguments to stderr, then exits the program with the default
+// error code.
+func die(args ...interface{}) {
+	fmt.Fprintln(os.Stderr, args...)
+	os.Exit(exitCodeGeneral)
 }
 
 // versionCmd is a cobra command that prints the version of siad.
@@ -67,5 +81,11 @@ func main() {
 
 	// Parse cmdline flags, overwriting both the default values and the config
 	// file values.
-	root.Execute()
+	if err := root.Execute(); err != nil {
+		// Since no commands return errors (all commands set Command.Run instead of
+		// Command.RunE), Command.Execute() should only return an error on an
+		// invalid command or flag. Therefore Command.Usage() was called (assuming
+		// Command.SilenceUsage is false) and we should exit with exitCodeUsage.
+		os.Exit(exitCodeUsage)
+	}
 }

--- a/siad/main.go
+++ b/siad/main.go
@@ -23,7 +23,7 @@ type Config struct {
 		RPCaddr  string
 		HostAddr string
 
-		Explorer          bool
+		Modules           string
 		NoBootstrap       bool
 		RequiredUserAgent string
 
@@ -56,7 +56,6 @@ func main() {
 
 	// Set default values, which have the lowest priority.
 	root.PersistentFlags().StringVarP(&globalConfig.Siad.RequiredUserAgent, "agent", "A", "Sia-Agent", "required substring for the user agent")
-	root.PersistentFlags().BoolVarP(&globalConfig.Siad.Explorer, "explorer", "E", false, "whether or not to run an explorer in the daemon")
 	root.PersistentFlags().StringVarP(&globalConfig.Siad.HostAddr, "host-addr", "H", ":9982", "which port the host listens on")
 	root.PersistentFlags().StringVarP(&globalConfig.Siad.ProfileDir, "profile-directory", "P", "profiles", "location of the profiling directory")
 	root.PersistentFlags().StringVarP(&globalConfig.Siad.APIaddr, "api-addr", "a", "localhost:9980", "which host:port the API server listens on")
@@ -64,6 +63,7 @@ func main() {
 	root.PersistentFlags().BoolVarP(&globalConfig.Siad.NoBootstrap, "no-bootstrap", "n", false, "disable bootstrapping on this run")
 	root.PersistentFlags().BoolVarP(&globalConfig.Siad.Profile, "profile", "p", false, "enable profiling")
 	root.PersistentFlags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
+	root.PersistentFlags().StringVarP(&globalConfig.Siad.Modules, "modules", "M", "cghmrtw", "enabled modules")
 
 	// Parse cmdline flags, overwriting both the default values and the config
 	// file values.


### PR DESCRIPTION
Specify modules for siad to load using the `-M` or `--modules` flag. Modules are specified by the first letter of the name. E.g. the default modules loaded are consensus (c), gateway (g), host (h), miner (m), renter (r), transaction pool (t), and wallet (w). This is equivalent to `siad --modules cghmrtw`.

On startup a status message is printed as each module is loaded. E.g.
```
$ siad
Loading...
(1/7) Loading gateway...
(2/7) Loading consensus...
(3/7) Loading transaction pool...
(4/7) Loading wallet...
(5/7) Loading miner...
(6/7) Loading host...
(7/7) Loading renter...
Finished loading in 167.819140245 seconds
```