### PR TITLE
misc IBD fixes

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -285,7 +285,7 @@ func (cs *ConsensusSet) AcceptBlock(b types.Block) error {
 	if err != nil {
 		return err
 	}
-	// Broadcast the block to all peers <= v0.5.1 and block header to all peers > v0.5.1.
+	// COMPATv0.5.1 - broadcast the block to all peers <= v0.5.1 and block header to all peers > v0.5.1.
 	var relayBlockPeers, relayHeaderPeers []modules.Peer
 	for _, p := range cs.gateway.Peers() {
 		if build.VersionCmp(p.Version, "0.5.1") <= 0 {

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -126,7 +126,7 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 
 		// Register RPCs
 		gateway.RegisterRPC("SendBlocks", cs.rpcSendBlocks)
-		gateway.RegisterRPC("RelayBlock", cs.rpcRelayBlock)
+		gateway.RegisterRPC("RelayBlock", cs.rpcRelayBlock) // COMPATv0.5.1
 		gateway.RegisterRPC("RelayHeader", cs.rpcRelayHeader)
 		gateway.RegisterRPC("SendBlk", cs.rpcSendBlk)
 		gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -156,7 +156,7 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) (returnErr 
 	// is to stop an attacker from preventing block broadcasts.
 	chainExtended := false
 	defer func() {
-		if chainExtended {
+		if chainExtended && cs.Synced() {
 			// The last block received will be the current block since
 			// managedAcceptBlock only returns nil if a block extends the longest chain.
 			currentBlock := cs.CurrentBlock()

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -160,7 +160,7 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) (returnErr 
 			// The last block received will be the current block since
 			// managedAcceptBlock only returns nil if a block extends the longest chain.
 			currentBlock := cs.CurrentBlock()
-			// Broadcast the block to all peers <= v0.5.1 and block header to all peers > v0.5.1
+			// COMPATv0.5.1 - broadcast the block to all peers <= v0.5.1 and block header to all peers > v0.5.1
 			var relayBlockPeers, relayHeaderPeers []modules.Peer
 			for _, p := range cs.gateway.Peers() {
 				if build.VersionCmp(p.Version, "0.5.1") <= 0 {
@@ -313,6 +313,7 @@ func (cs *ConsensusSet) rpcSendBlocks(conn modules.PeerConn) error {
 }
 
 // rpcRelayBlock is an RPC that accepts a block from a peer.
+// COMPATv0.5.1
 func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 	// Decode the block from the connection.
 	var b types.Block

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -448,7 +448,12 @@ func (cs *ConsensusSet) threadedInitialBlockchainDownload() {
 				numOutboundSynced++
 				continue
 			}
-			if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+			// TODO: Timeout errors returned by muxado do not conform to the net.Error
+			// interface and therefore we cannot check if the error is a timeout using
+			// the Timeout() method. Once muxado issue #14 is resolved change the below
+			// condition to:
+			//     if netErr, ok := returnErr.(net.Error); !ok || !netErr.Timeout() { ... }
+			if err.Error() != "Read timeout" && err.Error() != "Write timeout" {
 				// TODO: log the error returned by RPC.
 
 				// Disconnect if there is an unexpected error (not a timeout). This

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -236,7 +236,7 @@ func TestInitialBlockchainDownloadDisconnects(t *testing.T) {
 		errSendBlocksStalled,
 		// rpcErrs that should not cause a disconnect.
 		mockNetError{
-			error:   errors.New("mock timeout error"),
+			error:   errors.New("Read timeout"),
 			timeout: true,
 		},
 		// Need at least minNumOutbound peers that return nil for
@@ -347,7 +347,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	defer gatewayTimesout.Close()
 	mg.mu.Lock()
 	mg.rpcErrs[gatewayTimesout.Address()] = mockNetError{
-		error:   errors.New("mock timeout error"),
+		error:   errors.New("Read timeout"),
 		timeout: true,
 	}
 	mg.mu.Unlock()
@@ -390,7 +390,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 		defer tmpG.Close()
 		mg.mu.Lock()
 		mg.rpcErrs[tmpG.Address()] = mockNetError{
-			error:   errors.New("mock timeout error"),
+			error:   errors.New("Write timeout"),
 			timeout: true,
 		}
 		mg.mu.Unlock()

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -285,15 +285,60 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 	tests := []struct {
 		blocksToMine          int
 		expectedNumBroadcasts int
+		synced                bool
 	}{
-		{0, 0},
-		{1, 2},
-		{2, 2},
-		{int(MaxCatchUpBlocks), 2},
-		{2 * int(MaxCatchUpBlocks), 2},
-		{2*int(MaxCatchUpBlocks) + 1, 2},
+		// Test that no blocks are broadcast during IBD.
+		{
+			blocksToMine:          0,
+			expectedNumBroadcasts: 0,
+			synced:                false,
+		},
+		{
+			blocksToMine:          1,
+			expectedNumBroadcasts: 0,
+			synced:                false,
+		},
+		{
+			blocksToMine:          2,
+			expectedNumBroadcasts: 0,
+			synced:                false,
+		},
+		// Test that only one blocks is broadcast when IBD is done.
+		{
+			blocksToMine:          0,
+			expectedNumBroadcasts: 0,
+			synced:                true,
+		},
+		{
+			blocksToMine:          1,
+			expectedNumBroadcasts: 2,
+			synced:                true,
+		},
+		{
+			blocksToMine:          2,
+			expectedNumBroadcasts: 2,
+			synced:                true,
+		},
+		{
+			blocksToMine:          int(MaxCatchUpBlocks),
+			expectedNumBroadcasts: 2,
+			synced:                true,
+		},
+		{
+			blocksToMine:          2 * int(MaxCatchUpBlocks),
+			expectedNumBroadcasts: 2,
+			synced:                true,
+		},
+		{
+			blocksToMine:          2*int(MaxCatchUpBlocks) + 1,
+			expectedNumBroadcasts: 2,
+			synced:                true,
+		},
 	}
 	for _, test := range tests {
+		cst1.cs.mu.Lock()
+		cst1.cs.synced = test.synced
+		cst1.cs.mu.Unlock()
 		mg.mu.Lock()
 		mg.numBroadcasts = 0
 		mg.mu.Unlock()

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -290,6 +290,7 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 	// NOTE: The transaction set is only broadcast to v0.4.7 peers and above.
 	// v0.4.7-v0.5.1 broadcasted both transaction sets and individual transactions
 	// and those versions act as a bridge between v0.5.2+ and older versions.
+	// COMPATv0.4.6
 	var v047AndAbove []modules.Peer
 	for _, p := range tp.gateway.Peers() {
 		if build.VersionCmp(p.Version, "0.4.7") >= 0 {


### PR DESCRIPTION
Check for timeouts using muxado's timeout error instead of `net.Error.Timeout()`

Don't broadcast blocks in threadedReceiveBlocks during IBD. They are unnecessary and were caused by the frequent connection timeouts that are expected during IBD.

Also add a bunch of COMPAT comments that were previously missing.