### PR TITLE
Consensus logging

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -237,8 +237,10 @@ func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 			if err == errFutureTimestamp {
 				go func() {
 					time.Sleep(time.Duration(b.Timestamp-(types.CurrentTimestamp()+types.FutureThreshold)) * time.Second)
-					// TODO: log error returned by AcceptBlock if non-nill
-					cs.AcceptBlock(b) // NOTE: Error is not handled.
+					err := cs.AcceptBlock(b)
+					if err != nil {
+						cs.log.Println("WARN: failed to accept a future block:", err)
+					}
 				}()
 			}
 			return err

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -239,7 +239,7 @@ func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 					time.Sleep(time.Duration(b.Timestamp-(types.CurrentTimestamp()+types.FutureThreshold)) * time.Second)
 					err := cs.AcceptBlock(b)
 					if err != nil {
-						cs.log.Println("WARN: failed to accept a future block:", err)
+						cs.log.Debugln("WARN: failed to accept a future block:", err)
 					}
 				}()
 			}

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -8,6 +8,7 @@ package consensus
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -65,6 +66,7 @@ type ConsensusSet struct {
 
 	// Utilities
 	db         *persist.BoltDatabase
+	log        *persist.Logger
 	persistDir string
 	mu         demotemutex.DemoteMutex
 }
@@ -176,7 +178,15 @@ func (cs *ConsensusSet) ChildTarget(id types.BlockID) (target types.Target, exis
 func (cs *ConsensusSet) Close() error {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	return cs.db.Close()
+
+	var errs []error
+	if err := cs.db.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("db.Close failed: %v", err))
+	}
+	if err := cs.log.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("log.Close failed: %v", err))
+	}
+	return build.JoinErrors(errs, "; ")
 }
 
 // CurrentBlock returns the latest block in the heaviest known blockchain.

--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
 
 	"github.com/NebulousLabs/bolt"
 )
@@ -13,7 +15,8 @@ import (
 const (
 	// DatabaseFilename contains the filename of the database that will be used
 	// when managing consensus.
-	DatabaseFilename = "consensus.db"
+	DatabaseFilename = modules.ConsensusDir + ".db"
+	logFile          = modules.ConsensusDir + ".log"
 )
 
 // loadDB pulls all the blocks that have been saved to disk into memory, using
@@ -55,6 +58,12 @@ func (cs *ConsensusSet) loadDB() error {
 func (cs *ConsensusSet) initPersist() error {
 	// Create the consensus directory.
 	err := os.MkdirAll(cs.persistDir, 0700)
+	if err != nil {
+		return err
+	}
+
+	// Initialize the logger.
+	cs.log, err = persist.NewLogger(filepath.Join(cs.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -331,7 +331,7 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 		go func() {
 			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
-				cs.log.Println("WARN: failed to get parents of orphan block:", err)
+				cs.log.Debugln("WARN: failed to get parents of orphan block:", err)
 			}
 		}()
 	}
@@ -362,7 +362,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 		go func() {
 			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
-				cs.log.Println("WARN: failed to get parents of orphan header:", err)
+				cs.log.Debugln("WARN: failed to get parents of orphan header:", err)
 			}
 		}()
 		return nil
@@ -374,7 +374,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	go func() {
 		err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlk", cs.threadedReceiveBlock(h.ID()))
 		if err != nil {
-			cs.log.Println("WARN: failed to get header's corresponding block:", err)
+			cs.log.Debugln("WARN: failed to get header's corresponding block:", err)
 		}
 	}()
 	return nil

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -443,8 +443,9 @@ func (cs *ConsensusSet) threadedInitialBlockchainDownload() {
 	// Set the deadline 10 minutes in the future. After this deadline, we will say
 	// IBD is done as long as there is at least one outbound peer synced.
 	deadline := time.Now().Add(minIBDWaitTime)
+	numOutboundSynced := 0
 	for {
-		numOutboundSynced := 0
+		numOutboundSynced = 0
 		for _, p := range cs.gateway.Peers() {
 			// We only sync on outbound peers at first to make IBD less susceptible to
 			// fast-mining and other attacks, as outbound peers are more difficult to
@@ -488,7 +489,7 @@ func (cs *ConsensusSet) threadedInitialBlockchainDownload() {
 		}
 	}
 
-	cs.log.Println("INFO: IBD done")
+	cs.log.Printf("INFO: IBD done, synced with %v peers", numOutboundSynced)
 }
 
 // Synced returns true if the consensus set is synced with the network.

--- a/persist/log.go
+++ b/persist/log.go
@@ -77,3 +77,27 @@ func (l *Logger) Critical(v ...interface{}) {
 	l.Print("CRITICAL:", fmt.Sprintln(v...))
 	build.Critical(v...)
 }
+
+// Debug is equivalent to Logger.Print when build.DEBUG is true. Otherwise it
+// is a no-op.
+func (l *Logger) Debug(v ...interface{}) {
+	if build.DEBUG {
+		l.Print(v...)
+	}
+}
+
+// Debug is equivalent to Logger.Printf when build.DEBUG is true. Otherwise it
+// is a no-op.
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	if build.DEBUG {
+		l.Printf(format, v...)
+	}
+}
+
+// Debug is equivalent to Logger.Println when build.DEBUG is true. Otherwise it
+// is a no-op.
+func (l *Logger) Debugln(v ...interface{}) {
+	if build.DEBUG {
+		l.Println(v...)
+	}
+}

--- a/persist/log_test.go
+++ b/persist/log_test.go
@@ -55,7 +55,7 @@ func TestLogger(t *testing.T) {
 // TestLoggerCritical prints a critical message from the logger.
 func TestLoggerCritical(t *testing.T) {
 	// Create a folder for the log file.
-	testdir := build.TempDir(persistDir, "TestLogger")
+	testdir := build.TempDir(persistDir, "TestLoggerCritical")
 	err := os.MkdirAll(testdir, 0700)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Adds basic logging to consensus. None of the logging statements are wrapped in a `if build.DEBUG` as they are all logging errors that should not occur frequently.