### PR TITLE
additional debugging and sanity for miner

### DIFF
--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -118,6 +118,7 @@ func (m *Miner) startupRescan() error {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 
+		m.log.Println("Performing a miner rescan.")
 		m.persist.RecentChange = modules.ConsensusChangeID{}
 		m.persist.Height = 0
 		m.persist.Target = types.Target{}

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -14,11 +14,21 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 	for _, block := range cc.RevertedBlocks {
 		if block.ID() != types.GenesisBlock.ID() {
 			m.persist.Height--
+		} else if m.persist.Height != 0 {
+			// Sanity check - if the current block is the genesis block, the
+			// miner height should be set to zero.
+			m.log.Critical("Miner has detected a genesis block, but the height of the miner is set to ", m.persist.Height)
+			m.persist.Height = 0
 		}
 	}
 	for _, block := range cc.AppliedBlocks {
 		if block.ID() != types.GenesisBlock.ID() {
 			m.persist.Height++
+		} else if m.persist.Height != 0 {
+			// Sanity check - if the current block is the genesis block, the
+			// miner height should be set to zero.
+			m.log.Critical("Miner has detected a genesis block, but the height of the miner is set to ", m.persist.Height)
+			m.persist.Height = 0
 		}
 	}
 	// Sanity check - if the most recent block in the miner is the same as the
@@ -26,7 +36,7 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// set and the height of the miner should be the same.
 	if cc.AppliedBlocks[len(cc.AppliedBlocks)-1].ID() == m.cs.CurrentBlock().ID() {
 		if m.persist.Height != m.cs.Height() {
-			m.log.Critical("miner has a height mismatch: have ", m.persist.Height, " expected ", m.cs.Height())
+			m.log.Critical("Miner has a height mismatch: expecting ", m.cs.Height(), " but got ", m.persist.Height, ". Recent update had ", len(cc.RevertedBlocks), " reverted blocks, and ", len(cc.AppliedBlocks), " applied blocks.")
 			m.persist.Height = m.cs.Height()
 		}
 	}


### PR DESCRIPTION
Though I thought I had fixed the miner height bug, a user reported an
error message that suggested the problem had not been fixed. It also
appears like the problem may be more deep-seated than originally
suggested, instead of being a problem with the miner module it might
actually be a problem with the ConsensusChange propagation, which means
that more modules than just the miner would be affected.

I've added more sanity checks and logging messages to the miner, we
should be closer to getting to the bottom of this.