### PR TITLE
Object signing helpers

### DIFF
--- a/crypto/rand_test.go
+++ b/crypto/rand_test.go
@@ -25,3 +25,32 @@ func TestRandIntnPanics(t *testing.T) {
 		t.Error("expected panic for n <= 0")
 	}
 }
+
+// TestPerm tests the Perm function.
+func TestPerm(t *testing.T) {
+	chars := "abcde" // string to be permuted
+	createPerm := func() string {
+		perm, err := Perm(len(chars))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := make([]byte, len(chars))
+		for i, j := range perm {
+			s[i] = chars[j]
+		}
+		return string(s)
+	}
+
+	// create (factorial(len(chars)) * 100) permutations
+	permCount := make(map[string]int)
+	for i := 0; i < 12000; i++ {
+		permCount[createPerm()]++
+	}
+
+	// we should have seen each permutation approx. 100 times
+	for p, n := range permCount {
+		if n < 50 || n > 150 {
+			t.Errorf("saw permutation %v times: %v", n, p)
+		}
+	}
+}

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -82,10 +82,14 @@ func WriteSignedObject(w io.Writer, obj interface{}, sk SecretKey) error {
 // ReadSignedObject reads a length-prefixed object followed by its signature,
 // and verifies the signature.
 func ReadSignedObject(r io.Reader, obj interface{}, maxLen uint64, pk PublicKey) error {
-	// read the encoded object and signature
-	var encObj []byte
+	// read the encoded object
+	encObj, err := encoding.ReadPrefix(r, maxLen)
+	if err != nil {
+		return err
+	}
+	// read the signature
 	var sig Signature
-	err := encoding.NewDecoder(r).DecodeAll(&encObj, &sig)
+	err = encoding.NewDecoder(r).Decode(&sig)
 	if err != nil {
 		return err
 	}

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -25,14 +25,14 @@ const (
 
 type (
 	// PublicKey is an object that can be used to verify signatures.
-	PublicKey [ed25519.PublicKeySize]byte
+	PublicKey [PublicKeySize]byte
 
 	// SecretKey can be used to sign data for the corresponding public key.
-	SecretKey [ed25519.SecretKeySize]byte
+	SecretKey [SecretKeySize]byte
 
 	// Signature proves that data was signed by the owner of a particular
 	// public key's corresponding secret key.
-	Signature [ed25519.SignatureSize]byte
+	Signature [SignatureSize]byte
 )
 
 var (
@@ -100,6 +100,6 @@ func ReadSignedData(r io.Reader, obj interface{}, maxLen uint64, pk PublicKey) e
 
 // PublicKey returns the public key that corresponds to a secret key.
 func (sk SecretKey) PublicKey() (pk PublicKey) {
-	copy(pk[:], sk[32:])
+	copy(pk[:], sk[SecretKeySize-PublicKeySize:])
 	return
 }

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -330,3 +330,14 @@ func TestReadWriteSignedObject(t *testing.T) {
 		t.Fatal("expected decode error, got", err)
 	}
 }
+
+// TestPublicKey tests the PublicKey method
+func TestPublicKey(t *testing.T) {
+	sk, pk, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sk.PublicKey() != pk {
+		t.Fatal("PublicKey does not match actual public key:", pk, sk.PublicKey())
+	}
+}

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -187,10 +187,10 @@ func TestUnitSigning(t *testing.T) {
 	iterations := 200
 	for i := 0; i < iterations; i++ {
 		// Create dummy key pair.
-		var entropy [EntropySize]byte
-		entropy[0] = 5
-		entropy[1] = 8
-		sk, pk := stdKeyGen.generateDeterministic(entropy)
+		sk, pk, err := GenerateKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Generate and sign the data.
 		var randData Hash
@@ -320,8 +320,8 @@ func TestSignVerifyObject(t *testing.T) {
 	}
 }
 
-// TestPublicKey tests the PublicKey method
-func TestPublicKey(t *testing.T) {
+// TestUnitPublicKey tests the PublicKey method
+func TestUnitPublicKey(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		sk, pk, err := GenerateKeyPair()
 		if err != nil {

--- a/crypto/signatures_test.go
+++ b/crypto/signatures_test.go
@@ -322,11 +322,13 @@ func TestSignVerifyObject(t *testing.T) {
 
 // TestPublicKey tests the PublicKey method
 func TestPublicKey(t *testing.T) {
-	sk, pk, err := GenerateKeyPair()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sk.PublicKey() != pk {
-		t.Fatal("PublicKey does not match actual public key:", pk, sk.PublicKey())
+	for i := 0; i < 1000; i++ {
+		sk, pk, err := GenerateKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sk.PublicKey() != pk {
+			t.Error("PublicKey does not match actual public key:", pk, sk.PublicKey())
+		}
 	}
 }

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -224,35 +225,71 @@ func TestEncodeDecode(t *testing.T) {
 
 // TestEncodeAll tests the EncodeAll function.
 func TestEncodeAll(t *testing.T) {
-	var expected []byte
+	// EncodeAll should produce the same result as individually encoding each
+	// object
+	exp := new(bytes.Buffer)
+	enc := NewEncoder(exp)
 	for i := range testStructs {
-		expected = append(expected, Marshal(testStructs[i])...)
+		enc.Encode(testStructs[i])
 	}
 
 	b := new(bytes.Buffer)
 	NewEncoder(b).EncodeAll(testStructs...)
-	if !bytes.Equal(b.Bytes(), expected) {
-		t.Errorf("expected %v, got %v", expected, b.Bytes())
+	if !bytes.Equal(b.Bytes(), exp.Bytes()) {
+		t.Errorf("expected %v, got %v", exp.Bytes(), b.Bytes())
+	}
+
+	// hardcoded check
+	exp.Reset()
+	exp.Write([]byte{1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 'f', 'o', 'o', 1})
+
+	b.Reset()
+	NewEncoder(b).EncodeAll(1, 2, "foo", true)
+	if !bytes.Equal(b.Bytes(), exp.Bytes()) {
+		t.Errorf("expected %v, got %v", exp.Bytes(), b.Bytes())
 	}
 }
 
 // TestDecodeAll tests the DecodeAll function.
 func TestDecodeAll(t *testing.T) {
 	b := new(bytes.Buffer)
-	enc := NewEncoder(b)
-	for i := range testStructs {
-		enc.Encode(testStructs[i])
-	}
+	NewEncoder(b).EncodeAll(testStructs...)
 
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	err := NewDecoder(b).DecodeAll(emptyStructs...)
 	if err != nil {
 		t.Error(err)
 	}
+	empty0 := *emptyStructs[0].(*test0)
+	if !reflect.DeepEqual(empty0, testStructs[0]) {
+		t.Error("deep equal:", empty0, testStructs[0])
+	}
+	empty6 := emptyStructs[6].(*test6)
+	if !reflect.DeepEqual(empty6, testStructs[6]) {
+		t.Error("deep equal:", empty6, testStructs[6])
+	}
+
+	// hardcoded check
+	b.Reset()
+	b.Write([]byte{1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 'f', 'o', 'o', 1})
+
+	var (
+		one, two uint64
+		foo      string
+		tru      bool
+	)
+	err = NewDecoder(b).DecodeAll(&one, &two, &foo, &tru)
+	if err != nil {
+		t.Fatal(err)
+	} else if one != 1 || two != 2 || foo != "foo" || tru != true {
+		t.Error("values were not decoded correctly:", one, two, foo, tru)
+	}
 }
 
 // TestMarshalAll tests the MarshalAll function.
 func TestMarshalAll(t *testing.T) {
+	// MarshalAll should produce the same result as individually marshalling
+	// each object
 	var expected []byte
 	for i := range testStructs {
 		expected = append(expected, Marshal(testStructs[i])...)
@@ -262,19 +299,45 @@ func TestMarshalAll(t *testing.T) {
 	if !bytes.Equal(b, expected) {
 		t.Errorf("expected %v, got %v", expected, b)
 	}
+
+	// hardcoded check
+	exp := []byte{1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 'f', 'o', 'o', 1}
+	b = MarshalAll(1, 2, "foo", true)
+	if !bytes.Equal(b, exp) {
+		t.Errorf("expected %v, got %v", exp, b)
+	}
 }
 
 // TestUnmarshalAll tests the UnmarshalAll function.
 func TestUnmarshalAll(t *testing.T) {
-	var b []byte
-	for i := range testStructs {
-		b = append(b, Marshal(testStructs[i])...)
-	}
+	b := MarshalAll(testStructs...)
 
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	err := UnmarshalAll(b, emptyStructs...)
 	if err != nil {
 		t.Error(err)
+	}
+	empty1 := *emptyStructs[1].(*test1)
+	if !reflect.DeepEqual(empty1, testStructs[1]) {
+		t.Error("deep equal:", empty1, testStructs[1])
+	}
+	empty5 := *emptyStructs[5].(*test5)
+	if !reflect.DeepEqual(empty5, testStructs[5]) {
+		t.Error("deep equal:", empty5, testStructs[5])
+	}
+
+	// hardcoded check
+	b = []byte{1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 'f', 'o', 'o', 1}
+	var (
+		one, two uint64
+		foo      string
+		tru      bool
+	)
+	err = UnmarshalAll(b, &one, &two, &foo, &tru)
+	if err != nil {
+		t.Fatal(err)
+	} else if one != 1 || two != 2 || foo != "foo" || tru != true {
+		t.Error("values were not decoded correctly:", one, two, foo, tru)
 	}
 }
 

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -93,6 +93,7 @@ var testEncodings = [][]byte{
 	{3, 0, 0, 0, 0, 0, 0, 0, 'f', 'o', 'o'},
 }
 
+// TestEncode tests the Encode function.
 func TestEncode(t *testing.T) {
 	// use Marshal for convenience
 	for i := range testStructs {
@@ -125,6 +126,7 @@ func TestEncode(t *testing.T) {
 	enc.Encode(map[int]int{})
 }
 
+// TestDecode tests the Decode function.
 func TestDecode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -191,6 +193,8 @@ func TestDecode(t *testing.T) {
 
 }
 
+// TestMarshalUnmarshal tests the Marshal and Unmarshal functions, which are
+// inverses of each other.
 func TestMarshalUnmarshal(t *testing.T) {
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	for i := range testStructs {
@@ -202,6 +206,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 	}
 }
 
+// TestEncodeDecode tests the Encode and Decode functions, which are inverses
+// of each other.
 func TestEncodeDecode(t *testing.T) {
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	b := new(bytes.Buffer)
@@ -216,6 +222,7 @@ func TestEncodeDecode(t *testing.T) {
 	}
 }
 
+// TestEncodeAll tests the EncodeAll function.
 func TestEncodeAll(t *testing.T) {
 	var expected []byte
 	for i := range testStructs {
@@ -229,6 +236,7 @@ func TestEncodeAll(t *testing.T) {
 	}
 }
 
+// TestDecodeAll tests the DecodeAll function.
 func TestDecodeAll(t *testing.T) {
 	b := new(bytes.Buffer)
 	enc := NewEncoder(b)
@@ -243,6 +251,7 @@ func TestDecodeAll(t *testing.T) {
 	}
 }
 
+// TestMarshalAll tests the MarshalAll function.
 func TestMarshalAll(t *testing.T) {
 	var expected []byte
 	for i := range testStructs {
@@ -255,6 +264,7 @@ func TestMarshalAll(t *testing.T) {
 	}
 }
 
+// TestUnmarshalAll tests the UnmarshalAll function.
 func TestUnmarshalAll(t *testing.T) {
 	var b []byte
 	for i := range testStructs {
@@ -268,6 +278,8 @@ func TestUnmarshalAll(t *testing.T) {
 	}
 }
 
+// TestReadWriteFile tests the ReadFiles and WriteFile functions, which are
+// inverses of each other.
 func TestReadWriteFile(t *testing.T) {
 	// standard
 	os.MkdirAll(build.TempDir("encoding"), 0777)

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -216,15 +216,55 @@ func TestEncodeDecode(t *testing.T) {
 	}
 }
 
+func TestEncodeAll(t *testing.T) {
+	var expected []byte
+	for i := range testStructs {
+		expected = append(expected, Marshal(testStructs[i])...)
+	}
+
+	b := new(bytes.Buffer)
+	NewEncoder(b).EncodeAll(testStructs...)
+	if !bytes.Equal(b.Bytes(), expected) {
+		t.Errorf("expected %v, got %v", expected, b.Bytes())
+	}
+}
+
+func TestDecodeAll(t *testing.T) {
+	b := new(bytes.Buffer)
+	enc := NewEncoder(b)
+	for i := range testStructs {
+		enc.Encode(testStructs[i])
+	}
+
+	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
+	err := NewDecoder(b).DecodeAll(emptyStructs...)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestMarshalAll(t *testing.T) {
+	var expected []byte
+	for i := range testStructs {
+		expected = append(expected, Marshal(testStructs[i])...)
+	}
+
+	b := MarshalAll(testStructs...)
+	if !bytes.Equal(b, expected) {
+		t.Errorf("expected %v, got %v", expected, b)
+	}
+}
+
+func TestUnmarshalAll(t *testing.T) {
 	var b []byte
 	for i := range testStructs {
 		b = append(b, Marshal(testStructs[i])...)
 	}
 
-	expected := MarshalAll(testStructs...)
-	if !bytes.Equal(b, expected) {
-		t.Errorf("expected %v, got %v", expected, b)
+	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
+	err := UnmarshalAll(b, emptyStructs...)
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -34,9 +34,15 @@ func ReadObject(r io.Reader, obj interface{}, maxLen uint64) error {
 
 // WritePrefix writes a length-prefixed byte slice to w.
 func WritePrefix(w io.Writer, data []byte) error {
-	n, err := w.Write(append(EncUint64(uint64(len(data))), data...))
-	if n != len(data)+8 && err == nil {
+	n, err := w.Write(EncUint64(uint64(len(data))))
+	if err != nil {
+		return err
+	} else if n != 8 {
 		return io.ErrShortWrite
+	}
+	n, err = w.Write(data)
+	if err == nil && n != len(data) {
+		err = io.ErrShortWrite
 	}
 	return err
 }


### PR DESCRIPTION
Add two functions to the crypto package: `WriteSignedObject` and `ReadSignedObject`. They function identicially to `encoding.WriteObject` and `encoding.ReadObject`, except that `WriteSignedObject` also writes a signature of the encoded object's hash, and `ReadSignedObject` reads and verifies that hash. These functions will be useful in the new host/renter protocol, which requires reading and writing signed data. Both have 100% code coverage.
(Question: could we sign the object directly, instead of its hash?)

There is one quirk to the implementation, which is that the signature is not included in the length prefix. Most objects sent over a network carry a length-prefix, so that the receiver knows how much data to expect. Since the signature size is constant, we can remove its length prefix, saving 8 bytes.

Also add proper testing of the `PublicKey` method.