### PR TITLE
Remove compatibility for v0.4.6

### DIFF
--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -55,7 +55,9 @@ func (g *Gateway) RPC(addr modules.NetAddress, name string, fn modules.RPCFunc) 
 
 // RegisterRPC registers an RPCFunc as a handler for a given identifier. To
 // call an RPC, use gateway.RPC, supplying the same identifier given to
-// RegisterRPC. Identifiers should always use PascalCase.
+// RegisterRPC. Identifiers should always use PascalCase. The first 8
+// characters of an identifier should be unique, as the identifier used
+// internally is truncated to 8 bytes.
 func (g *Gateway) RegisterRPC(name string, fn modules.RPCFunc) {
 	id := g.mu.Lock()
 	defer g.mu.Unlock(id)

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -2,7 +2,6 @@ package transactionpool
 
 import (
 	"errors"
-	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -289,17 +288,6 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 	// Notify subscribers and broadcast the transaction set.
 	go tp.gateway.Broadcast("RelayTransactionSet", ts)
 	tp.updateSubscribersTransactions()
-
-	// COMPAT v0.4.6
-	//
-	// Transactions must be broadcast individually as well so that they will be
-	// seen by older nodes that don't support the "RelayTransactionSet" RPC.
-	go func() {
-		for _, t := range ts {
-			tp.gateway.Broadcast("RelayTransaction", t)
-			time.Sleep(time.Second * 15)
-		}
-	}()
 
 	return nil
 }

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -88,6 +88,8 @@ func New(cs modules.ConsensusSet, g modules.Gateway) (*TransactionPool, error) {
 		consensusChangeIndex: -1,
 	}
 	// Register RPCs
+	// TODO: rename RelayTransactionSet so that the conflicting RPC
+	// RelayTransaction calls v0.4.6 clients and earlier are ignored.
 	g.RegisterRPC("RelayTransactionSet", tp.relayTransactionSet)
 
 	// Subscribe the transaction pool to the consensus set.


### PR DESCRIPTION
AcceptTransactionSet was broadcasting both the RPC RelayTransactionSet and the RPC RelayTransaction to maintain compatibility with v0.4.6. But because rpcIDs are 8 bytes, the two rpcIDs collide.

Also add clarifying comment regarding RPC identifiers to `RegisterRPC`.