### PR TITLE
Sync bug fixes

### DIFF
--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -176,6 +176,7 @@ func (cs *ConsensusSet) sendBlocks(conn modules.PeerConn) error {
 			found = true
 			// Start from the child of the common block.
 			start = pb.Height + 1
+			break
 		}
 		return nil
 	})

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -215,7 +215,7 @@ func (cs *ConsensusSet) sendBlocks(conn modules.PeerConn) error {
 				}
 				blocks = append(blocks, pb.Block)
 			}
-			moreAvailable = start+MaxCatchUpBlocks < height
+			moreAvailable = start+MaxCatchUpBlocks <= height
 			start += MaxCatchUpBlocks
 			return nil
 		})

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -56,7 +56,7 @@ func blockHistory(tx *bolt.Tx) (blockIDs [32]types.BlockID) {
 		if i >= 9 {
 			step *= 2
 		}
-		if height < step {
+		if height <= step {
 			break
 		}
 		height -= step


### PR DESCRIPTION
This PR fixes 2 major and 1 minor bugs.

Major bugs:
* SendBlocks was sending the entire blockchain every time (tested in `TestRPCSendBlockSendsOnlyNecessaryBlocks`)
* SendBlocks would sometimes fail to send the last block (tested in `TestRPCSendBlocks`)

Minor bug:
* blockHistory included the genesis block twice sometimes (when height == step). This doesn't cause any problems, but no reason to not fix it. Even with this fix the genesis block is still included twice (once at blockHistory[0] and once at blockHistory[31]) if the only block is the genesis block, which should only happen during initial blockchain download.

This should dramatically improve syncing performance.