### PR TITLE
Deprecate `siac host hostdb`

### DIFF
--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -12,20 +12,27 @@ import (
 var (
 	hostdbCmd = &cobra.Command{
 		Use:   "hostdb",
-		Short: "List active hosts on the network",
-		Long:  "List active hosts on the network",
-		Run:   wrap(hostdbhostscmd),
+		Short: "View or modify the host database",
+		Long:  "Add and remove hosts, or list active hosts on the network.",
+		Run:   wrap(hostdblistcmd),
 	}
 
 	// DEPRECATED v0.5.2
 	hostdbDeprecatedCmd = &cobra.Command{
 		Use:        "hostdb",
 		Deprecated: "use `siac hostdb` instead.",
-		Run:        wrap(hostdbhostscmd),
+		Run:        wrap(hostdblistcmd),
+	}
+
+	hostdbListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List active hosts on the network",
+		Long:  "List active hosts on the network.",
+		Run:   wrap(hostdblistcmd),
 	}
 )
 
-func hostdbhostscmd() {
+func hostdblistcmd() {
 	info := new(api.ActiveHosts)
 	err := getAPI("/renter/hosts/active", info)
 	if err != nil {

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -16,6 +16,13 @@ var (
 		Long:  "List active hosts on the network",
 		Run:   wrap(hostdbhostscmd),
 	}
+
+	// DEPRECATED v0.5.2
+	hostdbDeprecatedCmd = &cobra.Command{
+		Use:        "hostdb",
+		Deprecated: "use `siac hostdb` instead.",
+		Run:        wrap(hostdbhostscmd),
+	}
 )
 
 func hostdbhostscmd() {

--- a/siac/main.go
+++ b/siac/main.go
@@ -184,9 +184,10 @@ func main() {
 
 	root.AddCommand(hostCmd)
 	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd)
+	hostCmd.Flags().BoolVarP(&hostVerbose, "verbose", "v", false, "Display detailed host info")
 
 	root.AddCommand(hostdbCmd)
-	hostCmd.Flags().BoolVarP(&hostVerbose, "verbose", "v", false, "Display detailed host info")
+	hostdbCmd.AddCommand(hostdbListCmd)
 
 	root.AddCommand(minerCmd)
 	minerCmd.AddCommand(minerStartCmd, minerStopCmd)

--- a/siac/main.go
+++ b/siac/main.go
@@ -186,7 +186,6 @@ func main() {
 	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd)
 
 	root.AddCommand(hostdbCmd)
-	hostCmd.AddCommand(hostdbCmd)
 	hostCmd.Flags().BoolVarP(&hostVerbose, "verbose", "v", false, "Display detailed host info")
 
 	root.AddCommand(minerCmd)
@@ -217,6 +216,8 @@ func main() {
 	minerCmd.AddCommand(minerDeprecatedStatusCmd)
 	walletCmd.AddCommand(walletDeprecatedStatusCmd)
 	renterCmd.AddCommand(renterDeprecatedDownloadQueueCmd)
+	// DEPRECATED v0.5.2
+	hostCmd.AddCommand(hostdbDeprecatedCmd)
 
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")


### PR DESCRIPTION
hostdb does not belong in host. Deprecated so as to preserve compatibility.