### PR TITLE
NetAddress fixup

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -105,7 +105,11 @@ func (srv *Server) hostHandlerPOST(w http.ResponseWriter, req *http.Request, _ h
 			}
 		}
 	}
-	srv.host.SetInternalSettings(settings)
+	err := srv.host.SetInternalSettings(settings)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	writeSuccess(w)
 }
 

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -256,13 +256,22 @@ func (st *serverTester) announceHost() error {
 		return err
 	}
 	// mine block
-	st.miner.AddBlock()
+	_, err = st.miner.AddBlock()
+	if err != nil {
+		return err
+	}
 	// wait for announcement
 	var hosts ActiveHosts
-	st.getAPI("/renter/hosts/active", &hosts)
+	err = st.getAPI("/renter/hosts/active", &hosts)
+	if err != nil {
+		return err
+	}
 	for i := 0; i < 20 && len(hosts.Hosts) == 0; i++ {
 		time.Sleep(100 * time.Millisecond)
-		st.getAPI("/renter/hosts/active", &hosts)
+		err = st.getAPI("/renter/hosts/active", &hosts)
+		if err != nil {
+			return err
+		}
 	}
 	if len(hosts.Hosts) == 0 {
 		return errors.New("host announcement not seen")

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -17,11 +17,6 @@ func newTestingGateway(name string, t *testing.T) *Gateway {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Manually add myAddr as a node. This is necessary because g.addNode
-	// rejects loopback addresses.
-	id := g.mu.Lock()
-	g.nodes[g.myAddr] = struct{}{}
-	g.mu.Unlock(id)
 	return g
 }
 

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -117,7 +117,7 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 // sendAddress is the calling end of the RelayNode RPC.
 func (g *Gateway) sendAddress(conn modules.PeerConn) error {
 	// don't send if we aren't connectible
-	if g.Address().Host() == "::1" {
+	if g.Address().IsLoopback() {
 		return errors.New("can't send address without knowing external IP")
 	}
 	return encoding.WriteObject(conn, g.Address())

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -75,7 +75,10 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	}
 	id := g.mu.Lock()
 	for _, node := range nodes {
-		g.addNode(node)
+		err := g.addNode(node)
+		if err != nil {
+			g.log.Printf("WARN: peer '%v' send the invalid addr '%v'", conn.RemoteAddr(), node)
+		}
 	}
 	g.save()
 	g.mu.Unlock(id)

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -22,8 +22,8 @@ func (g *Gateway) addNode(addr modules.NetAddress) error {
 		return errors.New("node already added")
 	} else if net.ParseIP(addr.Host()) == nil {
 		return errors.New("address is not routable: " + string(addr))
-	} else if net.ParseIP(addr.Host()).IsLoopback() {
-		return errors.New("cannot add loopback address")
+	} else if addr.IsValid() != nil {
+		return errors.New("address is not valid: " + string(addr))
 	}
 	g.nodes[addr] = struct{}{}
 	return nil
@@ -117,7 +117,7 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 // sendAddress is the calling end of the RelayNode RPC.
 func (g *Gateway) sendAddress(conn modules.PeerConn) error {
 	// don't send if we aren't connectible
-	if g.Address().IsLoopback() {
+	if g.Address().IsValid() != nil {
 		return errors.New("can't send address without knowing external IP")
 	}
 	return encoding.WriteObject(conn, g.Address())

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -25,8 +25,11 @@ func TestAddNode(t *testing.T) {
 	if err := g.addNode("foo"); err == nil {
 		t.Error("addNode added unroutable address")
 	}
-	if err := g.addNode("[::1]:9981"); err == nil {
-		t.Error("addNode added loopback address")
+	if err := g.addNode("foo:9981"); err == nil {
+		t.Error("addNode added a non-IP address")
+	}
+	if err := g.addNode("[::]:9981"); err == nil {
+		t.Error("addNode added unspecified address")
 	}
 }
 
@@ -50,24 +53,44 @@ func TestRandomNode(t *testing.T) {
 	g := newTestingGateway("TestRandomNode", t)
 	defer g.Close()
 
+	// Test with 0 nodes.
 	id := g.mu.RLock()
-	if addr, err := g.randomNode(); err != nil {
+	_, err := g.randomNode()
+	g.mu.RUnlock(id)
+	if err != errNoPeers {
+		t.Fatal("randomNode should fail when the gateway has 0 nodes")
+	}
+
+	// Test with 1 node.
+	id = g.mu.Lock()
+	if err = g.addNode(dummyNode); err != nil {
+		t.Fatal(err)
+	}
+	g.mu.Unlock(id)
+	id = g.mu.RLock()
+	addr, err := g.randomNode()
+	g.mu.RUnlock(id)
+	if err != nil {
 		t.Fatal("randomNode failed:", err)
-	} else if addr != g.Address() {
+	} else if addr != dummyNode {
 		t.Fatal("randomNode returned wrong address:", addr)
 	}
-	g.mu.RUnlock(id)
 
+	// Test again with 0 nodes.
 	id = g.mu.Lock()
-	g.removeNode(g.myAddr)
+	err = g.removeNode(dummyNode)
 	g.mu.Unlock(id)
-
+	if err != nil {
+		t.Fatal(err)
+	}
 	id = g.mu.RLock()
-	if _, err := g.randomNode(); err != errNoPeers {
+	_, err = g.randomNode()
+	g.mu.RUnlock(id)
+	if err != errNoPeers {
 		t.Fatalf("randomNode returned wrong error: expected %v, got %v", errNoPeers, err)
 	}
-	g.mu.RUnlock(id)
 
+	// Test with 3 nodes.
 	nodes := map[modules.NetAddress]int{
 		"111.111.111.111:1111": 0,
 		"111.111.111.111:2222": 0,
@@ -75,19 +98,22 @@ func TestRandomNode(t *testing.T) {
 	}
 	id = g.mu.Lock()
 	for addr := range nodes {
-		g.addNode(addr)
+		err := g.addNode(addr)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 	g.mu.Unlock(id)
 
-	id = g.mu.RLock()
 	for i := 0; i < len(nodes)*10; i++ {
+		id = g.mu.RLock()
 		addr, err := g.randomNode()
+		g.mu.RUnlock(id)
 		if err != nil {
 			t.Fatal("randomNode failed:", err)
 		}
 		nodes[addr]++
 	}
-	g.mu.RUnlock(id)
 	for node, count := range nodes {
 		if count == 0 { // 1-in-200000 chance of occuring naturally
 			t.Errorf("node %v was never selected", node)
@@ -169,12 +195,6 @@ func TestRelayNodes(t *testing.T) {
 	g3 := newTestingGateway("TestRelayNodes3", t)
 	defer g3.Close()
 
-	// overwrite g3's address with a non-loopback address;
-	// otherwise it will be rejected
-	id := g3.mu.Lock()
-	g3.myAddr = dummyNode
-	g3.mu.Unlock(id)
-
 	// normally the Gateway will only register this RPC if has discovered its
 	// IP through external means.
 	g3.RegisterConnectCall("RelayNode", g3.sendAddress)
@@ -193,7 +213,7 @@ func TestRelayNodes(t *testing.T) {
 
 	// g2 should have received g3's address from g1
 	time.Sleep(200 * time.Millisecond)
-	id = g2.mu.Lock()
+	id := g2.mu.Lock()
 	defer g2.mu.Unlock(id)
 	if _, ok := g2.nodes[g3.Address()]; !ok {
 		t.Fatal("node was not relayed:", g2.nodes)

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -207,10 +207,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 		return errors.New("can't connect to our own address")
 	}
 	if err := addr.IsValid(); err != nil {
-		// Allow loopback addresses only in testing.
-		if build.Release != "testing" || err != modules.ErrLoopbackAddr {
-			return errors.New("can't connect to invalid address")
-		}
+		return errors.New("can't connect to invalid address")
 	}
 
 	id := g.mu.RLock()

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -206,8 +206,11 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	if addr == g.Address() {
 		return errors.New("can't connect to our own address")
 	}
-	if build.Release != "testing" && addr.IsLoopback() {
-		return errors.New("can't connect to loopback address")
+	if err := addr.IsValid(); err != nil {
+		// Allow loopback addresses only in testing.
+		if build.Release != "testing" || err != modules.ErrLoopbackAddr {
+			return errors.New("can't connect to invalid address")
+		}
 	}
 
 	id := g.mu.RLock()

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -31,7 +31,7 @@ func TestAddPeer(t *testing.T) {
 	defer g.mu.Unlock(id)
 	g.addPeer(&peer{
 		Peer: modules.Peer{
-			NetAddress: "foo",
+			NetAddress: "foo.com:123",
 		},
 		sess: muxado.Client(new(dummyConn)),
 	})
@@ -52,7 +52,7 @@ func TestRandomInboundPeer(t *testing.T) {
 
 	g.addPeer(&peer{
 		Peer: modules.Peer{
-			NetAddress: "foo",
+			NetAddress: "foo.com:123",
 			Inbound:    true,
 		},
 		sess: muxado.Client(new(dummyConn)),
@@ -61,7 +61,7 @@ func TestRandomInboundPeer(t *testing.T) {
 		t.Fatal("gateway did not add peer")
 	}
 	addr, err := g.randomInboundPeer()
-	if err != nil || addr != "foo" {
+	if err != nil || addr != "foo.com:123" {
 		t.Fatal("gateway did not select random peer")
 	}
 }
@@ -461,7 +461,7 @@ func TestDisconnect(t *testing.T) {
 	g := newTestingGateway("TestDisconnect", t)
 	defer g.Close()
 
-	if err := g.Disconnect("bar"); err == nil {
+	if err := g.Disconnect("bar.com:123"); err == nil {
 		t.Fatal("disconnect removed unconnected peer")
 	}
 
@@ -485,12 +485,12 @@ func TestDisconnect(t *testing.T) {
 	id := g.mu.Lock()
 	g.addPeer(&peer{
 		Peer: modules.Peer{
-			NetAddress: "foo",
+			NetAddress: "foo.com:123",
 		},
 		sess: muxado.Client(conn),
 	})
 	g.mu.Unlock(id)
-	if err := g.Disconnect("foo"); err != nil {
+	if err := g.Disconnect("foo.com:123"); err != nil {
 		t.Fatal("disconnect failed:", err)
 	}
 }

--- a/modules/gateway/persist.go
+++ b/modules/gateway/persist.go
@@ -38,7 +38,10 @@ func (g *Gateway) load() error {
 		return err
 	}
 	for _, node := range nodes {
-		g.addNode(node)
+		err := g.addNode(node)
+		if err != nil {
+			g.log.Printf("WARN: error loading node '%v' from persist: %v", node, err)
+		}
 	}
 	return nil
 }

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -38,7 +38,7 @@ func TestRPC(t *testing.T) {
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 
-	if err := g1.RPC("foo", "", nil); err == nil {
+	if err := g1.RPC("foo.com:123", "", nil); err == nil {
 		t.Fatal("RPC on unconnected peer succeded")
 	}
 

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -61,8 +61,14 @@ func (g *Gateway) learnHostname(port string) {
 		return
 	}
 
+	addr := modules.NetAddress(net.JoinHostPort(host, port))
+	if err := addr.IsValid(); err != nil {
+		g.log.Printf("WARN: discovered hostname %q is invalid: %v", addr, err)
+		return
+	}
+
 	id := g.mu.Lock()
-	g.myAddr = modules.NetAddress(net.JoinHostPort(host, port))
+	g.myAddr = addr
 	g.mu.Unlock(id)
 
 	g.log.Println("INFO: our address is", g.myAddr)

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -41,7 +41,7 @@ func myExternalIP() (string, error) {
 // learnHostname discovers the external IP of the Gateway. Once the IP has
 // been discovered, it registers the ShareNodes RPC to be called on new
 // connections, advertising the IP to other nodes.
-func (g *Gateway) learnHostname() {
+func (g *Gateway) learnHostname(port string) {
 	if build.Release == "testing" {
 		return
 	}
@@ -62,7 +62,7 @@ func (g *Gateway) learnHostname() {
 	}
 
 	id := g.mu.Lock()
-	g.myAddr = modules.NetAddress(net.JoinHostPort(host, g.myAddr.Port()))
+	g.myAddr = modules.NetAddress(net.JoinHostPort(host, port))
 	g.mu.Unlock(id)
 
 	g.log.Println("INFO: our address is", g.myAddr)

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -115,7 +115,7 @@ func TestHostAnnounceAddress(t *testing.T) {
 
 	// Create an announcement, then use the address finding module to scan the
 	// blockchain for the host's address.
-	addr := modules.NetAddress("foo:1234")
+	addr := modules.NetAddress("foo.com:1234")
 	err = ht.host.AnnounceAddress(addr)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -405,7 +405,14 @@ func (h *Host) SetInternalSettings(settings modules.HostInternalSettings) error 
 	if settings.AcceptingContracts {
 		err := h.checkUnlockHash()
 		if err != nil {
-			return err
+			return errors.New("internal settings not updated, no unlock hash: " + err.Error())
+		}
+	}
+
+	if settings.NetAddress != "" {
+		err := settings.NetAddress.IsValid()
+		if err != nil {
+			return errors.New("internal settings not updated, invalid NetAddress: " + err.Error())
 		}
 	}
 
@@ -418,7 +425,12 @@ func (h *Host) SetInternalSettings(settings modules.HostInternalSettings) error 
 
 	h.settings = settings
 	h.revisionNumber++
-	return h.saveSync()
+
+	err := h.saveSync()
+	if err != nil {
+		return errors.New("internal settings updated, but failed saving to disk: " + err.Error())
+	}
+	return nil
 }
 
 // InternalSettings returns the settings of a host.

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -233,12 +233,6 @@ func newHost(dependencies dependencies, cs modules.ConsensusSet, tpool modules.T
 		return nil, errNilWallet
 	}
 
-	// Parse the port from the address.
-	_, port, err := net.SplitHostPort(listenerAddress)
-	if err != nil {
-		return nil, err
-	}
-
 	// Create the host object.
 	h := &Host{
 		cs:           cs,
@@ -249,8 +243,9 @@ func newHost(dependencies dependencies, cs modules.ConsensusSet, tpool modules.T
 		lockedStorageObligations: make(map[types.FileContractID]struct{}),
 
 		persistDir: persistDir,
-		port:       port,
 	}
+
+	var err error
 
 	// Add the storage manager to the host.
 	//

--- a/modules/host/host_errors_test.go
+++ b/modules/host/host_errors_test.go
@@ -35,7 +35,7 @@ func TestHostFailedMkdirAll(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newHost(dependencyErrMkdirAll{}, ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	_, err = newHost(dependencyErrMkdirAll{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrMkdirAll {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestHostFailedNewLogger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newHost(dependencyErrNewLogger{}, ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	_, err = newHost(dependencyErrNewLogger{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrNewLogger {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestHostFailedOpenDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newHost(dependencyErrOpenDatabase{}, ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	_, err = newHost(dependencyErrOpenDatabase{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrOpenDatabase {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestHostFailedLoadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newHost(dependencyErrLoadFile{}, ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	_, err = newHost(dependencyErrLoadFile{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrLoadFile {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestHostFailedListen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newHost(dependencyErrListen{}, ht.cs, ht.tpool, ht.wallet, ":0", filepath.Join(ht.persistDir, modules.HostDir))
+	_, err = newHost(dependencyErrListen{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrListen {
 		t.Fatal(err)
 	}

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -255,6 +255,125 @@ func TestNilValues(t *testing.T) {
 	}
 }
 
+// TestSetAndGetInternalSettings checks that the functions for interacting with
+// the host's internal settings object are working as expected.
+func TestSetAndGetInternalSettings(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	ht, err := newHostTester("TestSetAndGetInternalSettings")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the default settings get returned at first call.
+	settings := ht.host.InternalSettings()
+	if settings.AcceptingContracts != false {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MaxDuration != defaultMaxDuration {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MaxDownloadBatchSize != uint64(defaultMaxDownloadBatchSize) {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MaxReviseBatchSize != uint64(defaultMaxReviseBatchSize) {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.NetAddress != "" {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.WindowSize != defaultWindowSize {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.Collateral.Cmp(defaultCollateral) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.CollateralBudget.Cmp(defaultCollateralBudget) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MaxCollateralFraction.Cmp(defaultCollateralFraction) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MaxCollateral.Cmp(defaultMaxCollateral) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.DownloadLimitGrowth != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.DownloadLimitCap != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.DownloadSpeedLimit != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.UploadLimitGrowth != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.UploadLimitCap != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.UploadSpeedLimit != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MinimumContractPrice.Cmp(defaultContractPrice) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MinimumDownloadBandwidthPrice.Cmp(defaultDownloadBandwidthPrice) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MinimumStoragePrice.Cmp(defaultStoragePrice) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+	if settings.MinimumUploadBandwidthPrice.Cmp(defaultUploadBandwidthPrice) != 0 {
+		t.Error("settings retrieval did not return default value")
+	}
+
+	// Check that calling SetInternalSettings with valid settings updates the settings.
+	settings.AcceptingContracts = true
+	settings.NetAddress = "foo.com:123"
+	err = ht.host.SetInternalSettings(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings = ht.host.InternalSettings()
+	if settings.AcceptingContracts != true {
+		t.Fatal("SetInternalSettings failed to update settings")
+	}
+	if settings.NetAddress != "foo.com:123" {
+		t.Fatal("SetInternalSettings failed to update settings")
+	}
+
+	// Check that calling SetInternalSettings with invalid settings does not update the settings.
+	settings.NetAddress = "invalid"
+	err = ht.host.SetInternalSettings(settings)
+	if err == nil {
+		t.Fatal("expected SetInternalSettings to error with invalid settings")
+	}
+	settings = ht.host.InternalSettings()
+	if settings.NetAddress != "foo.com:123" {
+		t.Fatal("SetInternalSettings should not modify the settings if the new settings are invalid")
+	}
+
+	// Reload the host and verify that the altered settings persisted.
+	err = ht.host.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rebootSettings := rebootHost.InternalSettings()
+	if rebootSettings.AcceptingContracts != settings.AcceptingContracts {
+		t.Error("settings retrieval did not return updated value")
+	}
+	if rebootSettings.NetAddress != settings.NetAddress {
+		t.Error("settings retrieval did not return updated value")
+	}
+}
+
 /*
 // TestSetAndGetSettings checks that the functions for interacting with the
 // hosts settings object are working as expected.

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -46,7 +46,10 @@ func (h *Host) initNetworking(address string) (err error) {
 		return err
 	}
 	h.mu.Lock()
-	h.port = modules.NetAddress(h.listener.Addr().String()).Port()
+	_, h.port, err = net.SplitHostPort(h.listener.Addr().String())
+	if err != nil {
+		return err
+	}
 	if build.Release == "testing" {
 		h.autoAddress = modules.NetAddress(net.JoinHostPort("localhost", h.port))
 	}

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -45,11 +45,12 @@ func (h *Host) initNetworking(address string) (err error) {
 	if err != nil {
 		return err
 	}
-	h.mu.Lock()
-	_, h.port, err = net.SplitHostPort(h.listener.Addr().String())
+	_, port, err := net.SplitHostPort(h.listener.Addr().String())
 	if err != nil {
 		return err
 	}
+	h.mu.Lock()
+	h.port = port
 	if build.Release == "testing" {
 		h.autoAddress = modules.NetAddress(net.JoinHostPort("localhost", h.port))
 	}

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -157,11 +157,19 @@ func (h *Host) load() error {
 	// Copy over host identity.
 	h.announced = p.Announced
 	h.autoAddress = p.AutoAddress
+	if err := p.AutoAddress.IsValid(); err != nil {
+		h.log.Printf("WARN: AutoAddress '%v' loaded from persist is invalid: %v", p.AutoAddress, err)
+		h.autoAddress = ""
+	}
 	h.financialMetrics = p.FinancialMetrics
 	h.publicKey = p.PublicKey
 	h.revisionNumber = p.RevisionNumber
 	h.secretKey = p.SecretKey
 	h.settings = p.Settings
+	if err := p.Settings.NetAddress.IsValid(); err != nil {
+		h.log.Printf("WARN: NetAddress '%v' loaded from persist is invalid: %v", p.Settings.NetAddress, err)
+		h.settings.NetAddress = ""
+	}
 	h.unlockHash = p.UnlockHash
 
 	err = h.initConsensusSubscription()

--- a/modules/host/upnp.go
+++ b/modules/host/upnp.go
@@ -66,7 +66,7 @@ func (h *Host) managedLearnHostname() {
 	defer h.mu.Unlock()
 	autoAddress := modules.NetAddress(net.JoinHostPort(hostname, h.port))
 	if err := autoAddress.IsValid(); err != nil {
-		h.log.Printf("WARN: discovered net address '%v' is invalid: %v", autoAddress, err)
+		h.log.Printf("WARN: discovered hostname %q is invalid: %v", autoAddress, err)
 		return
 	}
 	if autoAddress == h.autoAddress && h.announced {

--- a/modules/host/upnp.go
+++ b/modules/host/upnp.go
@@ -65,6 +65,10 @@ func (h *Host) managedLearnHostname() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	autoAddress := modules.NetAddress(net.JoinHostPort(hostname, h.port))
+	if err := autoAddress.IsValid(); err != nil {
+		h.log.Printf("WARN: discovered net address '%v' is invalid: %v", autoAddress, err)
+		return
+	}
 	if autoAddress == h.autoAddress && h.announced {
 		// Nothing to do - the auto address has not changed and the previous
 		// annoucement was successful.

--- a/modules/negotiate.go
+++ b/modules/negotiate.go
@@ -340,6 +340,10 @@ func WriteNegotiationStop(w io.Writer) error {
 // the exact []byte that should be added to the arbitrary data of a
 // transaction.
 func CreateAnnouncement(addr NetAddress, pk types.SiaPublicKey, sk crypto.SecretKey) (signedAnnouncement []byte, err error) {
+	if err := addr.IsValid(); err != nil {
+		return nil, err
+	}
+
 	// Create the HostAnnouncement and marshal it.
 	annBytes := encoding.Marshal(HostAnnouncement{
 		Specifier:  PrefixHostAnnouncement,

--- a/modules/negotiate_test.go
+++ b/modules/negotiate_test.go
@@ -22,7 +22,7 @@ func TestAnnouncementHandling(t *testing.T) {
 		Algorithm: types.SignatureEd25519,
 		Key:       pk[:],
 	}
-	addr := NetAddress("foo:1234")
+	addr := NetAddress("f.o:1234")
 
 	// Generate the announcement.
 	annBytes, err := CreateAnnouncement(addr, spk, sk)

--- a/modules/netaddress.go
+++ b/modules/netaddress.go
@@ -3,7 +3,8 @@ package modules
 import (
 	"errors"
 	"net"
-	"unicode"
+	"strconv"
+	"strings"
 
 	"github.com/NebulousLabs/Sia/build"
 )
@@ -54,39 +55,53 @@ func (na NetAddress) isLoopback() bool {
 	return false
 }
 
-// IsValid returns nil if the NetAddress is valid. Valid is defined as being of
-// the form "host:port" such that "host" is not a loopback address (except in
-// testing) nor an unspecified IP address, and such that neither the host nor
-// port are blank, contain white space, or contain the null character.
+// IsValid returns an error if the NetAddress is invalid. A valid NetAddress
+// is of the form "host:port", such that "host" is either a valid IPv4/IPv6
+// address or a valid hostname, and "port" is an integer in the range
+// [1,65535]. Furthermore, "host" may not be a loopback address (except during
+// testing). Valid IPv4 addresses, IPv6 addresses, and hostnames are detailed
+// in RFCs 791, 2460, and 952, respectively.
 func (na NetAddress) IsValid() error {
+	if build.Release != "testing" && na.isLoopback() {
+		return errors.New("host is a loopback address")
+	}
+
 	host, port, err := net.SplitHostPort(string(na))
 	if err != nil {
 		return err
 	}
 
-	for _, runeValue := range host {
-		if unicode.IsSpace(runeValue) || runeValue == 0 {
-			return errors.New("host has invalid characters")
+	// First try to parse host as an IP address; if that fails, assume it is a
+	// hostname.
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsUnspecified() {
+			return errors.New("host is the unspecified address")
+		}
+	} else {
+		if len(host) < 1 || len(host) > 253 {
+			return errors.New("invalid hostname length")
+		}
+		for _, label := range strings.Split(host, ".") {
+			if len(label) < 1 || len(label) > 63 {
+				return errors.New("hostname contains label with invalid length")
+			}
+			for _, r := range strings.ToLower(label) {
+				isLetter := 'a' <= r && r <= 'z'
+				isNumber := '0' <= r && r <= '9'
+				isHyphen := r == '-'
+				if !(isLetter || isNumber || isHyphen) {
+					return errors.New("host contains invalid characters")
+				}
+			}
 		}
 	}
-	if host == "" {
-		return errors.New("host is blank")
-	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
-		return errors.New("host is the unspecified address")
+
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return errors.New("port is not an integer")
+	} else if portInt < 1 || portInt > 65535 {
+		return errors.New("port is invalid")
 	}
 
-	for _, runeValue := range port {
-		if unicode.IsSpace(runeValue) || runeValue == 0 {
-			return errors.New("port has invalid characters")
-		}
-	}
-	if port == "" {
-		return errors.New("port is blank")
-	}
-
-	if build.Release != "testing" && na.isLoopback() {
-		return errors.New("host is a loopback address")
-	}
 	return nil
 }

--- a/modules/netaddress.go
+++ b/modules/netaddress.go
@@ -13,28 +13,27 @@ import (
 type NetAddress string
 
 // Host removes the port from a NetAddress, returning just the host. If the
-// address is invalid, the empty string is returned.
+// address is not of the form "host:port" the empty string is returned. The
+// port will still be returned for invalid NetAddresses (e.g. "unqualified:0"
+// will return "unqualified"), but in general you should only call Host on
+// valid addresses.
 func (na NetAddress) Host() string {
 	host, _, err := net.SplitHostPort(string(na))
 	// 'host' is not always the empty string if an error is returned.
 	if err != nil {
 		return ""
 	}
-	if na.IsValid() != nil {
-		return ""
-	}
 	return host
 }
 
-// Port returns the NetAddress object's port number. The empty string is
-// returned if the NetAddress is invalid.
+// Port returns the NetAddress object's port number. If the address is not of
+// the form "host:port" the empty string is returned. The port will still be
+// returned for invalid NetAddresses (e.g. "localhost:0" will return "0"), but
+// in general you should only call Port on valid addresses.
 func (na NetAddress) Port() string {
 	_, port, err := net.SplitHostPort(string(na))
 	// 'port' will not always be the empty string if an error is returned.
 	if err != nil {
-		return ""
-	}
-	if na.IsValid() != nil {
 		return ""
 	}
 	return port

--- a/modules/netaddress.go
+++ b/modules/netaddress.go
@@ -36,10 +36,10 @@ func (na NetAddress) IsLoopback() bool {
 	}
 
 	host := na.Host()
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+	if ip := net.ParseIP(host); ip != nil && (ip.IsLoopback() || ip.IsUnspecified()) {
 		return true
 	}
-	if host == "localhost" || host == "::" || host == "0.0.0.0" {
+	if host == "localhost" {
 		return true
 	}
 	return false

--- a/modules/netaddress_test.go
+++ b/modules/netaddress_test.go
@@ -49,10 +49,12 @@ func TestIsLoopback(t *testing.T) {
 		{"localhost:1234", true},
 		{"127.0.0.1", false},
 		{"127.0.0.1:6723", true},
-		{"0.0.0.0:1234", true},
-		{"[::]:1234", true},
 		{"::1", false},
 		{"[::1]:7124", true},
+
+		// Unspecified address tests.
+		{"0.0.0.0:1234", false},
+		{"[::]:1234", false},
 
 		// Public name tests.
 		{"hn.com", false},
@@ -75,44 +77,66 @@ func TestIsLoopback(t *testing.T) {
 	}
 }
 
-// TestIsValid checks where a netaddress matches the regex for what counts as a
-// valid hostname or ip address.
+// TestIsValid tests that IsValid only returns nil for valid addresses, and
+// that it only returns ErrLoopbackAddr for loopback addresses.
 func TestIsValid(t *testing.T) {
 	t.Parallel()
 
-	testSet := []struct {
-		query           NetAddress
-		desiredResponse bool
+	tests := []struct {
+		addr       NetAddress
+		valid      bool
+		isLoopback bool
 	}{
 		// Networks such as 10.0.0.x have been omitted from testing - behavior
 		// for these networks is currently undefined.
 
-		// Localhost tests.
-		{"localhost", false},
-		{"localhost:1234", true},
-		{"127.0.0.1", false},
-		{"127.0.0.1:6723", true},
-		{"::1", false},
-		{"[::1]:7124", true},
-
-		// Public name tests.
-		{"hn.com", false},
-		{"hn.com:8811", true},
-		{"12.34.45.64", false},
-		{"12.34.45.64:7777", true},
-		{"::1:4646", false},
-		{"plain", false},
-		{"plain:6432", true},
-
-		// Garbage name tests.
-		{"", false},
-		{"garbage:6146:616", false},
-		{"[::1]", false},
-		// {"google.com:notAPort", false}, TODO: Failed test case.
+		// Garbage addresses
+		{addr: "", valid: false},
+		{addr: "foo:bar:baz", valid: false},
+		{addr: "garbage:6146:616", valid: false},
+		// Missing host / port
+		{addr: ":", valid: false},
+		{addr: "111.111.111.111", valid: false},
+		{addr: "12.34.45.64", valid: false},
+		{addr: "[::2]", valid: false},
+		{addr: "::2", valid: false},
+		{addr: "foo", valid: false},
+		{addr: "hn.com", valid: false},
+		{addr: "世界", valid: false},
+		{addr: "foo:", valid: false},
+		{addr: "世界:", valid: false},
+		{addr: ":foo", valid: false},
+		{addr: ":世界", valid: false},
+		// Invalid host / port chars
+		{addr: " foo:bar", valid: false},
+		{addr: "foo :bar", valid: false},
+		{addr: "f oo:bar", valid: false},
+		{addr: "foo: bar", valid: false},
+		{addr: "foo:bar ", valid: false},
+		{addr: "foo:b ar", valid: false},
+		{addr: "\x00:bar", valid: false},
+		{addr: "foo:\x00", valid: false},
+		// Loopback address
+		{addr: "localhost:bar", valid: false, isLoopback: true},
+		{addr: "127.0.0.1:bar", valid: false, isLoopback: true},
+		{addr: "[::1]:bar", valid: false, isLoopback: true},
+		// Unspecified address
+		{addr: "[::]:bar", valid: false},
+		{addr: "0.0.0.0:bar", valid: false},
+		// Valid addresses.
+		{addr: "foo:bar", valid: true},
+		{addr: "hn.com:8811", valid: true},
+		{addr: "[::2]:bar", valid: true},
+		{addr: "111.111.111.111:111", valid: true},
+		{addr: "12.34.45.64:7777", valid: true},
+		{addr: "世界:bar", valid: true},
+		{addr: "bar:世界", valid: true},
+		{addr: "世:界", valid: true},
 	}
-	for _, test := range testSet {
-		if test.query.IsValid() != test.desiredResponse {
-			t.Error("test failed:", test, test.query.IsValid())
+	for _, tt := range tests {
+		err := tt.addr.IsValid()
+		if (err == nil) != tt.valid || (err == ErrLoopbackAddr) != tt.isLoopback {
+			t.Errorf("test failed: got err: '%v', in test: '%v'", err, tt)
 		}
 	}
 }

--- a/modules/netaddress_test.go
+++ b/modules/netaddress_test.go
@@ -104,6 +104,7 @@ var (
 func TestHostPort(t *testing.T) {
 	t.Parallel()
 
+	// Test valid addrs.
 	for _, addr := range validAddrs {
 		na := NetAddress(addr)
 		host := na.Host()
@@ -119,16 +120,16 @@ func TestHostPort(t *testing.T) {
 			t.Errorf("Port() returned unexpected port for NetAddress '%v': expected '%v', got '%v'", na, expectedPort, port)
 		}
 	}
-	for _, addr := range invalidAddrs {
-		na := NetAddress(addr)
-		host := na.Host()
-		port := na.Port()
-		if host != "" {
-			t.Errorf("Expected Host() to return blank string for invalid NetAddress '%v', but got '%v'", na, host)
-		}
-		if port != "" {
-			t.Errorf("Expected Port() to return blank string for invalid NetAddress '%v', but got '%v'", na, port)
-		}
+
+	// Test that Host / Port return "" when net.SplitHostPort errors
+	na := NetAddress("::")
+	host := na.Host()
+	port := na.Port()
+	if host != "" {
+		t.Error("expected Host() to return blank for an un-splittable NetAddress, but it returned:", host)
+	}
+	if port != "" {
+		t.Error("expected Port() to return blank for an un-splittable NetAddress, but it returned:", port)
 	}
 }
 

--- a/modules/netaddress_test.go
+++ b/modules/netaddress_test.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -27,7 +28,11 @@ var (
 		"世界:",
 		":foo",
 		":世界",
+		"localhost:",
+		"[::1]:",
 		// Invalid host / port chars
+		"localhost:-",
+		"[::1]:-",
 		"foo:{}",
 		"{}:123",
 		" foo:123",
@@ -45,11 +50,30 @@ var (
 		// Unspecified address
 		"[::]:bar",
 		"0.0.0.0:bar",
+		// Invalid hostnames
+		"unqualifiedhost:123",
+		"Yo-Amazon.we-are-really-happy-for-you.and-we-will-let-you-finish.but-Sia-is-the-best-cloud-storage-of-all-time.of-all-time-of-all-time-of-all-time-of-all-time-of-all-time.of-all-time-of-all-time-of-all-time-of-all-time-of-all-time.of-all-time-of-all-time:123",
+		strings.Repeat("a", 64) + ".com:123",                       // 64 char long label too long.
+		strings.Repeat(strings.Repeat("a", 62)+".", 4) + "co:123",  // 254 char long hostname too long.
+		strings.Repeat(strings.Repeat("a", 62)+".", 4) + "co.:123", // 254 char long hostname with trailing dot too long.
+		"-foo.bar:123",
+		"foo-.bar:123",
+		"foo.-bar:123",
+		"foo.bar-:123",
+		"foo-bar.-baz:123",
+		"foo-bar.baz-:123",
+		"foo.-bar.baz:123",
+		"foo.bar-.baz:123",
+		".:123",
+		".foo.com:123",
+		"foo.com..:123",
 		// invalid port numbers
 		"foo:0",
 		"foo:65536",
 		"foo:-100",
 		"foo:1000000",
+		"localhost:0",
+		"[::1]:0",
 	}
 	validAddrs = []string{
 		// Loopback address (valid in testing only, can't really test this well)
@@ -57,9 +81,19 @@ var (
 		"127.0.0.1:123",
 		"[::1]:123",
 		// Valid addresses.
-		"foo:1",
-		"FOO:1",
+		"foo.com:1",
+		"foo.com.:1",
+		"a.b.c:1",
+		"a.b.c.:1",
+		"foo-bar.com:123",
+		"FOO.com:1",
+		"1foo.com:1",
+		"tld.foo.com:1",
 		"hn.com:8811",
+		strings.Repeat("foo.", 63) + "f:123",                     // 253 chars long
+		strings.Repeat("foo.", 63) + "f.:123",                    // 254 chars long, 253 chars long without trailing dot
+		strings.Repeat(strings.Repeat("a", 63)+".", 3) + "a:123", // 3x63 char length labels + 1x1 char length label without trailing dot
+		strings.Repeat(strings.Repeat("a", 63)+".", 3) + ":123",  // 3x63 char length labels with trailing dot
 		"[::2]:65535",
 		"111.111.111.111:111",
 		"12.34.45.64:7777",

--- a/modules/netaddress_test.go
+++ b/modules/netaddress_test.go
@@ -28,33 +28,41 @@ var (
 		":foo",
 		":世界",
 		// Invalid host / port chars
-		" foo:bar",
-		"foo :bar",
-		"f oo:bar",
-		"foo: bar",
-		"foo:bar ",
-		"foo:b ar",
-		"\x00:bar",
+		"foo:{}",
+		"{}:123",
+		" foo:123",
+		"foo :123",
+		"f oo:123",
+		"foo: 123",
+		"foo:123 ",
+		"foo:1 23",
+		"\x00:123",
 		"foo:\x00",
+		"世界:123",
+		"bar:世界",
+		"世:界",
+		`":"`,
 		// Unspecified address
 		"[::]:bar",
 		"0.0.0.0:bar",
+		// invalid port numbers
+		"foo:0",
+		"foo:65536",
+		"foo:-100",
+		"foo:1000000",
 	}
 	validAddrs = []string{
 		// Loopback address (valid in testing only, can't really test this well)
-		"localhost:bar",
-		"127.0.0.1:bar",
-		"[::1]:bar",
+		"localhost:123",
+		"127.0.0.1:123",
+		"[::1]:123",
 		// Valid addresses.
-		"foo:bar",
+		"foo:1",
+		"FOO:1",
 		"hn.com:8811",
-		"[::2]:bar",
+		"[::2]:65535",
 		"111.111.111.111:111",
 		"12.34.45.64:7777",
-		"世界:bar",
-		"bar:世界",
-		"世:界",
-		`":"`, // yeah, okay
 	}
 )
 
@@ -141,13 +149,13 @@ func TestIsValid(t *testing.T) {
 	for _, addr := range validAddrs {
 		na := NetAddress(addr)
 		if err := na.IsValid(); err != nil {
-			t.Error("IsValid returned non-nil for a valid NetAddress:", err)
+			t.Errorf("IsValid returned non-nil for valid NetAddress %q: %v", addr, err)
 		}
 	}
 	for _, addr := range invalidAddrs {
 		na := NetAddress(addr)
 		if err := na.IsValid(); err == nil {
-			t.Error("IsValid returned nil for an invalid NetAddress")
+			t.Errorf("IsValid returned nil for an invalid NetAddress %q: %v", addr, err)
 		}
 	}
 }

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -1,7 +1,6 @@
 package hostdb
 
 import (
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -23,10 +22,8 @@ type hostEntry struct {
 func (hdb *HostDB) insertHost(host modules.HostDBEntry) {
 	// Remove garbage hosts and local hosts (but allow local hosts in testing).
 	if err := host.NetAddress.IsValid(); err != nil {
-		// Allow loopback addresses in testing.
-		if build.Release != "testing" || err != modules.ErrLoopbackAddr {
-			return
-		}
+		hdb.log.Printf("WARN: host '%v' has an invalid NetAddress: %v", host.NetAddress, err)
+		return
 	}
 	// Don't do anything if we've already seen this host.
 	if _, exists := hdb.allHosts[host.NetAddress]; exists {

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -15,18 +15,18 @@ type hostEntry struct {
 	Online      bool
 }
 
-// insert adds a host entry to the state. The host will be inserted into the
-// set of all hosts, and if it is online and responding to requests it will be
-// put into the list of active hosts.
+// insertHost adds a host entry to the state. The host will be inserted into
+// the set of all hosts, and if it is online and responding to requests it will
+// be put into the list of active hosts.
 //
 // TODO: Function should return an error.
 func (hdb *HostDB) insertHost(host modules.HostDBEntry) {
-	// Remove garbage hosts and local hosts.
-	if !host.NetAddress.IsValid() {
-		return
-	}
-	if host.NetAddress.IsLoopback() && build.Release != "testing" {
-		return
+	// Remove garbage hosts and local hosts (but allow local hosts in testing).
+	if err := host.NetAddress.IsValid(); err != nil {
+		// Allow loopback addresses in testing.
+		if build.Release != "testing" || err != modules.ErrLoopbackAddr {
+			return
+		}
 	}
 	// Don't do anything if we've already seen this host.
 	if _, exists := hdb.allHosts[host.NetAddress]; exists {

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -24,7 +24,7 @@ func TestInsertHost(t *testing.T) {
 	}
 
 	// valid host should be scanned
-	dbe.NetAddress = "foo:1234"
+	dbe.NetAddress = "foo.com:1234"
 	hdb.insertHost(dbe)
 	select {
 	case <-hdb.scanPool:
@@ -116,12 +116,12 @@ func TestAveragePrice(t *testing.T) {
 func TestIsOffline(t *testing.T) {
 	hdb := &HostDB{
 		allHosts: map[modules.NetAddress]*hostEntry{
-			"foo:1234": &hostEntry{Online: true},
-			"bar:1234": &hostEntry{Online: false},
-			"baz:1234": &hostEntry{Online: true},
+			"foo.com:1234": &hostEntry{Online: true},
+			"bar.com:1234": &hostEntry{Online: false},
+			"baz.com:1234": &hostEntry{Online: true},
 		},
 		activeHosts: map[modules.NetAddress]*hostNode{
-			"foo:1234": nil,
+			"foo.com:1234": nil,
 		},
 		scanPool: make(chan *hostEntry),
 	}
@@ -130,10 +130,10 @@ func TestIsOffline(t *testing.T) {
 		addr    modules.NetAddress
 		offline bool
 	}{
-		{"foo:1234", false},
-		{"bar:1234", true},
-		{"baz:1234", false},
-		{"quux:1234", false},
+		{"foo.com:1234", false},
+		{"bar.com:1234", true},
+		{"baz.com:1234", false},
+		{"quux.com:1234", false},
 	}
 	for _, test := range tests {
 		if offline := hdb.IsOffline(test.addr); offline != test.offline {

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -136,7 +136,7 @@ func TestRescan(t *testing.T) {
 	}
 
 	// create a mocked consensus set with a different host announcement
-	annBytes, err := makeSignedAnnouncement("quux:1234")
+	annBytes, err := makeSignedAnnouncement("quux.com:1234")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestRescan(t *testing.T) {
 	if len(hdb.allHosts) != 1 {
 		t.Fatal("hostdb rescan resulted in wrong host set:", hdb.allHosts)
 	}
-	if _, exists := hdb.allHosts["quux:1234"]; !exists {
+	if _, exists := hdb.allHosts["quux.com:1234"]; !exists {
 		t.Fatal("hostdb rescan resulted in wrong host set:", hdb.allHosts)
 	}
 }

--- a/modules/renter/hostdb/update_test.go
+++ b/modules/renter/hostdb/update_test.go
@@ -25,7 +25,7 @@ func makeSignedAnnouncement(na modules.NetAddress) ([]byte, error) {
 
 // TestFindHostAnnouncements probes the findHostAnnouncements function
 func TestFindHostAnnouncements(t *testing.T) {
-	annBytes, err := makeSignedAnnouncement("foo:1234")
+	annBytes, err := makeSignedAnnouncement("foo.com:1234")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestReceiveConsensusSetUpdate(t *testing.T) {
 	hdb.persist = &memPersist{}
 
 	// Put a host announcement into a block.
-	annBytes, err := makeSignedAnnouncement("foo:1234")
+	annBytes, err := makeSignedAnnouncement("foo.com:1234")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -14,7 +14,7 @@ import (
 // fakeAddr returns a modules.NetAddress to be used in a HostEntry. Such
 // addresses are needed in order to satisfy the HostDB's "1 host per IP" rule.
 func fakeAddr(n uint8) modules.NetAddress {
-	return modules.NetAddress("127.0.0." + strconv.Itoa(int(n)) + "localhost:0")
+	return modules.NetAddress("127.0.0." + strconv.Itoa(int(n)) + ":1")
 }
 
 // uniformTreeVerification checks that everything makes sense in the tree given


### PR DESCRIPTION
Cleans up the NetAddress type. The main change is adding to the `IsValid()` method, which checks whether a NetAddress is a valid address. Valid is defined as being of the form "host:port" such that "host" is not a loopback address (except in testing) nor an unspecified IP address, and such that neither the host nor port are blank, contain white space, or contain the null character.

Previously some methods allowed loopback addresses in testing while others did not. This change makes loopback addresses always valid in testing only. This allows us to get rid of some kludges in the gateway testing.

Fixes #1040