### PR TITLE
Reduce the number of unnecessary block broadcasts

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -120,12 +120,12 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block) (ce changeEntry, err error
 	return ce, nil
 }
 
-// acceptBlockNoBroadcast accepts a block but does not broadcast it to any
-// peers. See comment for AcceptBlock. Typically AcceptBlock should be used.
-// This method should only be used when there would otherwise be multiple
+// managedAcceptBlock accepts a block but does not broadcast it to any peers.
+// See comment for AcceptBlock. Typically AcceptBlock should be used. This
+// method should only be used when there would otherwise be multiple
 // consecutive calls to AcceptBlock with each successive call accepting the
 // child block of the previous call.
-func (cs *ConsensusSet) acceptBlockNoBroadcast(b types.Block) error {
+func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 	// Grab a lock on the consensus set. Lock is demoted later in the function,
 	// failure to unlock before returning an error will cause a deadlock.
 	cs.mu.Lock()
@@ -188,7 +188,7 @@ func (cs *ConsensusSet) acceptBlockNoBroadcast(b types.Block) error {
 // it will be relayed to connected peers. This function should only be called
 // for new, untrusted blocks.
 func (cs *ConsensusSet) AcceptBlock(b types.Block) error {
-	err := cs.acceptBlockNoBroadcast(b)
+	err := cs.managedAcceptBlock(b)
 	if err != nil {
 		return err
 	}

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -711,7 +711,8 @@ type mockGatewayDoesBroadcast struct {
 
 // Broadcast is a mock implementation of modules.Gateway.Broadcast that
 // sends a sentinel value down a channel to signal it's been called.
-func (g *mockGatewayDoesBroadcast) Broadcast(string, interface{}) {
+func (g *mockGatewayDoesBroadcast) Broadcast(name string, obj interface{}) {
+	g.Gateway.Broadcast(name, obj)
 	g.broadcastCalled <- struct{}{}
 }
 

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -10,11 +10,16 @@ import (
 	"github.com/NebulousLabs/bolt"
 )
 
-const (
+var (
 	// MaxCatchUpBlocks is the maxiumum number of blocks that can be given to
 	// the consensus set in a single iteration during the initial blockchain
 	// download.
-	MaxCatchUpBlocks = 10
+	MaxCatchUpBlocks = func() types.BlockHeight {
+		if build.Release == "testing" {
+			return 3
+		}
+		return 10
+	}()
 )
 
 // blockHistory returns up to 32 block ids, starting with recent blocks and
@@ -93,7 +98,7 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 	for moreAvailable {
 		// Read a slice of blocks from the wire.
 		var newBlocks []types.Block
-		if err := encoding.ReadObject(conn, &newBlocks, MaxCatchUpBlocks*types.BlockSizeLimit); err != nil {
+		if err := encoding.ReadObject(conn, &newBlocks, uint64(MaxCatchUpBlocks)*types.BlockSizeLimit); err != nil {
 			return err
 		}
 		if err := encoding.ReadObject(conn, &moreAvailable, 1); err != nil {

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -15,10 +15,16 @@ var (
 	// the consensus set in a single iteration during the initial blockchain
 	// download.
 	MaxCatchUpBlocks = func() types.BlockHeight {
-		if build.Release == "testing" {
+		switch build.Release {
+		case "testing":
 			return 3
+		case "standard":
+			return 10
+		case "dev":
+			return 10
+		default:
+			panic("unrecognized build.Release")
 		}
-		return 10
 	}()
 )
 

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -93,6 +93,8 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 	chainExtended := false
 	defer func() {
 		if chainExtended {
+			// The last block received will be the current block since
+			// managedAcceptBlock only returns nil if a block extends the longest chain.
 			currentBlock := cs.CurrentBlock()
 			go cs.gateway.Broadcast("RelayBlock", currentBlock)
 		}
@@ -116,7 +118,7 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 			// Call managedAcceptBlock instead of AcceptBlock so as not to broadcast
 			// every block.
 			acceptErr := cs.managedAcceptBlock(block)
-			// Only broadcast the last block if a block was accepted.
+			// Set a flag to indicate that we should broadcast the last block received.
 			if acceptErr == nil {
 				chainExtended = true
 			}

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -96,7 +96,7 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 			if !moreAvailable && i == len(newBlocks)-1 {
 				acceptErr = cs.AcceptBlock(block)
 			} else {
-				acceptErr = cs.acceptBlockNoBroadcast(block)
+				acceptErr = cs.managedAcceptBlock(block)
 			}
 
 			// ErrNonExtendingBlock must be ignored until headers-first block

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -90,8 +90,14 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 		}
 
 		// Integrate the blocks into the consensus set.
-		for _, block := range newBlocks {
-			acceptErr := cs.AcceptBlock(block)
+		for i, block := range newBlocks {
+			// Only broadcast the last block.
+			var acceptErr error
+			if !moreAvailable && i == len(newBlocks)-1 {
+				acceptErr = cs.AcceptBlock(block)
+			} else {
+				acceptErr = cs.acceptBlockNoBroadcast(block)
+			}
 
 			// ErrNonExtendingBlock must be ignored until headers-first block
 			// sharing is implemented, block already in database should also be

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1,9 +1,11 @@
 package consensus
 
 import (
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/NebulousLabs/bolt"
@@ -226,10 +228,27 @@ func TestBlockHistory(t *testing.T) {
 	}
 }
 
-// TestSendBlocksBroadcasts tests that the SendBlocks RPC call only Broadcasts
-// one block, no matter how many blocks are sent. In the case 0 blocks are
-// sent, tests that Broadcast is never called.
-func TestSendBlocksBroadcasts(t *testing.T) {
+// mockGatewayCountBroadcasts implements modules.Gateway to mock the Broadcast
+// method.
+type mockGatewayCountBroadcasts struct {
+	modules.Gateway
+	numBroadcasts int
+	mu            sync.RWMutex
+}
+
+// Broadcast is a mock implementation of modules.Gateway.Broadcast that
+// increments a counter denoting the number of times it's been called.
+func (g *mockGatewayCountBroadcasts) Broadcast(string, interface{}) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.numBroadcasts++
+	return
+}
+
+// TestSendBlocksBroadcastsOnce tests that the SendBlocks RPC call only
+// Broadcasts one block, no matter how many blocks are sent. In the case 0
+// blocks are sent, tests that Broadcast is never called.
+func TestSendBlocksBroadcastsOnce(t *testing.T) {
 	// Setup consensus sets.
 	cst1, err := blankConsensusSetTester("TestSendBlocksBroadcastsOnce1")
 	if err != nil {
@@ -242,7 +261,7 @@ func TestSendBlocksBroadcasts(t *testing.T) {
 	}
 	defer cst2.Close()
 	// Setup mock gateway.
-	mg := mockGateway{Gateway: cst1.cs.gateway}
+	mg := mockGatewayCountBroadcasts{Gateway: cst1.cs.gateway}
 	cst1.cs.gateway = &mg
 	err = cst1.cs.gateway.Connect(cst2.cs.gateway.Address())
 	if err != nil {
@@ -282,7 +301,7 @@ func TestSendBlocksBroadcasts(t *testing.T) {
 		// Sleep to wait for possible calls to Broadcast to complete. We cannot
 		// wait on a channel because we don't know how many times broadcast has
 		// been called.
-		time.Sleep(1)
+		time.Sleep(10 * time.Millisecond)
 		mg.mu.RLock()
 		numBroadcasts := mg.numBroadcasts
 		mg.mu.RUnlock()

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -275,8 +275,8 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 		{0, 0},
 		{1, 1},
 		{2, 1},
-		{MaxCatchUpBlocks, 1},
-		{2 * MaxCatchUpBlocks, 1},
+		{int(MaxCatchUpBlocks), 1},
+		{2 * int(MaxCatchUpBlocks), 1},
 	}
 	for _, test := range tests {
 		mg.mu.Lock()

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -277,6 +277,7 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 		{2, 1},
 		{int(MaxCatchUpBlocks), 1},
 		{2 * int(MaxCatchUpBlocks), 1},
+		{2*int(MaxCatchUpBlocks) + 1, 1},
 	}
 	for _, test := range tests {
 		mg.mu.Lock()

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -238,11 +238,11 @@ type mockGatewayCountBroadcasts struct {
 
 // Broadcast is a mock implementation of modules.Gateway.Broadcast that
 // increments a counter denoting the number of times it's been called.
-func (g *mockGatewayCountBroadcasts) Broadcast(string, interface{}) {
+func (g *mockGatewayCountBroadcasts) Broadcast(name string, obj interface{}) {
 	g.mu.Lock()
-	defer g.mu.Unlock()
 	g.numBroadcasts++
-	return
+	g.mu.Unlock()
+	g.Gateway.Broadcast(name, obj)
 }
 
 // TestSendBlocksBroadcastsOnce tests that the SendBlocks RPC call only

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -260,7 +260,9 @@ func TestSendBlocksBroadcasts(t *testing.T) {
 		{2 * MaxCatchUpBlocks, 1},
 	}
 	for _, test := range tests {
+		mg.mu.Lock()
 		mg.numBroadcasts = 0
+		mg.mu.Unlock()
 		for i := 0; i < test.blocksToMine; i++ {
 			b, minerErr := cst2.miner.FindBlock()
 			if minerErr != nil {
@@ -281,8 +283,11 @@ func TestSendBlocksBroadcasts(t *testing.T) {
 		// wait on a channel because we don't know how many times broadcast has
 		// been called.
 		time.Sleep(1)
-		if mg.numBroadcasts != test.expectedNumBroadcasts {
-			t.Errorf("expected %d number of broadcasts, got %d", test.expectedNumBroadcasts, mg.numBroadcasts)
+		mg.mu.RLock()
+		numBroadcasts := mg.numBroadcasts
+		mg.mu.RUnlock()
+		if numBroadcasts != test.expectedNumBroadcasts {
+			t.Errorf("expected %d number of broadcasts, got %d", test.expectedNumBroadcasts, numBroadcasts)
 		}
 	}
 }


### PR DESCRIPTION
It is only necessary to broadcast the last block in a chain of calls to
AcceptBlock. This commit changes the behavior of threadedReceiveBlocks
to only broadcast the last block received. This is especially helpful
during the initial blockchain download. Instead of rebroadcasting every
block, only the last block in the initial blockchain download is
broadcasted.

Here's the gateway log after an initial blockchain download. Only one RelayBlock broadcast :)
```
$ cat gateway.log | grep RelayBlock
2016/02/04 17:32:26.716491 rpc.go:133: INFO: broadcasting RPC "RelayBlock" to 8 peers
```