### PR TITLE
New contract protocol (Renter side)

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -33,7 +33,7 @@ type RenterShareASCII struct {
 
 // ActiveHosts lists active hosts on the network.
 type ActiveHosts struct {
-	Hosts []modules.HostExternalSettings `json:"hosts"`
+	Hosts []modules.HostDBEntry `json:"hosts"`
 }
 
 // renterAllowanceHandlerGET handles the API call to get the allowance.

--- a/modules/host.go
+++ b/modules/host.go
@@ -34,6 +34,10 @@ const (
 	// The transaction pool's size limit for transaction sets has been chosen
 	// as a reasonable guideline for determining what is too large.
 	MaxFileContractSetLen = TransactionSetSizeLimit - 1e3
+
+	// MaxHostExternalSettingsLen is the maximum allowed size of an encoded
+	// HostExternalSettings.
+	MaxHostExternalSettingsLen = 16000
 )
 
 var (

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -76,6 +76,13 @@ type Allowance struct {
 	RenewWindow types.BlockHeight `json:"renewwindow"`
 }
 
+// A HostDBEntry represents one host entry in the Renter's host DB. It
+// aggregates the host's external settings with its public key.
+type HostDBEntry struct {
+	HostExternalSettings
+	PublicKey types.SiaPublicKey
+}
+
 // A Renter uploads, tracks, repairs, and downloads a set of files for the
 // user.
 type Renter interface {
@@ -84,10 +91,10 @@ type Renter interface {
 
 	// ActiveHosts returns the list of hosts that are actively being selected
 	// from.
-	ActiveHosts() []HostExternalSettings
+	ActiveHosts() []HostDBEntry
 
 	// AllHosts returns the full list of hosts known to the renter.
-	AllHosts() []HostExternalSettings
+	AllHosts() []HostDBEntry
 
 	// DeleteFile deletes a file entry from the renter.
 	DeleteFile(path string) error

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -45,6 +45,8 @@ type Contractor struct {
 	cachedAddress types.UnlockHash // to prevent excessive address creation
 	contracts     map[types.FileContractID]Contract
 	renewHeight   types.BlockHeight // height at which to renew contracts
+	spentPeriod   types.Currency    // number of coins spent on file contracts this period
+	spentTotal    types.Currency    // number of coins spent on file contracts ever
 
 	mu sync.RWMutex
 }
@@ -54,6 +56,13 @@ func (c *Contractor) Allowance() modules.Allowance {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.allowance
+}
+
+// Spending returns the number of coins spent on file contracts.
+func (c *Contractor) Spending() (types.Currency, types.Currency) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.spentPeriod, c.spentTotal
 }
 
 // SetAllowance sets the amount of money the Contractor is allowed to spend on
@@ -87,7 +96,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	// Otherwise, if the new allowance is "significantly different" (to be
 	// defined more precisely later), form intermediary contracts.
 	if a.Funds.Cmp(old.Funds) > 0 {
-		// not yet implemented
+		// TODO: implement
 		// c.formContracts(diff(a, old))
 	}
 

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -60,7 +60,7 @@ func (c *Contractor) Allowance() modules.Allowance {
 }
 
 // Spending returns the number of coins spent on file contracts.
-func (c *Contractor) Spending() (types.Currency, types.Currency) {
+func (c *Contractor) Spending() (period, total types.Currency) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.spentPeriod, c.spentTotal

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -29,8 +29,8 @@ func (newStub) StartTransaction() modules.TransactionBuilder        { return nil
 func (newStub) AcceptTransactionSet([]types.Transaction) error { return nil }
 
 // hdb stubs
-func (newStub) Host(modules.NetAddress) (settings modules.HostExternalSettings, ok bool) { return }
-func (newStub) RandomHosts(int, []modules.NetAddress) []modules.HostExternalSettings     { return nil }
+func (newStub) Host(modules.NetAddress) (settings modules.HostDBEntry, ok bool) { return }
+func (newStub) RandomHosts(int, []modules.NetAddress) []modules.HostDBEntry     { return nil }
 
 // TestNew tests the New function.
 func TestNew(t *testing.T) {
@@ -126,8 +126,8 @@ func TestAllowance(t *testing.T) {
 // its methods.
 type stubHostDB struct{}
 
-func (stubHostDB) Host(modules.NetAddress) (h modules.HostExternalSettings, ok bool)         { return }
-func (stubHostDB) RandomHosts(int, []modules.NetAddress) (hs []modules.HostExternalSettings) { return }
+func (stubHostDB) Host(modules.NetAddress) (h modules.HostDBEntry, ok bool)         { return }
+func (stubHostDB) RandomHosts(int, []modules.NetAddress) (hs []modules.HostDBEntry) { return }
 
 // TestSetAllowance tests the SetAllowance method.
 func TestSetAllowance(t *testing.T) {

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -40,8 +40,8 @@ type (
 	}
 
 	hostDB interface {
-		Host(modules.NetAddress) (modules.HostExternalSettings, bool)
-		RandomHosts(n int, exclude []modules.NetAddress) []modules.HostExternalSettings
+		Host(modules.NetAddress) (modules.HostDBEntry, bool)
+		RandomHosts(n int, exclude []modules.NetAddress) []modules.HostDBEntry
 	}
 
 	dialer interface {

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -83,25 +83,38 @@ func (he *hostEditor) Upload(data []byte) (uint64, error) {
 	he.contractor.mu.RLock()
 	height := he.contractor.blockHeight
 	he.contractor.mu.RUnlock()
-	if height > he.contract.FileContract.WindowStart {
+	if height >= he.contract.FileContract.WindowStart {
 		return 0, errors.New("contract has already ended")
 	}
-	piecePrice := types.NewCurrency64(uint64(len(data))).Mul(types.NewCurrency64(uint64(he.contract.FileContract.WindowStart - height))).Mul(he.price)
+	sectorPrice := he.price.Mul(types.NewCurrency64(SectorSize * uint64(he.contract.FileContract.WindowStart-height)))
 
 	// calculate the Merkle root of the new data (no error possible with bytes.Reader)
 	pieceRoot := crypto.MerkleRoot(data)
 
 	// calculate the new total Merkle root
+	newRoots := append(he.contract.MerkleRoots, pieceRoot)
 	tree := crypto.NewCachedTree(0) // height is not relevant here
-	for _, h := range he.contract.MerkleRoots {
+	for _, h := range newRoots {
 		tree.Push(h)
 	}
-	tree.Push(pieceRoot)
 	merkleRoot := tree.Root()
 
-	// revise the file contract
-	rev := newRevision(he.contract.LastRevision, uint64(len(data)), merkleRoot, piecePrice)
-	signedTxn, err := negotiateRevision(he.conn, rev, data, he.contract.SecretKey)
+	// send 'insert' action
+	err := encoding.WriteObject(he.conn, []modules.RevisionAction{{
+		Type:        modules.ActionInsert,
+		SectorIndex: uint64(len(newRoots)), // current length + 1
+	}})
+	if err != nil {
+		return 0, err
+	}
+	// send sector data
+	if err := encoding.WritePrefix(he.conn, data); err != nil {
+		return 0, err
+	}
+
+	// revise the file contract to cover the cost of the new sector
+	rev := newRevision(he.contract.LastRevision, merkleRoot, uint64(len(newRoots)), sectorPrice)
+	signedTxn, err := negotiateRevision(he.conn, rev, he.contract.SecretKey)
 	if err != nil {
 		return 0, err
 	}
@@ -109,7 +122,7 @@ func (he *hostEditor) Upload(data []byte) (uint64, error) {
 	// update host contract
 	he.contract.LastRevision = rev
 	he.contract.LastRevisionTxn = signedTxn
-	he.contract.MerkleRoots = append(he.contract.MerkleRoots, pieceRoot)
+	he.contract.MerkleRoots = newRoots
 
 	he.contractor.mu.Lock()
 	he.contractor.contracts[he.contract.ID] = he.contract
@@ -120,38 +133,61 @@ func (he *hostEditor) Upload(data []byte) (uint64, error) {
 }
 
 // Delete deletes a sector in a contract.
-// TODO: implement
 func (he *hostEditor) Delete(root crypto.Hash) error {
+	// calculate price
+	he.contractor.mu.RLock()
+	height := he.contractor.blockHeight
+	he.contractor.mu.RUnlock()
+	if height >= he.contract.FileContract.WindowStart {
+		return errors.New("contract has already ended")
+	}
+	// TODO: is this math correct?
+	sectorPrice := he.price.Mul(types.NewCurrency64(SectorSize * uint64(he.contract.FileContract.WindowStart-height)))
+
 	// calculate the new total Merkle root
-	// var newRoots []crypto.Hash
-	// for _, h := range he.contract.MerkleRoots {
-	// 	if h != root {
-	// 		newRoots = append(newRoots, h)
-	// 	}
-	// }
-	// tree := crypto.NewCachedTree(0) // height is not relevant here
-	// for _, h := range newRoots {
-	// 	tree.Push(h[:])
-	// }
-	// merkleRoot := tree.Root()
+	var newRoots []crypto.Hash
+	index := -1
+	for i, h := range he.contract.MerkleRoots {
+		if h != root {
+			index = i
+		} else {
+			newRoots = append(newRoots, h)
+		}
+	}
+	if index == -1 {
+		return errors.New("no record of that sector root")
+	}
+	tree := crypto.NewCachedTree(0) // height is not relevant here
+	for _, h := range newRoots {
+		tree.Push(h)
+	}
+	merkleRoot := tree.Root()
 
-	// // send 'delete' action, sector root, and new Merkle root
-	// encoding.WriteObject(he.conn, modules.RPCDelete)
-	// encoding.WriteObject(he.conn, root)
-	// encoding.WriteObject(he.conn, merkleRoot)
+	// send 'delete' action
+	err := encoding.WriteObject(he.conn, []modules.RevisionAction{{
+		Type:        modules.ActionDelete,
+		SectorIndex: uint64(index),
+	}})
+	if err != nil {
+		return err
+	}
 
-	// // read ok
-	// encoding.ReadObject(he.conn, &ok)
+	// revise the file contract to cover one fewer sector
+	rev := newRevision(he.contract.LastRevision, merkleRoot, uint64(len(newRoots)), sectorPrice)
+	signedTxn, err := negotiateRevision(he.conn, rev, he.contract.SecretKey)
+	if err != nil {
+		return err
+	}
 
-	// // update host contract
-	// he.contract.LastRevision = rev
-	// he.contract.LastRevisionTxn = signedTxn
-	// he.contract.MerkleRoots = newRoots
+	// update host contract
+	he.contract.LastRevision = rev
+	he.contract.LastRevisionTxn = signedTxn
+	he.contract.MerkleRoots = newRoots
 
-	// he.contractor.mu.Lock()
-	// he.contractor.contracts[he.contract.ID] = he.contract
-	// he.contractor.save()
-	// he.contractor.mu.Unlock()
+	he.contractor.mu.Lock()
+	he.contractor.contracts[he.contract.ID] = he.contract
+	he.contractor.save()
+	he.contractor.mu.Unlock()
 
 	return nil
 }
@@ -190,13 +226,32 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 		return nil, err
 	}
 	if err := encoding.WriteObject(conn, modules.RPCRevise); err != nil {
+		return nil, errors.New("couldn't initiate RPC: " + err.Error())
+	}
+
+	// verify the host's settings and confirm its identity
+	err = verifySettings(conn, host, c.hdb)
+	if err != nil {
 		return nil, err
+	}
+
+	// send acceptance and contract ID
+	if err := encoding.WriteObject(conn, modules.AcceptResponse); err != nil {
+		return nil, errors.New("couldn't send acceptance: " + err.Error())
 	}
 	if err := encoding.WriteObject(conn, contract.ID); err != nil {
-		return nil, err
+		return nil, errors.New("couldn't send contract ID: " + err.Error())
 	}
-	// TODO: some sort of acceptance would be good here, so that we know the
-	// Editor will actually work. Maybe send the Merkle root?
+
+	// read last txn
+	var lastRevisionTxn types.Transaction
+	if err := encoding.ReadObject(conn, &lastRevisionTxn, 2048); err != nil {
+		return nil, errors.New("couldn't read last revision transaction: " + err.Error())
+	} else if lastRevisionTxn.ID() != contract.LastRevisionTxn.ID() {
+		return nil, errors.New("desynchronized with host (revision transactions do not match)")
+	}
+
+	// the host is now ready to accept revisions
 
 	he := &hostEditor{
 		contract: contract,

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -230,7 +230,7 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 	}
 
 	// verify the host's settings and confirm its identity
-	err = verifySettings(conn, host, c.hdb)
+	host, err = verifySettings(conn, host, c.hdb)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -222,7 +222,7 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 	}
 	if !host.ContractPrice.IsZero() {
 		bytes, errOverflow := contract.LastRevision.NewValidProofOutputs[0].Value.Div(host.ContractPrice).Uint64()
-		if errOverflow == nil && bytes < SectorSize {
+		if errOverflow == nil && bytes < modules.SectorSize {
 			return nil, errors.New("contract has insufficient capacity")
 		}
 	}

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -165,11 +165,11 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 	if height > contract.FileContract.WindowStart {
 		return nil, errors.New("contract has already ended")
 	}
-	settings, ok := c.hdb.Host(contract.IP)
+	host, ok := c.hdb.Host(contract.IP)
 	if !ok {
 		return nil, errors.New("no record of that host")
 	}
-	if settings.ContractPrice.Cmp(maxPrice) > 0 {
+	if host.ContractPrice.Cmp(maxPrice) > 0 {
 		return nil, errTooExpensive
 	}
 
@@ -177,8 +177,8 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 	if len(contract.LastRevision.NewValidProofOutputs) != 2 {
 		return nil, errors.New("invalid contract")
 	}
-	if !settings.ContractPrice.IsZero() {
-		bytes, errOverflow := contract.LastRevision.NewValidProofOutputs[0].Value.Div(settings.ContractPrice).Uint64()
+	if !host.ContractPrice.IsZero() {
+		bytes, errOverflow := contract.LastRevision.NewValidProofOutputs[0].Value.Div(host.ContractPrice).Uint64()
 		if errOverflow == nil && bytes < SectorSize {
 			return nil, errors.New("contract has insufficient capacity")
 		}
@@ -200,7 +200,7 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 
 	he := &hostEditor{
 		contract: contract,
-		price:    settings.ContractPrice,
+		price:    host.ContractPrice,
 
 		conn:       conn,
 		contractor: c,

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -18,36 +18,39 @@ var (
 	errTooExpensive = errors.New("host price was too high")
 )
 
+// verifySettings reads a signed HostSettings object from conn, validates the
+// signature, and checks for discrepancies between the known settings and the
+// received settings. If there is a discrepancy, the hostDB is notified.
+func verifySettings(conn net.Conn, knownSettings modules.HostExternalSettings, hdb hostDB) error {
+	// read signed host settings
+	var recvSettings modules.HostExternalSettings
+	if err := crypto.ReadSignedObject(conn, &recvSettings, 2048, knownSettings.PublicKey); err != nil { // ??? how large?
+		return errors.New("couldn't read host's settings: " + err.Error())
+	}
+	// TODO: check settings. If there is a discrepancy, write the error to
+	// conn and update the hostdb
+	return nil
+}
+
 // negotiateContract establishes a connection to a host and negotiates an
 // initial file contract according to the terms of the host.
-func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileContract, txnBuilder transactionBuilder, tpool transactionPool) (Contract, error) {
+func negotiateContract(conn net.Conn, host modules.HostExternalSettings, fc types.FileContract, txnBuilder transactionBuilder, tpool transactionPool) (Contract, error) {
 	// allow 30 seconds for negotiation
 	conn.SetDeadline(time.Now().Add(30 * time.Second))
-
-	// read host key
-	var hostPublicKey types.SiaPublicKey
-	if err := encoding.ReadObject(conn, &hostPublicKey, 256); err != nil {
-		return Contract{}, errors.New("couldn't read host's public key: " + err.Error())
-	}
 
 	// create our key
 	ourSK, ourPK, err := crypto.GenerateKeyPair()
 	if err != nil {
+		encoding.WriteObject(conn, "internal error")
 		return Contract{}, errors.New("failed to generate keypair: " + err.Error())
 	}
 	ourPublicKey := types.SiaPublicKey{
 		Algorithm: types.SignatureEd25519,
 		Key:       ourPK[:],
 	}
-
-	// send our public key
-	if err := encoding.WriteObject(conn, ourPublicKey); err != nil {
-		return Contract{}, errors.New("couldn't send our public key: " + err.Error())
-	}
-
 	// create unlock conditions
 	uc := types.UnlockConditions{
-		PublicKeys:         []types.SiaPublicKey{ourPublicKey, hostPublicKey},
+		PublicKeys:         []types.SiaPublicKey{ourPublicKey, host.PublicKey},
 		SignaturesRequired: 2,
 	}
 
@@ -57,6 +60,7 @@ func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileCont
 	// build transaction containing fc
 	err = txnBuilder.FundSiacoins(fc.Payout)
 	if err != nil {
+		encoding.WriteObject(conn, "internal error")
 		return Contract{}, err
 	}
 	txnBuilder.AddFileContract(fc)
@@ -64,14 +68,24 @@ func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileCont
 	txnSet := append(parents, txn)
 
 	// calculate contract ID
-	fcid := txn.FileContractID(0) // TODO: is it actually 0?
+	fcid := txn.FileContractID(0)
 
-	// send txn
-	if err := encoding.WriteObject(conn, txnSet); err != nil {
-		return Contract{}, errors.New("couldn't send our proposed contract: " + err.Error())
+	// sign the txn
+	// TODO: needs to be fancy
+	signedTxnSet, err := txnBuilder.Sign(true)
+	if err != nil {
+		return Contract{}, err
 	}
 
-	// read back acceptance
+	// send acceptance and txn signed by us
+	if err := encoding.WriteObject(conn, modules.AcceptResponse); err != nil {
+		return Contract{}, errors.New("couldn't send acceptance: " + err.Error())
+	}
+	if err := encoding.WriteObject(conn, signedTxnSet); err != nil {
+		return Contract{}, errors.New("couldn't send the contract signed by us: " + err.Error())
+	}
+
+	// read acceptance and txn signed by host
 	var response string
 	if err := encoding.ReadObject(conn, &response, 128); err != nil {
 		return Contract{}, errors.New("couldn't read the host's response to our proposed contract: " + err.Error())
@@ -79,46 +93,17 @@ func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileCont
 	if response != modules.AcceptResponse {
 		return Contract{}, errors.New("host rejected proposed contract: " + response)
 	}
-
-	// read back txn with host collateral.
 	var hostTxnSet []types.Transaction
 	if err := encoding.ReadObject(conn, &hostTxnSet, types.BlockSizeLimit); err != nil {
 		return Contract{}, errors.New("couldn't read the host's updated contract: " + err.Error())
 	}
 
-	// check that txn is okay. For now, no collateral will be added, so the
-	// transaction sets should be identical.
-	if len(hostTxnSet) != len(txnSet) {
-		return Contract{}, errors.New("host sent bad collateral transaction")
-	}
-	for i := range hostTxnSet {
-		if hostTxnSet[i].ID() != txnSet[i].ID() {
-			return Contract{}, errors.New("host sent bad collateral transaction")
-		}
-	}
-
-	// sign the txn and resend
-	// NOTE: for now, we are assuming that the transaction has not changed
-	// since we sent it. Otherwise, the txnBuilder would have to be updated
-	// with whatever fields were added by the host.
-	signedTxnSet, err := txnBuilder.Sign(true)
-	if err != nil {
-		return Contract{}, err
-	}
-	if err := encoding.WriteObject(conn, signedTxnSet); err != nil {
-		return Contract{}, errors.New("couldn't send the contract signed by us: " + err.Error())
-	}
-
-	// read signed txn from host
-	var signedHostTxnSet []types.Transaction
-	if err := encoding.ReadObject(conn, &signedHostTxnSet, types.BlockSizeLimit); err != nil {
-		return Contract{}, errors.New("couldn't read the contract signed by the host: " + err.Error())
-	}
+	// TODO: check txn?
 
 	// submit to blockchain
-	err = tpool.AcceptTransactionSet(signedHostTxnSet)
+	err = tpool.AcceptTransactionSet(hostTxnSet)
 	if err == modules.ErrDuplicateTransactionSet {
-		// this can happen if the renter is uploading to itself
+		// as long as it made it into the transaction pool, we're good
 		err = nil
 	}
 	if err != nil {
@@ -127,7 +112,7 @@ func negotiateContract(conn net.Conn, addr modules.NetAddress, fc types.FileCont
 
 	// create host contract
 	contract := Contract{
-		IP:           addr,
+		IP:           host.NetAddress,
 		ID:           fcid,
 		FileContract: fc,
 		LastRevision: types.FileContractRevision{
@@ -177,8 +162,7 @@ func (c *Contractor) newContract(host modules.HostExternalSettings, filesize uin
 
 	// create file contract
 	renterCost := host.ContractPrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration)))
-	renterCost = renterCost.MulFloat(1.05) // extra buffer to guarantee we won't run out of money during revision
-	payout := renterCost                   // no collateral
+	payout := renterCost // no collateral
 
 	fc := types.FileContract{
 		FileSize:       0,
@@ -202,9 +186,6 @@ func (c *Contractor) newContract(host modules.HostExternalSettings, filesize uin
 		},
 	}
 
-	// create transaction builder
-	txnBuilder := c.wallet.StartTransaction()
-
 	// initiate connection
 	conn, err := c.dialer.DialTimeout(host.NetAddress, 15*time.Second)
 	if err != nil {
@@ -215,8 +196,17 @@ func (c *Contractor) newContract(host modules.HostExternalSettings, filesize uin
 		return Contract{}, err
 	}
 
+	// verify the host's settings and confirm its identity
+	err = verifySettings(conn, host, c.hdb)
+	if err != nil {
+		return Contract{}, err
+	}
+
+	// create transaction builder
+	txnBuilder := c.wallet.StartTransaction()
+
 	// execute negotiation protocol
-	contract, err := negotiateContract(conn, host.NetAddress, fc, txnBuilder, c.tpool)
+	contract, err := negotiateContract(conn, host, fc, txnBuilder, c.tpool)
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet
 		return Contract{}, err

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -242,7 +242,7 @@ func (c *Contractor) formContracts(a modules.Allowance) error {
 	// host for the specified duration.
 	costPerSector := avgPrice.
 		Mul(types.NewCurrency64(a.Hosts)).
-		Mul(types.NewCurrency64(SectorSize)).
+		Mul(types.NewCurrency64(modules.SectorSize)).
 		Mul(types.NewCurrency64(uint64(a.Period)))
 	if a.Funds.Cmp(costPerSector) < 0 {
 		return errors.New("insufficient funds")
@@ -255,7 +255,7 @@ func (c *Contractor) formContracts(a modules.Allowance) error {
 		// if there was an overflow, something is definitely wrong
 		return errors.New("allowance resulted in unexpectedly large contract size")
 	}
-	filesize := numSectors * SectorSize
+	filesize := numSectors * modules.SectorSize
 
 	// Form contracts with each host.
 	c.mu.RLock()

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -68,18 +68,15 @@ func negotiateContract(conn net.Conn, host modules.HostExternalSettings, fc type
 		return Contract{}, err
 	}
 	txnBuilder.AddFileContract(fc)
-	txn, parents := txnBuilder.View()
-	txnSet := append(parents, txn)
-
-	// calculate contract ID
-	fcid := txn.FileContractID(0)
 
 	// sign the txn
-	// TODO: needs to be fancy
-	signedTxnSet, err := txnBuilder.Sign(true)
+	signedTxnSet, err := txnBuilder.Sign(false)
 	if err != nil {
 		return Contract{}, err
 	}
+
+	// calculate contract ID
+	fcid := signedTxnSet[len(signedTxnSet)-1].FileContractID(0)
 
 	// send acceptance and txn signed by us
 	if err := encoding.WriteObject(conn, modules.AcceptResponse); err != nil {

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -214,8 +214,9 @@ func (c *Contractor) newContract(host modules.HostExternalSettings, filesize uin
 
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	// clear the cached address
-	c.cachedAddress = types.UnlockHash{}
+	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
+	c.spentTotal = c.spentTotal.Add(fc.Payout)
+	c.cachedAddress = types.UnlockHash{} // clear the cached address
 	c.save()
 	c.mu.Unlock()
 

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// the contractor will not form contracts above this price
-	maxPrice = types.SiacoinPrecision.Div(types.NewCurrency64(4320e9)).Mul(types.NewCurrency64(500)) // 500 SC / GB / Month
+	maxPrice = modules.StoragePriceToConsensus(500000) // 500k SC / TB / Month
 
 	errTooExpensive = errors.New("host price was too high")
 )

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -163,7 +163,7 @@ func (c *Contractor) newContract(host modules.HostExternalSettings, filesize uin
 
 	// create file contract
 	renterCost := host.ContractPrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration)))
-	payout := renterCost // no collateral
+	payout := renterCost.Add(host.Collateral)
 
 	fc := types.FileContract{
 		FileSize:       0,

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -28,6 +28,9 @@ func verifySettings(conn net.Conn, knownSettings modules.HostExternalSettings, h
 	if err := crypto.ReadSignedObject(conn, &recvSettings, 2048, knownSettings.PublicKey); err != nil { // ??? how large?
 		return modules.HostExternalSettings{}, errors.New("couldn't read host's settings: " + err.Error())
 	}
+	if !recvSettings.AcceptingContracts {
+		return recvSettings, errors.New("host is not accepting contracts")
+	}
 	// TODO: check settings. If there is a discrepancy, write the error to
 	// conn and update the hostdb
 	return recvSettings, nil

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -9,6 +9,7 @@ import (
 type contractorPersist struct {
 	Allowance   modules.Allowance
 	Contracts   []Contract
+	LastChange  modules.ConsensusChangeID
 	RenewHeight types.BlockHeight
 	SpentPeriod types.Currency
 	SpentTotal  types.Currency
@@ -18,6 +19,7 @@ type contractorPersist struct {
 func (c *Contractor) save() error {
 	data := contractorPersist{
 		Allowance:   c.allowance,
+		LastChange:  c.lastChange,
 		RenewHeight: c.renewHeight,
 		SpentPeriod: c.spentPeriod,
 		SpentTotal:  c.spentTotal,
@@ -39,6 +41,7 @@ func (c *Contractor) load() error {
 	for _, contract := range data.Contracts {
 		c.contracts[contract.ID] = contract
 	}
+	c.lastChange = data.LastChange
 	c.renewHeight = data.RenewHeight
 	c.spentPeriod = data.SpentPeriod
 	c.spentTotal = data.SpentTotal

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -10,16 +10,21 @@ type contractorPersist struct {
 	Allowance   modules.Allowance
 	Contracts   []Contract
 	RenewHeight types.BlockHeight
+	SpentPeriod types.Currency
+	SpentTotal  types.Currency
 }
 
 // save saves the hostdb persistence data to disk.
 func (c *Contractor) save() error {
-	var data contractorPersist
-	data.Allowance = c.allowance
+	data := contractorPersist{
+		Allowance:   c.allowance,
+		RenewHeight: c.renewHeight,
+		SpentPeriod: c.spentPeriod,
+		SpentTotal:  c.spentTotal,
+	}
 	for _, contract := range c.contracts {
 		data.Contracts = append(data.Contracts, contract)
 	}
-	data.RenewHeight = c.renewHeight
 	return c.persist.save(data)
 }
 
@@ -35,5 +40,7 @@ func (c *Contractor) load() error {
 		c.contracts[contract.ID] = contract
 	}
 	c.renewHeight = data.RenewHeight
+	c.spentPeriod = data.SpentPeriod
+	c.spentTotal = data.SpentTotal
 	return nil
 }

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -162,7 +162,7 @@ func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeig
 
 	costPerSector := avgPrice.
 		Mul(types.NewCurrency64(allowance.Hosts)).
-		Mul(types.NewCurrency64(SectorSize)).
+		Mul(types.NewCurrency64(modules.SectorSize)).
 		Mul(types.NewCurrency64(uint64(allowance.Period)))
 	if allowance.Funds.Cmp(costPerSector) < 0 {
 		// errors.New("insufficient funds")
@@ -174,7 +174,7 @@ func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeig
 	if err != nil {
 		// errors.New("allowance resulted in unexpectedly large contract size")
 	}
-	filesize := numSectors * SectorSize
+	filesize := numSectors * modules.SectorSize
 
 	for _, contract := range contracts {
 		if contract.FileContract.WindowStart < newHeight {

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -151,7 +151,7 @@ func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeig
 	var numHosts uint64
 	for _, contract := range contracts {
 		if h, ok := c.hdb.Host(contract.IP); ok {
-			sum = sum.Add(h.Price)
+			sum = sum.Add(h.ContractPrice)
 			numHosts++
 		}
 	}

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -155,8 +155,9 @@ func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeig
 			numHosts++
 		}
 	}
-	if numHosts < allowance.Hosts {
+	if numHosts == 0 || numHosts < allowance.Hosts {
 		// ??? get more
+		return
 	}
 	avgPrice := sum.Div(types.NewCurrency64(numHosts))
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -13,15 +14,13 @@ import (
 // managedRenew negotiates a new contract for data already stored with a host.
 // It returns the ID of the new contract. This is a blocking call that
 // performs network I/O.
-func (c *Contractor) managedRenew(fcid types.FileContractID, newEndHeight types.BlockHeight) (types.FileContractID, error) {
+// TODO: take an allowance and renew with those parameters
+func (c *Contractor) managedRenew(contract Contract, newEndHeight types.BlockHeight) (types.FileContractID, error) {
 	c.mu.RLock()
 	height := c.blockHeight
-	contract, ok := c.contracts[fcid]
-	host, eok := c.hdb.Host(contract.IP)
+	host, ok := c.hdb.Host(contract.IP)
 	c.mu.RUnlock()
 	if !ok {
-		return types.FileContractID{}, errors.New("no record of that contract")
-	} else if !eok {
 		return types.FileContractID{}, errors.New("no record of that host")
 	} else if newEndHeight < height {
 		return types.FileContractID{}, errors.New("cannot renew below current height")
@@ -72,9 +71,6 @@ func (c *Contractor) managedRenew(fcid types.FileContractID, newEndHeight types.
 		},
 	}
 
-	// create transaction builder
-	txnBuilder := c.wallet.StartTransaction()
-
 	// initiate connection
 	conn, err := c.dialer.DialTimeout(contract.IP, 15*time.Second)
 	if err != nil {
@@ -84,12 +80,32 @@ func (c *Contractor) managedRenew(fcid types.FileContractID, newEndHeight types.
 	if err := encoding.WriteObject(conn, modules.RPCRenew); err != nil {
 		return types.FileContractID{}, errors.New("couldn't initiate RPC: " + err.Error())
 	}
-	if err := encoding.WriteObject(conn, fcid); err != nil {
+
+	// verify the host's settings and confirm its identity
+	err = verifySettings(conn, host, c.hdb)
+	if err != nil {
+		return types.FileContractID{}, err
+	}
+
+	// send contract ID
+	if err := encoding.WriteObject(conn, contract.ID); err != nil {
 		return types.FileContractID{}, errors.New("couldn't send contract ID: " + err.Error())
 	}
 
+	// read missing sector roots
+	var missingSectors []crypto.Hash
+	if err := encoding.ReadObject(conn, &missingSectors, 2048); err != nil { // ?? length?
+		return types.FileContractID{}, errors.New("couldn't read missing sectors: " + err.Error())
+	}
+	if len(missingSectors) != 0 {
+		// TODO: reduce payouts? reupload sectors?
+	}
+
+	// create transaction builder
+	txnBuilder := c.wallet.StartTransaction()
+
 	// execute negotiation protocol
-	newContract, err := negotiateContract(conn, contract.IP, fc, txnBuilder, c.tpool)
+	newContract, err := negotiateContract(conn, host, fc, txnBuilder, c.tpool)
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet
 		return types.FileContractID{}, err
@@ -105,6 +121,21 @@ func (c *Contractor) managedRenew(fcid types.FileContractID, newEndHeight types.
 		c.log.Println("WARN: failed to save the contractor:", err)
 	}
 
+	// Delete a sector from the old contract, for anonymity reasons. (We don't
+	// want the same Merkle root to appear in the blockchain for every
+	// renewal.) Not a big deal if this fails, as long as it's not failing
+	// every time.
+	go func() {
+		he, err := c.Editor(contract)
+		if err == nil {
+			err = he.Delete(contract.MerkleRoots[0])
+			he.Close()
+		}
+		if err != nil {
+			c.log.Println("WARN: couldn't delete sector from expired contract:", err)
+		}
+	}()
+
 	return newContract.ID, nil
 }
 
@@ -118,7 +149,7 @@ func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeig
 		if contract.FileContract.WindowStart < newHeight {
 			go func() {
 				defer wg.Done()
-				_, err := c.managedRenew(contract.ID, newHeight)
+				_, err := c.managedRenew(contract, newHeight)
 				if err != nil {
 					c.log.Println("WARN: failed to renew contract", contract.ID, ":", err)
 				}
@@ -129,4 +160,5 @@ func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeig
 	wg.Wait()
 
 	// TODO: reset renewHeight if too many rewewals failed.
+	// TODO: form more contracts if numRenewed < allowance.Hosts
 }

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -114,6 +114,8 @@ func (c *Contractor) managedRenew(contract Contract, newEndHeight types.BlockHei
 	// update host contract
 	c.mu.Lock()
 	c.contracts[newContract.ID] = newContract
+	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
+	c.spentTotal = c.spentTotal.Add(fc.Payout)
 	c.cachedAddress = types.UnlockHash{} // clear cachedAddress
 	err = c.save()
 	c.mu.Unlock()

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -49,8 +49,7 @@ func (c *Contractor) managedRenew(fcid types.FileContractID, newEndHeight types.
 	}
 
 	renterCost := host.ContractPrice.Mul(types.NewCurrency64(contract.LastRevision.NewFileSize)).Mul(types.NewCurrency64(uint64(newEndHeight - height)))
-	renterCost = renterCost.MulFloat(1.05) // extra buffer to guarantee we won't run out of money during revision
-	payout := renterCost                   // no collateral
+	payout := renterCost // no collateral
 
 	// create file contract
 	fc := types.FileContract{

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -82,7 +82,7 @@ func (c *Contractor) managedRenew(contract Contract, newEndHeight types.BlockHei
 	}
 
 	// verify the host's settings and confirm its identity
-	err = verifySettings(conn, host, c.hdb)
+	host, err = verifySettings(conn, host, c.hdb)
 	if err != nil {
 		return types.FileContractID{}, err
 	}

--- a/modules/renter/contractor/revise.go
+++ b/modules/renter/contractor/revise.go
@@ -12,7 +12,7 @@ import (
 )
 
 // negotiateRevision sends the revision and new piece data to the host.
-func negotiateRevision(conn net.Conn, rev types.FileContractRevision, piece []byte, secretKey crypto.SecretKey) (types.Transaction, error) {
+func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey crypto.SecretKey) (types.Transaction, error) {
 	conn.SetDeadline(time.Now().Add(5 * time.Minute)) // sufficient to transfer 4 MB over 100 kbps
 	defer conn.SetDeadline(time.Now().Add(time.Hour)) // reset timeout after each revision
 
@@ -43,11 +43,6 @@ func negotiateRevision(conn net.Conn, rev types.FileContractRevision, piece []by
 		return types.Transaction{}, errors.New("host rejected revision: " + response)
 	}
 
-	// transfer piece
-	if _, err := conn.Write(piece); err != nil {
-		return types.Transaction{}, errors.New("couldn't transfer piece: " + err.Error())
-	}
-
 	// read txn signed by host
 	var signedHostTxn types.Transaction
 	if err := encoding.ReadObject(conn, &signedHostTxn, types.BlockSizeLimit); err != nil {
@@ -62,31 +57,52 @@ func negotiateRevision(conn net.Conn, rev types.FileContractRevision, piece []by
 }
 
 // newRevision revises the current revision to incorporate new data.
-func newRevision(rev types.FileContractRevision, pieceLen uint64, merkleRoot crypto.Hash, piecePrice types.Currency) types.FileContractRevision {
-	// prevent a negative currency panic
-	if piecePrice.Cmp(rev.NewValidProofOutputs[0].Value) > 0 {
-		// probably not enough money, but the host might accept it anyway
-		piecePrice = rev.NewValidProofOutputs[0].Value
+func newRevision(rev types.FileContractRevision, merkleRoot crypto.Hash, numSectors uint64, sectorPrice types.Currency) types.FileContractRevision {
+	// move safely moves n coins from src to dest, avoiding negative currency
+	// panics. The new values of src and dest are returned.
+	move := func(n, src, dest types.Currency) (types.Currency, types.Currency) {
+		if n.Cmp(src) > 0 {
+			n = src
+		}
+		return src.Sub(n), dest.Add(n)
 	}
+	// calculate price difference
+	var (
+		valid0  = rev.NewValidProofOutputs[0].Value
+		valid1  = rev.NewValidProofOutputs[1].Value
+		missed0 = rev.NewMissedProofOutputs[0].Value
+		missed1 = rev.NewMissedProofOutputs[1].Value
+	)
+	curSectors := rev.NewFileSize / SectorSize
+	if numSectors > curSectors {
+		diffPrice := sectorPrice.Mul(types.NewCurrency64(numSectors - curSectors))
+		// move valid payout from renter to host
+		valid0, valid1 = move(diffPrice, valid0, valid1)
+		// move missed payout from renter to void
+		missed0, missed1 = move(diffPrice, missed0, missed1)
+	} else if numSectors < curSectors {
+		diffPrice := sectorPrice.Mul(types.NewCurrency64(curSectors - numSectors))
+		// move valid payout from host to renter
+		valid1, valid0 = move(diffPrice, valid1, valid0)
+		// move missed payout from void to renter
+		missed1, missed0 = move(diffPrice, missed1, missed0)
+	}
+
 	return types.FileContractRevision{
 		ParentID:          rev.ParentID,
 		UnlockConditions:  rev.UnlockConditions,
 		NewRevisionNumber: rev.NewRevisionNumber + 1,
-		NewFileSize:       rev.NewFileSize + pieceLen,
+		NewFileSize:       numSectors * SectorSize,
 		NewFileMerkleRoot: merkleRoot,
 		NewWindowStart:    rev.NewWindowStart,
 		NewWindowEnd:      rev.NewWindowEnd,
 		NewValidProofOutputs: []types.SiacoinOutput{
-			// less returned to renter
-			{Value: rev.NewValidProofOutputs[0].Value.Sub(piecePrice), UnlockHash: rev.NewValidProofOutputs[0].UnlockHash},
-			// more given to host
-			{Value: rev.NewValidProofOutputs[1].Value.Add(piecePrice), UnlockHash: rev.NewValidProofOutputs[1].UnlockHash},
+			{Value: valid0, UnlockHash: rev.NewValidProofOutputs[0].UnlockHash},
+			{Value: valid1, UnlockHash: rev.NewValidProofOutputs[1].UnlockHash},
 		},
 		NewMissedProofOutputs: []types.SiacoinOutput{
-			// less returned to renter
-			{Value: rev.NewMissedProofOutputs[0].Value.Sub(piecePrice), UnlockHash: rev.NewMissedProofOutputs[0].UnlockHash},
-			// more given to void
-			{Value: rev.NewMissedProofOutputs[1].Value.Add(piecePrice), UnlockHash: rev.NewMissedProofOutputs[1].UnlockHash},
+			{Value: missed0, UnlockHash: rev.NewMissedProofOutputs[0].UnlockHash},
+			{Value: missed1, UnlockHash: rev.NewMissedProofOutputs[1].UnlockHash},
 		},
 		NewUnlockHash: rev.NewUnlockHash,
 	}

--- a/modules/renter/contractor/revise.go
+++ b/modules/renter/contractor/revise.go
@@ -56,7 +56,8 @@ func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey 
 	return signedHostTxn, nil
 }
 
-// newRevision revises the current revision to incorporate new data.
+// newRevision revises the current revision to cover a different number of
+// sectors.
 func newRevision(rev types.FileContractRevision, merkleRoot crypto.Hash, numSectors uint64, sectorPrice types.Currency) types.FileContractRevision {
 	// move safely moves n coins from src to dest, avoiding negative currency
 	// panics. The new values of src and dest are returned.

--- a/modules/renter/contractor/revise.go
+++ b/modules/renter/contractor/revise.go
@@ -74,7 +74,7 @@ func newRevision(rev types.FileContractRevision, merkleRoot crypto.Hash, numSect
 		missed0 = rev.NewMissedProofOutputs[0].Value
 		missed1 = rev.NewMissedProofOutputs[1].Value
 	)
-	curSectors := rev.NewFileSize / SectorSize
+	curSectors := rev.NewFileSize / modules.SectorSize
 	if numSectors > curSectors {
 		diffPrice := sectorPrice.Mul(types.NewCurrency64(numSectors - curSectors))
 		// move valid payout from renter to host
@@ -93,7 +93,7 @@ func newRevision(rev types.FileContractRevision, merkleRoot crypto.Hash, numSect
 		ParentID:          rev.ParentID,
 		UnlockConditions:  rev.UnlockConditions,
 		NewRevisionNumber: rev.NewRevisionNumber + 1,
-		NewFileSize:       numSectors * SectorSize,
+		NewFileSize:       numSectors * modules.SectorSize,
 		NewFileMerkleRoot: merkleRoot,
 		NewWindowStart:    rev.NewWindowStart,
 		NewWindowEnd:      rev.NewWindowEnd,

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -29,4 +29,6 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 		// reset the spentPeriod metric
 		c.spentPeriod = types.ZeroCurrency
 	}
+
+	c.lastChange = cc.ID
 }

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -26,5 +26,7 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	if c.blockHeight+c.allowance.RenewWindow >= c.renewHeight {
 		c.renewHeight += c.allowance.Period
 		go c.threadedRenewContracts(c.allowance, c.renewHeight)
+		// reset the spentPeriod metric
+		c.spentPeriod = types.ZeroCurrency
 	}
 }

--- a/modules/renter/contractor/upload_test.go
+++ b/modules/renter/contractor/upload_test.go
@@ -83,7 +83,7 @@ func TestEditor(t *testing.T) {
 	}
 
 	// give contract more value; it should be valid now
-	contract.LastRevision.NewValidProofOutputs[0].Value = types.NewCurrency64(SectorSize * 500)
+	contract.LastRevision.NewValidProofOutputs[0].Value = types.NewCurrency64(modules.SectorSize * 500)
 
 	// contract with unresponsive host
 	c.dialer = editorDialer(func() (net.Conn, error) {

--- a/modules/renter/contractor/upload_test.go
+++ b/modules/renter/contractor/upload_test.go
@@ -14,10 +14,10 @@ import (
 // editorHostDB is used to test the Editor method.
 type editorHostDB struct {
 	stubHostDB
-	hosts map[modules.NetAddress]modules.HostExternalSettings
+	hosts map[modules.NetAddress]modules.HostDBEntry
 }
 
-func (hdb editorHostDB) Host(addr modules.NetAddress) (modules.HostExternalSettings, bool) {
+func (hdb editorHostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, bool) {
 	h, ok := hdb.hosts[addr]
 	return h, ok
 }
@@ -33,7 +33,7 @@ func (dial editorDialer) DialTimeout(addr modules.NetAddress, timeout time.Durat
 func TestEditor(t *testing.T) {
 	// use a mock hostdb to supply hosts
 	hdb := &editorHostDB{
-		hosts: make(map[modules.NetAddress]modules.HostExternalSettings),
+		hosts: make(map[modules.NetAddress]modules.HostDBEntry),
 	}
 	c := &Contractor{
 		hdb: hdb,
@@ -54,14 +54,24 @@ func TestEditor(t *testing.T) {
 	c.blockHeight = 0
 
 	// expensive host
-	hdb.hosts["foo"] = modules.HostExternalSettings{ContractPrice: types.NewCurrency64(^uint64(0))}
+	hostSecretKey, hostPublicKey := crypto.GenerateKeyPairDeterministic([32]byte{})
+	dbe := modules.HostDBEntry{
+		PublicKey: types.SiaPublicKey{
+			Algorithm: types.SignatureEd25519,
+			Key:       hostPublicKey[:],
+		},
+	}
+	dbe.AcceptingContracts = true
+	dbe.ContractPrice = types.NewCurrency64(^uint64(0))
+	hdb.hosts["foo"] = dbe
 	_, err = c.Editor(Contract{IP: "foo"})
 	if err == nil {
 		t.Error("expected error, got nil")
 	}
 
 	// invalid contract
-	hdb.hosts["bar"] = modules.HostExternalSettings{ContractPrice: types.NewCurrency64(500)}
+	dbe.ContractPrice = types.NewCurrency64(500)
+	hdb.hosts["bar"] = dbe
 	_, err = c.Editor(Contract{IP: "bar"})
 	if err == nil {
 		t.Error("expected error, got nil")
@@ -126,8 +136,16 @@ func TestEditor(t *testing.T) {
 		// create an in-memory conn and spawn a goroutine to handle our half
 		ourConn, theirConn := net.Pipe()
 		go func() {
+			// read specifier
 			encoding.ReadObject(ourConn, new(types.Specifier), types.SpecifierLen)
-			encoding.ReadObject(ourConn, new(types.FileContractID), crypto.HashSize)
+			// send settings
+			crypto.WriteSignedObject(ourConn, dbe.HostExternalSettings, hostSecretKey)
+			// read acceptance
+			encoding.ReadObject(ourConn, new(string), modules.MaxErrorSize)
+			// read contract ID
+			encoding.ReadObject(ourConn, new(types.FileContractID), 32)
+			// send transaction
+			encoding.WriteObject(ourConn, contract.LastRevisionTxn)
 			ourConn.Close()
 		}()
 		return theirConn, nil

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -90,6 +90,7 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*Ho
 		persist: p,
 		log:     l,
 
+		// TODO: should index by pubkey, not ip
 		activeHosts: make(map[modules.NetAddress]*hostNode),
 		allHosts:    make(map[modules.NetAddress]*hostEntry),
 		scanPool:    make(chan *hostEntry, scanPoolSize),

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -8,7 +8,8 @@ import (
 
 // A hostEntry represents a host on the network.
 type hostEntry struct {
-	modules.HostExternalSettings
+	modules.HostDBEntry
+
 	weight      types.Currency
 	reliability types.Currency
 	online      bool
@@ -19,7 +20,7 @@ type hostEntry struct {
 // put into the list of active hosts.
 //
 // TODO: Function should return an error.
-func (hdb *HostDB) insertHost(host modules.HostExternalSettings) {
+func (hdb *HostDB) insertHost(host modules.HostDBEntry) {
 	// Remove garbage hosts and local hosts.
 	if !host.NetAddress.IsValid() {
 		return
@@ -34,8 +35,8 @@ func (hdb *HostDB) insertHost(host modules.HostExternalSettings) {
 
 	// Create hostEntry and add to allHosts.
 	h := &hostEntry{
-		HostExternalSettings: host,
-		reliability:          DefaultReliability,
+		HostDBEntry: host,
+		reliability: DefaultReliability,
 	}
 	hdb.allHosts[host.NetAddress] = h
 
@@ -60,36 +61,36 @@ func (hdb *HostDB) removeHost(addr modules.NetAddress) error {
 
 // Host returns the HostSettings associated with the specified NetAddress. If
 // no matching host is found, Host returns false.
-func (hdb *HostDB) Host(addr modules.NetAddress) (modules.HostExternalSettings, bool) {
+func (hdb *HostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, bool) {
 	hdb.mu.RLock()
 	defer hdb.mu.RUnlock()
 	entry, ok := hdb.allHosts[addr]
 	if !ok || entry == nil {
-		return modules.HostExternalSettings{}, false
+		return modules.HostDBEntry{}, false
 	}
-	return entry.HostExternalSettings, true
+	return entry.HostDBEntry, true
 }
 
 // ActiveHosts returns the hosts that can be randomly selected out of the
 // hostdb.
-func (hdb *HostDB) ActiveHosts() (activeHosts []modules.HostExternalSettings) {
+func (hdb *HostDB) ActiveHosts() (activeHosts []modules.HostDBEntry) {
 	hdb.mu.RLock()
 	defer hdb.mu.RUnlock()
 
 	for _, node := range hdb.activeHosts {
-		activeHosts = append(activeHosts, node.hostEntry.HostExternalSettings)
+		activeHosts = append(activeHosts, node.hostEntry.HostDBEntry)
 	}
 	return
 }
 
 // AllHosts returns all of the hosts known to the hostdb, including the
 // inactive ones.
-func (hdb *HostDB) AllHosts() (allHosts []modules.HostExternalSettings) {
+func (hdb *HostDB) AllHosts() (allHosts []modules.HostDBEntry) {
 	hdb.mu.RLock()
 	defer hdb.mu.RUnlock()
 
 	for _, entry := range hdb.allHosts {
-		allHosts = append(allHosts, entry.HostExternalSettings)
+		allHosts = append(allHosts, entry.HostDBEntry)
 	}
 	return
 }
@@ -122,7 +123,5 @@ func (hdb *HostDB) IsOffline(addr modules.NetAddress) bool {
 	if h, ok := hdb.allHosts[addr]; ok {
 		return !h.online
 	}
-	// no record of the host; add it to the HostDB
-	hdb.insertHost(modules.HostExternalSettings{NetAddress: addr})
 	return false
 }

--- a/modules/renter/hostdb/update_test.go
+++ b/modules/renter/hostdb/update_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -11,8 +12,15 @@ import (
 
 // TestFindHostAnnouncements probes the findHostAnnouncements function
 func TestFindHostAnnouncements(t *testing.T) {
-	// Create a block with a host announcement.
-	announcement := append(modules.PrefixHostAnnouncement[:], encoding.Marshal(modules.HostAnnouncement{})...)
+	// Create a block with a valid host announcement.
+	var emptyKey crypto.PublicKey
+	announcement := encoding.MarshalAll(modules.PrefixHostAnnouncement, modules.HostAnnouncement{
+		IPAddress: "foo:1234",
+		PublicKey: types.SiaPublicKey{
+			Algorithm: types.SignatureEd25519,
+			Key:       emptyKey[:],
+		},
+	})
 	b := types.Block{
 		Transactions: []types.Transaction{
 			types.Transaction{
@@ -48,12 +56,14 @@ func TestReceiveConsensusSetUpdate(t *testing.T) {
 	hdb := bareHostDB()
 
 	// Put a host announcement into a block.
-	announceBytes := encoding.MarshalAll(
-		modules.PrefixHostAnnouncement,
-		modules.HostAnnouncement{
-			IPAddress: "foo:1234",
+	var emptyKey crypto.PublicKey
+	announceBytes := encoding.MarshalAll(modules.PrefixHostAnnouncement, modules.HostAnnouncement{
+		IPAddress: "foo:1234",
+		PublicKey: types.SiaPublicKey{
+			Algorithm: types.SignatureEd25519,
+			Key:       emptyKey[:],
 		},
-	)
+	})
 	cc := modules.ConsensusChange{
 		AppliedBlocks: []types.Block{{
 			Transactions: []types.Transaction{{

--- a/modules/renter/hostdb/weightedlist.go
+++ b/modules/renter/hostdb/weightedlist.go
@@ -159,7 +159,7 @@ func (hdb *HostDB) isEmpty() bool {
 // may even be 0. The hosts that get returned first have the higher priority.
 // Hosts specified in 'ignore' will not be considered; pass 'nil' if no
 // blacklist is desired.
-func (hdb *HostDB) RandomHosts(n int, ignore []modules.NetAddress) (hosts []modules.HostExternalSettings) {
+func (hdb *HostDB) RandomHosts(n int, ignore []modules.NetAddress) (hosts []modules.HostDBEntry) {
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
 	if hdb.isEmpty() {
@@ -191,7 +191,7 @@ func (hdb *HostDB) RandomHosts(n int, ignore []modules.NetAddress) (hosts []modu
 		if err != nil {
 			break
 		}
-		hosts = append(hosts, node.hostEntry.HostExternalSettings)
+		hosts = append(hosts, node.hostEntry.HostDBEntry)
 
 		node.removeNode()
 		delete(hdb.activeHosts, node.hostEntry.NetAddress)

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -99,11 +99,13 @@ func TestWeightedList(t *testing.T) {
 	}
 
 	// Create a bunch of host entries of equal weight.
+	var dbe modules.HostDBEntry
 	firstInsertions := 64
 	for i := 0; i < firstInsertions; i++ {
+		dbe.NetAddress = fakeAddr(uint8(i))
 		entry := hostEntry{
-			HostExternalSettings: modules.HostExternalSettings{NetAddress: fakeAddr(uint8(i))},
-			weight:               types.NewCurrency64(10),
+			HostDBEntry: dbe,
+			weight:      types.NewCurrency64(10),
 		}
 		hdb.insertNode(&entry)
 	}
@@ -146,9 +148,10 @@ func TestWeightedList(t *testing.T) {
 	// Do some more insertions.
 	secondInsertions := 64
 	for i := firstInsertions; i < firstInsertions+secondInsertions; i++ {
+		dbe.NetAddress = fakeAddr(uint8(i))
 		entry := hostEntry{
-			HostExternalSettings: modules.HostExternalSettings{NetAddress: fakeAddr(uint8(i))},
-			weight:               types.NewCurrency64(10),
+			HostDBEntry: dbe,
+			weight:      types.NewCurrency64(10),
 		}
 		hdb.insertNode(&entry)
 	}
@@ -173,13 +176,15 @@ func TestVariedWeights(t *testing.T) {
 	// insert i hosts with the weights 0, 1, ..., i-1. 100e3 selections will be made
 	// per weight added to the tree, the total number of selections necessary
 	// will be tallied up as hosts are created.
+	var dbe modules.HostDBEntry
 	hostCount := 5
 	expectedPerWeight := int(10e3)
 	selections := 0
 	for i := 0; i < hostCount; i++ {
+		dbe.NetAddress = fakeAddr(uint8(i))
 		entry := hostEntry{
-			HostExternalSettings: modules.HostExternalSettings{NetAddress: fakeAddr(uint8(i))},
-			weight:               types.NewCurrency64(uint64(i)),
+			HostDBEntry: dbe,
+			weight:      types.NewCurrency64(uint64(i)),
 		}
 		hdb.insertNode(&entry)
 		selections += i * expectedPerWeight
@@ -229,9 +234,11 @@ func TestRepeatInsert(t *testing.T) {
 		scanPool:    make(chan *hostEntry, scanPoolSize),
 	}
 
+	var dbe modules.HostDBEntry
+	dbe.NetAddress = fakeAddr(0)
 	entry1 := hostEntry{
-		HostExternalSettings: modules.HostExternalSettings{NetAddress: fakeAddr(0)},
-		weight:               types.NewCurrency64(1),
+		HostDBEntry: dbe,
+		weight:      types.NewCurrency64(1),
 	}
 	entry2 := entry1
 	hdb.insertNode(&entry1)
@@ -276,17 +283,21 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Insert 3 hosts to be selected.
+	var dbe modules.HostDBEntry
+	dbe.NetAddress = fakeAddr(1)
 	entry1 := hostEntry{
-		HostExternalSettings: modules.HostExternalSettings{NetAddress: fakeAddr(1)},
-		weight:               types.NewCurrency64(1),
+		HostDBEntry: dbe,
+		weight:      types.NewCurrency64(1),
 	}
+	dbe.NetAddress = fakeAddr(2)
 	entry2 := hostEntry{
-		HostExternalSettings: modules.HostExternalSettings{NetAddress: fakeAddr(2)},
-		weight:               types.NewCurrency64(2),
+		HostDBEntry: dbe,
+		weight:      types.NewCurrency64(2),
 	}
+	dbe.NetAddress = fakeAddr(3)
 	entry3 := hostEntry{
-		HostExternalSettings: modules.HostExternalSettings{NetAddress: fakeAddr(3)},
-		weight:               types.NewCurrency64(3),
+		HostDBEntry: dbe,
+		weight:      types.NewCurrency64(3),
 	}
 	hdb.insertNode(&entry1)
 	hdb.insertNode(&entry2)

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -14,10 +14,10 @@ import (
 type hostDB interface {
 	// ActiveHosts returns the list of hosts that are actively being selected
 	// from.
-	ActiveHosts() []modules.HostExternalSettings
+	ActiveHosts() []modules.HostDBEntry
 
 	// AllHosts returns the full list of hosts known to the hostdb.
-	AllHosts() []modules.HostExternalSettings
+	AllHosts() []modules.HostDBEntry
 
 	// AveragePrice returns the average price of a host.
 	AveragePrice() types.Currency
@@ -116,8 +116,8 @@ func New(cs modules.ConsensusSet, wallet modules.Wallet, tpool modules.Transacti
 }
 
 // hostdb passthroughs
-func (r *Renter) ActiveHosts() []modules.HostExternalSettings { return r.hostDB.ActiveHosts() }
-func (r *Renter) AllHosts() []modules.HostExternalSettings    { return r.hostDB.AllHosts() }
+func (r *Renter) ActiveHosts() []modules.HostDBEntry { return r.hostDB.ActiveHosts() }
+func (r *Renter) AllHosts() []modules.HostDBEntry    { return r.hostDB.AllHosts() }
 
 // contractor passthroughs
 func (r *Renter) Allowance() modules.Allowance           { return r.hostContractor.Allowance() }

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -103,10 +103,10 @@ func newRenterTester(name string) (*renterTester, error) {
 // of the hostDB's methods on every mock.
 type stubHostDB struct{}
 
-func (stubHostDB) ActiveHosts() []modules.HostExternalSettings { return nil }
-func (stubHostDB) AllHosts() []modules.HostExternalSettings    { return nil }
-func (stubHostDB) AveragePrice() types.Currency                { return types.Currency{} }
-func (stubHostDB) IsOffline(modules.NetAddress) bool           { return true }
+func (stubHostDB) ActiveHosts() []modules.HostDBEntry { return nil }
+func (stubHostDB) AllHosts() []modules.HostDBEntry    { return nil }
+func (stubHostDB) AveragePrice() types.Currency       { return types.Currency{} }
+func (stubHostDB) IsOffline(modules.NetAddress) bool  { return true }
 
 // stubContractor is the minimal implementation of the hostContractor
 // interface.


### PR DESCRIPTION
The protocol code is almost ready, but not quite. There is some tricky signature stuff that I wasn't comfortable implementing on my own.

This PR also adds some spending metrics, and persistent subscription.

Not yet implemented:
- If the connection drops during revision, the renter should immediately attempt to reconnect and resend the last action.
- Need to figure out how host pubkeys should be handled by the hostdb. Right now I'm just assuming a `PublicKey` field in the host settings.
- The contract protocol should be documented extensively somewhere, perhaps in the doc folder. We wrote it down earlier so it shouldn't be hard to convert to a more readable format.