### PR TITLE
Fix Close bugs

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -120,7 +120,11 @@ func (srv *Server) Close() error {
 			errStrs = append(errStrs, fmt.Sprintf("explorer err: %v", err))
 		}
 	}
-	// TODO: close miner
+	if srv.miner != nil {
+		if err := srv.miner.Close(); err != nil {
+			errStrs = append(errStrs, fmt.Sprintf("miner err: %v", err))
+		}
+	}
 	if srv.wallet != nil {
 		// TODO: close wallet and lock the wallet in the wallet's Close method.
 		if srv.wallet.Unlocked() {

--- a/api/server.go
+++ b/api/server.go
@@ -76,14 +76,20 @@ func (srv *Server) Serve() error {
 	}
 
 	// safely close each module
+	if srv.host != nil {
+		srv.host.Close()
+	}
+	if srv.explorer != nil {
+		srv.explorer.Close()
+	}
+	if srv.wallet != nil {
+		srv.wallet.Lock()
+	}
 	if srv.cs != nil {
 		srv.cs.Close()
 	}
 	if srv.gateway != nil {
 		srv.gateway.Close()
-	}
-	if srv.wallet != nil {
-		srv.wallet.Lock()
 	}
 
 	return nil

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -54,10 +54,15 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 
 		server: srv,
 	}
+	errChan := make(chan error)
 	go func() {
 		listenErr := srv.Serve()
-		if listenErr != nil {
-			t.Fatal("API server quit:", listenErr)
+		errChan <- listenErr
+	}()
+	defer func() {
+		err := <-errChan
+		if err != nil {
+			t.Fatalf("API server quit: %v", err)
 		}
 	}()
 	defer st.server.Close()

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -68,7 +68,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 		t.Fatal(err)
 	}
 	if wg.Encrypted {
-		t.Error("Wallet has never been unlocked")
+		t.Error("Wallet has never been encrypted")
 	}
 	if wg.Unlocked {
 		t.Error("Wallet has never been unlocked")
@@ -240,7 +240,7 @@ func TestIntegrationWalletTransactionGETid(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestIntegrationWalletGETSiacoins")
+	st, err := createServerTester("TestIntegrationWalletTransactionGETid")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/build/errors.go
+++ b/build/errors.go
@@ -1,0 +1,23 @@
+package build
+
+import (
+	"errors"
+	"strings"
+)
+
+// JoinErrors concatenates the elements of errs to create a single error. The
+// separator string sep is placed between elements in the resulting error. Nil
+// errors are skipped. If errs is empty or only contains nil elements,
+// JoinErrors returns nil.
+func JoinErrors(errs []error, sep string) error {
+	var strs []string
+	for _, err := range errs {
+		if err != nil {
+			strs = append(strs, err.Error())
+		}
+	}
+	if len(strs) > 0 {
+		return errors.New(strings.Join(strs, sep))
+	}
+	return nil
+}

--- a/build/errors_test.go
+++ b/build/errors_test.go
@@ -1,0 +1,64 @@
+package build
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestJoinErrors tests that JoinErrors only returns non-nil when there are
+// non-nil elements in errs. And tests that the returned error's string the
+// concatenation of all the strings of the elements in errs, in order and
+// separated by sep.
+func TestJoinErrors(t *testing.T) {
+	tests := []struct {
+		errs       []error
+		sep        string
+		wantNil    bool
+		errStrWant string
+	}{
+		// Test that JoinErrors returns nil when errs is nil.
+		{
+			wantNil: true,
+		},
+		// Test that JoinErrors returns nil when errs is an empty slice.
+		{
+			errs:    []error{},
+			wantNil: true,
+		},
+		// Test that JoinErrors returns nil when errs has only nil elements.
+		{
+			errs:    []error{nil},
+			wantNil: true,
+		},
+		{
+			errs:    []error{nil, nil, nil},
+			wantNil: true,
+		},
+		// Test that JoinErrors returns non-nil with the expected string when errs has only one non-nil element.
+		{
+			errs:       []error{errors.New("foo")},
+			sep:        ";",
+			errStrWant: "foo",
+		},
+		// Test that JoinErrors returns non-nil with the expected string when errs has multiple non-nil elements.
+		{
+			errs:       []error{errors.New("foo"), errors.New("bar"), errors.New("baz")},
+			sep:        ";",
+			errStrWant: "foo;bar;baz",
+		},
+		// Test that nil errors are ignored.
+		{
+			errs:       []error{nil, errors.New("foo"), nil, nil, nil, errors.New("bar"), errors.New("baz"), nil, nil, nil},
+			sep:        ";",
+			errStrWant: "foo;bar;baz",
+		},
+	}
+	for _, tt := range tests {
+		err := JoinErrors(tt.errs, tt.sep)
+		if tt.wantNil && err != nil {
+			t.Errorf("expected nil error, got '%v'", err)
+		} else if err != nil && err.Error() != tt.errStrWant {
+			t.Errorf("expected '%v', got '%v'", tt.errStrWant, err)
+		}
+	}
+}

--- a/modules/gateway/persist.go
+++ b/modules/gateway/persist.go
@@ -1,12 +1,17 @@
 package gateway
 
 import (
-	"log"
-	"os"
 	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
+)
+
+const (
+	// nodesFile is the name of the file that contains all seen nodes.
+	nodesFile = "nodes.json"
+	// logFile is the name of the log file.
+	logFile = modules.GatewayDir + ".log"
 )
 
 var persistMetadata = persist.Metadata{
@@ -19,12 +24,12 @@ func (g *Gateway) save() error {
 	for node := range g.nodes {
 		nodes = append(nodes, node)
 	}
-	return persist.SaveFile(persistMetadata, nodes, filepath.Join(g.persistDir, "nodes.json"))
+	return persist.SaveFile(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile))
 }
 
 func (g *Gateway) load() error {
 	var nodes []modules.NetAddress
-	err := persist.LoadFile(persistMetadata, &nodes, filepath.Join(g.persistDir, "nodes.json"))
+	err := persist.LoadFile(persistMetadata, &nodes, filepath.Join(g.persistDir, nodesFile))
 	if err != nil {
 		return err
 	}
@@ -32,13 +37,4 @@ func (g *Gateway) load() error {
 		g.addNode(node)
 	}
 	return nil
-}
-
-func makeLogger(persistDir string) (*log.Logger, error) {
-	// if the log file already exists, append to it
-	logFile, err := os.OpenFile(filepath.Join(persistDir, "gateway.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
-	if err != nil {
-		return nil, err
-	}
-	return log.New(logFile, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile), nil
 }

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	// logFile establishes the name of the file that gets used for logging.
+	// settingsFile is the name of the file that stores host settings.
 	settingsFile = "settings.json"
-	logFile      = modules.HostDir + ".log"
+	// logFile establishes the name of the file that gets used for logging.
+	logFile = modules.HostDir + ".log"
 )
 
 // persistMetadata is the header that gets written to the persist file, and is

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -1,6 +1,8 @@
 package modules
 
 import (
+	"io"
+
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -71,4 +73,5 @@ type TestMiner interface {
 type Miner interface {
 	BlockManager
 	CPUMiner
+	io.Closer
 }

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-var (
+const (
 	// RenterDir is the name of the directory that is used to store the
 	// renter's persistent data.
 	RenterDir = "renter"

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -6,13 +6,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -20,6 +20,7 @@ import (
 const (
 	PersistFilename = "renter.json"
 	ShareExtension  = ".sia"
+	logFile         = modules.RenterDir + ".log"
 )
 
 var (
@@ -403,12 +404,10 @@ func (r *Renter) initPersist() error {
 	}
 
 	// Initialize the logger.
-	logFile, err := os.OpenFile(filepath.Join(r.persistDir, "renter.log"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
+	r.log, err = persist.NewLogger(filepath.Join(r.persistDir, logFile))
 	if err != nil {
 		return err
 	}
-	r.log = log.New(logFile, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
-	r.log.Println("STARTUP: Renter has started logging")
 
 	// Load the prior persistance structures.
 	err = r.load()

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -1,10 +1,9 @@
 package renter
 
 import (
-	"log"
-
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/hostdb"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -56,7 +55,7 @@ type Renter struct {
 
 	// resources
 	hostDB hostDB
-	log    *log.Logger
+	log    *persist.Logger
 
 	// variables
 	files         map[string]*file

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"crypto/rand"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -77,19 +76,6 @@ func (w *Wallet) saveSettings() error {
 	return persist.SaveFile(settingsMetadata, w.persist, filepath.Join(w.persistDir, settingsFile))
 }
 
-// initLog begins logging the wallet, appending to any existing wallet file and
-// writing a startup message to indicate that a new logging instance has been
-// created.
-func (w *Wallet) initLog() error {
-	logFile, err := os.OpenFile(filepath.Join(w.persistDir, logFile), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
-	if err != nil {
-		return err
-	}
-	w.log = log.New(logFile, "", modules.LogSettings)
-	w.log.Println("STARTUP: Wallet logging has started.")
-	return nil
-}
-
 // initSettings creates the settings object at startup. If a settings file
 // exists, the settings file will be loaded into memory. If the settings file
 // does not exist, a new.persist file will be created.
@@ -122,7 +108,7 @@ func (w *Wallet) initPersist() error {
 	}
 
 	// Start logging.
-	err = w.initLog()
+	w.log, err = persist.NewLogger(filepath.Join(w.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -2,12 +2,12 @@ package wallet
 
 import (
 	"errors"
-	"log"
 	"sort"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -93,7 +93,7 @@ type Wallet struct {
 	historicClaimStarts map[types.SiafundOutputID]types.Currency
 
 	persistDir string
-	log        *log.Logger
+	log        *persist.Logger
 	mu         sync.RWMutex
 }
 


### PR DESCRIPTION
There were a few bugs pertaining to module closing that are fixed in this PR:
* module Close methods would return immediately on error instead of finishing cleanup
* not all modules were Closed on API shutdown
* the gateway did not disconnect from its peers on shutdown

and a few improvements:
* module Close errors are returned from `Server.Close` instead of `Server.Serve`
* `Server.Close` waits for `Server.Serve` to terminate before terminating itself. This ensures the server is completely shutdown when `Server.Close` is done.

Also, the gateway now uses `persist.Logger` instead of `log.Logger` to be consistent with other modules.

Closes #1015 