### PR TITLE
Miner testing

### DIFF
--- a/build/critical.go
+++ b/build/critical.go
@@ -9,7 +9,9 @@ import (
 // which case panic will be called instead.
 func Critical(v ...interface{}) {
 	s := fmt.Sprintln(v...)
-	os.Stderr.WriteString(s)
+	if Release != "testing" || !DEBUG {
+		os.Stderr.WriteString(s)
+	}
 	if DEBUG {
 		panic(s)
 	}

--- a/modules/miner/blockmanager_test.go
+++ b/modules/miner/blockmanager_test.go
@@ -98,7 +98,7 @@ func TestIntegrationHeaderForWorkUpdates(t *testing.T) {
 }
 
 // TestIntegrationManyHeaders checks that requesting a full set of headers a
-// row results in all unique headers, and that all of them can be reassebled
+// row results in all unique headers, and that all of them can be reassembled
 // into valid blocks.
 func TestIntegrationManyHeaders(t *testing.T) {
 	if testing.Short() {

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -26,7 +26,8 @@ type minerTester struct {
 
 	miner *Miner
 
-	persistDir string
+	minedBlocks []types.Block
+	persistDir  string
 }
 
 // createMinerTester creates a minerTester that's ready for use.
@@ -83,10 +84,11 @@ func createMinerTester(name string) (*minerTester, error) {
 
 	// Mine until the wallet has money.
 	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
-		_, err = m.AddBlock()
+		b, err := m.AddBlock()
 		if err != nil {
 			return nil, err
 		}
+		mt.minedBlocks = append(mt.minedBlocks, b)
 	}
 
 	return mt, nil

--- a/modules/miner/update_test.go
+++ b/modules/miner/update_test.go
@@ -1,0 +1,127 @@
+package miner
+
+import (
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// TestIntegrationBlockHeightReorg checks that the miner has the correct block
+// height after a series of reorgs that go as far as the genesis block.
+func TestIntegrationBlockHeightReorg(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Create 3 miner testers that will be used to cause eachother to reorg.
+	mt1, err := createMinerTester("TestIntegrationBlockHeightReorg - 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mt2, err := createMinerTester("TestIntegrationBlockHeightReorg - 2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mt3, err := createMinerTester("TestIntegrationBlockHeightReorg - 3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put one ahead of the other multiple times, which should thrash around
+	// the height calculation and cause problems by dipping down to the genesis
+	// block repeatedly.
+	for i := 0; i < 2; i++ {
+		b, err := mt1.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mt1.minedBlocks = append(mt1.minedBlocks, b)
+	}
+	for i := 0; i < 3; i++ {
+		b, err := mt2.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mt2.minedBlocks = append(mt2.minedBlocks, b)
+	}
+	for _, block := range mt2.minedBlocks {
+		err = mt1.cs.AcceptBlock(block)
+		if err != nil && err != modules.ErrNonExtendingBlock {
+			t.Fatal(err)
+		}
+	}
+	if mt1.cs.CurrentBlock().ID() != mt2.cs.CurrentBlock().ID() {
+		t.Fatal("mt1 and mt2 should have the same current block")
+	}
+	for i := 0; i < 2; i++ {
+		b, err := mt1.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mt1.minedBlocks = append(mt1.minedBlocks, b)
+	}
+	for i := 0; i < 3; i++ {
+		b, err := mt2.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mt2.minedBlocks = append(mt2.minedBlocks, b)
+	}
+	for _, block := range mt2.minedBlocks {
+		err = mt1.cs.AcceptBlock(block)
+		if err != nil && err != modules.ErrNonExtendingBlock && err != modules.ErrBlockKnown {
+			t.Fatal(err)
+		}
+	}
+	if mt1.cs.CurrentBlock().ID() != mt2.cs.CurrentBlock().ID() {
+		t.Fatal("mt1 and mt2 should have the same current block")
+	}
+	for i := 0; i < 7; i++ {
+		b, err := mt3.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mt3.minedBlocks = append(mt3.minedBlocks, b)
+	}
+	for _, block := range mt3.minedBlocks {
+		err = mt1.cs.AcceptBlock(block)
+		if err != nil && err != modules.ErrNonExtendingBlock {
+			t.Fatal(err)
+		}
+	}
+	if mt1.cs.CurrentBlock().ID() == mt2.cs.CurrentBlock().ID() {
+		t.Fatal("mt1 and mt2 should not have the same block height")
+	}
+	if mt1.cs.CurrentBlock().ID() != mt3.cs.CurrentBlock().ID() {
+		t.Fatal("mt1 and mt3 should have the same current block")
+	}
+}
+
+// TestMinerHeightForcefulMismatch checks that the miner, when not running in
+// debug mode, does forceful self-correcting for height calculation.
+func TestMinerHeightForcefulMismatch(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	mt, err := createMinerTester("TestMinerHeightForcefulMismatch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := mt.miner.FindBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A panic should be triggered when AcceptBlock is called on the miner.
+	mt.miner.persist.Height--
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expecting a panic upon adding a block")
+		}
+	}()
+	err = mt.cs.AcceptBlock(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
I fixed the height calculation and added a sanity check. I also added some extra testing, improved the logging, and changed `build.Critical` to not print to stderr during normal testing, because it is triggered intentionally during testing.

The logic on `build.Critical` will only print to stderr if `build.Release != "testing" || !build.DEBUG`, which means that if you are doing testing without the DEBUG flag set, it will print.

This PR should fix the mining troubles that have been reported. As best I can tell, it affects all miners, is dependent on what order you see blocks in, and it's just coincidence that only 051 miners were affected this time around. I do believe the bug is fixed after this PR.