### PR TITLE
Versioned broadcast

### DIFF
--- a/api/gateway.go
+++ b/api/gateway.go
@@ -9,15 +9,15 @@ import (
 )
 
 type GatewayInfo struct {
-	NetAddress modules.NetAddress   `json:"netaddress"`
-	Peers      []modules.NetAddress `json:"peers"`
+	NetAddress modules.NetAddress `json:"netaddress"`
+	Peers      []modules.Peer     `json:"peers"`
 }
 
 // gatewayHandler handles the API call asking for the gatway status.
 func (srv *Server) gatewayHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	peers := srv.gateway.Peers()
 	if peers == nil {
-		peers = make([]modules.NetAddress, 0)
+		peers = make([]modules.Peer, 0)
 	}
 	writeJSON(w, GatewayInfo{srv.gateway.Address(), peers})
 }

--- a/api/gateway.go
+++ b/api/gateway.go
@@ -16,6 +16,9 @@ type GatewayInfo struct {
 // gatewayHandler handles the API call asking for the gatway status.
 func (srv *Server) gatewayHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	peers := srv.gateway.Peers()
+	// nil slices are marshalled as 'null' in JSON, whereas 0-length slices are
+	// marshalled as '[]'. The latter is preferred, indicating that the value
+	// exists but contains no elements.
 	if peers == nil {
 		peers = make([]modules.Peer, 0)
 	}

--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -40,7 +40,7 @@ func TestGatewayPeerAdd(t *testing.T) {
 
 	var info GatewayInfo
 	st.getAPI("/gateway", &info)
-	if len(info.Peers) != 1 || info.Peers[0] != peer.Address() {
+	if len(info.Peers) != 1 || info.Peers[0].NetAddress != peer.Address() {
 		t.Fatal("/gateway/add did not add peer", peer.Address())
 	}
 }
@@ -62,7 +62,7 @@ func TestGatewayPeerRemove(t *testing.T) {
 
 	var info GatewayInfo
 	st.getAPI("/gateway", &info)
-	if len(info.Peers) != 1 || info.Peers[0] != peer.Address() {
+	if len(info.Peers) != 1 || info.Peers[0].NetAddress != peer.Address() {
 		t.Fatal("/gateway/add did not add peer", peer.Address())
 	}
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -273,14 +273,17 @@ Response:
 ```
 struct {
 	netaddress string
-	peers      []string
+	peers      []struct {
+                netaddress string
+                version    string
+        }
 }
 ```
 'netaddress' is the network address of the Gateway, including its external IP
 address and the port Sia is listening on.
 
-'peers' is a list of the network addresses of peers that the Gateway is
-currently connected to.
+'peers' is a list of the network addresses and versions of peers that the
+Gateway is currently connected to.
 
 #### /gateway/add/{netaddress} [POST]
 

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -202,6 +202,6 @@ func (cs *ConsensusSet) AcceptBlock(b types.Block) error {
 		return err
 	}
 	// Broadcast the new block to all peers.
-	go cs.gateway.Broadcast("RelayBlock", b)
+	go cs.gateway.Broadcast("RelayBlock", b, nil)
 	return nil
 }

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -711,8 +711,8 @@ type mockGatewayDoesBroadcast struct {
 
 // Broadcast is a mock implementation of modules.Gateway.Broadcast that
 // sends a sentinel value down a channel to signal it's been called.
-func (g *mockGatewayDoesBroadcast) Broadcast(name string, obj interface{}) {
-	g.Gateway.Broadcast(name, obj)
+func (g *mockGatewayDoesBroadcast) Broadcast(name string, obj interface{}, peers []modules.Peer) {
+	g.Gateway.Broadcast(name, obj, peers)
 	g.broadcastCalled <- struct{}{}
 }
 

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -96,7 +96,8 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 			// The last block received will be the current block since
 			// managedAcceptBlock only returns nil if a block extends the longest chain.
 			currentBlock := cs.CurrentBlock()
-			go cs.gateway.Broadcast("RelayBlock", currentBlock)
+			// TODO: only broadcast blocks to peers v0.5.1 and below and headers to peers v0.5.2 and above.
+			go cs.gateway.Broadcast("RelayBlock", currentBlock, nil)
 		}
 	}()
 

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -96,7 +96,6 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 			// The last block received will be the current block since
 			// managedAcceptBlock only returns nil if a block extends the longest chain.
 			currentBlock := cs.CurrentBlock()
-			// TODO: only broadcast blocks to peers v0.5.1 and below and headers to peers v0.5.2 and above.
 			go cs.gateway.Broadcast("RelayBlock", currentBlock, nil)
 		}
 	}()

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -238,11 +238,11 @@ type mockGatewayCountBroadcasts struct {
 
 // Broadcast is a mock implementation of modules.Gateway.Broadcast that
 // increments a counter denoting the number of times it's been called.
-func (g *mockGatewayCountBroadcasts) Broadcast(name string, obj interface{}) {
+func (g *mockGatewayCountBroadcasts) Broadcast(name string, obj interface{}, peers []modules.Peer) {
 	g.mu.Lock()
 	g.numBroadcasts++
 	g.mu.Unlock()
-	g.Gateway.Broadcast(name, obj)
+	g.Gateway.Broadcast(name, obj, peers)
 }
 
 // TestSendBlocksBroadcastsOnce tests that the SendBlocks RPC call only

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -29,52 +29,54 @@ var (
 	}
 )
 
-// A PeerConn is the connection type used when communicating with peers during
-// an RPC. For now it is identical to a net.Conn.
-type PeerConn interface {
-	net.Conn
-}
+type (
+	// A PeerConn is the connection type used when communicating with peers during
+	// an RPC. For now it is identical to a net.Conn.
+	PeerConn interface {
+		net.Conn
+	}
 
-// RPCFunc is the type signature of functions that handle RPCs. It is used for
-// both the caller and the callee. RPCFuncs may perform locking. RPCFuncs may
-// close the connection early, and it is recommended that they do so to avoid
-// keeping the connection open after all necessary I/O has been performed.
-type RPCFunc func(PeerConn) error
+	// RPCFunc is the type signature of functions that handle RPCs. It is used for
+	// both the caller and the callee. RPCFuncs may perform locking. RPCFuncs may
+	// close the connection early, and it is recommended that they do so to avoid
+	// keeping the connection open after all necessary I/O has been performed.
+	RPCFunc func(PeerConn) error
 
-// A Gateway facilitates the interactions between the local node and remote
-// nodes (peers). It relays incoming blocks and transactions to local modules,
-// and broadcasts outgoing blocks and transactions to peers. In a broad sense,
-// it is responsible for ensuring that the local consensus set is consistent
-// with the "network" consensus set.
-type Gateway interface {
-	// Connect establishes a persistent connection to a peer.
-	Connect(NetAddress) error
+	// A Gateway facilitates the interactions between the local node and remote
+	// nodes (peers). It relays incoming blocks and transactions to local modules,
+	// and broadcasts outgoing blocks and transactions to peers. In a broad sense,
+	// it is responsible for ensuring that the local consensus set is consistent
+	// with the "network" consensus set.
+	Gateway interface {
+		// Connect establishes a persistent connection to a peer.
+		Connect(NetAddress) error
 
-	// Disconnect terminates a connection to a peer.
-	Disconnect(NetAddress) error
+		// Disconnect terminates a connection to a peer.
+		Disconnect(NetAddress) error
 
-	// Address returns the Gateway's address.
-	Address() NetAddress
+		// Address returns the Gateway's address.
+		Address() NetAddress
 
-	// Peers returns the addresses that the Gateway is currently connected to.
-	Peers() []NetAddress
+		// Peers returns the addresses that the Gateway is currently connected to.
+		Peers() []NetAddress
 
-	// RegisterRPC registers a function to handle incoming connections that
-	// supply the given RPC ID.
-	RegisterRPC(string, RPCFunc)
+		// RegisterRPC registers a function to handle incoming connections that
+		// supply the given RPC ID.
+		RegisterRPC(string, RPCFunc)
 
-	// RegisterConnectCall registers an RPC name and function to be called
-	// upon connecting to a peer.
-	RegisterConnectCall(string, RPCFunc)
+		// RegisterConnectCall registers an RPC name and function to be called
+		// upon connecting to a peer.
+		RegisterConnectCall(string, RPCFunc)
 
-	// RPC calls an RPC on the given address. RPC cannot be called on an
-	// address that the Gateway is not connected to.
-	RPC(NetAddress, string, RPCFunc) error
+		// RPC calls an RPC on the given address. RPC cannot be called on an
+		// address that the Gateway is not connected to.
+		RPC(NetAddress, string, RPCFunc) error
 
-	// Broadcast transmits obj, prefaced by the RPC name, to all of the
-	// Gateway's connected peers in parallel.
-	Broadcast(name string, obj interface{})
+		// Broadcast transmits obj, prefaced by the RPC name, to all of the
+		// Gateway's connected peers in parallel.
+		Broadcast(name string, obj interface{})
 
-	// Close safely stops the Gateway's listener process.
-	Close() error
-}
+		// Close safely stops the Gateway's listener process.
+		Close() error
+	}
+)

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -30,6 +30,12 @@ var (
 )
 
 type (
+	// Peer contains all the info necessary to Broadcast to a peer.
+	Peer struct {
+		NetAddress NetAddress `json:"netaddress"`
+		Version    string     `json:"version"`
+	}
+
 	// A PeerConn is the connection type used when communicating with peers during
 	// an RPC. For now it is identical to a net.Conn.
 	PeerConn interface {
@@ -58,7 +64,7 @@ type (
 		Address() NetAddress
 
 		// Peers returns the addresses that the Gateway is currently connected to.
-		Peers() []NetAddress
+		Peers() []Peer
 
 		// RegisterRPC registers a function to handle incoming connections that
 		// supply the given RPC ID.

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -79,8 +79,8 @@ type (
 		RPC(NetAddress, string, RPCFunc) error
 
 		// Broadcast transmits obj, prefaced by the RPC name, to all of the
-		// Gateway's connected peers in parallel.
-		Broadcast(name string, obj interface{})
+		// given peers in parallel.
+		Broadcast(name string, obj interface{}, peers []Peer)
 
 		// Close safely stops the Gateway's listener process.
 		Close() error

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -48,7 +48,7 @@ func TestPeers(t *testing.T) {
 		t.Fatal("failed to connect:", err)
 	}
 	peers := g1.Peers()
-	if len(peers) != 1 || peers[0] != g2.Address() {
+	if len(peers) != 1 || peers[0].NetAddress != g2.Address() {
 		t.Fatal("g1 has bad peer list:", peers)
 	}
 	err = g1.Disconnect(g2.Address())

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -99,7 +99,7 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 	}
 	g.save()
 	// relay
-	go g.Broadcast("RelayNode", addr)
+	go g.Broadcast("RelayNode", addr, nil)
 	return nil
 }
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -198,10 +198,11 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	var remoteVersion string
 	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
 		return err
-	} else if remoteVersion == "reject" {
-		return errors.New("peer rejected connection")
 	}
 	// decide whether to accept this version
+	if remoteVersion == "reject" {
+		return errors.New("peer rejected connection")
+	}
 	if build.VersionCmp(remoteVersion, "0.3.3") < 0 {
 		conn.Close()
 		return errors.New("unacceptable version: " + remoteVersion)

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -122,10 +122,14 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 		return
 	}
 
-	// check that version is acceptable
+	// Check that version is acceptable.
+	//
+	// Reject peers < v0.4.0 as the previous version is v0.3.3 which is
+	// pre-hardfork.
+	//
 	// NOTE: this version must be bumped whenever the gateway or consensus
 	// breaks compatibility.
-	if build.VersionCmp(remoteVersion, "0.3.3") < 0 {
+	if build.VersionCmp(remoteVersion, "0.4.0") < 0 {
 		encoding.WriteObject(conn, "reject")
 		conn.Close()
 		g.log.Printf("INFO: %v wanted to connect, but their version (%v) was unacceptable", addr, remoteVersion)
@@ -209,7 +213,14 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	if remoteVersion == "reject" {
 		return errors.New("peer rejected connection")
 	}
-	if build.VersionCmp(remoteVersion, "0.3.3") < 0 {
+	// Check that version is acceptable.
+	//
+	// Reject peers < v0.4.0 as the previous version is v0.3.3 which is
+	// pre-hardfork.
+	//
+	// NOTE: this version must be bumped whenever the gateway or consensus
+	// breaks compatibility.
+	if build.VersionCmp(remoteVersion, "0.4.0") < 0 {
 		conn.Close()
 		return errors.New("unacceptable version: " + remoteVersion)
 	}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -75,9 +75,9 @@ func (g *Gateway) randomPeer() (modules.NetAddress, error) {
 func (g *Gateway) randomInboundPeer() (modules.NetAddress, error) {
 	if len(g.peers) > 0 {
 		r, _ := crypto.RandIntn(len(g.peers))
-		for addr, peer := range g.peers {
+		for addr, p := range g.peers {
 			// only select inbound peers
-			if !peer.inbound {
+			if !p.inbound {
 				continue
 			}
 			if r <= 0 {

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -30,6 +30,7 @@ type peer struct {
 	addr    modules.NetAddress
 	sess    muxado.Session
 	inbound bool
+	version string
 }
 
 func (p *peer) open() (modules.PeerConn, error) {
@@ -163,7 +164,12 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 		g.log.Printf("INFO: disconnected from %v to make room for %v", kick, addr)
 	}
 	// add the peer
-	g.addPeer(&peer{addr: addr, sess: muxado.Server(conn), inbound: true})
+	g.addPeer(&peer{
+		addr:    addr,
+		sess:    muxado.Server(conn),
+		inbound: true,
+		version: remoteVersion,
+	})
 	g.mu.Unlock(id)
 
 	g.log.Printf("INFO: accepted connection from new peer %v (v%v)", addr, remoteVersion)
@@ -211,7 +217,12 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	g.log.Println("INFO: connected to new peer", addr)
 
 	id = g.mu.Lock()
-	g.addPeer(&peer{addr: addr, sess: muxado.Client(conn), inbound: false})
+	g.addPeer(&peer{
+		addr:    addr,
+		sess:    muxado.Client(conn),
+		inbound: false,
+		version: remoteVersion,
+	})
 	g.mu.Unlock(id)
 
 	// call initRPCs

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -292,12 +292,12 @@ func (g *Gateway) threadedPeerManager() {
 }
 
 // Peers returns the addresses currently connected to the Gateway.
-func (g *Gateway) Peers() []modules.NetAddress {
+func (g *Gateway) Peers() []modules.Peer {
 	id := g.mu.RLock()
 	defer g.mu.RUnlock(id)
-	var peers []modules.NetAddress
-	for addr := range g.peers {
-		peers = append(peers, addr)
+	var peers []modules.Peer
+	for _, p := range g.peers {
+		peers = append(peers, modules.Peer{NetAddress: p.addr, Version: p.version})
 	}
 	return peers
 }

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -16,8 +16,6 @@ import (
 const (
 	// the gateway will abort a connection attempt after this long
 	dialTimeout = 2 * time.Minute
-	// the gateway will sleep this long between incoming connections
-	acceptInterval = 3 * time.Second
 	// the gateway will not make outbound connections above this threshold
 	wellConnectedThreshold = 8
 	// the gateway will not accept inbound connections above this threshold
@@ -26,7 +24,23 @@ const (
 	minNodeListLen = 100
 )
 
-var errPeerRejectedConn = errors.New("peer rejected connection")
+var (
+	// The gateway will sleep this long between incoming connections.
+	acceptInterval = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 3 * time.Second
+		case "standard":
+			return 3 * time.Second
+		case "testing":
+			return 10 * time.Millisecond
+		default:
+			panic("unrecognized build.Release")
+		}
+	}()
+
+	errPeerRejectedConn = errors.New("peer rejected connection")
+)
 
 // insufficientVersionError indicates a peer's version is insufficient.
 type insufficientVersionError string

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -183,6 +183,270 @@ func TestConnect(t *testing.T) {
 	g.mu.RUnlock(id)
 }
 
+// TestConnectRejects tests that Gateway.Connect only accepts peers with
+// sufficient and valid versions.
+func TestConnectRejects(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	g := newTestingGateway("TestConnectRejects", t)
+	// Setup a listener that mocks Gateway.acceptConn, but sends the
+	// version sent over mockVersionChan instead of build.Version.
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mockVersionChan := make(chan string)
+	go func() {
+		for {
+			mockVersion := <-mockVersionChan
+			conn, err := listener.Accept()
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Read remote peer version.
+			var remoteVersion string
+			if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+				t.Fatal(err)
+			}
+			// Write our mock version.
+			if err := encoding.WriteObject(conn, mockVersion); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	tests := []struct {
+		version             string
+		errWant             error
+		insufficientVersion bool
+		msg                 string
+	}{
+		// Test that Connect fails when the remote peer's version is "reject".
+		{
+			version: "reject",
+			errWant: errPeerRejectedConn,
+			msg:     "Connect should fail when the remote peer rejects the connection",
+		},
+		// Test that Connect fails when the remote peer's version is ascii gibberish.
+		{
+			version:             "foobar",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is ascii gibberish",
+		},
+		// Test that Connect fails when the remote peer's version is utf8 gibberish.
+		{
+			version:             "世界",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is utf8 gibberish",
+		},
+		// Test that Connect fails when the remote peer's version is < 0.4.0 (0).
+		{
+			version:             "0",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is 0",
+		},
+		{
+			version:             "0.0.0",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is 0.0.0",
+		},
+		{
+			version:             "0000.0000.0000",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is 0000.0000.0000",
+		},
+		{
+			version:             "0.3.9",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is 0.3.9",
+		},
+		{
+			version:             "0.3.9999",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is 0.3.9999",
+		},
+		{
+			version:             "0.3.9.9.9",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is 0.3.9.9.9",
+		},
+		// Test that Connect succeeds when the remote peer's version is 0.4.0.
+		{
+			version: "0.4.0",
+			msg:     "Connect should succeed when the remote peer's version is 0.4.0",
+		},
+		// Test that Connect succeeds when the remote peer's version is > 0.4.0.
+		{
+			version: "9",
+			msg:     "Connect should succeed when the remote peer's version is 9",
+		},
+		{
+			version: "9.9.9",
+			msg:     "Connect should succeed when the remote peer's version is 9.9.9",
+		},
+		{
+			version: "9999.9999.9999",
+			msg:     "Connect should succeed when the remote peer's version is 9999.9999.9999",
+		},
+	}
+	for _, tt := range tests {
+		mockVersionChan <- tt.version
+		err = g.Connect(modules.NetAddress(listener.Addr().String()))
+		if tt.insufficientVersion {
+			// Check that the error is the expected type.
+			if _, ok := err.(insufficientVersionError); !ok {
+				t.Fatalf("expected Connect to error with insufficientVersionError: %s", tt.msg)
+			}
+		} else {
+			// Check that the error is the expected error.
+			if err != tt.errWant {
+				t.Fatalf("expected Connect to error with '%v', but got '%v': %s", tt.errWant, err, tt.msg)
+			}
+		}
+		g.Disconnect(modules.NetAddress(listener.Addr().String()))
+	}
+	listener.Close()
+}
+
+// mockGatewayWithVersion is a mock implementation of Gateway that sends a mock
+// version on Connect instead of build.Version.
+type mockGatewayWithVersion struct {
+	*Gateway
+	version    string
+	versionACK chan string
+}
+
+// Connect is a mock implementation of modules.Gateway.Connect that provides a
+// mock version to peers it connects to instead of build.Version. The version
+// ack written by the remote peer is written to the versionACK channel.
+func (g mockGatewayWithVersion) Connect(addr modules.NetAddress) error {
+	conn, err := net.DialTimeout("tcp", string(addr), dialTimeout)
+	if err != nil {
+		return err
+	}
+	// send mocked version
+	if err := encoding.WriteObject(conn, g.version); err != nil {
+		return err
+	}
+	// read version ack
+	var remoteVersion string
+	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+		return err
+	}
+	g.versionACK <- remoteVersion
+
+	return nil
+}
+
+// TestAcceptConnRejects tests that Gateway.acceptConn only accepts peers with
+// sufficient and valid versions.
+func TestAcceptConnRejects(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	g := newTestingGateway("TestAcceptConnRejects1", t)
+	defer g.Close()
+	mg := mockGatewayWithVersion{
+		Gateway:    newTestingGateway("TestAcceptConnRejects2", t),
+		versionACK: make(chan string),
+	}
+	defer mg.Close()
+
+	tests := []struct {
+		remoteVersion       string
+		versionResponseWant string
+		msg                 string
+	}{
+		// Test that acceptConn fails when the remote peer's version is "reject".
+		{
+			remoteVersion:       "reject",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is \"reject\"",
+		},
+		// Test that acceptConn fails when the remote peer's version is ascii gibberish.
+		{
+			remoteVersion:       "foobar",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is ascii giberish",
+		},
+		// Test that acceptConn fails when the remote peer's version is utf8 gibberish.
+		{
+			remoteVersion:       "世界",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is utf8 giberish",
+		},
+		// Test that acceptConn fails when the remote peer's version is < 0.4.0 (0).
+		{
+			remoteVersion:       "0",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is 0",
+		},
+		{
+			remoteVersion:       "0.0.0",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is 0.0.0",
+		},
+		{
+			remoteVersion:       "0000.0000.0000",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is 0000.000.000",
+		},
+		{
+			remoteVersion:       "0.3.9",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is 0.3.9",
+		},
+		{
+			remoteVersion:       "0.3.9999",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is 0.3.9999",
+		},
+		{
+			remoteVersion:       "0.3.9.9.9",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is 0.3.9.9.9",
+		},
+		// Test that acceptConn succeeds when the remote peer's version is 0.4.0.
+		{
+			remoteVersion:       "0.4.0",
+			versionResponseWant: build.Version,
+			msg:                 "acceptConn should accept a remote peer whose version is 0.4.0",
+		},
+		// Test that acceptConn succeeds when the remote peer's version is > 0.4.0.
+		{
+			remoteVersion:       "9",
+			versionResponseWant: build.Version,
+			msg:                 "acceptConn should accept a remote peer whose version is 9",
+		},
+		{
+			remoteVersion:       "9.9.9",
+			versionResponseWant: build.Version,
+			msg:                 "acceptConn should accept a remote peer whose version is 9.9.9",
+		},
+		{
+			remoteVersion:       "9999.9999.9999",
+			versionResponseWant: build.Version,
+			msg:                 "acceptConn should accept a remote peer whose version is 9999.9999.9999",
+		},
+	}
+	for _, tt := range tests {
+		mg.version = tt.remoteVersion
+		go func() {
+			err := mg.Connect(g.Address())
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+		remoteVersion := <-mg.versionACK
+		if remoteVersion != tt.versionResponseWant {
+			t.Fatalf(tt.msg)
+		}
+		g.Disconnect(mg.Address())
+		mg.Disconnect(g.Address())
+	}
+}
+
 func TestDisconnect(t *testing.T) {
 	g := newTestingGateway("TestDisconnect", t)
 	defer g.Close()

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -142,7 +142,7 @@ func (g *Gateway) Broadcast(name string, obj interface{}) {
 
 	var wg sync.WaitGroup
 	wg.Add(len(peers))
-	for _, addr := range peers {
+	for _, p := range peers {
 		go func(addr modules.NetAddress) {
 			err := g.RPC(addr, name, fn)
 			if err != nil {
@@ -151,7 +151,7 @@ func (g *Gateway) Broadcast(name string, obj interface{}) {
 				g.RPC(addr, name, fn)
 			}
 			wg.Done()
-		}(addr)
+		}(p.NetAddress)
 	}
 	wg.Wait()
 }

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -126,12 +126,15 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 	}
 }
 
-// Broadcast calls an RPC on all of the peers in the Gateway's peer list. The
-// calls are run in parallel. Broadcasts are restricted to "one-way" RPCs,
-// which simply write an object and disconnect. This is why Broadcast takes an
-// interface{} instead of an RPCFunc.
-func (g *Gateway) Broadcast(name string, obj interface{}) {
-	peers := g.Peers()
+// Broadcast calls an RPC on all of the specified peers. If peers is nil, the
+// RPC is called on all of the gateway's peer. The calls are run in parallel.
+// Broadcasts are restricted to "one-way" RPCs, which simply write an object
+// and disconnect. This is why Broadcast takes an interface{} instead of an
+// RPCFunc.
+func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) {
+	if peers == nil {
+		peers = g.Peers()
+	}
 	g.log.Printf("INFO: broadcasting RPC \"%v\" to %v peers", name, len(peers))
 
 	// only encode obj once, instead of using WriteObject

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"testing"
+	"time"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -163,6 +164,9 @@ func TestThreadedHandleConn(t *testing.T) {
 	}
 }
 
+// TestBroadcast tests that calling broadcast with a slice of peers only
+// broadcasts to those peers. Also tests that calling broadcast with nil peers
+// broadcasts to all peers.
 func TestBroadcast(t *testing.T) {
 	g1 := newTestingGateway("TestBroadcast1", t)
 	defer g1.Close()
@@ -181,22 +185,84 @@ func TestBroadcast(t *testing.T) {
 	}
 
 	var g2Payload, g3Payload string
-	doneChan := make(chan struct{})
+	g2DoneChan := make(chan struct{})
+	g3DoneChan := make(chan struct{})
+
 	g2.RegisterRPC("Recv", func(conn modules.PeerConn) error {
 		encoding.ReadObject(conn, &g2Payload, 100)
-		doneChan <- struct{}{}
+		g2DoneChan <- struct{}{}
 		return nil
 	})
 	g3.RegisterRPC("Recv", func(conn modules.PeerConn) error {
 		encoding.ReadObject(conn, &g3Payload, 100)
-		doneChan <- struct{}{}
+		g3DoneChan <- struct{}{}
 		return nil
 	})
 
-	g1.Broadcast("Recv", "foo")
-	<-doneChan
-	<-doneChan
+	// Test that calling broadcast with nil peers broadcasts to all peers.
+	g1.Broadcast("Recv", "foo", nil)
+	<-g2DoneChan
+	<-g3DoneChan
 	if g2Payload != "foo" || g3Payload != "foo" {
 		t.Fatal("broadcast failed:", g2Payload, g3Payload)
+	}
+
+	// Test that broadcasting to all peers in g1.Peers() broadcasts to all peers.
+	peers := g1.Peers()
+	g1.Broadcast("Recv", "bar", peers)
+	<-g2DoneChan
+	<-g3DoneChan
+	if g2Payload != "bar" || g3Payload != "bar" {
+		t.Fatal("broadcast failed:", g2Payload, g3Payload)
+	}
+
+	// Test that broadcasting to only g2 does not broadcast to g3.
+	peers = make([]modules.Peer, 0)
+	for _, p := range g1.Peers() {
+		if p.NetAddress == g2.Address() {
+			peers = append(peers, p)
+			break
+		}
+	}
+	g1.Broadcast("Recv", "baz", peers)
+	<-g2DoneChan
+	select {
+	case <-g3DoneChan:
+		t.Error("broadcast broadcasted to peers not in the peers arg")
+	case <-time.After(10 * time.Millisecond):
+	}
+	if g2Payload != "baz" {
+		t.Fatal("broadcast failed:", g2Payload)
+	}
+
+	// Test that broadcasting to only g3 does not broadcast to g2.
+	peers = make([]modules.Peer, 0)
+	for _, p := range g1.Peers() {
+		if p.NetAddress == g3.Address() {
+			peers = append(peers, p)
+			break
+		}
+	}
+	g1.Broadcast("Recv", "qux", peers)
+	<-g3DoneChan
+	select {
+	case <-g2DoneChan:
+		t.Error("broadcast broadcasted to peers not in the peers arg")
+	case <-time.After(10 * time.Millisecond):
+	}
+	if g3Payload != "qux" {
+		t.Fatal("broadcast failed:", g3Payload)
+	}
+
+	// Test that broadcasting to an empty slice (but not nil!) does not broadcast
+	// to either g2 or g3.
+	peers = make([]modules.Peer, 0)
+	g1.Broadcast("Recv", "quux", peers)
+	select {
+	case <-g2DoneChan:
+		t.Error("broadcast broadcasted to peers not in the peers arg")
+	case <-g3DoneChan:
+		t.Error("broadcast broadcasted to peers not in the peers arg")
+	case <-time.After(10 * time.Millisecond):
 	}
 }

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -286,7 +286,8 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 	}
 
 	// Notify subscribers and broadcast the transaction set.
-	go tp.gateway.Broadcast("RelayTransactionSet", ts)
+	// TODO: only broadcast to peers v0.4.7 and above.
+	go tp.gateway.Broadcast("RelayTransactionSet", ts, nil)
 	tp.updateSubscribersTransactions()
 
 	return nil

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -3,6 +3,7 @@ package transactionpool
 import (
 	"errors"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -286,8 +287,16 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 	}
 
 	// Notify subscribers and broadcast the transaction set.
-	// TODO: only broadcast to peers v0.4.7 and above.
-	go tp.gateway.Broadcast("RelayTransactionSet", ts, nil)
+	// NOTE: The transaction set is only broadcast to v0.4.7 peers and above.
+	// v0.4.7-v0.5.1 broadcasted both transaction sets and individual transactions
+	// and those versions act as a bridge between v0.5.2+ and older versions.
+	var v047AndAbove []modules.Peer
+	for _, p := range tp.gateway.Peers() {
+		if build.VersionCmp(p.Version, "0.4.7") >= 0 {
+			v047AndAbove = append(v047AndAbove, p)
+		}
+	}
+	go tp.gateway.Broadcast("RelayTransactionSet", ts, v047AndAbove)
 	tp.updateSubscribersTransactions()
 
 	return nil

--- a/siac/gatewaycmd.go
+++ b/siac/gatewaycmd.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
@@ -108,7 +110,10 @@ func gatewaylistcmd() {
 		return
 	}
 	fmt.Println(len(info.Peers), "active peers:")
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Address\tVersion")
 	for _, peer := range info.Peers {
-		fmt.Println("\t", peer)
+		fmt.Fprintf(w, "  %v\t%v\n", peer.NetAddress, peer.Version)
 	}
+	w.Flush()
 }


### PR DESCRIPTION
`BroadcastMinVersion` and `BroadcastMaxVersion` broadcast only to peers that are of at least or at most the specified version, respectively. This is necessary for the upcoming header broadcast PR which will need to broadcast blocks to older peers and headers to newer peers. It is also useful for general backwards compatibility considerations. As an example use, RelayTransactionSet is now only broadcast to peers that are at least v0.4.7, so as to limit the number of conflicting calls to the colliding old RPC name RelayTransaction.

I'm not too sure about the names, as `BroadcastMinVersion` makes it sound like it's broadcasting some version number.