### PR TITLE
Header flooding

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version is the current version of siad.
-const Version = "0.5.1"
+const Version = "0.5.2"
 
 // IsVersion returns whether str is a valid version number.
 func IsVersion(str string) bool {

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -108,6 +108,8 @@ func (cs *ConsensusSet) validateHeader(tx dbTx, h types.BlockHeader) error {
 	// TODO: check if the block is in the extreme or near future, and return
 	// errExtremeFutureTimestamp or errFutureTimestamp, respectively.
 
+	// TODO: check if the block is a non extending block.
+
 	return nil
 }
 
@@ -210,6 +212,7 @@ func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 			if err == errFutureTimestamp {
 				go func() {
 					time.Sleep(time.Duration(b.Timestamp-(types.CurrentTimestamp()+types.FutureThreshold)) * time.Second)
+					// TODO: log error returned by AcceptBlock if non-nill?
 					cs.AcceptBlock(b) // NOTE: Error is not handled.
 				}()
 			}

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"bytes"
 	"errors"
 	"time"
 
@@ -54,6 +55,12 @@ func (cs *ConsensusSet) validateHeaderAndBlock(tx dbTx, b types.Block) error {
 	minTimestamp := cs.blockRuleHelper.minimumValidChildTimestamp(blockMap, &parent)
 
 	return cs.blockValidator.ValidateBlock(b, minTimestamp, parent.ChildTarget, parent.Height+1)
+}
+
+// checkTarget returns true if the header's ID meets the given target.
+func checkHeaderTarget(h types.BlockHeader, target types.Target) bool {
+	blockHash := h.ID()
+	return bytes.Compare(target[:], blockHash[:]) >= 0
 }
 
 // addBlockToTree inserts a block into the blockNode tree by adding it to its

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -295,25 +295,3 @@ func (cs *ConsensusSet) AcceptBlock(b types.Block) error {
 	go cs.gateway.Broadcast("RelayHeader", b.Header(), relayHeaderPeers)
 	return nil
 }
-
-// managedAcceptHeader will validate a block header and see if it extends the
-// heaviest chain. If a header is valid and would extend the heaviest chain,
-// nil is returned. managedAcceptHeader does not fetch the corresponding block
-// and therefore can't accept the block itself. Just as managedAcceptBlock does
-// not broadcast the block, managedAcceptHeader does not broadcast the block
-// header.
-func (cs *ConsensusSet) managedAcceptHeader(h types.BlockHeader) error {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-	// Start verification inside of a bolt View tx.
-	err := cs.db.View(func(tx *bolt.Tx) error {
-		// Do not accept a header if the database is inconsistent.
-		if inconsistencyDetected(tx) {
-			return errInconsistentSet
-		}
-
-		// Do some relatively inexpensive checks to validate the header
-		return cs.validateHeader(boltTxWrapper{tx}, h)
-	})
-	return err
-}

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -224,13 +224,16 @@ func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 			//
 			// TODO: an attacker could mine many blocks off the genesis block all in the
 			// future and we would spawn a goroutine per each block. To fix this, either
-			// ban peers that send lots of future blocks OR stop spawning goroutines
+			// ban peers that send lots of future blocks and stop spawning goroutines
 			// after we are already waiting on a large number of future blocks.
 			//
 			// TODO: an attacker could broadcast a future block many times and we would
 			// spawn a goroutine for each broadcast. To fix this we should create a
 			// cache of future blocks, like we already do for DoS blocks, and only spawn
-			// a goroutine if we haven't already spawned one for that block.
+			// a goroutine if we haven't already spawned one for that block. To limit
+			// the size of the cache of future blocks, make it a constant size (say 50)
+			// over which we would evict the block furthest in the future before adding
+			// a new block to the cache.
 			if err == errFutureTimestamp {
 				go func() {
 					time.Sleep(time.Duration(b.Timestamp-(types.CurrentTimestamp()+types.FutureThreshold)) * time.Second)

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -118,10 +118,9 @@ func (cs *ConsensusSet) validateHeader(tx dbTx, h types.BlockHeader) error {
 		return errExtremeFutureTimestamp
 	}
 
-	// Check if the block is in the near future, but too far to be acceptable.
-	if h.Timestamp > types.CurrentTimestamp()+types.FutureThreshold {
-		return errFutureTimestamp
-	}
+	// We do not check if the header is in the near future here, because we want
+	// to get the corresponding block as soon as possible, even if the block is in
+	// the near future.
 
 	return nil
 }

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -18,9 +18,10 @@ var (
 	errOrphan          = errors.New("block has no known parent")
 )
 
-// validateHeader does some early, low computation verification on the block.
-// Callers should not assume that validation will happen in a particular order.
-func (cs *ConsensusSet) validateHeader(tx dbTx, b types.Block) error {
+// validateHeaderAndBlock does some early, low computation verification on the
+// block. Callers should not assume that validation will happen in a particular
+// order.
+func (cs *ConsensusSet) validateHeaderAndBlock(tx dbTx, b types.Block) error {
 	// See if the block is known already.
 	id := b.ID()
 	_, exists := cs.dosBlocks[id]
@@ -143,10 +144,10 @@ func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 			return errors.New("inconsistent database")
 		}
 
-		// Check that the header is valid. The header is checked first because it
-		// is not computationally expensive to verify, but it is computationally
-		// expensive to create.
-		err := cs.validateHeader(boltTxWrapper{tx}, b)
+		// Do some relatively inexpensive checks to validate the header and block.
+		// Validation generally occurs in the order of least expensive validation
+		// first.
+		err := cs.validateHeaderAndBlock(boltTxWrapper{tx}, b)
 		if err != nil {
 			// If the block is in the near future, but too far to be acceptable, then
 			// save the block and add it to the consensus set after it is no longer

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -613,7 +613,6 @@ func TestOrphanHandling(t *testing.T) {
 		t.Fatalf("expected %v, got %v", errOrphan, err)
 	}
 	// Try submitting an orphan block's header.
-	// TODO: why is the test above duplicated?
 	err = cst.cs.managedAcceptHeader(orphan.Header())
 	if err != errOrphan {
 		t.Fatalf("expected %v, got %v", errOrphan, err)

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -529,10 +529,6 @@ func TestIntegrationDoSBlockHandling(t *testing.T) {
 	if err != errDoSBlock {
 		t.Fatalf("expected %v, got %v", errDoSBlock, err)
 	}
-	err = cst.cs.managedAcceptHeader(dosBlock.Header())
-	if err != errDoSBlock {
-		t.Fatalf("expected %v, got %v", errDoSBlock, err)
-	}
 }
 
 // TestBlockKnownHandling submits known blocks to the consensus set.
@@ -569,12 +565,8 @@ func TestBlockKnownHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Submit all the blocks and headers again, looking for a 'stale block' error.
+	// Submit all the blocks again, looking for a 'stale block' error.
 	err = cst.cs.AcceptBlock(block1)
-	if err != modules.ErrBlockKnown {
-		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
-	}
-	err = cst.cs.managedAcceptHeader(block1.Header())
 	if err != modules.ErrBlockKnown {
 		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
 	}
@@ -582,20 +574,12 @@ func TestBlockKnownHandling(t *testing.T) {
 	if err != modules.ErrBlockKnown {
 		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
 	}
-	err = cst.cs.managedAcceptHeader(block2.Header())
-	if err != modules.ErrBlockKnown {
-		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
-	}
 	err = cst.cs.AcceptBlock(staleBlock)
 	if err != modules.ErrBlockKnown {
 		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
 	}
-	err = cst.cs.managedAcceptHeader(staleBlock.Header())
-	if err != modules.ErrBlockKnown {
-		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
-	}
 
-	// Try submitting the genesis block and its header.
+	// Try submitting the genesis block.
 	id, err := cst.cs.dbGetPath(0)
 	if err != nil {
 		t.Fatal(err)
@@ -605,10 +589,6 @@ func TestBlockKnownHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = cst.cs.AcceptBlock(genesisBlock.Block)
-	if err != modules.ErrBlockKnown {
-		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
-	}
-	err = cst.cs.managedAcceptHeader(genesisBlock.Block.Header())
 	if err != modules.ErrBlockKnown {
 		t.Fatalf("expected %v, got %v", modules.ErrBlockKnown, err)
 	}
@@ -637,15 +617,6 @@ func TestOrphanHandling(t *testing.T) {
 	if err != errOrphan {
 		t.Fatalf("expected %v, got %v", errOrphan, err)
 	}
-	// Try submitting an orphan block's header.
-	err = cst.cs.managedAcceptHeader(orphan.Header())
-	if err != errOrphan {
-		t.Fatalf("expected %v, got %v", errOrphan, err)
-	}
-	err = cst.cs.managedAcceptHeader(orphan.Header())
-	if err != errOrphan {
-		t.Fatalf("expected %v, got %v", errOrphan, err)
-	}
 }
 
 // TestMissedTarget submits a block that does not meet the required target.
@@ -671,10 +642,6 @@ func TestMissedTarget(t *testing.T) {
 		t.Fatal("unable to find a failing target")
 	}
 	err = cst.cs.AcceptBlock(block)
-	if err != modules.ErrBlockUnsolved {
-		t.Fatalf("expected %v, got %v", modules.ErrBlockUnsolved, err)
-	}
-	err = cst.cs.managedAcceptHeader(block.Header())
 	if err != modules.ErrBlockUnsolved {
 		t.Fatalf("expected %v, got %v", modules.ErrBlockUnsolved, err)
 	}
@@ -734,10 +701,6 @@ func TestEarlyTimestampHandling(t *testing.T) {
 	if err != errEarlyTimestamp {
 		t.Fatalf("expected %v, got %v", errEarlyTimestamp, err)
 	}
-	err = cst.cs.managedAcceptHeader(solvedBlock.Header())
-	if err != errEarlyTimestamp {
-		t.Fatalf("expected %v, got %v", errEarlyTimestamp, err)
-	}
 }
 
 // testFutureTimestampHandling checks that blocks in the future (but not
@@ -760,11 +723,6 @@ func TestFutureTimestampHandling(t *testing.T) {
 	}
 	block.Timestamp = types.CurrentTimestamp() + 2 + types.FutureThreshold
 	solvedBlock, _ := cst.miner.SolveBlock(block, target)
-	// managedAcceptHeader should not error when the block is in the near future.
-	err = cst.cs.managedAcceptHeader(solvedBlock.Header())
-	if err != nil {
-		t.Fatalf("expected %v, got %v", nil, err)
-	}
 	err = cst.cs.AcceptBlock(solvedBlock)
 	if err != errFutureTimestamp {
 		t.Fatalf("expected %v, got %v", errFutureTimestamp, err)
@@ -808,10 +766,6 @@ func TestExtremeFutureTimestampHandling(t *testing.T) {
 	}
 	block.Timestamp = types.CurrentTimestamp() + 2 + types.ExtremeFutureThreshold
 	solvedBlock, _ := cst.miner.SolveBlock(block, target)
-	err = cst.cs.managedAcceptHeader(solvedBlock.Header())
-	if err != errExtremeFutureTimestamp {
-		t.Fatalf("expected %v, got %v", errFutureTimestamp, err)
-	}
 	err = cst.cs.AcceptBlock(solvedBlock)
 	if err != errExtremeFutureTimestamp {
 		t.Fatalf("expected %v, got %v", errFutureTimestamp, err)

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -32,6 +32,18 @@ var (
 		},
 	}
 
+	parentBlockHighTargetUnmarshaler = mockBlockMarshaler{
+		[]predefinedBlockUnmarshal{
+			{parentBlockSerialized, mockParentHighTarget(), nil},
+		},
+	}
+
+	parentBlockLowTargetUnmarshaler = mockBlockMarshaler{
+		[]predefinedBlockUnmarshal{
+			{parentBlockSerialized, mockParentLowTarget(), nil},
+		},
+	}
+
 	unmarshalFailedErr = errors.New("mock unmarshal failed")
 
 	failingBlockUnmarshaler = mockBlockMarshaler{
@@ -171,6 +183,19 @@ func mockParent() (parent processedBlock) {
 	return parent
 }
 
+// mockParent returns a mock processedBlock with its ChildTarget member
+// initialized to a the maximum value.
+func mockParentHighTarget() (parent processedBlock) {
+	parent.ChildTarget = types.RootDepth
+	return parent
+}
+
+// mockParent returns a mock processedBlock with its ChildTarget member
+// initialized to the minimum value.
+func mockParentLowTarget() (parent processedBlock) {
+	return parent
+}
+
 // TestUnitValidateHeaderAndBlock runs a series of unit tests for validateHeaderAndBlock.
 func TestUnitValidateHeaderAndBlock(t *testing.T) {
 	var tests = []struct {
@@ -307,6 +332,131 @@ func TestCheckHeaderTarget(t *testing.T) {
 		}
 		if checkHeaderTarget(h, tt.target) != checkTarget(b, tt.target) {
 			t.Errorf("checkHeaderTarget and checkTarget do not match for target %v", tt.target)
+		}
+	}
+}
+
+// TestUnitValidateHeader runs a series of unit tests for validateHeader.
+func TestUnitValidateHeader(t *testing.T) {
+	mockValidBlockID := mockValidBlock.ID()
+	var tests = []struct {
+		header                 types.BlockHeader
+		dosBlocks              map[types.BlockID]struct{}
+		blockMapPairs          []blockMapPair
+		earliestValidTimestamp types.Timestamp
+		marshaler              mockBlockMarshaler
+		useNilBlockMap         bool
+		errWant                error
+		msg                    string
+	}{
+		// Test that known dos blocks are rejected.
+		{
+			header: mockValidBlock.Header(),
+			// Create a dosBlocks map where mockValidBlock is marked as a bad block.
+			dosBlocks: map[types.BlockID]struct{}{
+				mockValidBlock.ID(): struct{}{},
+			},
+			blockMapPairs:          serializedParentBlockMap,
+			earliestValidTimestamp: mockValidBlock.Timestamp,
+			marshaler:              parentBlockUnmarshaler,
+			errWant:                errDoSBlock,
+			msg:                    "validateHeader should reject known bad blocks",
+		},
+		// Test that blocks are rejected if a block map doesn't exist.
+		{
+			header:                 mockValidBlock.Header(),
+			dosBlocks:              make(map[types.BlockID]struct{}),
+			blockMapPairs:          serializedParentBlockMap,
+			earliestValidTimestamp: mockValidBlock.Timestamp,
+			marshaler:              parentBlockUnmarshaler,
+			useNilBlockMap:         true,
+			errWant:                errNoBlockMap,
+			msg:                    "validateHeader should fail when no block map is found in the database",
+		},
+		// Test that known blocks are rejected.
+		{
+			header:                 mockValidBlock.Header(),
+			dosBlocks:              make(map[types.BlockID]struct{}),
+			blockMapPairs:          []blockMapPair{{mockValidBlockID[:], []byte{}}},
+			earliestValidTimestamp: mockValidBlock.Timestamp,
+			marshaler:              parentBlockUnmarshaler,
+			errWant:                modules.ErrBlockKnown,
+			msg:                    "validateHeader should fail when the block has been seen before",
+		},
+		// Test that blocks with unknown parents (orphans) are rejected.
+		{
+			header:                 mockValidBlock.Header(),
+			dosBlocks:              make(map[types.BlockID]struct{}),
+			earliestValidTimestamp: mockValidBlock.Timestamp,
+			marshaler:              parentBlockUnmarshaler,
+			errWant:                errOrphan,
+			msg:                    "validateHeader should reject a block if its parent block does not appear in the block database",
+		},
+		// Test that blocks whose parents don't unmarshal are rejected.
+		{
+			header:                 mockValidBlock.Header(),
+			dosBlocks:              make(map[types.BlockID]struct{}),
+			blockMapPairs:          serializedParentBlockMap,
+			earliestValidTimestamp: mockValidBlock.Timestamp,
+			marshaler:              failingBlockUnmarshaler,
+			errWant:                unmarshalFailedErr,
+			msg:                    "validateHeader should fail when unmarshaling the parent block fails",
+		},
+		// Test that blocks with too early of a timestamp are rejected.
+		{
+			header:                 mockValidBlock.Header(),
+			dosBlocks:              make(map[types.BlockID]struct{}),
+			blockMapPairs:          serializedParentBlockMap,
+			earliestValidTimestamp: mockValidBlock.Timestamp + 1,
+			marshaler:              parentBlockUnmarshaler,
+			errWant:                errEarlyTimestamp,
+			msg:                    "validateHeader should fail when the header's timestamp is too early",
+		},
+		// Test that blocks with too large of a target are rejected.
+		{
+			header:                 mockValidBlock.Header(),
+			dosBlocks:              make(map[types.BlockID]struct{}),
+			blockMapPairs:          serializedParentBlockMap,
+			earliestValidTimestamp: mockValidBlock.Timestamp,
+			marshaler:              parentBlockLowTargetUnmarshaler,
+			errWant:                modules.ErrBlockUnsolved,
+			msg:                    "validateHeader should reject blocks with an insufficiently low target",
+		},
+		// Test that valid blocks are accepted.
+		{
+			header:                 mockValidBlock.Header(),
+			dosBlocks:              make(map[types.BlockID]struct{}),
+			blockMapPairs:          serializedParentBlockMap,
+			earliestValidTimestamp: mockValidBlock.Timestamp,
+			marshaler:              parentBlockHighTargetUnmarshaler,
+			errWant:                nil,
+			msg:                    "validateHeader should accept a valid block",
+		},
+	}
+	for _, tt := range tests {
+		// Initialize the blockmap in the tx.
+		bucket := mockDbBucket{map[string][]byte{}}
+		for _, mapPair := range tt.blockMapPairs {
+			bucket.Set(mapPair.key, mapPair.val)
+		}
+		dbBucketMap := map[string]dbBucket{}
+		if tt.useNilBlockMap {
+			dbBucketMap[string(BlockMap)] = nil
+		} else {
+			dbBucketMap[string(BlockMap)] = bucket
+		}
+		tx := mockDbTx{dbBucketMap}
+
+		cs := ConsensusSet{
+			dosBlocks: tt.dosBlocks,
+			marshaler: tt.marshaler,
+			blockRuleHelper: mockBlockRuleHelper{
+				minTimestamp: tt.earliestValidTimestamp,
+			},
+		}
+		err := cs.validateHeader(tx, tt.header)
+		if err != tt.errWant {
+			t.Errorf("%s: expected to fail with `%v', got: `%v'", tt.msg, tt.errWant, err)
 		}
 	}
 }

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -286,6 +286,31 @@ func TestUnitValidateHeaderAndBlock(t *testing.T) {
 	}
 }
 
+// TestCheckHeaderTarget probes the checkHeaderTarget function and checks that
+// the result matches the result of checkTarget.
+func TestCheckHeaderTarget(t *testing.T) {
+	var b types.Block
+	var h types.BlockHeader
+
+	tests := []struct {
+		target   types.Target
+		expected bool
+		msg      string
+	}{
+		{types.RootDepth, true, "checkHeaderTarget failed for a low target"},
+		{types.Target{}, false, "checkHeaderTarget passed for a high target"},
+		{types.Target(h.ID()), true, "checkHeaderTarget failed for a same target"},
+	}
+	for _, tt := range tests {
+		if checkHeaderTarget(h, tt.target) != tt.expected {
+			t.Error(tt.msg)
+		}
+		if checkHeaderTarget(h, tt.target) != checkTarget(b, tt.target) {
+			t.Errorf("checkHeaderTarget and checkTarget do not match for target %v", tt.target)
+		}
+	}
+}
+
 // TestIntegrationDoSBlockHandling checks that saved bad blocks are correctly
 // ignored.
 func TestIntegrationDoSBlockHandling(t *testing.T) {

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -171,8 +171,8 @@ func mockParent() (parent processedBlock) {
 	return parent
 }
 
-// TestUnitValidateHeader runs a series of unit tests for validateHeader.
-func TestUnitValidateHeader(t *testing.T) {
+// TestUnitValidateHeaderAndBlock runs a series of unit tests for validateHeaderAndBlock.
+func TestUnitValidateHeaderAndBlock(t *testing.T) {
 	var tests = []struct {
 		block                  types.Block
 		dosBlocks              map[types.BlockID]struct{}
@@ -191,7 +191,7 @@ func TestUnitValidateHeader(t *testing.T) {
 			earliestValidTimestamp: mockValidBlock.Timestamp,
 			marshaler:              parentBlockUnmarshaler,
 			errWant:                errNoBlockMap,
-			msg:                    "validateHeader should fail when no block map is found in the database",
+			msg:                    "validateHeaderAndBlock should fail when no block map is found in the database",
 		},
 		{
 			block: mockValidBlock,
@@ -202,7 +202,7 @@ func TestUnitValidateHeader(t *testing.T) {
 			earliestValidTimestamp: mockValidBlock.Timestamp,
 			marshaler:              parentBlockUnmarshaler,
 			errWant:                errDoSBlock,
-			msg:                    "validateHeader should reject known bad blocks",
+			msg:                    "validateHeaderAndBlock should reject known bad blocks",
 		},
 		{
 			block:                  mockValidBlock,
@@ -210,7 +210,7 @@ func TestUnitValidateHeader(t *testing.T) {
 			earliestValidTimestamp: mockValidBlock.Timestamp,
 			marshaler:              parentBlockUnmarshaler,
 			errWant:                errOrphan,
-			msg:                    "validateHeader should reject a block if its parent block does not appear in the block database",
+			msg:                    "validateHeaderAndBlock should reject a block if its parent block does not appear in the block database",
 		},
 		{
 			block:                  mockValidBlock,
@@ -219,7 +219,7 @@ func TestUnitValidateHeader(t *testing.T) {
 			earliestValidTimestamp: mockValidBlock.Timestamp,
 			marshaler:              failingBlockUnmarshaler,
 			errWant:                unmarshalFailedErr,
-			msg:                    "validateHeader should fail when unmarshaling the parent block fails",
+			msg:                    "validateHeaderAndBlock should fail when unmarshaling the parent block fails",
 		},
 		{
 			block:     mockInvalidBlock,
@@ -231,7 +231,7 @@ func TestUnitValidateHeader(t *testing.T) {
 			marshaler:              parentBlockUnmarshaler,
 			validateBlockErr:       errBadMinerPayouts,
 			errWant:                errBadMinerPayouts,
-			msg:                    "validateHeader should reject a block if ValidateBlock returns an error for the block",
+			msg:                    "validateHeaderAndBlock should reject a block if ValidateBlock returns an error for the block",
 		},
 		{
 			block:                  mockValidBlock,
@@ -240,7 +240,7 @@ func TestUnitValidateHeader(t *testing.T) {
 			earliestValidTimestamp: mockValidBlock.Timestamp,
 			marshaler:              parentBlockUnmarshaler,
 			errWant:                nil,
-			msg:                    "validateHeader should accept a valid block",
+			msg:                    "validateHeaderAndBlock should accept a valid block",
 		},
 	}
 	for _, tt := range tests {
@@ -268,7 +268,7 @@ func TestUnitValidateHeader(t *testing.T) {
 		}
 		// Reset the stored parameters to ValidateBlock.
 		validateBlockParamsGot = validateBlockParams{}
-		err := cs.validateHeader(tx, tt.block)
+		err := cs.validateHeaderAndBlock(tx, tt.block)
 		if err != tt.errWant {
 			t.Errorf("%s: expected to fail with `%v', got: `%v'", tt.msg, tt.errWant, err)
 		}

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -1013,6 +1013,9 @@ func TestAcceptBlockBroadcasts(t *testing.T) {
 	}
 	select {
 	case <-mg.broadcastCalled:
+		// Broadcast is called twice, once to broadcast blocks to peers <= v0.5.1
+		// and once to broadcast block headers to peers > v0.5.1.
+		<-mg.broadcastCalled
 	case <-time.After(10 * time.Millisecond):
 		t.Error("expected AcceptBlock to broadcast a valid block")
 	}

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -114,6 +114,7 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 	// Register RPCs
 	gateway.RegisterRPC("SendBlocks", cs.sendBlocks)
 	gateway.RegisterRPC("RelayBlock", cs.relayBlock)
+	gateway.RegisterRPC("Send1Blk", cs.send1Blk)
 	gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)
 
 	return cs, nil

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -114,6 +114,7 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 	// Register RPCs
 	gateway.RegisterRPC("SendBlocks", cs.sendBlocks)
 	gateway.RegisterRPC("RelayBlock", cs.relayBlock)
+	gateway.RegisterRPC("RelayHeader", cs.relayHeader)
 	gateway.RegisterRPC("Send1Blk", cs.send1Blk)
 	gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)
 

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -115,7 +115,7 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 	gateway.RegisterRPC("SendBlocks", cs.rpcSendBlocks)
 	gateway.RegisterRPC("RelayBlock", cs.rpcRelayBlock)
 	gateway.RegisterRPC("RelayHeader", cs.rpcRelayHeader)
-	gateway.RegisterRPC("BlockID", cs.rpcBlockID)
+	gateway.RegisterRPC("SendBlk", cs.rpcSendBlk)
 	gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)
 
 	return cs, nil

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -112,9 +112,9 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 	}
 
 	// Register RPCs
-	gateway.RegisterRPC("SendBlocks", cs.sendBlocks)
-	gateway.RegisterRPC("RelayBlock", cs.relayBlock)
-	gateway.RegisterRPC("RelayHeader", cs.relayHeader)
+	gateway.RegisterRPC("SendBlocks", cs.rpcSendBlocks)
+	gateway.RegisterRPC("RelayBlock", cs.rpcRelayBlock)
+	gateway.RegisterRPC("RelayHeader", cs.rpcRelayHeader)
 	gateway.RegisterRPC("BlockID", cs.rpcBlockID)
 	gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)
 

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -115,7 +115,7 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 	gateway.RegisterRPC("SendBlocks", cs.sendBlocks)
 	gateway.RegisterRPC("RelayBlock", cs.relayBlock)
 	gateway.RegisterRPC("RelayHeader", cs.relayHeader)
-	gateway.RegisterRPC("Send1Blk", cs.send1Blk)
+	gateway.RegisterRPC("BlockID", cs.rpcBlockID)
 	gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)
 
 	return cs, nil

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -285,12 +285,6 @@ func (cs *ConsensusSet) relayHeader(conn modules.PeerConn) error {
 
 	// Submit the header to the consensus set.
 	err = cs.managedAcceptHeader(h)
-	if err == errFutureTimestamp {
-		// Ignore errFutureTimestamp so that the block is downloaded and passed to
-		// managedAcceptHeader, which will spawn a go thread that waits until the
-		// timestamp would be valid before trying to accept it again.
-		err = nil
-	}
 	if err == errOrphan {
 		// If the header is an orphan, try to find the parents.
 		//
@@ -299,8 +293,7 @@ func (cs *ConsensusSet) relayHeader(conn modules.PeerConn) error {
 		// from inside another RPC?
 		go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
 		return nil
-	}
-	if err != nil {
+	} else if err != nil {
 		return err
 	}
 	// If the header is valid and extends the heaviest chain, fetch, accept it,

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -263,9 +263,7 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 		// received from the peer is discarded and will be downloaded again if
 		// the parent is found.
 		//
-		// TODO: log error returned if non-nill? OR we could not use a goroutine and
-		// just return the result of the RPC call. Is it back practice to call an RPC
-		// from inside another RPC?
+		// TODO: log error returned if non-nill.
 		go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
 	}
 	if err != nil {
@@ -293,9 +291,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	if err == errOrphan {
 		// If the header is an orphan, try to find the parents.
 		//
-		// TODO: log error returned if non-nill? OR we could not use a goroutine and
-		// just return the result of the RPC call. Is it back practice to call an RPC
-		// from inside another RPC?
+		// TODO: log error returned if non-nill.
 		go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
 		return nil
 	} else if err != nil {
@@ -304,9 +300,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	// If the header is valid and extends the heaviest chain, fetch, accept it,
 	// and broadcast it.
 	//
-	// TODO: log error returned if non-nill? OR we could not use a goroutine and
-	// just return the result of the RPC call. Is it back practice to call an RPC
-	// from inside another RPC?
+	// TODO: log error returned if non-nill.
 	go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "BlockID", cs.threadedReceiveBlock(h.ID()))
 	return nil
 }

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -1,8 +1,6 @@
 package consensus
 
 import (
-	"errors"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -317,14 +315,6 @@ func (cs *ConsensusSet) send1Blk(conn modules.PeerConn) error {
 		pb, err := getBlockMap(tx, id)
 		if err != nil {
 			return err
-		}
-		// TODO: are these sanity checks necessary?
-		pathID, err := getPath(tx, pb.Height)
-		if err != nil {
-			return err
-		}
-		if pathID != pb.Block.ID() {
-			return errors.New("pathID and processed block's ID do not match")
 		}
 		b = pb.Block
 		return nil

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -301,12 +301,12 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	// and broadcast it.
 	//
 	// TODO: log error returned if non-nill.
-	go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "BlockID", cs.threadedReceiveBlock(h.ID()))
+	go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlk", cs.threadedReceiveBlock(h.ID()))
 	return nil
 }
 
-// rpcBlockID is an RPC that sends the requested block to the requesting peer.
-func (cs *ConsensusSet) rpcBlockID(conn modules.PeerConn) error {
+// rpcSendBlk is an RPC that sends the requested block to the requesting peer.
+func (cs *ConsensusSet) rpcSendBlk(conn modules.PeerConn) error {
 	// Decode the block id from the conneciton.
 	var id types.BlockID
 	err := encoding.ReadObject(conn, &id, crypto.HashSize)
@@ -336,7 +336,7 @@ func (cs *ConsensusSet) rpcBlockID(conn modules.PeerConn) error {
 
 // threadedReceiveBlock takes a block id and returns an RPCFunc that requests
 // that block and then calls AcceptBlock on it. The returned function should be
-// used as the calling end of the BlockID RPC. Note that although the function
+// used as the calling end of the SendBlk RPC. Note that although the function
 // itself does not do any locking, it is still prefixed with "threaded" because
 // the function it returns calls the exported method AcceptBlock.
 func (cs *ConsensusSet) threadedReceiveBlock(id types.BlockID) modules.RPCFunc {

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -286,11 +286,6 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	// Start verification inside of a bolt View tx.
 	cs.mu.RLock()
 	err = cs.db.View(func(tx *bolt.Tx) error {
-		// Do not accept a header if the database is inconsistent.
-		if inconsistencyDetected(tx) {
-			return errInconsistentSet
-		}
-
 		// Do some relatively inexpensive checks to validate the header
 		return cs.validateHeader(boltTxWrapper{tx}, h)
 	})

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -146,12 +146,12 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 	return nil
 }
 
-// sendBlocks is the receiving end of the SendBlocks RPC. It returns a
+// rpcSendBlocks is the receiving end of the SendBlocks RPC. It returns a
 // sequential set of blocks based on the 32 input block IDs. The most recent
 // known ID is used as the starting point, and up to 'MaxCatchUpBlocks' from
 // that BlockHeight onwards are returned. It also sends a boolean indicating
 // whether more blocks are available.
-func (cs *ConsensusSet) sendBlocks(conn modules.PeerConn) error {
+func (cs *ConsensusSet) rpcSendBlocks(conn modules.PeerConn) error {
 	// Read a list of blocks known to the requester and find the most recent
 	// block from the current path.
 	var knownBlocks [32]types.BlockID
@@ -247,8 +247,8 @@ func (cs *ConsensusSet) sendBlocks(conn modules.PeerConn) error {
 	return nil
 }
 
-// relayBlock is an RPC that accepts a block from a peer.
-func (cs *ConsensusSet) relayBlock(conn modules.PeerConn) error {
+// rpcRelayBlock is an RPC that accepts a block from a peer.
+func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 	// Decode the block from the connection.
 	var b types.Block
 	err := encoding.ReadObject(conn, &b, types.BlockSizeLimit)
@@ -274,8 +274,8 @@ func (cs *ConsensusSet) relayBlock(conn modules.PeerConn) error {
 	return nil
 }
 
-// relayHeader is an RPC that accepts a block header from a peer.
-func (cs *ConsensusSet) relayHeader(conn modules.PeerConn) error {
+// rpcRelayHeader is an RPC that accepts a block header from a peer.
+func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	// Decode the block header from the connection.
 	var h types.BlockHeader
 	err := encoding.ReadObject(conn, &h, types.BlockHeaderSize)

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -249,12 +249,13 @@ func (cs *ConsensusSet) relayBlock(conn modules.PeerConn) error {
 		return err
 	}
 
-	// Submit the block to the consensus set.
+	// Submit the block to the consensus set and broadcast it.
 	err = cs.AcceptBlock(b)
 	if err == errOrphan {
 		// If the block is an orphan, try to find the parents. The block
 		// received from the peer is discarded and will be downloaded again if
 		// the parent is found.
+		// TODO: log error returned if non-nill?
 		go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
 	}
 	if err != nil {

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -296,13 +296,13 @@ func (cs *ConsensusSet) relayHeader(conn modules.PeerConn) error {
 		// If the header is valid and extends the heaviest chain, fetch, accept it,
 		// and broadcast it.
 		// TODO: log error returned if non-nill?
-		go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "Send1Blk", cs.threadedReceiveBlock(h.ID()))
+		go cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "BlockID", cs.threadedReceiveBlock(h.ID()))
 	}
 	return err
 }
 
-// send1Blk is an RPC that sends the requested block to the requesting peer.
-func (cs *ConsensusSet) send1Blk(conn modules.PeerConn) error {
+// rpcBlockID is an RPC that sends the requested block to the requesting peer.
+func (cs *ConsensusSet) rpcBlockID(conn modules.PeerConn) error {
 	// Decode the block id from the conneciton.
 	var id types.BlockID
 	err := encoding.ReadObject(conn, &id, crypto.HashSize)
@@ -332,7 +332,7 @@ func (cs *ConsensusSet) send1Blk(conn modules.PeerConn) error {
 
 // threadedReceiveBlock takes a block id and returns an RPCFunc that requests
 // that block and then calls AcceptBlock on it. The returned function should be
-// used as the calling end of the Send1Blk RPC. Note that although the function
+// used as the calling end of the BlockID RPC. Note that although the function
 // itself does not do any locking, it is still prefixed with "threaded" because
 // the function it returns calls the exported method AcceptBlock.
 func (cs *ConsensusSet) threadedReceiveBlock(id types.BlockID) modules.RPCFunc {

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1023,9 +1023,9 @@ func TestRelayHeader(t *testing.T) {
 		{
 			header:  types.GenesisBlock.Header(),
 			errWant: modules.ErrBlockKnown,
-			errMSG:  "relayHeader should reject known blocks",
+			errMSG:  "relayHeader should reject headers to known blocks",
 		},
-		// Test that relayHeader rejects orphan blocks.
+		// Test that relayHeader requests the parent blocks of orphan headers.
 		{
 			header:  types.BlockHeader{},
 			errWant: errOrphan,
@@ -1037,7 +1037,7 @@ func TestRelayHeader(t *testing.T) {
 		{
 			header:  validBlock.Header(),
 			errWant: nil,
-			errMSG:  "relayHeader should accept a valid block",
+			errMSG:  "relayHeader should accept a valid header",
 			rpcWant: "Send1Blk",
 			rpcMSG:  "relayHeader should request the block of a valid header",
 		},
@@ -1045,9 +1045,9 @@ func TestRelayHeader(t *testing.T) {
 		{
 			header:  futureBlock.Header(),
 			errWant: errFutureTimestamp,
-			errMSG:  "relayHeader should return an error for a future block",
+			errMSG:  "relayHeader should return an error for a future header",
 			rpcWant: "Send1Blk",
-			rpcMSG:  "relayHeader should request a future, but otherwise valid block",
+			rpcMSG:  "relayHeader should request the corresponding block to a future, but otherwise valid header",
 		},
 	}
 	for _, tt := range tests {

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1115,7 +1115,7 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	select {
 	case <-mg.broadcastCalled:
 		t.Fatal("RelayHeader broadcasted an invalid block header")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	// Test that broadcasting a valid block header over RelayHeader on cst1.cs
@@ -1134,7 +1134,7 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 		// Broadcast is called twice, once to broadcast blocks to peers <= v0.5.1
 		// and once to broadcast block headers to peers > v0.5.1.
 		<-mg.broadcastCalled
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 		t.Fatal("RelayHeader didn't broadcast a valid block header")
 	}
 }

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1028,8 +1028,8 @@ func TestRelayHeader(t *testing.T) {
 		// Test that relayHeader requests the parent blocks of orphan headers.
 		{
 			header:  types.BlockHeader{},
-			errWant: errOrphan,
-			errMSG:  "relayHeader should reject orphan blocks",
+			errWant: nil,
+			errMSG:  "relayHeader should not return an error for orphan headers",
 			rpcWant: "SendBlocks",
 			rpcMSG:  "relayHeader should request blocks when the relayed header is an orphan",
 		},
@@ -1044,8 +1044,8 @@ func TestRelayHeader(t *testing.T) {
 		// Test that relayHeader requests a future, but otherwise valid block.
 		{
 			header:  futureBlock.Header(),
-			errWant: errFutureTimestamp,
-			errMSG:  "relayHeader should return an error for a future header",
+			errWant: nil,
+			errMSG:  "relayHeader should not return an error for a future header",
 			rpcWant: "BlockID",
 			rpcMSG:  "relayHeader should request the corresponding block to a future, but otherwise valid header",
 		},

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -282,11 +282,11 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 		expectedNumBroadcasts int
 	}{
 		{0, 0},
-		{1, 1},
-		{2, 1},
-		{int(MaxCatchUpBlocks), 1},
-		{2 * int(MaxCatchUpBlocks), 1},
-		{2*int(MaxCatchUpBlocks) + 1, 1},
+		{1, 2},
+		{2, 2},
+		{int(MaxCatchUpBlocks), 2},
+		{2 * int(MaxCatchUpBlocks), 2},
+		{2*int(MaxCatchUpBlocks) + 1, 2},
 	}
 	for _, test := range tests {
 		mg.mu.Lock()
@@ -1128,6 +1128,9 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	cst1.cs.gateway.Broadcast("RelayHeader", validBlock.Header(), cst1.cs.gateway.Peers())
 	select {
 	case <-mg.broadcastCalled:
+		// Broadcast is called twice, once to broadcast blocks to peers <= v0.5.1
+		// and once to broadcast block headers to peers > v0.5.1.
+		<-mg.broadcastCalled
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("RelayHeader didn't broadcast a valid block header")
 	}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -980,8 +980,8 @@ func (g *mockGatewayCallsRPC) RPC(addr modules.NetAddress, name string, fn modul
 	return nil
 }
 
-// TestRelayHeader tests that relayHeader requests the corresponding blocks to
-// valid headers with known parents, or requests the block history to orphan
+// TestRelayHeader tests that rpcRelayHeader requests the corresponding blocks
+// to valid headers with known parents, or requests the block history to orphan
 // headers.
 func TestRelayHeader(t *testing.T) {
 	cst, err := blankConsensusSetTester("TestRelayHeader")
@@ -997,14 +997,14 @@ func TestRelayHeader(t *testing.T) {
 
 	p1, p2 := net.Pipe()
 
-	// Valid block that relayHeader should accept.
+	// Valid block that rpcRelayHeader should accept.
 	validBlock, err := cst.miner.FindBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// A block in the near future that relayHeader return an error for, but still
-	// request the corresponding block.
+	// A block in the near future that rpcRelayHeader return an error for, but
+	// still request the corresponding block.
 	block, target, err := cst.miner.BlockForWork()
 	if err != nil {
 		t.Fatal(err)
@@ -1019,42 +1019,42 @@ func TestRelayHeader(t *testing.T) {
 		rpcWant string
 		rpcMSG  string
 	}{
-		// Test that relayHeader rejects known blocks.
+		// Test that rpcRelayHeader rejects known blocks.
 		{
 			header:  types.GenesisBlock.Header(),
 			errWant: modules.ErrBlockKnown,
-			errMSG:  "relayHeader should reject headers to known blocks",
+			errMSG:  "rpcRelayHeader should reject headers to known blocks",
 		},
-		// Test that relayHeader requests the parent blocks of orphan headers.
+		// Test that rpcRelayHeader requests the parent blocks of orphan headers.
 		{
 			header:  types.BlockHeader{},
 			errWant: nil,
-			errMSG:  "relayHeader should not return an error for orphan headers",
+			errMSG:  "rpcRelayHeader should not return an error for orphan headers",
 			rpcWant: "SendBlocks",
-			rpcMSG:  "relayHeader should request blocks when the relayed header is an orphan",
+			rpcMSG:  "rpcRelayHeader should request blocks when the relayed header is an orphan",
 		},
-		// Test that relayHeader accepts a valid header that extends the longest chain.
+		// Test that rpcRelayHeader accepts a valid header that extends the longest chain.
 		{
 			header:  validBlock.Header(),
 			errWant: nil,
-			errMSG:  "relayHeader should accept a valid header",
+			errMSG:  "rpcRelayHeader should accept a valid header",
 			rpcWant: "BlockID",
-			rpcMSG:  "relayHeader should request the block of a valid header",
+			rpcMSG:  "rpcRelayHeader should request the block of a valid header",
 		},
-		// Test that relayHeader requests a future, but otherwise valid block.
+		// Test that rpcRelayHeader requests a future, but otherwise valid block.
 		{
 			header:  futureBlock.Header(),
 			errWant: nil,
-			errMSG:  "relayHeader should not return an error for a future header",
+			errMSG:  "rpcRelayHeader should not return an error for a future header",
 			rpcWant: "BlockID",
-			rpcMSG:  "relayHeader should request the corresponding block to a future, but otherwise valid header",
+			rpcMSG:  "rpcRelayHeader should request the corresponding block to a future, but otherwise valid header",
 		},
 	}
 	for _, tt := range tests {
 		go func() {
 			encoding.WriteObject(p1, tt.header)
 		}()
-		err = cst.cs.relayHeader(p2)
+		err = cst.cs.rpcRelayHeader(p2)
 		if err != tt.errWant {
 			t.Errorf("%s: expected '%v', got '%v'", tt.errMSG, tt.errWant, err)
 		}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -697,6 +697,7 @@ func TestSend1Blk(t *testing.T) {
 		errWant error
 		msg     string
 	}{
+		// TODO: Test with a failing database.
 		// Test with a failing reader.
 		{
 			conn:    mockPeerConnFailingReader{PeerConn: p1},
@@ -718,8 +719,6 @@ func TestSend1Blk(t *testing.T) {
 			errWant: errNilItem,
 			msg:     "expected send1Blk to error with a nonexistent block id",
 		},
-		// TODO: Other sanity checks? e.g. test if getPath returns an error or pathID != pb.Block.ID().
-		// TODO: Test with an otherwise failing db?
 		// Test with a failing writer.
 		{
 			conn: mockPeerConnFailingWriter{PeerConn: p1},

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -679,10 +679,10 @@ func (mockPeerConnFailingWriter) Write([]byte) (int, error) {
 	return 0, errFailingWriter
 }
 
-// TestBlockID probes the ConsensusSet.rpcBlockID method and tests that it
+// TestSendBlk probes the ConsensusSet.rpcSendBlk method and tests that it
 // correctly receives block ids and writes out the corresponding blocks.
-func TestBlockID(t *testing.T) {
-	cst, err := blankConsensusSetTester("TestBlockID")
+func TestSendBlk(t *testing.T) {
+	cst, err := blankConsensusSetTester("TestSendBlk")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -704,7 +704,7 @@ func TestBlockID(t *testing.T) {
 			conn:    mockPeerConnFailingReader{PeerConn: p1},
 			fn:      func() { fnErr <- nil },
 			errWant: errFailingReader,
-			msg:     "expected rpcBlockID to error with a failing reader conn",
+			msg:     "expected rpcSendBlk to error with a failing reader conn",
 		},
 		// Test with a block id not found in the blockmap.
 		{
@@ -714,7 +714,7 @@ func TestBlockID(t *testing.T) {
 				fnErr <- encoding.WriteObject(p2, types.BlockID{})
 			},
 			errWant: errNilItem,
-			msg:     "expected rpcBlockID to error with a nonexistent block id",
+			msg:     "expected rpcSendBlk to error with a nonexistent block id",
 		},
 		// Test with a failing writer.
 		{
@@ -724,7 +724,7 @@ func TestBlockID(t *testing.T) {
 				fnErr <- encoding.WriteObject(p2, types.GenesisBlock.ID())
 			},
 			errWant: errFailingWriter,
-			msg:     "expected rpcBlockID to error with a failing writer conn",
+			msg:     "expected rpcSendBlk to error with a failing writer conn",
 		},
 		// Test with a valid conn and valid block.
 		{
@@ -742,18 +742,18 @@ func TestBlockID(t *testing.T) {
 				}
 				// Verify the block is the expected block.
 				if block.ID() != types.GenesisBlock.ID() {
-					fnErr <- fmt.Errorf("rpcBlockID wrote a different block to conn than the block requested. requested block id: %v, received block id: %v", types.GenesisBlock.ID(), block.ID())
+					fnErr <- fmt.Errorf("rpcSendBlk wrote a different block to conn than the block requested. requested block id: %v, received block id: %v", types.GenesisBlock.ID(), block.ID())
 				}
 
 				fnErr <- nil
 			},
 			errWant: nil,
-			msg:     "expected rpcBlockID to succeed with a valid conn and valid block",
+			msg:     "expected rpcSendBlk to succeed with a valid conn and valid block",
 		},
 	}
 	for _, tt := range tests {
 		go tt.fn()
-		err := cst.cs.rpcBlockID(tt.conn)
+		err := cst.cs.rpcSendBlk(tt.conn)
 		if err != tt.errWant {
 			t.Errorf("%s: expected to fail with `%v', got: `%v'", tt.msg, tt.errWant, err)
 		}
@@ -883,15 +883,15 @@ func TestThreadedReceiveBlock(t *testing.T) {
 	}
 }
 
-// TestIntegrationBlockIDRPC probes the BlockID RPC and tests that blocks are
+// TestIntegrationSendBlkRPC probes the SendBlk RPC and tests that blocks are
 // correctly requested, received, and accepted into the consensus set.
-func TestIntegrationBlockIDRPC(t *testing.T) {
-	cst1, err := blankConsensusSetTester("TestIntegrationBlockIDRPC1")
+func TestIntegrationSendBlkRPC(t *testing.T) {
+	cst1, err := blankConsensusSetTester("TestIntegrationSendBlkRPC1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cst1.Close()
-	cst2, err := blankConsensusSetTester("TestIntegrationBlockIDRPC2")
+	cst2, err := blankConsensusSetTester("TestIntegrationSendBlkRPC2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -907,13 +907,13 @@ func TestIntegrationBlockIDRPC(t *testing.T) {
 	}
 
 	// Test that cst1 doesn't accept a block it's already seen (the genesis block).
-	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "BlockID", cst1.cs.threadedReceiveBlock(types.GenesisBlock.ID()))
+	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "SendBlk", cst1.cs.threadedReceiveBlock(types.GenesisBlock.ID()))
 	if err != modules.ErrBlockKnown {
 		t.Errorf("cst1 should reject known blocks: expected error '%v', got '%v'", modules.ErrBlockKnown, err)
 	}
 
 	// Test that cst2 errors when it doesn't recognize the requested block.
-	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "BlockID", cst1.cs.threadedReceiveBlock(types.BlockID{}))
+	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "SendBlk", cst1.cs.threadedReceiveBlock(types.BlockID{}))
 	if err != io.EOF {
 		t.Errorf("cst2 shouldn't return a block it doesn't recognize: expected error '%v', got '%v'", io.EOF, err)
 	}
@@ -927,7 +927,7 @@ func TestIntegrationBlockIDRPC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "BlockID", cst1.cs.threadedReceiveBlock(block.ID()))
+	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "SendBlk", cst1.cs.threadedReceiveBlock(block.ID()))
 	if err != nil {
 		t.Errorf("cst1 should accept a block that extends its longest chain: expected nil error, got '%v'", err)
 	}
@@ -941,7 +941,7 @@ func TestIntegrationBlockIDRPC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = cst2.cs.gateway.RPC(cst1.cs.gateway.Address(), "BlockID", cst2.cs.threadedReceiveBlock(block.ID()))
+	err = cst2.cs.gateway.RPC(cst1.cs.gateway.Address(), "SendBlk", cst2.cs.threadedReceiveBlock(block.ID()))
 	if err != nil {
 		t.Errorf("cst2 should accept a block that extends its longest chain: expected nil error, got '%v'", err)
 	}
@@ -963,7 +963,7 @@ func TestIntegrationBlockIDRPC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "BlockID", cst1.cs.threadedReceiveBlock(block.ID()))
+	err = cst1.cs.gateway.RPC(cst2.cs.gateway.Address(), "SendBlk", cst1.cs.threadedReceiveBlock(block.ID()))
 	if err != errOrphan {
 		t.Errorf("cst1 should not accept an orphan block: expected error '%v', got '%v'", errOrphan, err)
 	}
@@ -1037,7 +1037,7 @@ func TestRelayHeader(t *testing.T) {
 			header:  validBlock.Header(),
 			errWant: nil,
 			errMSG:  "rpcRelayHeader should accept a valid header",
-			rpcWant: "BlockID",
+			rpcWant: "SendBlk",
 			rpcMSG:  "rpcRelayHeader should request the block of a valid header",
 		},
 		// Test that rpcRelayHeader requests a future, but otherwise valid block.
@@ -1045,7 +1045,7 @@ func TestRelayHeader(t *testing.T) {
 			header:  futureBlock.Header(),
 			errWant: nil,
 			errMSG:  "rpcRelayHeader should not return an error for a future header",
-			rpcWant: "BlockID",
+			rpcWant: "SendBlk",
 			rpcMSG:  "rpcRelayHeader should request the corresponding block to a future, but otherwise valid header",
 		},
 	}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1049,13 +1049,18 @@ func TestRelayHeader(t *testing.T) {
 			rpcMSG:  "rpcRelayHeader should request the corresponding block to a future, but otherwise valid header",
 		},
 	}
+	errChan := make(chan error)
 	for _, tt := range tests {
 		go func() {
-			encoding.WriteObject(p1, tt.header)
+			errChan <- encoding.WriteObject(p1, tt.header)
 		}()
 		err = cst.cs.rpcRelayHeader(p2)
 		if err != tt.errWant {
 			t.Errorf("%s: expected '%v', got '%v'", tt.errMSG, tt.errWant, err)
+		}
+		err = <-errChan
+		if err != nil {
+			t.Fatal(err)
 		}
 		if tt.rpcWant == "" {
 			select {

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -114,6 +114,9 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 		g.log.Printf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RemoteAddr(), id)
 		return
 	}
+	if build.DEBUG {
+		g.log.Printf("INFO: incoming conn %v requested RPC \"%v\"", conn.RemoteAddr(), id)
+	}
 
 	// call fn
 	err := fn(conn)

--- a/types/block.go
+++ b/types/block.go
@@ -76,6 +76,11 @@ func CalculateNumSiacoins(height BlockHeight) Currency {
 	return deflationSiacoins.Add(trailingSiacoins)
 }
 
+// ID returns the ID of a Block, which is calculated by hashing the header.
+func (h BlockHeader) ID() BlockID {
+	return BlockID(crypto.HashObject(h))
+}
+
 // CalculateSubsidy takes a block and a height and determines the block
 // subsidy.
 func (b Block) CalculateSubsidy(height BlockHeight) Currency {
@@ -100,14 +105,9 @@ func (b Block) Header() BlockHeader {
 
 // ID returns the ID of a Block, which is calculated by hashing the
 // concatenation of the block's parent's ID, nonce, and the result of the
-// b.MerkleRoot().
+// b.MerkleRoot(). It is equivalent to calling block.Header().ID()
 func (b Block) ID() BlockID {
-	return BlockID(crypto.HashObject(b.Header()))
-}
-
-// ID returns the ID of a Block, which is calculated by hashing the header.
-func (h BlockHeader) ID() BlockID {
-	return BlockID(crypto.HashObject(h))
+	return b.Header().ID()
 }
 
 // MerkleRoot calculates the Merkle root of a Block. The leaves of the Merkle

--- a/types/block.go
+++ b/types/block.go
@@ -99,6 +99,13 @@ func (b Block) ID() BlockID {
 	return BlockID(crypto.HashObject(b.Header()))
 }
 
+// ID returns the ID of a Block, which is calculated by hashing the
+// concatenation of the block's parent's ID, nonce, and the result of the
+// b.MerkleRoot().
+func (h BlockHeader) ID() BlockID {
+	return BlockID(crypto.HashObject(h))
+}
+
 // MerkleRoot calculates the Merkle root of a Block. The leaves of the Merkle
 // tree are composed of the Timestamp, the miner outputs (one leaf per
 // payout), and the transactions (one leaf per transaction).

--- a/types/block.go
+++ b/types/block.go
@@ -13,6 +13,10 @@ import (
 	"github.com/NebulousLabs/Sia/encoding"
 )
 
+const (
+	BlockHeaderSize = 80 // 32 (ParentID) + 8 (Nonce) + 8 (Timestamp) + 32 (MerkleRoot)
+)
+
 type (
 	// A Block is a summary of changes to the state that have occurred since the
 	// previous block. Blocks reference the ID of the previous block (their

--- a/types/block.go
+++ b/types/block.go
@@ -14,7 +14,9 @@ import (
 )
 
 const (
-	BlockHeaderSize = 80 // 32 (ParentID) + 8 (Nonce) + 8 (Timestamp) + 32 (MerkleRoot)
+	// BlockHeaderSize is the size, in bytes, of a block header.
+	// 32 (ParentID) + 8 (Nonce) + 8 (Timestamp) + 32 (MerkleRoot)
+	BlockHeaderSize = 80
 )
 
 type (
@@ -103,9 +105,7 @@ func (b Block) ID() BlockID {
 	return BlockID(crypto.HashObject(b.Header()))
 }
 
-// ID returns the ID of a Block, which is calculated by hashing the
-// concatenation of the block's parent's ID, nonce, and the result of the
-// b.MerkleRoot().
+// ID returns the ID of a Block, which is calculated by hashing the header.
 func (h BlockHeader) ID() BlockID {
 	return BlockID(crypto.HashObject(h))
 }

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -113,6 +113,44 @@ func TestBlockID(t *testing.T) {
 	}
 }
 
+// TestHeaderID probes the ID function of the BlockHeader type.
+func TestHeaderID(t *testing.T) {
+	// Create a bunch of different blocks and check that all of them have
+	// unique ids.
+	var blocks []Block
+	var b Block
+
+	blocks = append(blocks, b)
+	b.ParentID[0] = 1
+	blocks = append(blocks, b)
+	b.Nonce[0] = 45
+	blocks = append(blocks, b)
+	b.Timestamp = CurrentTimestamp()
+	blocks = append(blocks, b)
+	b.MinerPayouts = append(b.MinerPayouts, SiacoinOutput{Value: CalculateCoinbase(0)})
+	blocks = append(blocks, b)
+	b.MinerPayouts = append(b.MinerPayouts, SiacoinOutput{Value: CalculateCoinbase(0)})
+	blocks = append(blocks, b)
+	b.Transactions = append(b.Transactions, Transaction{MinerFees: []Currency{CalculateCoinbase(1)}})
+	blocks = append(blocks, b)
+	b.Transactions = append(b.Transactions, Transaction{MinerFees: []Currency{CalculateCoinbase(1)}})
+	blocks = append(blocks, b)
+
+	knownIDs := make(map[BlockID]struct{})
+	for i, block := range blocks {
+		blockID := block.ID()
+		headerID := block.Header().ID()
+		if blockID != headerID {
+			t.Error("headerID does not match blockID for index", i)
+		}
+		_, exists := knownIDs[headerID]
+		if exists {
+			t.Error("id repeat for index", i)
+		}
+		knownIDs[headerID] = struct{}{}
+	}
+}
+
 // TestBlockCalculateSubsidy probes the CalculateSubsidy function of the block
 // type.
 func TestBlockCalculateSubsidy(t *testing.T) {


### PR DESCRIPTION
This PR implements header broadcasting.

I tried to keep the changes to existing consensus code as minimal as possible. The only real changes to existing code should be:
* `validateHeader` renamed to `validateHeaderAndBlock`
* `AcceptBlock` and `threadedReceiveBlocks` broadcast blocks to some peers and headers to others, depending on their versions.

Everything else is new code and only deals with header broadcasting.

`RelayHeader` RPC mirrors the `RelayBlock` RPC used for block flooding. Every call to `RelayBlock` is also replaced with a branching broadcast that broadcasts `RelayHeader` to new peers (v0.5.2 and newer) and `RelayBlock` to old peers.

`managedAcceptHeader` mirrors `managedAcceptBlock` and does all of the header validation. However, unlike its counterpart, it cannot accept anything into the blockchain as it does not have the block and header-first blockchain downloads haven't been implemented yet. Instead, it returns `nil` if the header is valid. It is then up to the caller of `managedAcceptHeader` ( `RelayHeader`) to download the block and call either `managedAcceptBlock` or `AcceptBlock` on it.

`Send1Blk` is analogous to `SendBlocks`, but for just one block. It is used to download a block corresponding to a validated block header. Peers can request blocks from other peers by the block id. The requesting peer then calls `AcceptBlock` on the received block.

I tried to keep the commits clean and separated, so going through the diffs commit by commit should be easy.