### PR TITLE
Check error returned from ConsensusSetPersistentSubscribe

### DIFF
--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -128,7 +128,10 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 		return nil, err
 	}
 
-	cs.ConsensusSetPersistentSubscribe(e, modules.ConsensusChangeID{})
+	err = cs.ConsensusSetPersistentSubscribe(e, modules.ConsensusChangeID{})
+	if err != nil {
+		return nil, errors.New("explorer subscription failed: " + err.Error())
+	}
 
 	return e, nil
 }

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -134,7 +134,10 @@ func newHostDB(cs consensusSet, w wallet, tp transactionPool, d dialer, s sleepe
 	}
 	go hdb.threadedScan()
 
-	cs.ConsensusSetPersistentSubscribe(hdb, modules.ConsensusChangeID{})
+	err = cs.ConsensusSetPersistentSubscribe(hdb, modules.ConsensusChangeID{})
+	if err != nil {
+		return nil, errors.New("hostdb subscription failed: " + err.Error())
+	}
 
 	return hdb, nil
 }

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -91,7 +91,10 @@ func New(cs modules.ConsensusSet, g modules.Gateway) (*TransactionPool, error) {
 	g.RegisterRPC("RelayTransactionSet", tp.relayTransactionSet)
 
 	// Subscribe the transaction pool to the consensus set.
-	cs.ConsensusSetPersistentSubscribe(tp, modules.ConsensusChangeID{})
+	err := cs.ConsensusSetPersistentSubscribe(tp, modules.ConsensusChangeID{})
+	if err != nil {
+		return nil, errors.New("transactionpool subscription failed: " + err.Error())
+	}
 
 	return tp, nil
 }

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -206,7 +206,10 @@ func (w *Wallet) Unlock(masterKey crypto.TwofishKey) error {
 	// Subscribe to the consensus set if this is the first unlock for the
 	// wallet object.
 	if !subscribed {
-		w.cs.ConsensusSetPersistentSubscribe(w, modules.ConsensusChangeID{})
+		err = w.cs.ConsensusSetPersistentSubscribe(w, modules.ConsensusChangeID{})
+		if err != nil {
+			return errors.New("wallet subscription failed: " + err.Error())
+		}
 		w.tpool.TransactionPoolSubscribe(w)
 		w.mu.Lock()
 		w.subscribed = true


### PR DESCRIPTION
Because all modules (but the miner) subscribe to the consensus set with an initial change id of the genesis block, it's only possible for an error to be returned by `ConsensusSetPersistentSubscribe` right now if `computeConsensusChange` fails. In the future these modules will use a more recent `ConsensusChangeID` which could return make `ConsensusSetPersistentSubscribe` return `ErrInvalidConsensusChangeID` if the module and the consensus package become desynchronized.