### PR TITLE
Explorer Database

### DIFF
--- a/api/explorer.go
+++ b/api/explorer.go
@@ -317,6 +317,13 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
+	// TODO: lookups on the zero hash are too expensive to allow. Need a
+	// better way to handle this case.
+	if hash == (types.UnlockHash{}) {
+		writeError(w, "can't lookup the empty unlock hash", http.StatusBadRequest)
+		return
+	}
+
 	// Try the hash as an unlock hash. Unlock hash is checked last because
 	// unlock hashes do not have collision-free guarantees. Someone can create
 	// an unlock hash that collides with another object id. They will not be

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/NebulousLabs/Sia/encoding"
-	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/NebulousLabs/bolt"
@@ -152,38 +151,13 @@ func dbGetSiafundOutputTxnIDs(id types.SiafundOutputID, ids *[]types.Transaction
 
 // Internal bucket getters/setters
 
-// Set/Get block height
-func dbSetInternalBlockHeight(height types.BlockHeight) func(*bolt.Tx) error {
+func dbSetInternal(key []byte, val interface{}) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {
-		return tx.Bucket(bucketInternal).Put(internalBlockHeight, encoding.Marshal(height))
+		return tx.Bucket(bucketInternal).Put(key, encoding.Marshal(val))
 	}
 }
-func dbGetInternalBlockHeight(height *types.BlockHeight) func(*bolt.Tx) error {
+func dbGetInternal(key []byte, val interface{}) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {
-		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalBlockHeight), height)
-	}
-}
-
-// Set/Get recent change
-func dbSetInternalRecentChange(id modules.ConsensusChangeID) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return tx.Bucket(bucketInternal).Put(internalRecentChange, encoding.Marshal(id))
-	}
-}
-func dbGetInternalRecentChange(id *modules.ConsensusChangeID) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalRecentChange), id)
-	}
-}
-
-// Set/Get difficulty
-func dbSetInternalDifficulty(difficulty types.Target) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return tx.Bucket(bucketInternal).Put(internalDifficulty, encoding.Marshal(difficulty))
-	}
-}
-func dbGetInternalDifficulty(difficulty *types.Target) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalDifficulty), difficulty)
+		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(key), val)
 	}
 }

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/NebulousLabs/bolt"
@@ -161,5 +162,43 @@ func dbGetSiafundOutput(id types.SiafundOutputID, sco *types.SiafundOutput) func
 func dbGetSiafundOutputTxnIDs(id types.SiafundOutputID, ids *[]types.TransactionID) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {
 		return getTransactionIDSet(tx.Bucket(bucketSiafundOutputIDs).Bucket(encoding.Marshal(id)), ids)
+	}
+}
+
+// Internal bucket getters/setters
+
+// Set/Get block height
+func dbSetInternalBlockHeight(height types.BlockHeight) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketInternal).Put(internalBlockHeight, encoding.Marshal(height))
+	}
+}
+func dbGetInternalBlockHeight(height *types.BlockHeight) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalBlockHeight), height)
+	}
+}
+
+// Set/Get recent change
+func dbSetInternalRecentChange(id modules.ConsensusChangeID) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketInternal).Put(internalRecentChange, encoding.Marshal(id))
+	}
+}
+func dbGetInternalRecentChange(id *modules.ConsensusChangeID) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalRecentChange), id)
+	}
+}
+
+// Set/Get difficulty
+func dbSetInternalDifficulty(difficulty types.Target) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketInternal).Put(internalDifficulty, encoding.Marshal(difficulty))
+	}
+}
+func dbGetInternalDifficulty(difficulty *types.Target) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalDifficulty), difficulty)
 	}
 }

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -35,10 +35,24 @@ var (
 	internalRecentChange = []byte("RecentChange")
 )
 
-// getAndDecode returns a 'func(*bolt.Tx) error' that retrieves and decodes a
-// value from the specified bucket. If the value does not exist, getAndDecode
-// returns errNotExist.
-func getAndDecode(bucket []byte, key, val interface{}) func(*bolt.Tx) error {
+// These functions all return a 'func(*bolt.Tx) error', which, allows them to
+// be called concisely with the db.View and db.Update functions, e.g.:
+//
+//    var height types.BlockHeight
+//    db.View(dbGetAndDecode(bucketBlockIDs, id, &height))
+//
+// Instead of:
+//
+//   var height types.BlockHeight
+//   db.View(func(tx *bolt.Tx) error {
+//       bytes := tx.Bucket(bucketBlockIDs).Get(encoding.Marshal(id))
+//       return encoding.Unmarshal(bytes, &height)
+//   })
+
+// dbGetAndDecode returns a 'func(*bolt.Tx) error' that retrieves and decodes
+// a value from the specified bucket. If the value does not exist,
+// dbGetAndDecode returns errNotExist.
+func dbGetAndDecode(bucket []byte, key, val interface{}) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {
 		valBytes := tx.Bucket(bucket).Get(encoding.Marshal(key))
 		if valBytes == nil {
@@ -48,10 +62,10 @@ func getAndDecode(bucket []byte, key, val interface{}) func(*bolt.Tx) error {
 	}
 }
 
-// getTransactionIDSet returns a 'func(*bolt.Tx) error' that decodes a bucket
-// of transaction IDs into a slice. If the bucket is nil, getTransactionIDSet
-// returns errNotExist.
-func getTransactionIDSet(bucket []byte, key interface{}, ids *[]types.TransactionID) func(*bolt.Tx) error {
+// dbGetTransactionIDSet returns a 'func(*bolt.Tx) error' that decodes a
+// bucket of transaction IDs into a slice. If the bucket is nil,
+// dbGetTransactionIDSet returns errNotExist.
+func dbGetTransactionIDSet(bucket []byte, key interface{}, ids *[]types.TransactionID) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucket).Bucket(encoding.Marshal(key))
 		if b == nil {
@@ -77,85 +91,14 @@ func getTransactionIDSet(bucket []byte, key interface{}, ids *[]types.Transactio
 	}
 }
 
-// These functions all return a 'func(*bolt.Tx) error', which, when called,
-// decodes a value into a supplied pointer. This allows them to be called
-// concisely with the db.View and db.Update functions, e.g.:
-//
-//    var height types.BlockHeight
-//    db.View(dbGetBlockHeight(id, &height))
-//
-// Instead of:
-//
-//   var height types.BlockHeight
-//   db.View(func(tx *bolt.Tx) error {
-//       var err error
-//       height, err = dbGetBlockHeight(tx, id)
-//       return err
-//   })
-
-// dbGetBlockHeight retrieves the block height of the specified block ID.
-func dbGetBlockHeight(id types.BlockID, height *types.BlockHeight) func(*bolt.Tx) error {
-	return getAndDecode(bucketBlockIDs, id, height)
-}
-
-// dbGetBlockFacts retrieves the blockFacts of the specified block ID.
-func dbGetBlockFacts(id types.BlockID, facts *blockFacts) func(*bolt.Tx) error {
-	return getAndDecode(bucketBlockFacts, id, facts)
-}
-
-// dbGetTransactionHeight retrieves the height at which a specified
-// transaction appeared.
-func dbGetTransactionHeight(id types.TransactionID, height *types.BlockHeight) func(*bolt.Tx) error {
-	return getAndDecode(bucketTransactionIDs, id, height)
-}
-
-// dbGetUnlockHashTxnIDs retrieves the IDs of all the transactions that
-// contain the specified unlock hash.
-func dbGetUnlockHashTxnIDs(uh types.UnlockHash, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return getTransactionIDSet(bucketUnlockHashes, uh, ids)
-}
-
-// dbGetSiacoinOutput will return the siacoin output associated with the specified ID.
-func dbGetSiacoinOutput(id types.SiacoinOutputID, sco *types.SiacoinOutput) func(*bolt.Tx) error {
-	return getAndDecode(bucketSiacoinOutputs, id, &sco)
-}
-
-// dbGetSiacoinOutputTxnIDs returns all of the transactions that contain the
-// specified siacoin output ID.
-func dbGetSiacoinOutputTxnIDs(id types.SiacoinOutputID, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return getTransactionIDSet(bucketSiacoinOutputIDs, id, ids)
-}
-
-// dbGetFileContractHistory returns the fileContractHistory associated with
-// the specified ID.
-func dbGetFileContractHistory(id types.FileContractID, history *fileContractHistory) func(*bolt.Tx) error {
-	return getAndDecode(bucketFileContractHistories, id, &history)
-}
-
-// dbGetFileContractTxnIDs returns all of the transactions that contain the
-// specified file contract ID.
-func dbGetFileContractTxnIDs(id types.FileContractID, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return getTransactionIDSet(bucketFileContractIDs, id, ids)
-}
-
-// dbGetSiafundOutput will return the siafund output associated with the specified ID.
-func dbGetSiafundOutput(id types.SiafundOutputID, sco *types.SiafundOutput) func(*bolt.Tx) error {
-	return getAndDecode(bucketSiafundOutputs, id, &sco)
-}
-
-// dbGetSiafundOutputTxnIDs returns all of the transactions that contain the
-// specified siafund output ID.
-func dbGetSiafundOutputTxnIDs(id types.SiafundOutputID, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return getTransactionIDSet(bucketSiafundOutputIDs, id, ids)
-}
-
-// Internal bucket getters/setters
-
+// dbSetInternal sets the specified key of bucketInternal to the encoded value.
 func dbSetInternal(key []byte, val interface{}) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {
 		return tx.Bucket(bucketInternal).Put(key, encoding.Marshal(val))
 	}
 }
+
+// dbGetInternal decodes the specified key of bucketInternal into the supplied pointer.
 func dbGetInternal(key []byte, val interface{}) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {
 		return encoding.Unmarshal(tx.Bucket(bucketInternal).Get(key), val)

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -1,0 +1,183 @@
+package explorer
+
+import (
+	"errors"
+
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
+)
+
+var (
+	errNotExist = errors.New("entry does not exist")
+
+	// database buckets
+	bucketBlockFacts            = []byte("BlockFacts")
+	bucketBlockHashes           = []byte("BlockHashes")
+	bucketBlocksDifficulty      = []byte("BlocksDifficulty")
+	bucketBlockTargets          = []byte("BlockTargets")
+	bucketFileContractHistories = []byte("FileContractHistories")
+	bucketFileContractIDs       = []byte("FileContractIDs")
+	bucketRecentChange          = []byte("RecentChange")
+	bucketSiacoinOutputIDs      = []byte("SiacoinOutputIDs")
+	bucketSiacoinOutputs        = []byte("SiacoinOutputs")
+	bucketSiafundOutputIDs      = []byte("SiafundOutputIDs")
+	bucketSiafundOutputs        = []byte("SiafundOutputs")
+	bucketTransactionHashes     = []byte("TransactionHashes")
+	bucketUnlockHashes          = []byte("UnlockHashes")
+)
+
+// getAndDecode is a helper function that retrieves and decodes a value from
+// the specified bucket. If the value does not exist, getAndDecode returns
+// errNotExist.
+func getAndDecode(bucket *bolt.Bucket, key, val interface{}) error {
+	valBytes := bucket.Get(encoding.Marshal(key))
+	if valBytes == nil {
+		return errNotExist
+	}
+	return encoding.Unmarshal(valBytes, val)
+}
+
+// getTransactionIDSet is a helper function that decodes a bucket of
+// transaction IDs into a slice.
+func getTransactionIDSet(bucket *bolt.Bucket) (ids []types.TransactionID, err error) {
+	err = bucket.ForEach(func(txid, _ []byte) error {
+		var id types.TransactionID
+		err := encoding.Unmarshal(txid, &id)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+		return nil
+	})
+	return
+}
+
+// dbGetBlockHeight retrieves the block height of the specified block ID.
+func dbGetBlockHeight(tx *bolt.Tx, id types.BlockID) (height types.BlockHeight, err error) {
+	err = getAndDecode(tx.Bucket(bucketBlockHashes), id, &height)
+	return
+}
+
+// dbGetBlockFacts returns the blockFacts at a specified height.
+func dbGetBlockFacts(tx *bolt.Tx, height types.BlockHeight) (facts blockFacts, err error) {
+	b := tx.Bucket(bucketBlockFacts)
+	err = getAndDecode(b, height, &facts)
+	if err != nil {
+		return
+	}
+	// also look up the maturity timestamp, if possible
+	// TODO: does this make sense? Why not set maturityTimestamp elsewhere, like in update.go?
+	if height > types.MaturityDelay {
+		var bf2 blockFacts
+		err = getAndDecode(b, height, &bf2)
+		if err != nil {
+			return
+		}
+		facts.maturityTimestamp = bf2.timestamp
+	}
+	return
+}
+
+// dbGetTransactionHeight returns the height at which a specified transaction
+// appeared.
+func dbGetTransactionHeight(tx *bolt.Tx, id types.TransactionID) (height types.BlockHeight, err error) {
+	err = getAndDecode(tx.Bucket(bucketTransactionHashes), id, &height)
+	return
+}
+
+// dbGetUnlockHashTxnIDs returns the IDs of all the transactions that contain
+// the specified unlock hash.
+func dbGetUnlockHashTxnIDs(tx *bolt.Tx, uh types.UnlockHash) (ids []types.TransactionID, err error) {
+	hashBucket := tx.Bucket(bucketUnlockHashes).Bucket(encoding.Marshal(uh))
+	if hashBucket == nil {
+		return nil, errNotExist
+	}
+	err = hashBucket.ForEach(func(txid, _ []byte) error {
+		var id types.TransactionID
+		err := encoding.Unmarshal(txid, &id)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+		return nil
+	})
+	return
+}
+
+// dbGetSiacoinOutput will return the siacoin output associated with the specified ID.
+func dbGetSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID) (sco types.SiacoinOutput, err error) {
+	err = getAndDecode(tx.Bucket(bucketSiacoinOutputs), id, &sco)
+	return
+}
+
+// dbGetSiacoinOutputTxnIDs returns all of the transactions that contain the
+// specified siacoin output ID.
+func dbGetSiacoinOutputTxnIDs(tx *bolt.Tx, id types.SiacoinOutputID) (ids []types.TransactionID, err error) {
+	scoBucket := tx.Bucket(bucketSiacoinOutputIDs).Bucket(encoding.Marshal(id))
+	if scoBucket == nil {
+		return nil, errNotExist
+	}
+	err = scoBucket.ForEach(func(txid, _ []byte) error {
+		var id types.TransactionID
+		err := encoding.Unmarshal(txid, &id)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+		return nil
+	})
+	return
+}
+
+// dbGetFileContractHistory returns the fileContractHistory associated with
+// the specified ID.
+func dbGetFileContractHistory(tx *bolt.Tx, id types.FileContractID) (history fileContractHistory, err error) {
+	err = getAndDecode(tx.Bucket(bucketFileContractHistories), id, &history)
+	return
+}
+
+// dbGetFileContractTxnIDs returns all of the transactions that contain the
+// specified file contract ID.
+func dbGetFileContractTxnIDs(tx *bolt.Tx, id types.FileContractID) (ids []types.TransactionID, err error) {
+	fcBucket := tx.Bucket(bucketFileContractIDs).Bucket(encoding.Marshal(id))
+	if fcBucket == nil {
+		return nil, errNotExist
+	}
+	err = fcBucket.ForEach(func(txid, _ []byte) error {
+		var id types.TransactionID
+		err := encoding.Unmarshal(txid, &id)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+		return nil
+	})
+	return
+}
+
+// dbGetSiafundOutput will return the siafund output associated with the specified ID.
+func dbGetSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) (sco types.SiafundOutput, err error) {
+	err = getAndDecode(tx.Bucket(bucketSiafundOutputs), id, &sco)
+	return
+}
+
+// dbGetSiafundOutputTxnIDs returns all of the transactions that contain the
+// specified siafund output ID.
+func dbGetSiafundOutputTxnIDs(tx *bolt.Tx, id types.SiafundOutputID) (ids []types.TransactionID, err error) {
+	scoBucket := tx.Bucket(bucketSiafundOutputIDs).Bucket(encoding.Marshal(id))
+	if scoBucket == nil {
+		return nil, errNotExist
+	}
+	err = scoBucket.ForEach(func(txid, _ []byte) error {
+		var id types.TransactionID
+		err := encoding.Unmarshal(txid, &id)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, id)
+		return nil
+	})
+	return
+}

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -31,7 +31,6 @@ var (
 
 	// keys for bucketInternal
 	internalBlockHeight  = []byte("BlockHeight")
-	internalDifficulty   = []byte("Difficulty")
 	internalRecentChange = []byte("RecentChange")
 )
 

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -40,144 +40,134 @@ func getAndDecode(bucket *bolt.Bucket, key, val interface{}) error {
 }
 
 // getTransactionIDSet is a helper function that decodes a bucket of
