### PR TITLE
Negate siafund pool diff direction instead of hardcoding revert

### DIFF
--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -42,7 +42,7 @@ func (cs *ConsensusSet) computeConsensusChange(tx *bolt.Tx, ce changeEntry) (cc 
 		}
 		for i := len(revertedBlock.SiafundPoolDiffs) - 1; i >= 0; i-- {
 			sfpd := revertedBlock.SiafundPoolDiffs[i]
-			sfpd.Direction = modules.DiffRevert
+			sfpd.Direction = !sfpd.Direction
 			cc.SiafundPoolDiffs = append(cc.SiafundPoolDiffs, sfpd)
 		}
 	}


### PR DESCRIPTION
From the lines above I think this was a typo. My understanding of consensus is lacking so I'm not sure what the impact of this bug was, if it even was a bug.