### PR TITLE
Remove readlock from managedRPCSettings

### DIFF
--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -154,7 +154,5 @@ func (h *Host) threadedListen() {
 
 // managedRPCSettings is an rpc that returns the host's settings.
 func (h *Host) managedRPCSettings(conn net.Conn) error {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
 	return encoding.WriteObject(conn, h.Settings())
 }


### PR DESCRIPTION
The readlock wasn't necessary as managedRPCSettings only called the exported method Settings() which has it's own readlock. The extra readlock made it possible for a deadlock to occur if a different goroutine tried to obtain a writelock after managedRPCSettings's readlock but before Settings() readlock.

fixes #1009
thanks @david60!