-// transaction IDs into a slice.
-func getTransactionIDSet(bucket *bolt.Bucket) (ids []types.TransactionID, err error) {
-	err = bucket.ForEach(func(txid, _ []byte) error {
+// transaction IDs into a slice. If the bucket is nil, getTransactionIDSet
+// returns errNotExist.
+func getTransactionIDSet(bucket *bolt.Bucket, ids *[]types.TransactionID) error {
+	if bucket == nil {
+		return errNotExist
+	}
+	// decode into a local slice
+	var txids []types.TransactionID
+	err := bucket.ForEach(func(txid, _ []byte) error {
 		var id types.TransactionID
 		err := encoding.Unmarshal(txid, &id)
 		if err != nil {
 			return err
 		}
-		ids = append(ids, id)
+		txids = append(txids, id)
 		return nil
 	})
-	return
+	if err != nil {
+		return err
+	}
+	// set pointer
+	*ids = txids
+	return nil
 }
+
+// These functions all return a 'func(*bolt.Tx) error', which, when called,
+// decodes a value into a supplied pointer. This allows them to be called
+// concisely with the db.View and db.Update functions, e.g.:
+//
+//    var height types.BlockHeight
+//    db.View(dbGetBlockHeight(id, &height))
+//
+// Instead of:
+//
+//   var height types.BlockHeight
+//   db.View(func(tx *bolt.Tx) error {
+//       var err error
+//       height, err = dbGetBlockHeight(tx, id)
+//       return err
+//   })
 
 // dbGetBlockHeight retrieves the block height of the specified block ID.
-func dbGetBlockHeight(tx *bolt.Tx, id types.BlockID) (height types.BlockHeight, err error) {
-	err = getAndDecode(tx.Bucket(bucketBlockHashes), id, &height)
-	return
+func dbGetBlockHeight(id types.BlockID, height *types.BlockHeight) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getAndDecode(tx.Bucket(bucketBlockHashes), id, height)
+	}
 }
 
-// dbGetBlockFacts returns the blockFacts at a specified height.
-func dbGetBlockFacts(tx *bolt.Tx, height types.BlockHeight) (facts blockFacts, err error) {
-	b := tx.Bucket(bucketBlockFacts)
-	err = getAndDecode(b, height, &facts)
-	if err != nil {
-		return
-	}
-	// also look up the maturity timestamp, if possible
-	// TODO: does this make sense? Why not set maturityTimestamp elsewhere, like in update.go?
-	if height > types.MaturityDelay {
-		var bf2 blockFacts
-		err = getAndDecode(b, height, &bf2)
-		if err != nil {
-			return
-		}
-		facts.maturityTimestamp = bf2.timestamp
-	}
-	return
-}
-
-// dbGetTransactionHeight returns the height at which a specified transaction
-// appeared.
-func dbGetTransactionHeight(tx *bolt.Tx, id types.TransactionID) (height types.BlockHeight, err error) {
-	err = getAndDecode(tx.Bucket(bucketTransactionHashes), id, &height)
-	return
-}
-
-// dbGetUnlockHashTxnIDs returns the IDs of all the transactions that contain
-// the specified unlock hash.
-func dbGetUnlockHashTxnIDs(tx *bolt.Tx, uh types.UnlockHash) (ids []types.TransactionID, err error) {
-	hashBucket := tx.Bucket(bucketUnlockHashes).Bucket(encoding.Marshal(uh))
-	if hashBucket == nil {
-		return nil, errNotExist
-	}
-	err = hashBucket.ForEach(func(txid, _ []byte) error {
-		var id types.TransactionID
-		err := encoding.Unmarshal(txid, &id)
+// dbGetBlockFacts retrieves the blockFacts at a specified height.
+func dbGetBlockFacts(height types.BlockHeight, facts *blockFacts) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketBlockFacts)
+		err := getAndDecode(b, height, facts)
 		if err != nil {
 			return err
 		}
-		ids = append(ids, id)
+		// also look up the maturity timestamp, if possible
+		// TODO: does this make sense? Why not set maturityTimestamp elsewhere, like in update.go?
+		if height > types.MaturityDelay {
+			var bf2 blockFacts
+			err = getAndDecode(b, height, &bf2)
+			if err != nil {
+				return err
+			}
+			facts.maturityTimestamp = bf2.timestamp
+		}
 		return nil
-	})
-	return
+	}
+}
+
+// dbGetTransactionHeight retrieves the height at which a specified
+// transaction appeared.
+func dbGetTransactionHeight(id types.TransactionID, height *types.BlockHeight) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getAndDecode(tx.Bucket(bucketTransactionHashes), id, height)
+	}
+}
+
+// dbGetUnlockHashTxnIDs retrieves the IDs of all the transactions that
+// contain the specified unlock hash.
+func dbGetUnlockHashTxnIDs(uh types.UnlockHash, ids *[]types.TransactionID) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getTransactionIDSet(tx.Bucket(bucketUnlockHashes).Bucket(encoding.Marshal(uh)), ids)
+	}
 }
 
 // dbGetSiacoinOutput will return the siacoin output associated with the specified ID.
-func dbGetSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID) (sco types.SiacoinOutput, err error) {
-	err = getAndDecode(tx.Bucket(bucketSiacoinOutputs), id, &sco)
-	return
+func dbGetSiacoinOutput(id types.SiacoinOutputID, sco *types.SiacoinOutput) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getAndDecode(tx.Bucket(bucketSiacoinOutputs), id, &sco)
+	}
 }
 
 // dbGetSiacoinOutputTxnIDs returns all of the transactions that contain the
 // specified siacoin output ID.
-func dbGetSiacoinOutputTxnIDs(tx *bolt.Tx, id types.SiacoinOutputID) (ids []types.TransactionID, err error) {
-	scoBucket := tx.Bucket(bucketSiacoinOutputIDs).Bucket(encoding.Marshal(id))
-	if scoBucket == nil {
-		return nil, errNotExist
+func dbGetSiacoinOutputTxnIDs(id types.SiacoinOutputID, ids *[]types.TransactionID) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getTransactionIDSet(tx.Bucket(bucketSiacoinOutputIDs).Bucket(encoding.Marshal(id)), ids)
 	}
-	err = scoBucket.ForEach(func(txid, _ []byte) error {
-		var id types.TransactionID
-		err := encoding.Unmarshal(txid, &id)
-		if err != nil {
-			return err
-		}
-		ids = append(ids, id)
-		return nil
-	})
-	return
 }
 
 // dbGetFileContractHistory returns the fileContractHistory associated with
 // the specified ID.
-func dbGetFileContractHistory(tx *bolt.Tx, id types.FileContractID) (history fileContractHistory, err error) {
-	err = getAndDecode(tx.Bucket(bucketFileContractHistories), id, &history)
-	return
+func dbGetFileContractHistory(id types.FileContractID, history *fileContractHistory) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getAndDecode(tx.Bucket(bucketFileContractHistories), id, &history)
+	}
 }
 
 // dbGetFileContractTxnIDs returns all of the transactions that contain the
 // specified file contract ID.
-func dbGetFileContractTxnIDs(tx *bolt.Tx, id types.FileContractID) (ids []types.TransactionID, err error) {
-	fcBucket := tx.Bucket(bucketFileContractIDs).Bucket(encoding.Marshal(id))
-	if fcBucket == nil {
-		return nil, errNotExist
+func dbGetFileContractTxnIDs(id types.FileContractID, ids *[]types.TransactionID) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getTransactionIDSet(tx.Bucket(bucketFileContractIDs).Bucket(encoding.Marshal(id)), ids)
 	}
-	err = fcBucket.ForEach(func(txid, _ []byte) error {
-		var id types.TransactionID
-		err := encoding.Unmarshal(txid, &id)
-		if err != nil {
-			return err
-		}
-		ids = append(ids, id)
-		return nil
-	})
-	return
 }
 
 // dbGetSiafundOutput will return the siafund output associated with the specified ID.
-func dbGetSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) (sco types.SiafundOutput, err error) {
-	err = getAndDecode(tx.Bucket(bucketSiafundOutputs), id, &sco)
-	return
+func dbGetSiafundOutput(id types.SiafundOutputID, sco *types.SiafundOutput) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getAndDecode(tx.Bucket(bucketSiafundOutputs), id, &sco)
+	}
 }
 
 // dbGetSiafundOutputTxnIDs returns all of the transactions that contain the
 // specified siafund output ID.
-func dbGetSiafundOutputTxnIDs(tx *bolt.Tx, id types.SiafundOutputID) (ids []types.TransactionID, err error) {
-	scoBucket := tx.Bucket(bucketSiafundOutputIDs).Bucket(encoding.Marshal(id))
-	if scoBucket == nil {
-		return nil, errNotExist
+func dbGetSiafundOutputTxnIDs(id types.SiafundOutputID, ids *[]types.TransactionID) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		return getTransactionIDSet(tx.Bucket(bucketSiafundOutputIDs).Bucket(encoding.Marshal(id)), ids)
 	}
-	err = scoBucket.ForEach(func(txid, _ []byte) error {
-		var id types.TransactionID
-		err := encoding.Unmarshal(txid, &id)
-		if err != nil {
-			return err
-		}
-		ids = append(ids, id)
-		return nil
-	})
-	return
 }

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -36,41 +36,46 @@ var (
 	internalRecentChange = []byte("RecentChange")
 )
 
