### PR TITLE
Siac renter verbose filelist

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -52,6 +52,7 @@ type FileInfo struct {
 	Filesize       uint64            `json:"filesize"`
 	Available      bool              `json:"available"`
 	Renewing       bool              `json:"renewing"`
+	Redundancy     float64           `json:"redundancy"`
 	UploadProgress float64           `json:"uploadprogress"`
 	Expiration     types.BlockHeight `json:"expiration"`
 }

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -107,13 +108,13 @@ func (f *file) uploadProgress() float64 {
 	return 100 * (float64(uploaded) / float64(desired))
 }
 
-// redundancy returns the redundancy of the least redundant chunk. -1 is
-// returned if the file has 0 chunks. A file becomes available when this
-// redundancy is >= 1. Assumes that every piece is unique within a file
-// contract.
+// redundancy returns the redundancy of the least redundant chunk. A file
+// becomes available when this redundancy is >= 1. Assumes that every piece is
+// unique within a file contract.
 func (f *file) redundancy() float64 {
 	if f.numChunks() == 0 {
-		return -1
+		build.Critical("cannot get redundancy of a file with 0 chunks")
+		return 0
 	}
 	piecesPerChunk := make([]int, f.numChunks())
 	for _, fc := range f.contracts {

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -2,6 +2,7 @@ package renter
 
 import (
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -113,14 +114,15 @@ func (f *file) uploadProgress() float64 {
 // unique within a file contract. -1 is returned if the file has size 0.
 func (f *file) redundancy() float64 {
 	if f.size == 0 {
-		return -1
+		return math.NaN()
 	}
 	piecesPerChunk := make([]int, f.numChunks())
-	// We cannot get the redundancy if piecesPerChunk has 0 length because later
-	// in the function we use the first element of the slice.
+	// If the file has non-0 size then the number of chunks should also be
+	// non-0. Therefore the f.size == 0 conditional block above must appear
+	// before this check.
 	if len(piecesPerChunk) == 0 {
 		build.Critical("cannot get redundancy of a file with 0 chunks")
-		return 0
+		return math.NaN()
 	}
 	for _, fc := range f.contracts {
 		for _, p := range fc.Pieces {

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -110,13 +110,18 @@ func (f *file) uploadProgress() float64 {
 
 // redundancy returns the redundancy of the least redundant chunk. A file
 // becomes available when this redundancy is >= 1. Assumes that every piece is
-// unique within a file contract.
+// unique within a file contract. -1 is returned if the file has size 0.
 func (f *file) redundancy() float64 {
-	if f.numChunks() == 0 {
+	if f.size == 0 {
+		return -1
+	}
+	piecesPerChunk := make([]int, f.numChunks())
+	// We cannot get the redundancy if piecesPerChunk has 0 length because later
+	// in the function we use the first element of the slice.
+	if len(piecesPerChunk) == 0 {
 		build.Critical("cannot get redundancy of a file with 0 chunks")
 		return 0
 	}
-	piecesPerChunk := make([]int, f.numChunks())
 	for _, fc := range f.contracts {
 		for _, p := range fc.Pieces {
 			piecesPerChunk[p.Chunk]++

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -59,35 +59,90 @@ func TestFileAvailable(t *testing.T) {
 	}
 }
 
+// TestFileRedundancy tests that redundancy is correctly calculated for files
+// with varying number of filecontracts and erasure code settings.
 func TestFileRedundancy(t *testing.T) {
-	testNData := []int{1, 2, 10}
-	for _, nData := range testNData {
+	nDatas := []int{1, 2, 10}
+	for _, nData := range nDatas {
 		rsc, _ := NewRSCode(nData, 10)
 		f := &file{
 			size:        1000,
-			erasureCode: rsc,
 			pieceSize:   100,
+			contracts:   make(map[types.FileContractID]fileContract),
+			erasureCode: rsc,
 		}
 
-		r := f.redundancy()
-		if r != 0 {
+		// Test that an empty file has 0 redundancy.
+		if r := f.redundancy(); r != 0 {
 			t.Error("expected 0 redundancy, got", r)
 		}
-
-		testRedundancies := []uint64{1, 6, 10}
-		for _, testR := range testRedundancies {
-			var fc fileContract
-			for i := uint64(0); i < f.numChunks(); i++ {
-				for j := uint64(0); j < testR; j++ {
-					fc.Pieces = append(fc.Pieces, pieceData{Chunk: i, Piece: j})
+		// Test that a file with 1 filecontract that has a piece for every chunk but
+		// one chunk still has a redundancy of 0.
+		fc := fileContract{
+			ID: types.FileContractID{0},
+		}
+		for i := uint64(0); i < f.numChunks()-1; i++ {
+			pd := pieceData{
+				Chunk: i,
+				Piece: 0,
+			}
+			fc.Pieces = append(fc.Pieces, pd)
+		}
+		f.contracts[fc.ID] = fc
+		if r := f.redundancy(); r != 0 {
+			t.Error("expected 0 redundancy, got", r)
+		}
+		// Test that adding another filecontract with a piece for every chunk but one
+		// chunk still results in a file with redundancy 0.
+		fc = fileContract{
+			ID: types.FileContractID{1},
+		}
+		for i := uint64(0); i < f.numChunks()-1; i++ {
+			pd := pieceData{
+				Chunk: i,
+				Piece: 1,
+			}
+			fc.Pieces = append(fc.Pieces, pd)
+		}
+		f.contracts[fc.ID] = fc
+		if r := f.redundancy(); r != 0 {
+			t.Error("expected 0 redundancy, got", r)
+		}
+		// Test that adding a file contract with a piece for the missing chunk
+		// results in a file with redundancy > 0 && <= 1.
+		fc = fileContract{
+			ID: types.FileContractID{2},
+		}
+		pd := pieceData{
+			Chunk: f.numChunks() - 1,
+			Piece: 0,
+		}
+		fc.Pieces = append(fc.Pieces, pd)
+		f.contracts[fc.ID] = fc
+		// 1.0 / MinPieces because the chunk with the least number of pieces has 1 piece.
+		expectedR := 1.0 / float64(f.erasureCode.MinPieces())
+		if r := f.redundancy(); r == 0 || r > 1 || r != expectedR {
+			t.Errorf("expected %f redundancy, got %f", expectedR, r)
+		}
+		// Test that adding a file contract that has erasureCode.MinPieces() pieces
+		// per chunk for all chunks results in a file with redundancy > 1.
+		fc = fileContract{
+			ID: types.FileContractID{3},
+		}
+		for iChunk := uint64(0); iChunk < f.numChunks(); iChunk++ {
+			for iPiece := 0; iPiece < f.erasureCode.MinPieces(); iPiece++ {
+				pd := pieceData{
+					Chunk: iChunk,
+					Piece: uint64(iPiece),
 				}
+				fc.Pieces = append(fc.Pieces, pd)
 			}
-			f.contracts = map[types.FileContractID]fileContract{types.FileContractID{}: fc}
-			expectedR := float64(testR) / float64(nData)
-			r = f.redundancy()
-			if r != expectedR {
-				t.Errorf("expected %f redundancy, got %f", expectedR, r)
-			}
+		}
+		f.contracts[fc.ID] = fc
+		// 1+MinPieces / MinPieces because the chunk with the least number of pieces has 1+MinPieces pieces.
+		expectedR = float64(1+f.erasureCode.MinPieces()) / float64(f.erasureCode.MinPieces())
+		if r := f.redundancy(); r <= 1 || r != expectedR {
+			t.Errorf("expected a redundancy >1 and equal to %f, got %f", expectedR, r)
 		}
 	}
 }

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -74,12 +74,12 @@ func TestFileRedundancy(t *testing.T) {
 			t.Error("expected 0 redundancy, got", r)
 		}
 
-		testRedundancies := []int{1, 6, 10}
+		testRedundancies := []uint64{1, 6, 10}
 		for _, testR := range testRedundancies {
 			var fc fileContract
 			for i := uint64(0); i < f.numChunks(); i++ {
-				for j := 0; j < testR; j++ {
-					fc.Pieces = append(fc.Pieces, pieceData{Chunk: i, Piece: 0})
+				for j := uint64(0); j < testR; j++ {
+					fc.Pieces = append(fc.Pieces, pieceData{Chunk: i, Piece: j})
 				}
 			}
 			f.contracts = map[types.FileContractID]fileContract{types.FileContractID{}: fc}

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -108,10 +108,7 @@ func hostcmd() {
 		die("Could not fetch host settings:", err)
 	}
 	// convert accepting bool
-	accept := "Yes"
-	if !hg.AcceptingContracts {
-		accept = "No"
-	}
+	accept := yesNo(hg.AcceptingContracts)
 	// convert price to SC/GB/mo
 	price := new(big.Rat).SetInt(hg.Price.Big())
 	price.Mul(price, big.NewRat(4320, 1e24/1e9))

--- a/siac/main.go
+++ b/siac/main.go
@@ -23,6 +23,7 @@ var (
 	initPassword      bool   // supply a custom password when creating a wallet
 	hostVerbose       bool   // display additional host info
 	renterShowHistory bool   // Show download history in addition to download queue.
+	renterListVerbose bool   // Show additional info about uploaded files.
 )
 
 // exit codes
@@ -205,6 +206,7 @@ func main() {
 		renterFilesListCmd, renterFilesLoadCmd, renterFilesLoadASCIICmd, renterFilesRenameCmd,
 		renterFilesShareCmd, renterFilesShareASCIICmd, renterFilesUploadCmd, renterUploadsCmd)
 	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
+	renterFilesListCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
 
 	root.AddCommand(gatewayCmd)
 	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayAddressCmd, gatewayListCmd)

--- a/siac/main.go
+++ b/siac/main.go
@@ -161,6 +161,14 @@ func die(args ...interface{}) {
 	os.Exit(exitCodeGeneral)
 }
 
+// yesNo returns "Yes" if b is true, and "No" if b is false.
+func yesNo(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}
+
 func version() {
 	println("Sia Client v" + build.Version)
 }

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -247,14 +247,8 @@ func renterfileslistcmd() {
 	for _, file := range rf.Files {
 		fmt.Fprintf(w, "%s", filesizeUnits(int64(file.Filesize)))
 		if renterListVerbose {
-			availableStr := "No"
-			if file.Available {
-				availableStr = "Yes"
-			}
-			renewingStr := "No"
-			if file.Renewing {
-				renewingStr = "Yes"
-			}
+			availableStr := yesNo(file.Available)
+			renewingStr := yesNo(file.Renewing)
 			fmt.Fprintf(w, "\t%s\t%0.2f%%\t%0.2f\t%s", availableStr, file.UploadProgress, file.Redundancy, renewingStr)
 		}
 		fmt.Fprintf(w, "\t%s", file.SiaPath)

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -250,7 +250,7 @@ func renterfileslistcmd() {
 			availableStr := yesNo(file.Available)
 			renewingStr := yesNo(file.Renewing)
 			redundancyStr := fmt.Sprintf("%.2f", file.Redundancy)
-			if file.Redundancy < 0 {
+			if math.IsNaN(file.Redundancy) {
 				redundancyStr = "-"
 			}
 			uploadProgressStr := fmt.Sprintf("%.2f%%", file.UploadProgress)

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -249,7 +249,11 @@ func renterfileslistcmd() {
 		if renterListVerbose {
 			availableStr := yesNo(file.Available)
 			renewingStr := yesNo(file.Renewing)
-			fmt.Fprintf(w, "\t%s\t%7.2f%%\t%10.2f\t%s", availableStr, file.UploadProgress, file.Redundancy, renewingStr)
+			redundancyStr := fmt.Sprintf("%.2f", file.Redundancy)
+			if file.Redundancy < 0 {
+				redundancyStr = "-"
+			}
+			fmt.Fprintf(w, "\t%s\t%7.2f%%\t%10s\t%s", availableStr, file.UploadProgress, redundancyStr, renewingStr)
 		}
 		fmt.Fprintf(w, "\t%s", file.SiaPath)
 		if !renterListVerbose && !file.Available {

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -253,7 +253,11 @@ func renterfileslistcmd() {
 			if file.Redundancy < 0 {
 				redundancyStr = "-"
 			}
-			fmt.Fprintf(w, "\t%s\t%7.2f%%\t%10s\t%s", availableStr, file.UploadProgress, redundancyStr, renewingStr)
+			uploadProgressStr := fmt.Sprintf("%.2f%%", file.UploadProgress)
+			if math.IsNaN(file.UploadProgress) {
+				uploadProgressStr = "-"
+			}
+			fmt.Fprintf(w, "\t%s\t%8s\t%10s\t%s", availableStr, uploadProgressStr, redundancyStr, renewingStr)
 		}
 		fmt.Fprintf(w, "\t%s", file.SiaPath)
 		if !renterListVerbose && !file.Available {

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -245,11 +245,11 @@ func renterfileslistcmd() {
 		fmt.Fprintln(w, "File size\tAvailable\tProgress\tRedundancy\tRenewing\tSia path")
 	}
 	for _, file := range rf.Files {
-		fmt.Fprintf(w, "%s", filesizeUnits(int64(file.Filesize)))
+		fmt.Fprintf(w, "%9s", filesizeUnits(int64(file.Filesize)))
 		if renterListVerbose {
 			availableStr := yesNo(file.Available)
 			renewingStr := yesNo(file.Renewing)
-			fmt.Fprintf(w, "\t%s\t%0.2f%%\t%0.2f\t%s", availableStr, file.UploadProgress, file.Redundancy, renewingStr)
+			fmt.Fprintf(w, "\t%s\t%7.2f%%\t%10.2f\t%s", availableStr, file.UploadProgress, file.Redundancy, renewingStr)
 		}
 		fmt.Fprintf(w, "\t%s", file.SiaPath)
 		if !renterListVerbose && !file.Available {


### PR DESCRIPTION
`siac renter list [-v, --verbose]` prints a tabular file list with more information such as File size, Availability, Progress, Redundancy, Renewing, and Sia path,

Redundancy is the redundancy of the least redundant chunk.