### PR TITLE
Broadcast to 0 peers on nil peers arg

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -202,6 +202,7 @@ func (cs *ConsensusSet) AcceptBlock(b types.Block) error {
 		return err
 	}
 	// Broadcast the new block to all peers.
-	go cs.gateway.Broadcast("RelayBlock", b, nil)
+	peers := cs.gateway.Peers()
+	go cs.gateway.Broadcast("RelayBlock", b, peers)
 	return nil
 }

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -96,7 +96,8 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 			// The last block received will be the current block since
 			// managedAcceptBlock only returns nil if a block extends the longest chain.
 			currentBlock := cs.CurrentBlock()
-			go cs.gateway.Broadcast("RelayBlock", currentBlock, nil)
+			peers := cs.gateway.Peers()
+			go cs.gateway.Broadcast("RelayBlock", currentBlock, peers)
 		}
 	}()
 

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -122,7 +122,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 		err = nil
 	}
 	if err != nil {
-		g.log.Printf("WARN: incoming RPC \"%v\" failed: %v", id, err)
+		g.log.Printf("WARN: incoming RPC \"%v\" from conn %v failed: %v", id, conn.RemoteAddr(), err)
 	}
 }
 

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -126,15 +126,11 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 	}
 }
 
-// Broadcast calls an RPC on all of the specified peers. If peers is nil, the
-// RPC is called on all of the gateway's peer. The calls are run in parallel.
-// Broadcasts are restricted to "one-way" RPCs, which simply write an object
-// and disconnect. This is why Broadcast takes an interface{} instead of an
-// RPCFunc.
+// Broadcast calls an RPC on all of the specified peers. The calls are run in
+// parallel. Broadcasts are restricted to "one-way" RPCs, which simply write an
+// object and disconnect. This is why Broadcast takes an interface{} instead of
+// an RPCFunc.
 func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) {
-	if peers == nil {
-		peers = g.Peers()
-	}
 	g.log.Printf("INFO: broadcasting RPC \"%v\" to %v peers", name, len(peers))
 
 	// only encode obj once, instead of using WriteObject


### PR DESCRIPTION
It was too easy to write bugs where the gateway to broadcast to all peers if no peers matched the filtering criteria. For example the following would broadcast to all peers if there were no peers >=v0.4.7
```go
var v047AndAbove []modules.Peer
for _, p := range tp.gateway.Peers() {
        if build.VersionCmp(p.Version, "0.4.7") >= 0 {
                v047AndAbove = append(v047AndAbove, p)
        }
}
go tp.gateway.Broadcast("RelayTransactionSet", ts, v047AndAbove)
```

Also add the connection address to the log output when an RPC fails