### PR TITLE
Gateway testing bug fix

### DIFF
--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -32,7 +32,7 @@ func TestGatewayPeerAdd(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	peer, err := gateway.New(":0", build.TempDir("api", "TestGatewayPeerAdd", "gateway"))
+	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerAdd", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestGatewayPeerRemove(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	peer, err := gateway.New(":0", build.TempDir("api", "TestGatewayPeerRemove", "gateway"))
+	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerRemove", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -46,7 +46,7 @@ type serverTester struct {
 // server tester, without creating any directories or mining any blocks.
 func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester, error) {
 	// Create the modules.
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	if err != nil {
 		return nil, err
 	}
-	h, err := host.New(cs, tp, w, ":0", filepath.Join(testdir, modules.HostDir))
+	h, err := host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer(":0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 // is disabled.
 func assembleExplorerServerTester(testdir string) (*serverTester, error) {
 	// Create the modules.
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func assembleExplorerServerTester(testdir string) (*serverTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer(":0", "", cs, e, g, nil, nil, nil, nil, nil)
+	srv, err := NewServer("localhost:0", "", cs, e, g, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -24,7 +24,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 
 	// Check a wallet that has never been encrypted.
 	testdir := build.TempDir("api", "TestIntegrationWalletGETEncrypted")
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal("Failed to create gateway:", err)
 	}
@@ -40,7 +40,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create wallet:", err)
 	}
-	srv, err := NewServer(":0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	}
 	// Create a server object without encrypting or unlocking the wallet.
 	testdir := build.TempDir("api", "TestIntegrationWalletBlankEncrypt")
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := NewServer(":0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -108,7 +108,7 @@ func blankConsensusSetTester(name string) (*consensusSetTester, error) {
 	testdir := build.TempDir(modules.ConsensusDir, name)
 
 	// Create modules.
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func TestDatabaseClosing(t *testing.T) {
 	testdir := build.TempDir(modules.ConsensusDir, "TestClosing")
 
 	// Create the gateway.
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/persist_test.go
+++ b/modules/consensus/persist_test.go
@@ -25,7 +25,7 @@ func TestSaveLoad(t *testing.T) {
 
 	// Reassigning this will lose subscribers and such, but we
 	// just want to call load and get a hash
-	g, err := gateway.New(":0", build.TempDir(modules.ConsensusDir, "TestSaveLoad", modules.GatewayDir))
+	g, err := gateway.New("localhost:0", build.TempDir(modules.ConsensusDir, "TestSaveLoad", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/processedblock_test.go
+++ b/modules/consensus/processedblock_test.go
@@ -23,7 +23,7 @@ func TestIntegrationMinimumValidChildTimestamp(t *testing.T) {
 
 	// Create a custom consnesus set to control the blocks.
 	testdir := build.TempDir(modules.ConsensusDir, "TestIntegrationMinimumValidChildTimestamp")
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -551,7 +551,7 @@ func TestRPCSendBlockSendsOnlyNecessaryBlocks(t *testing.T) {
 	// can connect it to the remote peer before calling consensus.New so as to
 	// prevent SendBlocks from triggering on Connect.
 	testdir := build.TempDir(modules.ConsensusDir, "TestRPCSendBlockSendsOnlyNecessaryBlocks - local")
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/explorer/explorer_test.go
+++ b/modules/explorer/explorer_test.go
@@ -34,7 +34,7 @@ type explorerTester struct {
 func createExplorerTester(name string) (*explorerTester, error) {
 	// Create and assemble the dependencies.
 	testdir := build.TempDir(modules.ExplorerDir, name)
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (et *explorerTester) reorgToBlank() error {
 	dir := et.testdir + " - " + persist.RandomSuffix()
 
 	// Create a miner and all dependencies to create an alternate chain.
-	g, err := gateway.New(":0", filepath.Join(dir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(dir, modules.GatewayDir))
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func TestNilExplorerDependencies(t *testing.T) {
 func TestExplorerGenesisHeight(t *testing.T) {
 	// Create the dependencies.
 	testdir := build.TempDir(modules.HostDir, "TestExplorerGenesisHeight")
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -25,16 +25,25 @@ func newTestingGateway(name string, t *testing.T) *Gateway {
 	return g
 }
 
+// TestAddress tests that Gateway.Address returns the address of its listener.
+// Also tests that the address is not unspecified and is a loopback address.
+// The address must be a loopback address for testing.
 func TestAddress(t *testing.T) {
 	g := newTestingGateway("TestAddress", t)
 	defer g.Close()
 	if g.Address() != g.myAddr {
 		t.Fatal("Address does not return g.myAddr")
 	}
-	port := modules.NetAddress(g.listener.Addr().String()).Port()
-	expAddr := modules.NetAddress(net.JoinHostPort("::", port))
-	if g.Address() != expAddr {
-		t.Fatalf("Wrong address: expected %v, got %v", expAddr, g.Address())
+	if g.Address() != modules.NetAddress(g.listener.Addr().String()) {
+		t.Fatalf("wrong address: expected %v, got %v", g.listener.Addr(), g.Address())
+	}
+	host := modules.NetAddress(g.listener.Addr().String()).Host()
+	ip := net.ParseIP(host)
+	if ip.IsUnspecified() {
+		t.Fatal("expected a non-unspecified address")
+	}
+	if !ip.IsLoopback() {
+		t.Fatal("expected a loopback address")
 	}
 }
 

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -13,7 +13,7 @@ import (
 
 // newTestingGateway returns a gateway read to use in a testing environment.
 func newTestingGateway(name string, t *testing.T) *Gateway {
-	g, err := New(":0", build.TempDir("gateway", name))
+	g, err := New("localhost:0", build.TempDir("gateway", name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestNew(t *testing.T) {
 	if _, err := New("", ""); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
-	if _, err := New(":0", ""); err == nil {
+	if _, err := New("localhost:0", ""); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
 	if g, err := New("foo", build.TempDir("gateway", "TestNew1")); err == nil {
@@ -78,7 +78,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal("couldn't create corrupted file:", err)
 	}
-	if _, err := New(":0", dir); err == nil {
+	if _, err := New("localhost:0", dir); err == nil {
 		t.Fatal("expected load error, got nil")
 	}
 }

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -192,7 +192,7 @@ func TestConnectRejects(t *testing.T) {
 	g := newTestingGateway("TestConnectRejects", t)
 	// Setup a listener that mocks Gateway.acceptConn, but sends the
 	// version sent over mockVersionChan instead of build.Version.
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +456,7 @@ func TestDisconnect(t *testing.T) {
 	}
 
 	// dummy listener to accept connection
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal("couldn't start listener:", err)
 	}

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -12,7 +12,7 @@ func TestLoad(t *testing.T) {
 	g.mu.Unlock(id)
 	g.Close()
 
-	g2, err := New(":0", g.persistDir)
+	g2, err := New("localhost:0", g.persistDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -104,7 +104,7 @@ func blankHostTester(name string) (*hostTester, error) {
 	testdir := build.TempDir(modules.HostDir, name)
 
 	// Create the modules.
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func blankHostTester(name string) (*hostTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	h, err := New(cs, tp, w, ":0", filepath.Join(testdir, modules.HostDir))
+	h, err := New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		return nil, err
 	}
@@ -214,15 +214,15 @@ func TestNilValues(t *testing.T) {
 	}
 
 	hostDir := filepath.Join(ht.persistDir, modules.HostDir)
-	_, err = New(nil, ht.tpool, ht.wallet, ":0", hostDir)
+	_, err = New(nil, ht.tpool, ht.wallet, "localhost:0", hostDir)
 	if err != errNilCS {
 		t.Fatal("could not trigger errNilCS")
 	}
-	_, err = New(ht.cs, nil, ht.wallet, ":0", hostDir)
+	_, err = New(ht.cs, nil, ht.wallet, "localhost:0", hostDir)
 	if err != errNilTpool {
 		t.Fatal("could not trigger errNilTpool")
 	}
-	_, err = New(ht.cs, ht.tpool, nil, ":0", hostDir)
+	_, err = New(ht.cs, ht.tpool, nil, "localhost:0", hostDir)
 	if err != errNilWallet {
 		t.Fatal("Could not trigger errNilWallet")
 	}
@@ -289,7 +289,7 @@ func TestSetAndGetSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +359,7 @@ func TestPersistentSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	h, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -38,7 +38,7 @@ func TestRPCMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/persist_compat_test.go
+++ b/modules/host/persist_compat_test.go
@@ -69,7 +69,7 @@ func TestPersistCompat04(t *testing.T) {
 	}
 
 	// Re-open the host, which will be loading from the compatibility file.
-	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/persist_test.go
+++ b/modules/host/persist_test.go
@@ -78,7 +78,7 @@ func TestIntegrationValuePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	newHost, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	newHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/update_test.go
+++ b/modules/host/update_test.go
@@ -165,7 +165,7 @@ func TestIntegrationAutoRescan(t *testing.T) {
 
 	// Create a new host and check that the persist variables have correctly
 	// reset.
-	h, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	h, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/upload_test.go
+++ b/modules/host/upload_test.go
@@ -279,7 +279,7 @@ func TestFailedObligation(t *testing.T) {
 
 	// Restart the host. While catching up, the host should realize that it
 	// missed a storage proof, and should delete the obligation.
-	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,7 +338,7 @@ func TestRestartSuccessObligation(t *testing.T) {
 
 	// Restart the host, and mine enough blocks that the host can submit a
 	// successful storage proof.
-	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestRestartCorruptSuccessObligation(t *testing.T) {
 
 	// Restart the host, and mine enough blocks that the host can submit a
 	// successful storage proof.
-	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -34,7 +34,7 @@ func createMinerTester(name string) (*minerTester, error) {
 	testdir := build.TempDir(modules.MinerDir, name)
 
 	// Create the modules.
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/hostdb/negotiate_test.go
+++ b/modules/renter/hostdb/negotiate_test.go
@@ -40,7 +40,7 @@ func (rt *hostdbTester) Close() error {
 func newHostDBTester(name string) (*hostdbTester, error) {
 	// Create the modules.
 	testdir := build.TempDir("hostdb", name)
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -14,7 +14,7 @@ import (
 // fakeAddr returns a modules.NetAddress to be used in a HostEntry. Such
 // addresses are needed in order to satisfy the HostDB's "1 host per IP" rule.
 func fakeAddr(n uint8) modules.NetAddress {
-	return modules.NetAddress("127.0.0." + strconv.Itoa(int(n)) + ":0")
+	return modules.NetAddress("127.0.0." + strconv.Itoa(int(n)) + "localhost:0")
 }
 
 // uniformTreeVerification checks that everything makes sense in the tree given

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -39,7 +39,7 @@ func (rt *renterTester) Close() error {
 func newRenterTester(name string) (*renterTester, error) {
 	// Create the modules.
 	testdir := build.TempDir("renter", name)
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -31,7 +31,7 @@ type tpoolTester struct {
 func createTpoolTester(name string) (*tpoolTester, error) {
 	// Initialize the modules.
 	testdir := build.TempDir(modules.TransactionPoolDir, name)
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func createTpoolTester(name string) (*tpoolTester, error) {
 func TestIntegrationNewNilInputs(t *testing.T) {
 	// Create a gateway and consensus set.
 	testdir := build.TempDir(modules.TransactionPoolDir, "TestNewNilInputs")
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -33,7 +33,7 @@ type walletTester struct {
 func createWalletTester(name string) (*walletTester, error) {
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func createWalletTester(name string) (*walletTester, error) {
 func createBlankWalletTester(name string) (*walletTester, error) {
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (wt *walletTester) closeWt() {
 // TestNilInputs tries starting the wallet using nil inputs.
 func TestNilInputs(t *testing.T) {
 	testdir := build.TempDir(modules.WalletDir, "TestNilInputs")
-	g, err := gateway.New(":0", filepath.Join(testdir, modules.GatewayDir))
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
There was a bug in testing that prevented an RPC from calling another RPC. This was because a gateway would connect to a peer with the address "[::]:port" (the unspecified IPV6 address), but during the RPC the `conn` would have the remote address "[::1]:port" (the localhost IPV6 address). The fix is to use "localhost:0" instead of ":0".

This bug only affected tests and the only files changed in this PR are test files.