### PR TITLE
Remove Consensus Startup Code

### DIFF
--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -176,12 +176,6 @@ type (
 		// to rescan the blockchain.
 		ConsensusChange(i int) (ConsensusChange, error)
 
-		// ConsensusSetSubscribe will subscribe another module to the consensus
-		// set. Every time that there is a change to the consensus set, an update
-		// will be sent to the module via the 'ReceiveConsensusSetUpdate' function.
-		// This is a thread-safe way of managing updates.
-		ConsensusSetSubscribe(ConsensusSetSubscriber)
-
 		// ConsensusSetPersistentSubscribe adds a subscriber to the list of
 		// subscribers, and gives them every consensus change that has occured
 		// since the change with the provided id.

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -170,12 +170,6 @@ type (
 		// run any required closing routines.
 		Close() error
 
-		// ConsensusChange returns the ith consensus change that was broadcast to
-		// subscribers by the consensus set. An error is returned if i consensus
-		// changes have not been broadcast. The primary purpose of this function is
-		// to rescan the blockchain.
-		ConsensusChange(i int) (ConsensusChange, error)
-
 		// ConsensusSetPersistentSubscribe adds a subscriber to the list of
 		// subscribers, and gives them every consensus change that has occured
 		// since the change with the provided id.

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -109,7 +109,6 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block) (ce changeEntry, err error
 		if err != nil {
 			return err
 		}
-		cs.changeLog = append(cs.changeLog, ce)
 		return nil
 	})
 	if err != nil {

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -34,9 +34,9 @@ type ConsensusSet struct {
 	// The block root contains the genesis block.
 	blockRoot processedBlock
 
-	// Modules subscribed to the consensus set will receive an ordered list of
-	// changes that occur to the consensus set, computed using the changeLog.
-	changeLog   []changeEntry
+	// Subscribers to the consensus set will receive a changelog every time
+	// there is an update to the consensus set. At initialization, they receive
+	// all changes that they are missing.
 	subscribers []modules.ConsensusSetSubscriber
 
 	// dosBlocks are blocks that are invalid, but the invalidity is only

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -117,29 +117,6 @@ func (cs *ConsensusSet) ConsensusChange(i int) (cc modules.ConsensusChange, err 
 	return cc, nil
 }
 
-// ConsensusSetSubscribe accepts a new subscriber who will receive a call to
-// ProcessConsensusChange every time there is a change in the consensus set.
-func (cs *ConsensusSet) ConsensusSetSubscribe(subscriber modules.ConsensusSetSubscriber) {
-	cs.mu.Lock()
-	cs.subscribers = append(cs.subscribers, subscriber)
-	cs.mu.Demote()
-	defer cs.mu.DemotedUnlock()
-
-	err := cs.db.View(func(tx *bolt.Tx) error {
-		for i := range cs.changeLog {
-			cc, err := cs.computeConsensusChange(tx, cs.changeLog[i])
-			if err != nil && build.DEBUG {
-				panic(err)
-			}
-			subscriber.ProcessConsensusChange(cc)
-		}
-		return nil
-	})
-	if build.DEBUG && err != nil {
-		panic(err)
-	}
-}
-
 // initializePersistentSubscribe will take a subscriber and feed them all of the
 // consensus changes that have occurred since the change provided.
 //

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -128,7 +128,7 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 		return nil, err
 	}
 
-	cs.ConsensusSetSubscribe(e)
+	cs.ConsensusSetPersistentSubscribe(e, modules.ConsensusChangeID{})
 
 	return e, nil
 }

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -102,7 +102,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	}
 
 	// Add the bootstrap peers to the node list.
-	if build.Release != "testing" {
+	if build.Release == "standard" {
 		for _, addr := range modules.BootstrapPeers {
 			g.addNode(addr)
 		}

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -14,7 +14,7 @@ import (
 // interface possible makes it easier to mock these dependencies in testing.
 type (
 	consensusSet interface {
-		ConsensusSetSubscribe(modules.ConsensusSetSubscriber)
+		ConsensusSetPersistentSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error
 	}
 	// in order to restrict the modules.TransactionBuilder interface, we must
 	// provide a shim to bridge the gap between modules.Wallet and

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -134,7 +134,7 @@ func newHostDB(cs consensusSet, w wallet, tp transactionPool, d dialer, s sleepe
 	}
 	go hdb.threadedScan()
 
-	cs.ConsensusSetSubscribe(hdb)
+	cs.ConsensusSetPersistentSubscribe(hdb, modules.ConsensusChangeID{})
 
 	return hdb, nil
 }

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -28,7 +28,9 @@ func bareHostDB() *HostDB {
 type newStub struct{}
 
 // consensus set stubs
-func (newStub) ConsensusSetSubscribe(modules.ConsensusSetSubscriber) {}
+func (newStub) ConsensusSetPersistentSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error {
+	return nil
+}
 
 // wallet stubs
 func (newStub) NextAddress() (uc types.UnlockConditions, err error) { return }

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -91,7 +91,7 @@ func New(cs modules.ConsensusSet, g modules.Gateway) (*TransactionPool, error) {
 	g.RegisterRPC("RelayTransactionSet", tp.relayTransactionSet)
 
 	// Subscribe the transaction pool to the consensus set.
-	cs.ConsensusSetSubscribe(tp)
+	cs.ConsensusSetPersistentSubscribe(tp, modules.ConsensusChangeID{})
 
 	return tp, nil
 }

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -206,7 +206,7 @@ func (w *Wallet) Unlock(masterKey crypto.TwofishKey) error {
 	// Subscribe to the consensus set if this is the first unlock for the
 	// wallet object.
 	if !subscribed {
-		w.cs.ConsensusSetSubscribe(w)
+		w.cs.ConsensusSetPersistentSubscribe(w, modules.ConsensusChangeID{})
 		w.tpool.TransactionPoolSubscribe(w)
 		w.mu.Lock()
 		w.subscribed = true


### PR DESCRIPTION
The consensus package, prior to this PR, needed to scan the whole blockchain at startup so that it could put some change entries in memory. With a simple change that I should have made a while ago, I've removed the need to do that. Now, all modules subscribe using the `PersistSubscribe` function, which could really be renamed the `Subscribe` function at this point. Two methods of the consensus interface have been removed entirely, `ConsensusChange` and `ConsensusSetSubscribe`. 

This should decrease startup time and also hopefully reduce memory usage at peak, though it's clear that Sia inefficiently uses memory in a lot of ways. Just like with the long startup time, I think that getting the memory usage back down is going to require a large number of smaller optimizations rather than a single large optimization.

I think I can point to IBD and inefficient block + transaction broadcasting as responsible for as much as half of the memory that siad uses, and is probably responsible for a lot of network consumption and performance problems during IBD. But in general I think we've been sloppy about keeping memory usage to a minimum, and probably the same with computation.

At this point, we're going to need to keep an eye on all of those things, as well as go back through our old code and make sure we are being efficient.