-// getAndDecode is a helper function that retrieves and decodes a value from
-// the specified bucket. If the value does not exist, getAndDecode returns
-// errNotExist.
-func getAndDecode(bucket *bolt.Bucket, key, val interface{}) error {
-	valBytes := bucket.Get(encoding.Marshal(key))
-	if valBytes == nil {
-		return errNotExist
+// getAndDecode returns a 'func(*bolt.Tx) error' that retrieves and decodes a
+// value from the specified bucket. If the value does not exist, getAndDecode
+// returns errNotExist.
+func getAndDecode(bucket []byte, key, val interface{}) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		valBytes := tx.Bucket(bucket).Get(encoding.Marshal(key))
+		if valBytes == nil {
+			return errNotExist
+		}
+		return encoding.Unmarshal(valBytes, val)
 	}
-	return encoding.Unmarshal(valBytes, val)
 }
 
-// getTransactionIDSet is a helper function that decodes a bucket of
-// transaction IDs into a slice. If the bucket is nil, getTransactionIDSet
+// getTransactionIDSet returns a 'func(*bolt.Tx) error' that decodes a bucket
+// of transaction IDs into a slice. If the bucket is nil, getTransactionIDSet
 // returns errNotExist.
-func getTransactionIDSet(bucket *bolt.Bucket, ids *[]types.TransactionID) error {
-	if bucket == nil {
-		return errNotExist
-	}
-	// decode into a local slice
-	var txids []types.TransactionID
-	err := bucket.ForEach(func(txid, _ []byte) error {
-		var id types.TransactionID
-		err := encoding.Unmarshal(txid, &id)
+func getTransactionIDSet(bucket []byte, key interface{}, ids *[]types.TransactionID) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucket).Bucket(encoding.Marshal(key))
+		if b == nil {
+			return errNotExist
+		}
+		// decode into a local slice
+		var txids []types.TransactionID
+		err := b.ForEach(func(txid, _ []byte) error {
+			var id types.TransactionID
+			err := encoding.Unmarshal(txid, &id)
+			if err != nil {
+				return err
+			}
+			txids = append(txids, id)
+			return nil
+		})
 		if err != nil {
 			return err
 		}
-		txids = append(txids, id)
+		// set pointer
+		*ids = txids
 		return nil
-	})
-	if err != nil {
-		return err
 	}
-	// set pointer
-	*ids = txids
-	return nil
 }
 
 // These functions all return a 'func(*bolt.Tx) error', which, when called,
@@ -91,78 +96,58 @@ func getTransactionIDSet(bucket *bolt.Bucket, ids *[]types.TransactionID) error 
 
 // dbGetBlockHeight retrieves the block height of the specified block ID.
 func dbGetBlockHeight(id types.BlockID, height *types.BlockHeight) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getAndDecode(tx.Bucket(bucketBlockIDs), id, height)
-	}
+	return getAndDecode(bucketBlockIDs, id, height)
 }
 
 // dbGetBlockFacts retrieves the blockFacts of the specified block ID.
 func dbGetBlockFacts(id types.BlockID, facts *blockFacts) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getAndDecode(tx.Bucket(bucketBlockFacts), id, facts)
-	}
+	return getAndDecode(bucketBlockFacts, id, facts)
 }
 
 // dbGetTransactionHeight retrieves the height at which a specified
 // transaction appeared.
 func dbGetTransactionHeight(id types.TransactionID, height *types.BlockHeight) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getAndDecode(tx.Bucket(bucketTransactionIDs), id, height)
-	}
+	return getAndDecode(bucketTransactionIDs, id, height)
 }
 
 // dbGetUnlockHashTxnIDs retrieves the IDs of all the transactions that
 // contain the specified unlock hash.
 func dbGetUnlockHashTxnIDs(uh types.UnlockHash, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getTransactionIDSet(tx.Bucket(bucketUnlockHashes).Bucket(encoding.Marshal(uh)), ids)
-	}
+	return getTransactionIDSet(bucketUnlockHashes, uh, ids)
 }
 
 // dbGetSiacoinOutput will return the siacoin output associated with the specified ID.
 func dbGetSiacoinOutput(id types.SiacoinOutputID, sco *types.SiacoinOutput) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getAndDecode(tx.Bucket(bucketSiacoinOutputs), id, &sco)
-	}
+	return getAndDecode(bucketSiacoinOutputs, id, &sco)
 }
 
 // dbGetSiacoinOutputTxnIDs returns all of the transactions that contain the
 // specified siacoin output ID.
 func dbGetSiacoinOutputTxnIDs(id types.SiacoinOutputID, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getTransactionIDSet(tx.Bucket(bucketSiacoinOutputIDs).Bucket(encoding.Marshal(id)), ids)
-	}
+	return getTransactionIDSet(bucketSiacoinOutputIDs, id, ids)
 }
 
 // dbGetFileContractHistory returns the fileContractHistory associated with
 // the specified ID.
 func dbGetFileContractHistory(id types.FileContractID, history *fileContractHistory) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getAndDecode(tx.Bucket(bucketFileContractHistories), id, &history)
-	}
+	return getAndDecode(bucketFileContractHistories, id, &history)
 }
 
 // dbGetFileContractTxnIDs returns all of the transactions that contain the
 // specified file contract ID.
 func dbGetFileContractTxnIDs(id types.FileContractID, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getTransactionIDSet(tx.Bucket(bucketFileContractIDs).Bucket(encoding.Marshal(id)), ids)
-	}
+	return getTransactionIDSet(bucketFileContractIDs, id, ids)
 }
 
 // dbGetSiafundOutput will return the siafund output associated with the specified ID.
 func dbGetSiafundOutput(id types.SiafundOutputID, sco *types.SiafundOutput) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getAndDecode(tx.Bucket(bucketSiafundOutputs), id, &sco)
-	}
+	return getAndDecode(bucketSiafundOutputs, id, &sco)
 }
 
 // dbGetSiafundOutputTxnIDs returns all of the transactions that contain the
 // specified siafund output ID.
 func dbGetSiafundOutputTxnIDs(id types.SiafundOutputID, ids *[]types.TransactionID) func(*bolt.Tx) error {
-	return func(tx *bolt.Tx) error {
-		return getTransactionIDSet(tx.Bucket(bucketSiafundOutputIDs).Bucket(encoding.Marshal(id)), ids)
-	}
+	return getTransactionIDSet(bucketSiafundOutputIDs, id, ids)
 }
 
 // Internal bucket getters/setters

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -72,7 +72,7 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 
 	// retrieve the current ConsensusChangeID
 	var recentChange modules.ConsensusChangeID
-	err = e.db.View(dbGetInternalRecentChange(&recentChange))
+	err = e.db.View(dbGetInternal(internalRecentChange, &recentChange))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -70,8 +70,16 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 		return nil, err
 	}
 
