### PR TITLE
Proper HostDB persistence

### DIFF
--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -53,6 +53,7 @@ type HostDB struct {
 	scanPool chan *hostEntry
 
 	blockHeight types.BlockHeight
+	lastChange  modules.ConsensusChangeID
 
 	mu sync.RWMutex
 }
@@ -108,7 +109,12 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*Ho
 	}
 	go hdb.threadedScan()
 
-	err = cs.ConsensusSetPersistentSubscribe(hdb, modules.ConsensusChangeID{})
+	err = cs.ConsensusSetPersistentSubscribe(hdb, hdb.lastChange)
+	if err == modules.ErrInvalidConsensusChangeID {
+		hdb.lastChange = modules.ConsensusChangeID{}
+		// subscribe again using the new ID
+		err = cs.ConsensusSetPersistentSubscribe(hdb, hdb.lastChange)
+	}
 	if err != nil {
 		return nil, errors.New("hostdb subscription failed: " + err.Error())
 	}

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -112,6 +112,9 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*Ho
 	err = cs.ConsensusSetPersistentSubscribe(hdb, hdb.lastChange)
 	if err == modules.ErrInvalidConsensusChangeID {
 		hdb.lastChange = modules.ConsensusChangeID{}
+		// clear the host sets
+		hdb.activeHosts = make(map[modules.NetAddress]*hostNode)
+		hdb.allHosts = make(map[modules.NetAddress]*hostEntry)
 		// subscribe again using the new ID
 		err = cs.ConsensusSetPersistentSubscribe(hdb, hdb.lastChange)
 	}

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -10,9 +10,9 @@ import (
 type hostEntry struct {
 	modules.HostDBEntry
 
-	weight      types.Currency
-	reliability types.Currency
-	online      bool
+	Weight      types.Currency
+	Reliability types.Currency
+	Online      bool
 }
 
 // insert adds a host entry to the state. The host will be inserted into the
@@ -36,7 +36,7 @@ func (hdb *HostDB) insertHost(host modules.HostDBEntry) {
 	// Create hostEntry and add to allHosts.
 	h := &hostEntry{
 		HostDBEntry: host,
-		reliability: DefaultReliability,
+		Reliability: DefaultReliability,
 	}
 	hdb.allHosts[host.NetAddress] = h
 
@@ -121,7 +121,7 @@ func (hdb *HostDB) IsOffline(addr modules.NetAddress) bool {
 		return false
 	}
 	if h, ok := hdb.allHosts[addr]; ok {
-		return !h.online
+		return !h.Online
 	}
 	return false
 }

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -92,7 +92,7 @@ func TestAveragePrice(t *testing.T) {
 	h1 := new(hostEntry)
 	h1.NetAddress = "foo"
 	h1.ContractPrice = types.NewCurrency64(100)
-	h1.weight = baseWeight
+	h1.Weight = baseWeight
 	hdb.insertNode(h1)
 	if avg := hdb.AveragePrice(); avg.Cmp(h1.ContractPrice) != 0 {
 		t.Error("average of one host should be that host's price:", avg)
@@ -102,7 +102,7 @@ func TestAveragePrice(t *testing.T) {
 	h2 := new(hostEntry)
 	h2.NetAddress = "bar"
 	h2.ContractPrice = types.NewCurrency64(300)
-	h2.weight = baseWeight
+	h2.Weight = baseWeight
 	hdb.insertNode(h2)
 	if len(hdb.activeHosts) != 2 {
 		t.Error("host was not added:", hdb.activeHosts)
@@ -116,9 +116,9 @@ func TestAveragePrice(t *testing.T) {
 func TestIsOffline(t *testing.T) {
 	hdb := &HostDB{
 		allHosts: map[modules.NetAddress]*hostEntry{
-			"foo:1234": &hostEntry{online: true},
-			"bar:1234": &hostEntry{online: false},
-			"baz:1234": &hostEntry{online: true},
+			"foo:1234": &hostEntry{Online: true},
+			"bar:1234": &hostEntry{Online: false},
+			"baz:1234": &hostEntry{Online: true},
 		},
 		activeHosts: map[modules.NetAddress]*hostNode{
 			"foo:1234": nil,

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -2,15 +2,34 @@ package hostdb
 
 // hdbPersist defines what HostDB data persists across sessions.
 type hdbPersist struct {
-	// TODO: save hosts
+	AllHosts    []hostEntry
+	ActiveHosts []hostEntry
 }
 
 // save saves the hostdb persistence data to disk.
 func (hdb *HostDB) save() error {
-	return nil
+	var data hdbPersist
+	for _, entry := range hdb.allHosts {
+		data.AllHosts = append(data.AllHosts, *entry)
+	}
+	for _, node := range hdb.activeHosts {
+		data.ActiveHosts = append(data.ActiveHosts, *node.hostEntry)
+	}
+	return hdb.persist.save(data)
 }
 
 // load loads the hostdb persistence data from disk.
 func (hdb *HostDB) load() error {
+	var data hdbPersist
+	err := hdb.persist.load(&data)
+	if err != nil {
+		return err
+	}
+	for _, entry := range data.AllHosts {
+		hdb.allHosts[entry.NetAddress] = &entry
+	}
+	for _, entry := range data.ActiveHosts {
+		hdb.insertNode(&entry)
+	}
 	return nil
 }

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -1,9 +1,14 @@
 package hostdb
 
+import (
+	"github.com/NebulousLabs/Sia/modules"
+)
+
 // hdbPersist defines what HostDB data persists across sessions.
 type hdbPersist struct {
 	AllHosts    []hostEntry
 	ActiveHosts []hostEntry
+	LastChange  modules.ConsensusChangeID
 }
 
 // save saves the hostdb persistence data to disk.
@@ -15,6 +20,7 @@ func (hdb *HostDB) save() error {
 	for _, node := range hdb.activeHosts {
 		data.ActiveHosts = append(data.ActiveHosts, *node.hostEntry)
 	}
+	data.LastChange = hdb.lastChange
 	return hdb.persist.save(data)
 }
 
@@ -31,5 +37,6 @@ func (hdb *HostDB) load() error {
 	for _, entry := range data.ActiveHosts {
 		hdb.insertNode(&entry)
 	}
+	hdb.lastChange = data.LastChange
 	return nil
 }

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -2,6 +2,8 @@ package hostdb
 
 import (
 	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // memPersist implements the persister interface in-memory.
@@ -12,5 +14,55 @@ func (m memPersist) load(data *hdbPersist) error { *data = hdbPersist(m); return
 
 // TestSaveLoad tests that the hostdb can save and load itself.
 func TestSaveLoad(t *testing.T) {
-	t.Skip("host persistence not implemented")
+	// create hostdb with mocked persist dependency
+	hdb := bareHostDB()
+	hdb.persist = new(memPersist)
+
+	// add some fake hosts
+	var host1, host2, host3 hostEntry
+	host1.NetAddress = "foo"
+	host2.NetAddress = "bar"
+	host3.NetAddress = "baz"
+	hdb.allHosts = map[modules.NetAddress]*hostEntry{
+		host1.NetAddress: &host1,
+		host2.NetAddress: &host2,
+		host3.NetAddress: &host3,
+	}
+	hdb.activeHosts = map[modules.NetAddress]*hostNode{
+		host1.NetAddress: &hostNode{hostEntry: &host1},
+		host2.NetAddress: &hostNode{hostEntry: &host2},
+		host3.NetAddress: &hostNode{hostEntry: &host3},
+	}
+	hdb.lastChange = modules.ConsensusChangeID{1, 2, 3}
+
+	// save and reload
+	err := hdb.save()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = hdb.load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that LastChange was loaded
+	if hdb.lastChange != (modules.ConsensusChangeID{1, 2, 3}) {
+		t.Error("wrong consensus change ID was loaded:", hdb.lastChange)
+	}
+
+	// check that AllHosts was loaded
+	_, ok0 := hdb.allHosts[host1.NetAddress]
+	_, ok1 := hdb.allHosts[host2.NetAddress]
+	_, ok2 := hdb.allHosts[host3.NetAddress]
+	if !ok0 || !ok1 || !ok2 || len(hdb.allHosts) != 3 {
+		t.Fatal("allHosts was not restored properly:", hdb.allHosts)
+	}
+
+	// check that ActiveHosts was loaded
+	_, ok0 = hdb.activeHosts[host1.NetAddress]
+	_, ok1 = hdb.activeHosts[host2.NetAddress]
+	_, ok2 = hdb.activeHosts[host3.NetAddress]
+	if !ok0 || !ok1 || !ok2 || len(hdb.activeHosts) != 3 {
+		t.Fatal("active was not restored properly:", hdb.activeHosts)
+	}
 }

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -59,8 +59,8 @@ func (hdb *HostDB) decrementReliability(addr modules.NetAddress, penalty types.C
 		// TODO: should panic here
 		return
 	}
-	entry.reliability = entry.reliability.Sub(penalty)
-	entry.online = false
+	entry.Reliability = entry.Reliability.Sub(penalty)
+	entry.Online = false
 
 	// If the entry is in the active database, remove it from the active
 	// database.
@@ -72,7 +72,7 @@ func (hdb *HostDB) decrementReliability(addr modules.NetAddress, penalty types.C
 
 	// If the reliability has fallen to 0, remove the host from the
 	// database entirely.
-	if entry.reliability.IsZero() {
+	if entry.Reliability.IsZero() {
 		delete(hdb.allHosts, addr)
 	}
 }
@@ -120,9 +120,9 @@ func (hdb *HostDB) threadedProbeHosts() {
 			// must be preserved.
 			settings.NetAddress = hostEntry.HostExternalSettings.NetAddress
 			hostEntry.HostExternalSettings = settings
-			hostEntry.reliability = MaxReliability
-			hostEntry.weight = calculateHostWeight(*hostEntry)
-			hostEntry.online = true
+			hostEntry.Reliability = MaxReliability
+			hostEntry.Weight = calculateHostWeight(*hostEntry)
+			hostEntry.Online = true
 
 			// If 'maxActiveHosts' has not been reached, add the host to the
 			// activeHosts tree.

--- a/modules/renter/hostdb/scan_test.go
+++ b/modules/renter/hostdb/scan_test.go
@@ -24,7 +24,7 @@ func TestDecrementReliability(t *testing.T) {
 	// from activeHosts.
 	h := new(hostEntry)
 	h.NetAddress = "foo"
-	h.reliability = types.NewCurrency64(1)
+	h.Reliability = types.NewCurrency64(1)
 	hdb.allHosts[h.NetAddress] = h
 	hdb.activeHosts[h.NetAddress] = &hostNode{hostEntry: h}
 	hdb.decrementReliability(h.NetAddress, types.NewCurrency64(0))
@@ -33,7 +33,7 @@ func TestDecrementReliability(t *testing.T) {
 	}
 
 	// Decrement reliability to 0. This should remove the host from allHosts.
-	hdb.decrementReliability(h.NetAddress, h.reliability)
+	hdb.decrementReliability(h.NetAddress, h.Reliability)
 	if len(hdb.AllHosts()) != 0 {
 		t.Error("decrementing did not remove host from allHosts")
 	}
@@ -63,7 +63,7 @@ func TestThreadedProbeHosts(t *testing.T) {
 		Algorithm: types.SignatureEd25519,
 		Key:       pk[:],
 	}
-	h.reliability = baseWeight // enough to withstand a few failures
+	h.Reliability = baseWeight // enough to withstand a few failures
 
 	// define a helper function for running threadedProbeHosts. We send the
 	// hostEntry, close the channel, and then call threadedProbeHosts.
@@ -132,7 +132,7 @@ func TestThreadedScan(t *testing.T) {
 	// create a host to be scanned
 	h := new(hostEntry)
 	h.NetAddress = "foo"
-	h.reliability = types.NewCurrency64(1)
+	h.Reliability = types.NewCurrency64(1)
 	hdb.activeHosts[h.NetAddress] = &hostNode{hostEntry: h}
 
 	// perform one scan

--- a/modules/renter/hostdb/weightedlist.go
+++ b/modules/renter/hostdb/weightedlist.go
@@ -43,7 +43,7 @@ type hostNode struct {
 func createNode(parent *hostNode, entry *hostEntry) *hostNode {
 	return &hostNode{
 		parent: parent,
-		weight: entry.weight,
+		weight: entry.Weight,
 		count:  1,
 
 		taken:     true,
@@ -82,12 +82,12 @@ func (hn *hostNode) nodeAtWeight(weight types.Currency) (*hostNode, error) {
 	return hn, nil
 }
 
-// recursiveInsert is a recurisve function for adding a hostNode to an existing tree
+// recursiveInsert is a recursive function for adding a hostNode to an existing tree
 // of hostNodes. The first call should always be on hostdb.hostTree. Running
 // time of recursiveInsert is log(n) in the maximum number of elements that have
 // ever been in the tree.
 func (hn *hostNode) recursiveInsert(entry *hostEntry) (nodesAdded int, newNode *hostNode) {
-	hn.weight = hn.weight.Add(entry.weight)
+	hn.weight = hn.weight.Add(entry.Weight)
 
 	// If the current node is empty, add the entry but don't increase the
 	// count.
@@ -118,7 +118,7 @@ func (hn *hostNode) recursiveInsert(entry *hostEntry) (nodesAdded int, newNode *
 }
 
 // insertNode inserts a host entry into the host tree, removing
-// any conflicts. The host settings are assummed to be correct. Though hosts
+// any conflicts. The host settings are assumed to be correct. Though hosts
 // with 0 weight will never be selected, they are accepted into the tree.
 func (hdb *HostDB) insertNode(entry *hostEntry) {
 	// If there's already a host of the same id, remove that host.
@@ -140,11 +140,11 @@ func (hdb *HostDB) insertNode(entry *hostEntry) {
 // remove takes a node and removes it from the tree by climbing through the
 // list of parents. remove does not delete nodes.
 func (hn *hostNode) removeNode() {
-	hn.weight = hn.weight.Sub(hn.hostEntry.weight)
+	hn.weight = hn.weight.Sub(hn.hostEntry.Weight)
 	hn.taken = false
 	current := hn.parent
 	for current != nil {
-		current.weight = current.weight.Sub(hn.hostEntry.weight)
+		current.weight = current.weight.Sub(hn.hostEntry.Weight)
 		current = current.parent
 	}
 }

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -22,7 +22,7 @@ func fakeAddr(n uint8) modules.NetAddress {
 // every entropy has the same weight.
 func uniformTreeVerification(hdb *HostDB, numEntries int) error {
 	// Check that the weight of the hostTree is what is expected.
-	expectedWeight := types.NewCurrency64(uint64(numEntries)).Mul(hdb.hostTree.hostEntry.weight)
+	expectedWeight := types.NewCurrency64(uint64(numEntries)).Mul(hdb.hostTree.hostEntry.Weight)
 	if hdb.hostTree.weight.Cmp(expectedWeight) != 0 {
 		return errors.New("expected weight is incorrect")
 	}
@@ -105,7 +105,7 @@ func TestWeightedList(t *testing.T) {
 		dbe.NetAddress = fakeAddr(uint8(i))
 		entry := hostEntry{
 			HostDBEntry: dbe,
-			weight:      types.NewCurrency64(10),
+			Weight:      types.NewCurrency64(10),
 		}
 		hdb.insertNode(&entry)
 	}
@@ -151,7 +151,7 @@ func TestWeightedList(t *testing.T) {
 		dbe.NetAddress = fakeAddr(uint8(i))
 		entry := hostEntry{
 			HostDBEntry: dbe,
-			weight:      types.NewCurrency64(10),
+			Weight:      types.NewCurrency64(10),
 		}
 		hdb.insertNode(&entry)
 	}
@@ -184,7 +184,7 @@ func TestVariedWeights(t *testing.T) {
 		dbe.NetAddress = fakeAddr(uint8(i))
 		entry := hostEntry{
 			HostDBEntry: dbe,
-			weight:      types.NewCurrency64(uint64(i)),
+			Weight:      types.NewCurrency64(uint64(i)),
 		}
 		hdb.insertNode(&entry)
 		selections += i * expectedPerWeight
@@ -202,7 +202,7 @@ func TestVariedWeights(t *testing.T) {
 		if !exists {
 			t.Fatal("can't find randomly selected node in tree")
 		}
-		selectionMap[node.hostEntry.weight.String()]++
+		selectionMap[node.hostEntry.Weight.String()]++
 	}
 
 	// Check that each host was selected an expected number of times. An error
@@ -238,12 +238,12 @@ func TestRepeatInsert(t *testing.T) {
 	dbe.NetAddress = fakeAddr(0)
 	entry1 := hostEntry{
 		HostDBEntry: dbe,
-		weight:      types.NewCurrency64(1),
+		Weight:      types.NewCurrency64(1),
 	}
 	entry2 := entry1
 	hdb.insertNode(&entry1)
 
-	entry2.weight = types.NewCurrency64(100)
+	entry2.Weight = types.NewCurrency64(100)
 	hdb.insertNode(&entry2)
 	if len(hdb.activeHosts) != 1 {
 		t.Error("insterting the same entry twice should result in only 1 entry in the hostdb")
@@ -255,7 +255,7 @@ func TestNodeAtWeight(t *testing.T) {
 	// create hostTree
 	h1 := new(hostEntry)
 	h1.NetAddress = "foo"
-	h1.weight = baseWeight
+	h1.Weight = baseWeight
 	ht := createNode(nil, h1)
 
 	// overweight
@@ -287,17 +287,17 @@ func TestRandomHosts(t *testing.T) {
 	dbe.NetAddress = fakeAddr(1)
 	entry1 := hostEntry{
 		HostDBEntry: dbe,
-		weight:      types.NewCurrency64(1),
+		Weight:      types.NewCurrency64(1),
 	}
 	dbe.NetAddress = fakeAddr(2)
 	entry2 := hostEntry{
 		HostDBEntry: dbe,
-		weight:      types.NewCurrency64(2),
+		Weight:      types.NewCurrency64(2),
 	}
 	dbe.NetAddress = fakeAddr(3)
 	entry3 := hostEntry{
 		HostDBEntry: dbe,
-		weight:      types.NewCurrency64(3),
+		Weight:      types.NewCurrency64(3),
 	}
 	hdb.insertNode(&entry1)
 	hdb.insertNode(&entry2)


### PR DESCRIPTION
The HostDB should no longer rescan every host on startup.
This is important for the contractor to function well.