### PR TITLE
Shutdown API server only after /daemon/stop request completes

### DIFF
--- a/api/daemon.go
+++ b/api/daemon.go
@@ -106,5 +106,12 @@ func (srv *Server) daemonStopHandler(w http.ResponseWriter, _ *http.Request, _ h
 	// can't write after we stop the server, so lie a bit.
 	writeSuccess(w)
 
+	// need to flush the response before shutting down the server
+	f, ok := w.(http.Flusher)
+	if !ok {
+		panic("Server does not support flushing")
+	}
+	f.Flush()
+
 	srv.Close()
 }

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -21,3 +21,20 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("/daemon/version reporting bad version: expected %v, got %v", build.Version, dv.Version)
 	}
 }
+
+// TestStop tests the /daemon/stop handler.
+func TestStop(t *testing.T) {
+	st, err := createServerTester("TestStop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var success struct{ Success bool }
+	err = st.getAPI("/daemon/stop", &success)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.getAPI("/daemon/stop", &success)
+	if err == nil {
+		t.Fatal("after /daemon/stop, subsequent calls should fail")
+	}
+}


### PR DESCRIPTION
Without this change, `siac stop` will print `no response from daemon`, even though the daemon shuts down correctly.