-	err = cs.ConsensusSetSubscribe(e, modules.ConsensusChangeBeginning)
+	// retrieve the current ConsensusChangeID
+	var recentChange modules.ConsensusChangeID
+	err = e.db.View(dbGetInternalRecentChange(&recentChange))
 	if err != nil {
+		return nil, err
+	}
+
+	err = cs.ConsensusSetSubscribe(e, recentChange)
+	if err != nil {
+		// TODO: restart from 0
 		return nil, errors.New("explorer subscription failed: " + err.Error())
 	}
 

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -18,6 +19,21 @@ const (
 
 var (
 	errNilCS = errors.New("explorer cannot use a nil consensus set")
+
+	// database buckets
+	bucketBlockFacts            = []byte("BlockFacts")
+	bucketBlockHashes           = []byte("BlockHashes")
+	bucketBlocksDifficulty      = []byte("BlocksDifficulty")
+	bucketBlockTargets          = []byte("BlockTargets")
+	bucketFileContractHistories = []byte("FileContractHistories")
+	bucketFileContractIDs       = []byte("FileContractIDs")
+	bucketRecentChange          = []byte("RecentChange")
+	bucketSiacoinOutputIDs      = []byte("SiacoinOutputIDs")
+	bucketSiacoinOutputs        = []byte("SiacoinOutputs")
+	bucketSiafundOutputIDs      = []byte("SiafundOutputIDs")
+	bucketSiafundOutputs        = []byte("SiafundOutputs")
+	bucketTransactionHashes     = []byte("TransactionHashes")
+	bucketUnlockHashes          = []byte("UnlockHashes")
 )
 
 type (

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -25,47 +25,20 @@ type (
 	// revisions that have affected a file contract through the life of the
 	// blockchain.
 	fileContractHistory struct {
-		contract     types.FileContract
-		revisions    []types.FileContractRevision
-		storageProof types.StorageProof
+		Contract     types.FileContract
+		Revisions    []types.FileContractRevision
+		StorageProof types.StorageProof
 	}
 
-	// blockFacts contians a set of facts about the consensus set related to a
+	// blockFacts contains a set of facts about the consensus set related to a
 	// certain block. The explorer needs some additional information in the
 	// history so that it can calculate certain values, which is one of the
 	// reasons that the explorer uses a separate struct instead of
 	// modules.BlockFacts.
 	blockFacts struct {
-		// Block information.
-		currentBlock      types.BlockID
-		blockchainHeight  types.BlockHeight
-		target            types.Target
-		timestamp         types.Timestamp
-		maturityTimestamp types.Timestamp
-		estimatedHashrate types.Currency
-		totalCoins        types.Currency
+		modules.BlockFacts
 
-		// Transaction type counts.
-		minerPayoutCount          uint64
-		transactionCount          uint64
-		siacoinInputCount         uint64
-		siacoinOutputCount        uint64
-		fileContractCount         uint64
-		fileContractRevisionCount uint64
-		storageProofCount         uint64
-		siafundInputCount         uint64
-		siafundOutputCount        uint64
-		minerFeeCount             uint64
-		arbitraryDataCount        uint64
-		transactionSignatureCount uint64
-
-		// Factoids about file contracts.
-		activeContractCost  types.Currency
-		activeContractCount uint64
-		activeContractSize  types.Currency
-		totalContractCost   types.Currency
-		totalContractSize   types.Currency
-		totalRevisionVolume types.Currency
+		Timestamp types.Timestamp
 	}
 
 	// An Explorer contains a more comprehensive view of the blockchain,

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -19,21 +19,6 @@ const (
 
 var (
 	errNilCS = errors.New("explorer cannot use a nil consensus set")
-
-	// database buckets
-	bucketBlockFacts            = []byte("BlockFacts")
-	bucketBlockHashes           = []byte("BlockHashes")
-	bucketBlocksDifficulty      = []byte("BlocksDifficulty")
-	bucketBlockTargets          = []byte("BlockTargets")
-	bucketFileContractHistories = []byte("FileContractHistories")
-	bucketFileContractIDs       = []byte("FileContractIDs")
-	bucketRecentChange          = []byte("RecentChange")
-	bucketSiacoinOutputIDs      = []byte("SiacoinOutputIDs")
-	bucketSiacoinOutputs        = []byte("SiacoinOutputs")
-	bucketSiafundOutputIDs      = []byte("SiafundOutputIDs")
-	bucketSiafundOutputs        = []byte("SiafundOutputs")
-	bucketTransactionHashes     = []byte("TransactionHashes")
-	bucketUnlockHashes          = []byte("UnlockHashes")
 )
 
 type (

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -13,7 +13,7 @@ import (
 const (
 	// hashrateEstimationBlocks is the number of blocks that are used to
 	// estimate the current hashrate.
-	hashrateEstimationBlocks = 72 // 12 hours
+	hashrateEstimationBlocks = 200 // 33 hours
 )
 
 var (

--- a/modules/explorer/explorer_test.go
+++ b/modules/explorer/explorer_test.go
@@ -136,7 +136,7 @@ func (et *explorerTester) reorgToBlank() error {
 
 	// Mine blocks until the height is higher than the existing consensus,
 	// submitting each block to the explorerTester.
-	currentHeight := et.explorer.blockchainHeight
+	currentHeight := cs.Height()
 	for i := types.BlockHeight(0); i <= currentHeight+1; i++ {
 		block, err := m.AddBlock()
 		if err != nil {
@@ -147,7 +147,7 @@ func (et *explorerTester) reorgToBlank() error {
 	return nil
 }
 
-// TestNilExplorerDependencies tries to initalize an explorer with nil
+// TestNilExplorerDependencies tries to initialize an explorer with nil
 // dependencies, checks that the correct error is returned.
 func TestNilExplorerDependencies(t *testing.T) {
 	_, err := New(nil, "expdir")
@@ -176,7 +176,14 @@ func TestExplorerGenesisHeight(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if e.blockchainHeight != 0 {
-		t.Error("genesis height was not set to zero after explorer initialization")
+	block, height, exists := e.Block(types.GenesisBlock.ID())
+	if !exists {
+		t.Error("explorer missing genesis block after initialization")
+	}
+	if block.ID() != types.GenesisBlock.ID() {
+		t.Error("explorer returned wrong genesis block")
+	}
+	if height != 0 {
+		t.Errorf("genesis block hash wrong height: expected 0, got %v", height)
 	}
 }

--- a/modules/explorer/info.go
+++ b/modules/explorer/info.go
@@ -24,8 +24,13 @@ func (e *Explorer) Block(id types.BlockID) (types.Block, types.BlockHeight, bool
 // at a given block height, and a bool indicating whether facts exist for the
 // given height.
 func (e *Explorer) BlockFacts(height types.BlockHeight) (modules.BlockFacts, bool) {
+	block, exists := e.cs.BlockAtHeight(height)
+	if !exists {
+		return modules.BlockFacts{}, false
+	}
+
 	var bf blockFacts
-	err := e.db.View(dbGetBlockFacts(height, &bf))
+	err := e.db.View(dbGetBlockFacts(block.ID(), &bf))
 	if err != nil {
 		return modules.BlockFacts{}, false
 	}

--- a/modules/explorer/info.go
+++ b/modules/explorer/info.go
@@ -35,38 +35,7 @@ func (e *Explorer) BlockFacts(height types.BlockHeight) (modules.BlockFacts, boo
 		return modules.BlockFacts{}, false
 	}
 
-	// convert to modules.BlockFacts
-	return modules.BlockFacts{
-		BlockID:           bf.currentBlock,
-		Difficulty:        bf.target.Difficulty(),
-		EstimatedHashrate: bf.estimatedHashrate,
-		Height:            bf.blockchainHeight,
-		MaturityTimestamp: bf.maturityTimestamp,
-		Target:            bf.target,
-		TotalCoins:        bf.totalCoins,
-
-		// Transaction type counts.
-		MinerPayoutCount:          bf.minerPayoutCount,
-		TransactionCount:          bf.transactionCount,
-		SiacoinInputCount:         bf.siacoinInputCount,
-		SiacoinOutputCount:        bf.siacoinOutputCount,
-		FileContractCount:         bf.fileContractCount,
-		FileContractRevisionCount: bf.fileContractRevisionCount,
-		StorageProofCount:         bf.storageProofCount,
-		SiafundInputCount:         bf.siafundInputCount,
-		SiafundOutputCount:        bf.siafundOutputCount,
-		MinerFeeCount:             bf.minerFeeCount,
-		ArbitraryDataCount:        bf.arbitraryDataCount,
-		TransactionSignatureCount: bf.transactionSignatureCount,
-
-		// Factoids about file contracts.
-		ActiveContractCost:  bf.activeContractCost,
-		ActiveContractCount: bf.activeContractCount,
-		ActiveContractSize:  bf.activeContractSize,
-		TotalContractCost:   bf.totalContractCost,
-		TotalContractSize:   bf.totalContractSize,
-		TotalRevisionVolume: bf.totalRevisionVolume,
-	}, true
+	return bf.BlockFacts, true
 }
 
 // Transaction takes a transaction ID and finds the block containing the
@@ -127,10 +96,10 @@ func (e *Explorer) SiacoinOutputID(id types.SiacoinOutputID) []types.Transaction
 func (e *Explorer) FileContractHistory(id types.FileContractID) (fc types.FileContract, fcrs []types.FileContractRevision, fcE bool, spE bool) {
 	var history fileContractHistory
 	err := e.db.View(dbGetFileContractHistory(id, &history))
-	fc = history.contract
-	fcrs = history.revisions
+	fc = history.Contract
+	fcrs = history.Revisions
 	fcE = err == nil
-	spE = history.storageProof.ParentID == id
+	spE = history.StorageProof.ParentID == id
 	return
 }
 

--- a/modules/explorer/info.go
+++ b/modules/explorer/info.go
@@ -9,7 +9,7 @@ import (
 // block is in the consensus set.
 func (e *Explorer) Block(id types.BlockID) (types.Block, types.BlockHeight, bool) {
 	var height types.BlockHeight
-	err := e.db.View(dbGetBlockHeight(id, &height))
+	err := e.db.View(dbGetAndDecode(bucketBlockIDs, id, &height))
 	if err != nil {
 		return types.Block{}, 0, false
 	}
@@ -30,7 +30,7 @@ func (e *Explorer) BlockFacts(height types.BlockHeight) (modules.BlockFacts, boo
 	}
 
 	var bf blockFacts
-	err := e.db.View(dbGetBlockFacts(block.ID(), &bf))
+	err := e.db.View(dbGetAndDecode(bucketBlockFacts, block.ID(), &bf))
 	if err != nil {
 		return modules.BlockFacts{}, false
 	}
@@ -43,7 +43,7 @@ func (e *Explorer) BlockFacts(height types.BlockHeight) (modules.BlockFacts, boo
 // block ID. To find the transaction, iterate through the block.
 func (e *Explorer) Transaction(id types.TransactionID) (types.Block, types.BlockHeight, bool) {
 	var height types.BlockHeight
-	err := e.db.View(dbGetTransactionHeight(id, &height))
+	err := e.db.View(dbGetAndDecode(bucketTransactionIDs, id, &height))
 	if err != nil {
 		return types.Block{}, 0, false
 	}
@@ -59,7 +59,7 @@ func (e *Explorer) Transaction(id types.TransactionID) (types.Block, types.Block
 // blockchain.
 func (e *Explorer) UnlockHash(uh types.UnlockHash) []types.TransactionID {
 	var ids []types.TransactionID
-	err := e.db.View(dbGetUnlockHashTxnIDs(uh, &ids))
+	err := e.db.View(dbGetTransactionIDSet(bucketUnlockHashes, uh, &ids))
 	if err != nil {
 		ids = nil
 	}
@@ -69,7 +69,7 @@ func (e *Explorer) UnlockHash(uh types.UnlockHash) []types.TransactionID {
 // SiacoinOutput returns the siacoin output associated with the specified ID.
 func (e *Explorer) SiacoinOutput(id types.SiacoinOutputID) (types.SiacoinOutput, bool) {
 	var sco types.SiacoinOutput
-	err := e.db.View(dbGetSiacoinOutput(id, &sco))
+	err := e.db.View(dbGetAndDecode(bucketSiacoinOutputs, id, &sco))
 	if err != nil {
 		return types.SiacoinOutput{}, false
 	}
@@ -81,7 +81,7 @@ func (e *Explorer) SiacoinOutput(id types.SiacoinOutputID) (types.SiacoinOutput,
 // not appear in the blockchain.
 func (e *Explorer) SiacoinOutputID(id types.SiacoinOutputID) []types.TransactionID {
 	var ids []types.TransactionID
-	err := e.db.View(dbGetSiacoinOutputTxnIDs(id, &ids))
+	err := e.db.View(dbGetTransactionIDSet(bucketSiacoinOutputIDs, id, &ids))
 	if err != nil {
 		ids = nil
 	}
@@ -95,7 +95,7 @@ func (e *Explorer) SiacoinOutputID(id types.SiacoinOutputID) []types.Transaction
 // whether a storage proof was successfully submitted for the file contract.
 func (e *Explorer) FileContractHistory(id types.FileContractID) (fc types.FileContract, fcrs []types.FileContractRevision, fcE bool, spE bool) {
 	var history fileContractHistory
-	err := e.db.View(dbGetFileContractHistory(id, &history))
+	err := e.db.View(dbGetAndDecode(bucketFileContractHistories, id, &history))
 	fc = history.Contract
 	fcrs = history.Revisions
 	fcE = err == nil
@@ -108,7 +108,7 @@ func (e *Explorer) FileContractHistory(id types.FileContractID) (fc types.FileCo
 // appear in the blockchain.
 func (e *Explorer) FileContractID(id types.FileContractID) []types.TransactionID {
 	var ids []types.TransactionID
-	err := e.db.View(dbGetFileContractTxnIDs(id, &ids))
+	err := e.db.View(dbGetTransactionIDSet(bucketFileContractIDs, id, &ids))
 	if err != nil {
 		ids = nil
 	}
@@ -118,7 +118,7 @@ func (e *Explorer) FileContractID(id types.FileContractID) []types.TransactionID
 // SiafundOutput returns the siafund output associated with the specified ID.
 func (e *Explorer) SiafundOutput(id types.SiafundOutputID) (types.SiafundOutput, bool) {
 	var sco types.SiafundOutput
-	err := e.db.View(dbGetSiafundOutput(id, &sco))
+	err := e.db.View(dbGetAndDecode(bucketSiafundOutputs, id, &sco))
 	if err != nil {
 		return types.SiafundOutput{}, false
 	}
@@ -130,7 +130,7 @@ func (e *Explorer) SiafundOutput(id types.SiafundOutputID) (types.SiafundOutput,
 // not appear in the blockchain.
 func (e *Explorer) SiafundOutputID(id types.SiafundOutputID) []types.TransactionID {
 	var ids []types.TransactionID
-	err := e.db.View(dbGetSiafundOutputTxnIDs(id, &ids))
+	err := e.db.View(dbGetTransactionIDSet(bucketSiafundOutputIDs, id, &ids))
 	if err != nil {
 		ids = nil
 	}

--- a/modules/explorer/info_test.go
+++ b/modules/explorer/info_test.go
@@ -8,7 +8,7 @@ import (
 
 // TestImmediateBlockFacts grabs the block facts object from the block explorer
 // at the current height and verifies that the data has been filled out.
-func TestImmedieateBlockFacts(t *testing.T) {
+func TestImmediateBlockFacts(t *testing.T) {
 	et, err := createExplorerTester("TestImmediateBlockFacts")
 	if err != nil {
 		t.Fatal(err)
@@ -18,11 +18,13 @@ func TestImmedieateBlockFacts(t *testing.T) {
 	if !exists {
 		t.Fatal("could not find block facts for current height")
 	}
-	if facts.Height != et.explorer.blockchainHeight || et.explorer.blockchainHeight == 0 {
-		t.Error("wrong height reported in facts object")
+	var explorerHeight types.BlockHeight
+	err = et.explorer.db.View(dbGetInternal(internalBlockHeight, &explorerHeight))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if facts.TransactionCount != et.explorer.transactionCount || et.explorer.transactionCount == 0 {
-		t.Error("wrong transaction count reported in facts object")
+	if facts.Height != explorerHeight || explorerHeight == 0 {
+		t.Error("wrong height reported in facts object")
 	}
 	if facts.TotalCoins.Cmp(types.CalculateNumSiacoins(et.cs.Height())) != 0 {
 		t.Error("wrong number of total coins:", facts.TotalCoins, et.cs.Height())

--- a/modules/explorer/persist.go
+++ b/modules/explorer/persist.go
@@ -61,7 +61,6 @@ func (e *Explorer) initPersist() error {
 			key, val []byte
 		}{
 			{internalBlockHeight, encoding.Marshal(types.BlockHeight(0))},
-			{internalDifficulty, encoding.Marshal(types.RootDepth)},
 			{internalRecentChange, encoding.Marshal(modules.ConsensusChangeID{})},
 		}
 		b := tx.Bucket(bucketInternal)

--- a/modules/explorer/persist.go
+++ b/modules/explorer/persist.go
@@ -77,6 +77,9 @@ func (e *Explorer) initPersist() error {
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/modules/explorer/persist.go
+++ b/modules/explorer/persist.go
@@ -2,7 +2,17 @@ package explorer
 
 import (
 	"os"
+	"path/filepath"
+
+	"github.com/NebulousLabs/Sia/persist"
+
+	"github.com/NebulousLabs/bolt"
 )
+
+var explorerMetadata = persist.Metadata{
+	Header:  "Sia Explorer",
+	Version: "0.5.2",
+}
 
 // initPersist initializes the persistent structures of the explorer module.
 func (e *Explorer) initPersist() error {
@@ -11,5 +21,39 @@ func (e *Explorer) initPersist() error {
 	if err != nil {
 		return err
 	}
+
+	// Open the database
+	db, err := persist.OpenDatabase(explorerMetadata, filepath.Join(e.persistDir, "explorer.db"))
+	if err != nil {
+		return err
+	}
+	e.db = db
+
+	// Initialize the database
+	err = e.db.Update(func(tx *bolt.Tx) error {
+		buckets := [][]byte{
+			bucketBlockFacts,
+			bucketBlockHashes,
+			bucketBlocksDifficulty,
+			bucketBlockTargets,
+			bucketFileContractHistories,
+			bucketFileContractIDs,
+			bucketRecentChange,
+			bucketSiacoinOutputIDs,
+			bucketSiacoinOutputs,
+			bucketSiafundOutputIDs,
+			bucketSiafundOutputs,
+			bucketTransactionHashes,
+			bucketUnlockHashes,
+		}
+		for _, b := range buckets {
+			_, err := tx.CreateBucketIfNotExists(b)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
 	return nil
 }

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -28,7 +28,7 @@ func (e *Explorer) ProcessConsensusChange(cc modules.ConsensusChange) {
 
 		// get starting block height
 		var blockheight types.BlockHeight
-		err = dbGetInternalBlockHeight(&blockheight)(tx)
+		err = dbGetInternal(internalBlockHeight, &blockheight)(tx)
 		if err != nil {
 			return err
 		}
@@ -223,13 +223,13 @@ func (e *Explorer) ProcessConsensusChange(cc modules.ConsensusChange) {
 		}
 
 		// set final blockheight
-		err = dbSetInternalBlockHeight(blockheight)(tx)
+		err = dbSetInternal(internalBlockHeight, blockheight)(tx)
 		if err != nil {
 			return err
 		}
 
 		// set change ID
-		err = dbSetInternalRecentChange(cc.ID)(tx)
+		err = dbSetInternal(internalRecentChange, cc.ID)(tx)
 		if err != nil {
 			return err
 		}
@@ -282,17 +282,17 @@ func dbAddBlockTarget(tx *bolt.Tx, id types.BlockID, target types.Target) {
 	mustPut(tx.Bucket(bucketBlockTargets), id, target)
 	// update difficulty
 	var difficulty types.Target
-	assertNil(dbGetInternalDifficulty(&difficulty)(tx))
+	assertNil(dbGetInternal(internalDifficulty, &difficulty)(tx))
 	difficulty = difficulty.AddDifficulties(target)
-	assertNil(dbSetInternalDifficulty(difficulty)(tx))
+	assertNil(dbSetInternal(internalDifficulty, difficulty)(tx))
 }
 func dbRemoveBlockTarget(tx *bolt.Tx, id types.BlockID, target types.Target) {
 	mustDelete(tx.Bucket(bucketBlockTargets), id)
 	// update difficulty
 	var difficulty types.Target
-	assertNil(dbGetInternalDifficulty(&difficulty)(tx))
+	assertNil(dbGetInternal(internalDifficulty, &difficulty)(tx))
 	difficulty = difficulty.SubtractDifficulties(target)
-	assertNil(dbSetInternalDifficulty(difficulty)(tx))
+	assertNil(dbSetInternal(internalDifficulty, difficulty)(tx))
 }
 
 // Add/Remove file contract

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -1,387 +1,509 @@
 package explorer
 
 import (
+	"fmt"
+
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
 )
 
 // ProcessConsensusChange follows the most recent changes to the consensus set,
 // including parsing new blocks and updating the utxo sets.
 func (e *Explorer) ProcessConsensusChange(cc modules.ConsensusChange) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
 	if len(cc.AppliedBlocks) == 0 {
 		build.Critical("Explorer.ProcessConsensusChange called with a ConensusChange that has no AppliedBlocks")
 	}
 
-	// Update cumulative stats for reverted blocks.
-	for _, block := range cc.RevertedBlocks {
-		bid := block.ID()
-		tbid := types.TransactionID(bid)
+	err := e.db.Update(func(tx *bolt.Tx) (err error) {
+		// use exception-style error handling to enable more concise update code
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("%v", r)
+			}
+		}()
 
-		// Update all of the explorer statistics.
-		e.blockchainHeight--
-		e.target = e.blockTargets[bid]
-		e.timestamp = block.Timestamp
-		e.blocksDifficulty = e.blocksDifficulty.SubtractDifficulties(e.target)
-		if e.blockchainHeight > hashrateEstimationBlocks {
-			e.blocksDifficulty = e.blocksDifficulty.AddDifficulties(e.historicFacts[e.blockchainHeight-hashrateEstimationBlocks].target)
-			secondsPassed := e.timestamp - e.historicFacts[e.blockchainHeight-hashrateEstimationBlocks].timestamp
-			e.estimatedHashrate = e.blocksDifficulty.Difficulty().Div(types.NewCurrency64(uint64(secondsPassed)))
+		// get starting block height
+		var blockheight types.BlockHeight
+		err = encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalBlockHeight), &blockheight)
+		if err != nil {
+			return err
 		}
 
-		// Delete the block from the list of active blocks.
-		delete(e.blockHashes, bid)
-		delete(e.blockTargets, bid)
-		delete(e.transactionHashes, tbid) // Miner payouts are a transaction.
+		// Update cumulative stats for reverted blocks.
+		for _, block := range cc.RevertedBlocks {
+			bid := block.ID()
+			tbid := types.TransactionID(bid)
 
-		// Catalog the removed miner payouts.
-		for j, payout := range block.MinerPayouts {
-			scoid := block.MinerPayoutID(uint64(j))
-			delete(e.siacoinOutputIDs[scoid], tbid)
-			delete(e.unlockHashes[payout.UnlockHash], tbid)
-			e.minerPayoutCount--
+			blockheight--
+			dbRemoveBlockID(tx, bid)
+			dbRemoveTransactionID(tx, tbid) // Miner payouts are a transaction
+
+			target, exists := e.cs.ChildTarget(block.ParentID)
+			if !exists {
+				target = types.RootTarget
+			}
+			dbRemoveBlockTarget(tx, bid, target)
+
+			// Remove miner payouts
+			for j, payout := range block.MinerPayouts {
+				scoid := block.MinerPayoutID(uint64(j))
+				dbRemoveSiacoinOutputID(tx, scoid, tbid)
+				dbRemoveUnlockHash(tx, payout.UnlockHash, tbid)
+			}
+
+			// Remove transactions
+			for _, txn := range block.Transactions {
+				txid := txn.ID()
+				dbRemoveTransactionID(tx, txid)
+
+				for _, sci := range txn.SiacoinInputs {
+					dbRemoveSiacoinOutputID(tx, sci.ParentID, txid)
+					dbRemoveUnlockHash(tx, sci.UnlockConditions.UnlockHash(), txid)
+				}
+				for k, sco := range txn.SiacoinOutputs {
+					scoid := txn.SiacoinOutputID(uint64(k))
+					dbRemoveSiacoinOutputID(tx, scoid, txid)
+					dbRemoveUnlockHash(tx, sco.UnlockHash, txid)
+					dbRemoveSiacoinOutput(tx, scoid)
+				}
+				for k, fc := range txn.FileContracts {
+					fcid := txn.FileContractID(uint64(k))
+					dbRemoveFileContractID(tx, fcid, txid)
+					dbRemoveUnlockHash(tx, fc.UnlockHash, txid)
+					for l, sco := range fc.ValidProofOutputs {
+						scoid := fcid.StorageProofOutputID(types.ProofValid, uint64(l))
+						dbRemoveSiacoinOutputID(tx, scoid, txid)
+						dbRemoveUnlockHash(tx, sco.UnlockHash, txid)
+					}
+					for l, sco := range fc.MissedProofOutputs {
+						scoid := fcid.StorageProofOutputID(types.ProofMissed, uint64(l))
+						dbRemoveSiacoinOutputID(tx, scoid, txid)
+						dbRemoveUnlockHash(tx, sco.UnlockHash, txid)
+					}
+					dbRemoveFileContract(tx, fcid)
+				}
+				for _, fcr := range txn.FileContractRevisions {
+					dbRemoveFileContractID(tx, fcr.ParentID, txid)
+					dbRemoveUnlockHash(tx, fcr.UnlockConditions.UnlockHash(), txid)
+					dbRemoveUnlockHash(tx, fcr.NewUnlockHash, txid)
+					for l, sco := range fcr.NewValidProofOutputs {
+						scoid := fcr.ParentID.StorageProofOutputID(types.ProofValid, uint64(l))
+						dbRemoveSiacoinOutputID(tx, scoid, txid)
+						dbRemoveUnlockHash(tx, sco.UnlockHash, txid)
+					}
+					for l, sco := range fcr.NewMissedProofOutputs {
+						scoid := fcr.ParentID.StorageProofOutputID(types.ProofMissed, uint64(l))
+						dbRemoveSiacoinOutputID(tx, scoid, txid)
+						dbRemoveUnlockHash(tx, sco.UnlockHash, txid)
+					}
+					// Remove the file contract revision from the revision chain.
+					dbRemoveFileContractRevision(tx, fcr.ParentID)
+				}
+				for _, sp := range txn.StorageProofs {
+					dbRemoveStorageProof(tx, sp.ParentID)
+				}
+				for _, sfi := range txn.SiafundInputs {
+					dbRemoveSiafundOutputID(tx, sfi.ParentID, txid)
+					dbRemoveUnlockHash(tx, sfi.UnlockConditions.UnlockHash(), txid)
+					dbRemoveUnlockHash(tx, sfi.ClaimUnlockHash, txid)
+				}
+				for k, sfo := range txn.SiafundOutputs {
+					sfoid := txn.SiafundOutputID(uint64(k))
+					dbRemoveSiafundOutputID(tx, sfoid, txid)
+					dbRemoveUnlockHash(tx, sfo.UnlockHash, txid)
+				}
+			}
+
+			// remove the associated block facts
+			dbRemoveBlockFacts(tx, bid)
 		}
 
-		// Update cumulative stats for reverted transcations.
-		for _, txn := range block.Transactions {
-			txid := txn.ID()
-			e.transactionCount--
-			delete(e.transactionHashes, txid)
+		// Update cumulative stats for applied blocks.
+		for _, block := range cc.AppliedBlocks {
+			bid := block.ID()
+			tbid := types.TransactionID(bid)
 
-			for _, sci := range txn.SiacoinInputs {
-				delete(e.siacoinOutputIDs[sci.ParentID], txid)
-				delete(e.unlockHashes[sci.UnlockConditions.UnlockHash()], txid)
-				e.siacoinInputCount--
+			// special handling for genesis block
+			if bid == types.GenesisBlock.ID() {
+				dbAddGenesisBlock(tx)
+				continue
 			}
-			for k, sco := range txn.SiacoinOutputs {
-				delete(e.siacoinOutputIDs[txn.SiacoinOutputID(uint64(k))], txid)
-				delete(e.unlockHashes[sco.UnlockHash], txid)
-				e.siacoinOutputCount--
+
+			blockheight++
+			dbAddBlockID(tx, bid, blockheight)
+			dbAddTransactionID(tx, tbid, blockheight) // Miner payouts are a transaction
+
+			target, exists := e.cs.ChildTarget(block.ParentID)
+			if !exists {
+				target = types.RootTarget
 			}
-			for k, fc := range txn.FileContracts {
-				fcid := txn.FileContractID(uint64(k))
-				delete(e.fileContractIDs[fcid], txid)
-				delete(e.unlockHashes[fc.UnlockHash], txid)
-				for l, sco := range fc.ValidProofOutputs {
-					scoid := fcid.StorageProofOutputID(types.ProofValid, uint64(l))
-					delete(e.siacoinOutputIDs[scoid], txid)
-					delete(e.unlockHashes[sco.UnlockHash], txid)
+			dbAddBlockTarget(tx, bid, target)
+
+			// Catalog the new miner payouts.
+			for j, payout := range block.MinerPayouts {
+				scoid := block.MinerPayoutID(uint64(j))
+				dbAddSiacoinOutputID(tx, scoid, tbid)
+				dbAddUnlockHash(tx, payout.UnlockHash, tbid)
+			}
+
+			// Update cumulative stats for applied transactions.
+			for _, txn := range block.Transactions {
+				// Add the transaction to the list of active transactions.
+				txid := txn.ID()
+				dbAddTransactionID(tx, txid, blockheight)
+
+				for _, sci := range txn.SiacoinInputs {
+					dbAddSiacoinOutputID(tx, sci.ParentID, txid)
+					dbAddUnlockHash(tx, sci.UnlockConditions.UnlockHash(), txid)
 				}
-				for l, sco := range fc.MissedProofOutputs {
-					scoid := fcid.StorageProofOutputID(types.ProofMissed, uint64(l))
-					delete(e.siacoinOutputIDs[scoid], txid)
-					delete(e.unlockHashes[sco.UnlockHash], txid)
+				for j, sco := range txn.SiacoinOutputs {
+					scoid := txn.SiacoinOutputID(uint64(j))
+					dbAddSiacoinOutputID(tx, scoid, txid)
+					dbAddUnlockHash(tx, sco.UnlockHash, txid)
+					dbAddSiacoinOutput(tx, scoid, sco)
 				}
-				e.fileContractCount--
-				e.totalContractCost = e.totalContractCost.Sub(fc.Payout)
-				e.totalContractSize = e.totalContractSize.Sub(types.NewCurrency64(fc.FileSize))
-			}
-			for _, fcr := range txn.FileContractRevisions {
-				delete(e.fileContractIDs[fcr.ParentID], txid)
-				delete(e.unlockHashes[fcr.UnlockConditions.UnlockHash()], txid)
-				delete(e.unlockHashes[fcr.NewUnlockHash], txid)
-				// Remove the file contract revision from the revision chain.
-				e.fileContractHistories[fcr.ParentID].revisions = e.fileContractHistories[fcr.ParentID].revisions[:len(e.fileContractHistories[fcr.ParentID].revisions)-1]
-				for l, sco := range fcr.NewValidProofOutputs {
-					scoid := fcr.ParentID.StorageProofOutputID(types.ProofValid, uint64(l))
-					delete(e.siacoinOutputIDs[scoid], txid)
-					delete(e.unlockHashes[sco.UnlockHash], txid)
+				for k, fc := range txn.FileContracts {
+					fcid := txn.FileContractID(uint64(k))
+					dbAddFileContractID(tx, fcid, txid)
+					dbAddUnlockHash(tx, fc.UnlockHash, txid)
+					dbAddFileContract(tx, fcid, fc)
+					for l, sco := range fc.ValidProofOutputs {
+						scoid := fcid.StorageProofOutputID(types.ProofValid, uint64(l))
+						dbAddSiacoinOutputID(tx, scoid, txid)
+						dbAddUnlockHash(tx, sco.UnlockHash, txid)
+					}
+					for l, sco := range fc.MissedProofOutputs {
+						scoid := fcid.StorageProofOutputID(types.ProofMissed, uint64(l))
+						dbAddSiacoinOutputID(tx, scoid, txid)
+						dbAddUnlockHash(tx, sco.UnlockHash, txid)
+					}
 				}
-				for l, sco := range fcr.NewMissedProofOutputs {
-					scoid := fcr.ParentID.StorageProofOutputID(types.ProofMissed, uint64(l))
-					delete(e.siacoinOutputIDs[scoid], txid)
-					delete(e.unlockHashes[sco.UnlockHash], txid)
+				for _, fcr := range txn.FileContractRevisions {
+					dbAddFileContractID(tx, fcr.ParentID, txid)
+					dbAddUnlockHash(tx, fcr.UnlockConditions.UnlockHash(), txid)
+					dbAddUnlockHash(tx, fcr.NewUnlockHash, txid)
+					for l, sco := range fcr.NewValidProofOutputs {
+						scoid := fcr.ParentID.StorageProofOutputID(types.ProofValid, uint64(l))
+						dbAddSiacoinOutputID(tx, scoid, txid)
+						dbAddUnlockHash(tx, sco.UnlockHash, txid)
+					}
+					for l, sco := range fcr.NewMissedProofOutputs {
+						scoid := fcr.ParentID.StorageProofOutputID(types.ProofMissed, uint64(l))
+						dbAddSiacoinOutputID(tx, scoid, txid)
+						dbAddUnlockHash(tx, sco.UnlockHash, txid)
+					}
+					dbAddFileContractRevision(tx, fcr.ParentID, fcr)
 				}
-				e.fileContractRevisionCount--
-				e.totalContractSize = e.totalContractSize.Sub(types.NewCurrency64(fcr.NewFileSize))
-				e.totalRevisionVolume = e.totalRevisionVolume.Sub(types.NewCurrency64(fcr.NewFileSize))
+				for _, sp := range txn.StorageProofs {
+					dbAddFileContractID(tx, sp.ParentID, txid)
+					dbAddStorageProof(tx, sp.ParentID, sp)
+				}
+				for _, sfi := range txn.SiafundInputs {
+					dbAddSiafundOutputID(tx, sfi.ParentID, txid)
+					dbAddUnlockHash(tx, sfi.UnlockConditions.UnlockHash(), txid)
+					dbAddUnlockHash(tx, sfi.ClaimUnlockHash, txid)
+				}
+				for k, sfo := range txn.SiafundOutputs {
+					sfoid := txn.SiafundOutputID(uint64(k))
+					dbAddSiafundOutputID(tx, sfoid, txid)
+					dbAddUnlockHash(tx, sfo.UnlockHash, txid)
+					dbAddSiafundOutput(tx, sfoid, sfo)
+				}
 			}
-			for _, sp := range txn.StorageProofs {
-				delete(e.fileContractIDs[sp.ParentID], txid)
-				e.storageProofCount--
-			}
-			for _, sfi := range txn.SiafundInputs {
-				delete(e.siafundOutputIDs[sfi.ParentID], txid)
-				delete(e.unlockHashes[sfi.UnlockConditions.UnlockHash()], txid)
-				delete(e.unlockHashes[sfi.ClaimUnlockHash], txid)
-				e.siafundInputCount--
-			}
-			for k, sfo := range txn.SiafundOutputs {
-				sfoid := txn.SiafundOutputID(uint64(k))
-				delete(e.siafundOutputIDs[sfoid], txid)
-				delete(e.unlockHashes[sfo.UnlockHash], txid)
-				e.siafundOutputCount--
-			}
-			for _ = range txn.MinerFees {
-				e.minerFeeCount--
-			}
-			for _ = range txn.ArbitraryData {
-				e.arbitraryDataCount--
-			}
-			for _ = range txn.TransactionSignatures {
-				e.transactionSignatureCount--
+
+			// calculate and add new block facts, if possible
+			if tx.Bucket(bucketBlockFacts).Get(encoding.Marshal(block.ParentID)) != nil {
+				facts := dbCalculateBlockFacts(tx, e.cs, block)
+				dbAddBlockFacts(tx, facts)
 			}
 		}
+
+		// set final blockheight
+		dbSetBlockHeight(tx, blockheight)
+
+		// TODO: set cc.ID
+		// TODO: incorporate cc.FileContractDiffs
+		return nil
+	})
+	if err != nil {
+		build.Critical("explorer update failed:", err)
 	}
-	// Delete all of the block facts for the reverted blocks.
-	e.historicFacts = e.historicFacts[:len(e.historicFacts)-len(cc.RevertedBlocks)]
+}
 
-	// Update cumulative stats for applied blocks.
-	for _, block := range cc.AppliedBlocks {
-		// Add the block to the list of active blocks.
-		bid := block.ID()
-		tbid := types.TransactionID(bid)
-		e.currentBlock = bid
-		e.blockchainHeight++
-		var exists bool
-		e.target, exists = e.cs.ChildTarget(block.ParentID)
+// helper functions
+func assertNil(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+func mustPut(bucket *bolt.Bucket, key, val interface{}) {
+	assertNil(bucket.Put(encoding.Marshal(key), encoding.Marshal(val)))
+}
+func mustPutSet(bucket *bolt.Bucket, key interface{}) {
+	assertNil(bucket.Put(encoding.Marshal(key), nil))
+}
+func mustDelete(bucket *bolt.Bucket, key interface{}) {
+	assertNil(bucket.Delete(encoding.Marshal(key)))
+}
+
+// These functions panic on error. The panic will be caught by
+// ProcessConsensusChange.
+
+func dbSetBlockHeight(tx *bolt.Tx, height types.BlockHeight) {
+	err := tx.Bucket(bucketInternal).Put(internalBlockHeight, encoding.Marshal(height))
+	assertNil(err)
+}
+
+// Add/Remove block ID
+func dbAddBlockID(tx *bolt.Tx, id types.BlockID, height types.BlockHeight) {
+	mustPut(tx.Bucket(bucketBlockIDs), id, height)
+}
+func dbRemoveBlockID(tx *bolt.Tx, id types.BlockID) {
+	mustDelete(tx.Bucket(bucketBlockIDs), id)
+}
+
+// Add/Remove block facts
+func dbAddBlockFacts(tx *bolt.Tx, facts blockFacts) {
+	mustPut(tx.Bucket(bucketBlockFacts), facts.currentBlock, facts)
+}
+func dbRemoveBlockFacts(tx *bolt.Tx, id types.BlockID) {
+	mustDelete(tx.Bucket(bucketBlockFacts), id)
+}
+
+// Add/Remove block target
+func dbAddBlockTarget(tx *bolt.Tx, id types.BlockID, target types.Target) {
+	mustPut(tx.Bucket(bucketBlockTargets), id, target)
+	// update difficulty
+	b := tx.Bucket(bucketInternal)
+	var difficulty types.Target
+	assertNil(encoding.Unmarshal(b.Get(internalDifficulty), &difficulty))
+	difficulty = difficulty.AddDifficulties(target)
+	assertNil(b.Put(internalDifficulty, encoding.Marshal(difficulty)))
+}
+func dbRemoveBlockTarget(tx *bolt.Tx, id types.BlockID, target types.Target) {
+	mustDelete(tx.Bucket(bucketBlockTargets), id)
+	// update difficulty
+	b := tx.Bucket(bucketInternal)
+	var difficulty types.Target
+	assertNil(encoding.Unmarshal(b.Get(internalDifficulty), &difficulty))
+	difficulty = difficulty.SubtractDifficulties(target)
+	assertNil(b.Put(internalDifficulty, encoding.Marshal(difficulty)))
+}
+
+// Add/Remove file contract
+func dbAddFileContract(tx *bolt.Tx, id types.FileContractID, fc types.FileContract) {
+	history := fileContractHistory{contract: fc}
+	mustPut(tx.Bucket(bucketFileContractHistories), id, history)
+}
+func dbRemoveFileContract(tx *bolt.Tx, id types.FileContractID) {
+	mustDelete(tx.Bucket(bucketFileContractHistories), id)
+}
+
+// Add/Remove txid from file contract ID bucket
+func dbAddFileContractID(tx *bolt.Tx, id types.FileContractID, txid types.TransactionID) {
+	b, err := tx.Bucket(bucketFileContractIDs).CreateBucketIfNotExists(encoding.Marshal(id))
+	assertNil(err)
+	mustPutSet(b, txid)
+}
+func dbRemoveFileContractID(tx *bolt.Tx, id types.FileContractID, txid types.TransactionID) {
+	// TODO: delete bucket when it becomes empty
+	mustDelete(tx.Bucket(bucketFileContractIDs).Bucket(encoding.Marshal(id)), txid)
+}
+
+func dbAddFileContractRevision(tx *bolt.Tx, fcid types.FileContractID, fcr types.FileContractRevision) {
+	b := tx.Bucket(bucketFileContractHistories)
+	var history fileContractHistory
+	assertNil(getAndDecode(b, fcid, &history))
+	history.revisions = append(history.revisions, fcr)
+	mustPut(b, fcid, history)
+}
+func dbRemoveFileContractRevision(tx *bolt.Tx, fcid types.FileContractID) {
+	b := tx.Bucket(bucketFileContractHistories)
+	var history fileContractHistory
+	assertNil(getAndDecode(b, fcid, &history))
+	// TODO: could be more rigorous
+	history.revisions = history.revisions[:len(history.revisions)-1]
+	mustPut(b, fcid, history)
+}
+
+// Add/Remove siacoin output
+func dbAddSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID, output types.SiacoinOutput) {
+	mustPut(tx.Bucket(bucketSiacoinOutputs), id, output)
+}
+func dbRemoveSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID) {
+	mustDelete(tx.Bucket(bucketSiacoinOutputs), id)
+}
+
+// Add/Remove txid from siacoin output ID bucket
+func dbAddSiacoinOutputID(tx *bolt.Tx, id types.SiacoinOutputID, txid types.TransactionID) {
+	b, err := tx.Bucket(bucketSiacoinOutputIDs).CreateBucketIfNotExists(encoding.Marshal(id))
+	assertNil(err)
+	mustPutSet(b, txid)
+}
+func dbRemoveSiacoinOutputID(tx *bolt.Tx, id types.SiacoinOutputID, txid types.TransactionID) {
+	// TODO: delete bucket when it becomes empty
+	mustDelete(tx.Bucket(bucketSiacoinOutputIDs).Bucket(encoding.Marshal(id)), txid)
+}
+
+// Add/Remove siafund output
+func dbAddSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID, output types.SiafundOutput) {
+	mustPut(tx.Bucket(bucketSiafundOutputs), id, output)
+}
+func dbRemoveSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) {
+	mustDelete(tx.Bucket(bucketSiafundOutputs), id)
+}
+
+// Add/Remove txid from siafund output ID bucket
+func dbAddSiafundOutputID(tx *bolt.Tx, id types.SiafundOutputID, txid types.TransactionID) {
+	b, err := tx.Bucket(bucketSiafundOutputIDs).CreateBucketIfNotExists(encoding.Marshal(id))
+	assertNil(err)
+	mustPutSet(b, txid)
+}
+func dbRemoveSiafundOutputID(tx *bolt.Tx, id types.SiafundOutputID, txid types.TransactionID) {
+	// TODO: delete bucket when it becomes empty
+	mustDelete(tx.Bucket(bucketSiafundOutputIDs).Bucket(encoding.Marshal(id)), txid)
+}
+
+// Add/Remove storage proof
+func dbAddStorageProof(tx *bolt.Tx, fcid types.FileContractID, sp types.StorageProof) {
+	b := tx.Bucket(bucketFileContractHistories)
+	var history fileContractHistory
+	assertNil(getAndDecode(b, fcid, &history))
+	history.storageProof = sp
+	mustPut(b, fcid, history)
+}
+func dbRemoveStorageProof(tx *bolt.Tx, fcid types.FileContractID) {
+	dbAddStorageProof(tx, fcid, types.StorageProof{})
+}
+
+// Add/Remove transaction ID
+func dbAddTransactionID(tx *bolt.Tx, id types.TransactionID, height types.BlockHeight) {
+	mustPut(tx.Bucket(bucketTransactionIDs), id, height)
+}
+func dbRemoveTransactionID(tx *bolt.Tx, id types.TransactionID) {
+	mustDelete(tx.Bucket(bucketTransactionIDs), id)
+}
+
+// Add/Remove txid from unlock hash bucket
+func dbAddUnlockHash(tx *bolt.Tx, uh types.UnlockHash, txid types.TransactionID) {
+	b, err := tx.Bucket(bucketUnlockHashes).CreateBucketIfNotExists(encoding.Marshal(uh))
+	assertNil(err)
+	mustPutSet(b, txid)
+}
+func dbRemoveUnlockHash(tx *bolt.Tx, uh types.UnlockHash, txid types.TransactionID) {
+	// TODO: delete bucket when it becomes empty
+	mustDelete(tx.Bucket(bucketUnlockHashes).Bucket(encoding.Marshal(uh)), txid)
+}
+
+func dbCalculateBlockFacts(tx *bolt.Tx, cs modules.ConsensusSet, block types.Block) blockFacts {
+	// get the parent block facts
+	var bf blockFacts
+	err := getAndDecode(tx.Bucket(bucketBlockFacts), block.ParentID, &bf)
+	assertNil(err)
+
+	// get target
+	target, exists := cs.ChildTarget(block.ParentID)
+	if !exists {
+		panic(fmt.Sprint("ConsensusSet is missing target of known block", block.ParentID))
+	}
+
+	// update fields
+	bf.currentBlock = block.ID()
+	bf.blockchainHeight++
+	bf.target = target
+	bf.timestamp = block.Timestamp
+	bf.totalCoins = types.CalculateNumSiacoins(bf.blockchainHeight)
+
+	// calculate maturity timestamp
+	var maturityTimestamp types.Timestamp
+	if bf.blockchainHeight > types.MaturityDelay {
+		oldBlock, exists := cs.BlockAtHeight(bf.blockchainHeight - types.MaturityDelay)
 		if !exists {
-			e.target = types.RootTarget
+			panic(fmt.Sprint("ConsensusSet is missing block at height", bf.blockchainHeight-types.MaturityDelay))
 		}
-		e.timestamp = block.Timestamp
-		if e.blockchainHeight > types.MaturityDelay {
-			e.maturityTimestamp = e.historicFacts[e.blockchainHeight-types.MaturityDelay].timestamp
+		maturityTimestamp = oldBlock.Timestamp
+	}
+	bf.maturityTimestamp = maturityTimestamp
+
+	// get difficulty
+	var difficulty types.Target
+	err = encoding.Unmarshal(tx.Bucket(bucketInternal).Get(internalDifficulty), &difficulty)
+	assertNil(err)
+
+	// calculate hashrate
+	var estimatedHashrate types.Currency
+	difficulty = difficulty.AddDifficulties(target)
+	if bf.blockchainHeight > hashrateEstimationBlocks {
+		oldBlock, exists := cs.BlockAtHeight(bf.blockchainHeight - hashrateEstimationBlocks)
+		if !exists {
+			panic(fmt.Sprint("ConsensusSet is missing block at height", bf.blockchainHeight-hashrateEstimationBlocks))
 		}
-		e.blocksDifficulty = e.blocksDifficulty.AddDifficulties(e.target)
-		if e.blockchainHeight > hashrateEstimationBlocks {
-			e.blocksDifficulty = e.blocksDifficulty.SubtractDifficulties(e.historicFacts[e.blockchainHeight-hashrateEstimationBlocks].target)
-			secondsPassed := e.timestamp - e.historicFacts[e.blockchainHeight-hashrateEstimationBlocks].timestamp
-			e.estimatedHashrate = e.blocksDifficulty.Difficulty().Div(types.NewCurrency64(uint64(secondsPassed)))
+		oldTarget, exists := cs.ChildTarget(oldBlock.ID())
+		if !exists {
+			panic(fmt.Sprint("ConsensusSet is missing target of known block", oldBlock.ID()))
 		}
-		e.totalCoins = types.CalculateNumSiacoins(e.blockchainHeight)
+		hashDifficulty := difficulty.SubtractDifficulties(oldTarget)
+		secondsPassed := block.Timestamp - oldBlock.Timestamp
+		estimatedHashrate = hashDifficulty.Difficulty().Div(types.NewCurrency64(uint64(secondsPassed)))
+	}
+	bf.estimatedHashrate = estimatedHashrate
 
-		e.blockHashes[bid] = e.blockchainHeight
-		e.transactionHashes[tbid] = e.blockchainHeight // Miner payouts are a transaciton.
-		e.blockTargets[bid] = e.target
+	bf.minerPayoutCount += uint64(len(block.MinerPayouts))
+	bf.transactionCount += uint64(len(block.Transactions))
+	for _, txn := range block.Transactions {
+		bf.siacoinInputCount += uint64(len(txn.SiacoinInputs))
+		bf.siacoinOutputCount += uint64(len(txn.SiacoinOutputs))
+		bf.fileContractCount += uint64(len(txn.FileContracts))
+		bf.fileContractRevisionCount += uint64(len(txn.FileContractRevisions))
+		bf.storageProofCount += uint64(len(txn.StorageProofs))
+		bf.siafundInputCount += uint64(len(txn.SiafundInputs))
+		bf.siafundOutputCount += uint64(len(txn.SiafundOutputs))
+		bf.minerFeeCount += uint64(len(txn.MinerFees))
+		bf.arbitraryDataCount += uint64(len(txn.ArbitraryData))
+		bf.transactionSignatureCount += uint64(len(txn.TransactionSignatures))
 
-		// Catalog the new miner payouts.
-		for j, payout := range block.MinerPayouts {
-			scoid := block.MinerPayoutID(uint64(j))
-			_, exists := e.siacoinOutputIDs[scoid]
-			if !exists {
-				e.siacoinOutputIDs[scoid] = make(map[types.TransactionID]struct{})
-			}
-			e.siacoinOutputIDs[scoid][tbid] = struct{}{}
-			_, exists = e.unlockHashes[payout.UnlockHash]
-			if !exists {
-				e.unlockHashes[payout.UnlockHash] = make(map[types.TransactionID]struct{})
-			}
-			e.unlockHashes[payout.UnlockHash][tbid] = struct{}{}
-			e.minerPayoutCount++
+		for _, fc := range txn.FileContracts {
+			bf.totalContractCost = bf.totalContractCost.Add(fc.Payout)
+			bf.totalContractSize = bf.totalContractSize.Add(types.NewCurrency64(fc.FileSize))
 		}
-
-		// Update cumulative stats for applied transactions.
-		for _, txn := range block.Transactions {
-			// Add the transaction to the list of active transactions.
-			txid := txn.ID()
-			e.transactionCount++
-			e.transactionHashes[txid] = e.blockchainHeight
-
-			for _, sci := range txn.SiacoinInputs {
-				_, exists := e.siacoinOutputIDs[sci.ParentID]
-				if build.DEBUG && !exists {
-					panic("siacoin input without siacoin output")
-				} else if !exists {
-					e.siacoinOutputIDs[sci.ParentID] = make(map[types.TransactionID]struct{})
-				}
-				e.siacoinOutputIDs[sci.ParentID][txid] = struct{}{}
-				_, exists = e.unlockHashes[sci.UnlockConditions.UnlockHash()]
-				if build.DEBUG && !exists {
-					panic("unlock conditions without a parent unlock hash")
-				} else if !exists {
-					e.unlockHashes[sci.UnlockConditions.UnlockHash()] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[sci.UnlockConditions.UnlockHash()][txid] = struct{}{}
-				e.siacoinInputCount++
-			}
-			for j, sco := range txn.SiacoinOutputs {
-				scoid := txn.SiacoinOutputID(uint64(j))
-				_, exists := e.siacoinOutputIDs[scoid]
-				if !exists {
-					e.siacoinOutputIDs[scoid] = make(map[types.TransactionID]struct{})
-				}
-				e.siacoinOutputIDs[scoid][txid] = struct{}{}
-				_, exists = e.unlockHashes[sco.UnlockHash]
-				if !exists {
-					e.unlockHashes[sco.UnlockHash] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[sco.UnlockHash][txn.ID()] = struct{}{}
-				e.siacoinOutputs[scoid] = sco
-				e.siacoinOutputCount++
-			}
-			for k, fc := range txn.FileContracts {
-				fcid := txn.FileContractID(uint64(k))
-				_, exists := e.fileContractIDs[fcid]
-				if !exists {
-					e.fileContractIDs[fcid] = make(map[types.TransactionID]struct{})
-				}
-				e.fileContractIDs[fcid][txid] = struct{}{}
-				_, exists = e.unlockHashes[fc.UnlockHash]
-				if !exists {
-					e.unlockHashes[fc.UnlockHash] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[fc.UnlockHash][txid] = struct{}{}
-				e.fileContractHistories[fcid] = &fileContractHistory{contract: fc}
-				for l, sco := range fc.ValidProofOutputs {
-					scoid := fcid.StorageProofOutputID(types.ProofValid, uint64(l))
-					_, exists = e.siacoinOutputIDs[scoid]
-					if !exists {
-						e.siacoinOutputIDs[scoid] = make(map[types.TransactionID]struct{})
-					}
-					e.siacoinOutputIDs[scoid][txid] = struct{}{}
-					_, exists = e.unlockHashes[sco.UnlockHash]
-					if !exists {
-						e.unlockHashes[sco.UnlockHash] = make(map[types.TransactionID]struct{})
-					}
-					e.unlockHashes[sco.UnlockHash][txid] = struct{}{}
-				}
-				for l, sco := range fc.MissedProofOutputs {
-					scoid := fcid.StorageProofOutputID(types.ProofMissed, uint64(l))
-					_, exists = e.siacoinOutputIDs[scoid]
-					if !exists {
-						e.siacoinOutputIDs[scoid] = make(map[types.TransactionID]struct{})
-					}
-					e.siacoinOutputIDs[scoid][txid] = struct{}{}
-					_, exists = e.unlockHashes[sco.UnlockHash]
-					if !exists {
-						e.unlockHashes[sco.UnlockHash] = make(map[types.TransactionID]struct{})
-					}
-					e.unlockHashes[sco.UnlockHash][txid] = struct{}{}
-				}
-				e.fileContractCount++
-				e.totalContractCost = e.totalContractCost.Add(fc.Payout)
-				e.totalContractSize = e.totalContractSize.Add(types.NewCurrency64(fc.FileSize))
-			}
-			for _, fcr := range txn.FileContractRevisions {
-				_, exists := e.fileContractIDs[fcr.ParentID]
-				if build.DEBUG && !exists {
-					panic("revision without entry in file contract list")
-				} else if !exists {
-					e.fileContractIDs[fcr.ParentID] = make(map[types.TransactionID]struct{})
-				}
-				e.fileContractIDs[fcr.ParentID][txid] = struct{}{}
-				_, exists = e.unlockHashes[fcr.UnlockConditions.UnlockHash()]
-				if build.DEBUG && !exists {
-					panic("unlock conditions without unlock hash")
-				} else if !exists {
-					e.unlockHashes[fcr.UnlockConditions.UnlockHash()] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[fcr.UnlockConditions.UnlockHash()][txid] = struct{}{}
-				_, exists = e.unlockHashes[fcr.NewUnlockHash]
-				if !exists {
-					e.unlockHashes[fcr.NewUnlockHash] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[fcr.NewUnlockHash][txid] = struct{}{}
-				for l, sco := range fcr.NewValidProofOutputs {
-					scoid := fcr.ParentID.StorageProofOutputID(types.ProofValid, uint64(l))
-					_, exists = e.siacoinOutputIDs[scoid]
-					if !exists {
-						e.siacoinOutputIDs[scoid] = make(map[types.TransactionID]struct{})
-					}
-					e.siacoinOutputIDs[scoid][txid] = struct{}{}
-					_, exists = e.unlockHashes[sco.UnlockHash]
-					if !exists {
-						e.unlockHashes[sco.UnlockHash] = make(map[types.TransactionID]struct{})
-					}
-					e.unlockHashes[sco.UnlockHash][txid] = struct{}{}
-				}
-				for l, sco := range fcr.NewMissedProofOutputs {
-					scoid := fcr.ParentID.StorageProofOutputID(types.ProofMissed, uint64(l))
-					_, exists = e.siacoinOutputIDs[scoid]
-					if !exists {
-						e.siacoinOutputIDs[scoid] = make(map[types.TransactionID]struct{})
-					}
-					e.siacoinOutputIDs[scoid][txid] = struct{}{}
-					_, exists = e.unlockHashes[sco.UnlockHash]
-					if !exists {
-						e.unlockHashes[sco.UnlockHash] = make(map[types.TransactionID]struct{})
-					}
-					e.unlockHashes[sco.UnlockHash][txid] = struct{}{}
-				}
-				e.fileContractRevisionCount++
-				e.totalContractSize = e.totalContractSize.Add(types.NewCurrency64(fcr.NewFileSize))
-				e.totalRevisionVolume = e.totalRevisionVolume.Add(types.NewCurrency64(fcr.NewFileSize))
-				e.fileContractHistories[fcr.ParentID].revisions = append(e.fileContractHistories[fcr.ParentID].revisions, fcr)
-			}
-			for _, sp := range txn.StorageProofs {
-				_, exists := e.fileContractIDs[sp.ParentID]
-				if build.DEBUG && !exists {
-					panic("storage proof without file contract parent")
-				} else if !exists {
-					e.fileContractIDs[sp.ParentID] = make(map[types.TransactionID]struct{})
-				}
-				e.fileContractIDs[sp.ParentID][txid] = struct{}{}
-				e.fileContractHistories[sp.ParentID].storageProof = sp
-				e.storageProofCount++
-			}
-			for _, sfi := range txn.SiafundInputs {
-				_, exists := e.siafundOutputIDs[sfi.ParentID]
-				if build.DEBUG && !exists {
-					panic("siafund input without corresponding output")
-				} else if !exists {
-					e.siafundOutputIDs[sfi.ParentID] = make(map[types.TransactionID]struct{})
-				}
-				e.siafundOutputIDs[sfi.ParentID][txid] = struct{}{}
-				_, exists = e.unlockHashes[sfi.UnlockConditions.UnlockHash()]
-				if build.DEBUG && !exists {
-					panic("unlock conditions without unlock hash")
-				} else if !exists {
-					e.unlockHashes[sfi.UnlockConditions.UnlockHash()] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[sfi.UnlockConditions.UnlockHash()][txid] = struct{}{}
-				_, exists = e.unlockHashes[sfi.ClaimUnlockHash]
-				if !exists {
-					e.unlockHashes[sfi.ClaimUnlockHash] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[sfi.ClaimUnlockHash][txid] = struct{}{}
-				e.siafundInputCount++
-			}
-			for k, sfo := range txn.SiafundOutputs {
-				sfoid := txn.SiafundOutputID(uint64(k))
-				_, exists := e.siafundOutputIDs[sfoid]
-				if !exists {
-					e.siafundOutputIDs[sfoid] = make(map[types.TransactionID]struct{})
-				}
-				e.siafundOutputIDs[sfoid][txid] = struct{}{}
-				_, exists = e.unlockHashes[sfo.UnlockHash]
-				if !exists {
-					e.unlockHashes[sfo.UnlockHash] = make(map[types.TransactionID]struct{})
-				}
-				e.unlockHashes[sfo.UnlockHash][txid] = struct{}{}
-				e.siafundOutputs[sfoid] = sfo
-				e.siafundOutputCount++
-			}
-			for _ = range txn.MinerFees {
-				e.minerFeeCount++
-			}
-			for _ = range txn.ArbitraryData {
-				e.arbitraryDataCount++
-			}
-			for _ = range txn.TransactionSignatures {
-				e.transactionSignatureCount++
-			}
+		for _, fcr := range txn.FileContractRevisions {
+			bf.totalContractSize = bf.totalContractSize.Add(types.NewCurrency64(fcr.NewFileSize))
+			bf.totalRevisionVolume = bf.totalRevisionVolume.Add(types.NewCurrency64(fcr.NewFileSize))
 		}
-
-		// Set the current block and copy over the historic facts.
-		e.historicFacts = append(e.historicFacts, e.blockFacts)
 	}
 
-	// Compute the changes in the active set. Note, because this is calculated
-	// at the end instead of in a loop, the historic facts may contain
-	// inaccuracies about the active set. This should not be a problem except
-	// for large reorgs.
-	for _, diff := range cc.FileContractDiffs {
-		if diff.Direction == modules.DiffApply {
-			e.activeContractCount++
-			e.activeContractCost = e.activeContractCost.Add(diff.FileContract.Payout)
-			e.activeContractSize = e.activeContractSize.Add(types.NewCurrency64(diff.FileContract.FileSize))
-		} else {
-			e.activeContractCount--
-			e.activeContractCost = e.activeContractCost.Sub(diff.FileContract.Payout)
-			e.activeContractSize = e.activeContractSize.Sub(types.NewCurrency64(diff.FileContract.FileSize))
-		}
+	return bf
+}
+
+// Special handling for the genesis block. No other functions are called on it.
+func dbAddGenesisBlock(tx *bolt.Tx) {
+	id := types.GenesisBlock.ID()
+	dbAddBlockID(tx, id, 0)
+	txid := types.GenesisBlock.Transactions[0].ID()
+	dbAddTransactionID(tx, txid, 0)
+	for i, sfo := range types.GenesisSiafundAllocation {
+		sfoid := types.GenesisBlock.Transactions[0].SiafundOutputID(uint64(i))
+		dbAddSiafundOutputID(tx, sfoid, txid)
+		dbAddUnlockHash(tx, sfo.UnlockHash, txid)
+		dbAddSiafundOutput(tx, sfoid, sfo)
 	}
+	dbAddBlockFacts(tx, blockFacts{
+		currentBlock:        id,
+		blockchainHeight:    0,
+		target:              types.RootTarget,
+		timestamp:           types.GenesisBlock.Timestamp,
+		estimatedHashrate:   types.ZeroCurrency,
+		totalCoins:          types.CalculateCoinbase(0),
+		siafundOutputCount:  uint64(len(types.GenesisSiafundAllocation)),
+		transactionCount:    1,
+		activeContractCost:  types.ZeroCurrency,
+		activeContractSize:  types.ZeroCurrency,
+		totalContractCost:   types.ZeroCurrency,
+		totalContractSize:   types.ZeroCurrency,
+		totalRevisionVolume: types.ZeroCurrency,
+	})
 }

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -318,14 +318,14 @@ func dbRemoveFileContractID(tx *bolt.Tx, id types.FileContractID, txid types.Tra
 func dbAddFileContractRevision(tx *bolt.Tx, fcid types.FileContractID, fcr types.FileContractRevision) {
 	b := tx.Bucket(bucketFileContractHistories)
 	var history fileContractHistory
-	assertNil(getAndDecode(b, fcid, &history))
+	assertNil(dbGetFileContractHistory(fcid, &history)(tx))
 	history.Revisions = append(history.Revisions, fcr)
 	mustPut(b, fcid, history)
 }
 func dbRemoveFileContractRevision(tx *bolt.Tx, fcid types.FileContractID) {
 	b := tx.Bucket(bucketFileContractHistories)
 	var history fileContractHistory
-	assertNil(getAndDecode(b, fcid, &history))
+	assertNil(dbGetFileContractHistory(fcid, &history)(tx))
 	// TODO: could be more rigorous
 	history.Revisions = history.Revisions[:len(history.Revisions)-1]
 	mustPut(b, fcid, history)
@@ -373,7 +373,7 @@ func dbRemoveSiafundOutputID(tx *bolt.Tx, id types.SiafundOutputID, txid types.T
 func dbAddStorageProof(tx *bolt.Tx, fcid types.FileContractID, sp types.StorageProof) {
 	b := tx.Bucket(bucketFileContractHistories)
 	var history fileContractHistory
-	assertNil(getAndDecode(b, fcid, &history))
+	assertNil(dbGetFileContractHistory(fcid, &history)(tx))
 	history.StorageProof = sp
 	mustPut(b, fcid, history)
 }
@@ -403,7 +403,7 @@ func dbRemoveUnlockHash(tx *bolt.Tx, uh types.UnlockHash, txid types.Transaction
 func dbCalculateBlockFacts(tx *bolt.Tx, cs modules.ConsensusSet, block types.Block) blockFacts {
 	// get the parent block facts
 	var bf blockFacts
-	err := getAndDecode(tx.Bucket(bucketBlockFacts), block.ParentID, &bf)
+	err := dbGetBlockFacts(block.ParentID, &bf)(tx)
 	assertNil(err)
 
 	// get target

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -309,19 +309,9 @@ func dbRemoveBlockFacts(tx *bolt.Tx, id types.BlockID) {
 // Add/Remove block target
 func dbAddBlockTarget(tx *bolt.Tx, id types.BlockID, target types.Target) {
 	mustPut(tx.Bucket(bucketBlockTargets), id, target)
-	// update difficulty
-	var difficulty types.Target
-	assertNil(dbGetInternal(internalDifficulty, &difficulty)(tx))
-	difficulty = difficulty.AddDifficulties(target)
-	assertNil(dbSetInternal(internalDifficulty, difficulty)(tx))
 }
 func dbRemoveBlockTarget(tx *bolt.Tx, id types.BlockID, target types.Target) {
 	mustDelete(tx.Bucket(bucketBlockTargets), id)
-	// update difficulty
-	var difficulty types.Target
-	assertNil(dbGetInternal(internalDifficulty, &difficulty)(tx))
-	difficulty = difficulty.SubtractDifficulties(target)
-	assertNil(dbSetInternal(internalDifficulty, difficulty)(tx))
 }
 
 // Add/Remove file contract

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -452,7 +452,7 @@ func dbCalculateBlockFacts(tx *bolt.Tx, cs modules.ConsensusSet, block types.Blo
 	if bf.Height > hashrateEstimationBlocks {
 		var totalDifficulty = bf.Target
 		var oldestTimestamp types.Timestamp
-		for i := types.BlockHeight(0); i < hashrateEstimationBlocks; i++ {
+		for i := types.BlockHeight(1); i < hashrateEstimationBlocks; i++ {
 			b, exists := cs.BlockAtHeight(bf.Height - i)
 			if !exists {
 				panic(fmt.Sprint("ConsensusSet is missing block at height", bf.Height-hashrateEstimationBlocks))

--- a/modules/explorer/update.go
+++ b/modules/explorer/update.go
@@ -316,19 +316,17 @@ func dbRemoveFileContractID(tx *bolt.Tx, id types.FileContractID, txid types.Tra
 }
 
 func dbAddFileContractRevision(tx *bolt.Tx, fcid types.FileContractID, fcr types.FileContractRevision) {
-	b := tx.Bucket(bucketFileContractHistories)
 	var history fileContractHistory
-	assertNil(dbGetFileContractHistory(fcid, &history)(tx))
+	assertNil(dbGetAndDecode(bucketFileContractHistories, fcid, &history)(tx))
 	history.Revisions = append(history.Revisions, fcr)
-	mustPut(b, fcid, history)
+	mustPut(tx.Bucket(bucketFileContractHistories), fcid, history)
 }
 func dbRemoveFileContractRevision(tx *bolt.Tx, fcid types.FileContractID) {
-	b := tx.Bucket(bucketFileContractHistories)
 	var history fileContractHistory
-	assertNil(dbGetFileContractHistory(fcid, &history)(tx))
+	assertNil(dbGetAndDecode(bucketFileContractHistories, fcid, &history)(tx))
 	// TODO: could be more rigorous
 	history.Revisions = history.Revisions[:len(history.Revisions)-1]
-	mustPut(b, fcid, history)
+	mustPut(tx.Bucket(bucketFileContractHistories), fcid, history)
 }
 
 // Add/Remove siacoin output
@@ -371,11 +369,10 @@ func dbRemoveSiafundOutputID(tx *bolt.Tx, id types.SiafundOutputID, txid types.T
 
 // Add/Remove storage proof
 func dbAddStorageProof(tx *bolt.Tx, fcid types.FileContractID, sp types.StorageProof) {
-	b := tx.Bucket(bucketFileContractHistories)
 	var history fileContractHistory
-	assertNil(dbGetFileContractHistory(fcid, &history)(tx))
+	assertNil(dbGetAndDecode(bucketFileContractHistories, fcid, &history)(tx))
 	history.StorageProof = sp
-	mustPut(b, fcid, history)
+	mustPut(tx.Bucket(bucketFileContractHistories), fcid, history)
 }
 func dbRemoveStorageProof(tx *bolt.Tx, fcid types.FileContractID) {
 	dbAddStorageProof(tx, fcid, types.StorageProof{})
@@ -403,7 +400,7 @@ func dbRemoveUnlockHash(tx *bolt.Tx, uh types.UnlockHash, txid types.Transaction
 func dbCalculateBlockFacts(tx *bolt.Tx, cs modules.ConsensusSet, block types.Block) blockFacts {
 	// get the parent block facts
 	var bf blockFacts
-	err := dbGetBlockFacts(block.ParentID, &bf)(tx)
+	err := dbGetAndDecode(bucketBlockFacts, block.ParentID, &bf)(tx)
 	assertNil(err)
 
 	// get target


### PR DESCRIPTION
I know this was gonna be Jordan's job, but I got tired of restarting the explorer and banged it out in two days. Sorry.

Previously, `siad -M cge` consumed about 2GB of memory, causing it to crash on many systems. Notably, it was crashing http://explore.sia.tech, filling up both its 2GB physical RAM and 2GB swap.

As of this PR, the explorer database now resides on disk, in a bolt database. `siad -M cge` consumes less than 10MB of RAM (!!). I found out that `htop` may be misleading for judging memory usage; it seems to include the mmap overhead of bolt. (The explorer database is about 2GB.) `pmap -x $(pidof siad)` gives more accurate results.

I tried to preserve the old logic as much as possible, but it's quite likely that a discrepancy or two has snuck in. I know for sure that the difficulty calculation has changed, and likely the estimated hashrate as well. I would appreciate some assistance in calculating those values correctly. The way we handle FileContractDiffs is pretty gross too. My gut says there's a much better way to do it.
The only major changes were to block facts. The old explorer kept a set of "current" facts, but the new model just maps each block to its facts. This broke one test (see TODO). Also, `blockFacts` now embeds a `modules.BlockFacts`. They only difference between the two is that `blockFacts` has an extra `Timestamp` field, and `modules.BlockFacts` has a redundant `Difficulty` field (can be calculated from the target).

Finally, I need to add code to handle subscription errors. Restarting from 0 seems sensible, but the existing database needs to be wiped first.

Oh yeah -- no new tests added. :I
I've run it locally and confirmed that it functions as expected, but obviously some rigorous testing would be better.

ALSO: I think I may have identified what was "pushing the explorer over the edge" and causing it to crash. If you ask it about the zero hash, it will report every transaction containing the zero hash, which is... a lot. Even with the DB, memory and CPU usage spike for multiple minutes.
We could triage this by intercepting the zero hash in the API, but I'm not sure what the best behavior is long-term.