### PR TITLE
Make tests that often take >3s long tests

### DIFF
--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -259,6 +259,10 @@ func (g *mockGatewayCountBroadcasts) Broadcast(name string, obj interface{}, pee
 // Broadcasts one block, no matter how many blocks are sent. In the case 0
 // blocks are sent, tests that Broadcast is never called.
 func TestSendBlocksBroadcastsOnce(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// Setup consensus sets.
 	cst1, err := blankConsensusSetTester("TestSendBlocksBroadcastsOnce1")
 	if err != nil {

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -369,13 +369,13 @@ func TestCallingRPCFromRPC(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected FOO RPC to be called")
 	}
 
 	select {
 	case <-barChan:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected BAR RPC to be called")
 	}
 }


### PR DESCRIPTION
And adjust some `time.After` constants that are too short for slow Travis

This should fix most of the non-deterministic test failing I've been seeing recently.