### PR TITLE
5 minute timeout for getting blocks from peers

### DIFF
--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -42,8 +42,7 @@ var (
 		case "dev":
 			return 40 * time.Second
 		case "standard":
-			// TODO: 45 minutes for 0.5.2 RC2. Change back to 5 minutes for release.
-			return 45 * time.Minute
+			return 5 * time.Minute
 		case "testing":
 			return 5 * time.Second
 		default:


### PR DESCRIPTION
To prevent one peer from being able to slow things down too much, the
gateway will switch peers every 5 minutes during ibd. Due to a previous
bug in the gateway code, this limit had to be set to 45 minutes until a
sufficient number of peers had upgraded to the new code.

Enough peers have now upgraded.