### PR TITLE
Create dotsia package

### DIFF
--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -214,9 +214,9 @@ type Sector struct {
 	Piece      uint64 `json:"piece"`
 }
 
-// validate checks that f conforms to the specification defined in the package
-// docstring.
-func (f *File) validate() bool {
+// Validate checks that f conforms to the specification defined in the package
+// docstring. Files returned by Decode are automatically validated.
+func (f *File) Validate() bool {
 	// check path
 	if !filepath.IsAbs(f.Path) || filepath.Clean(f.Path) != f.Path || f.Path == "/" {
 		return false
@@ -332,7 +332,7 @@ func Decode(r io.Reader) ([]*File, error) {
 		err = dec.Decode(f)
 		if err != nil {
 			return nil, err
-		} else if !f.validate() {
+		} else if !f.Validate() {
 			return nil, ErrInvalid
 		}
 		files = append(files, f)

--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -45,7 +45,7 @@ const (
 
 var (
 	ErrNotSiaFile   = errors.New("not a .sia file")
-	ErrIncompatible = errors.New("file is not compatible with current version")
+	ErrIncompatible = errors.New("file is not compatible with version " + Version)
 
 	currentMetadata = Metadata{
 		Header:  Header,

--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -15,15 +15,14 @@ object corresponding to the Metadata type exported by this package. This
 object contains a version string, which indicates the version of the .sia
 format used. At this time, the .sia format has no promise of backwards or
 forwards compatibility, except that the version field will never be removed
-from the metadata object.
+from the metadata object. Backwards compatibility will be guaranteed as of the
+1.0 release of Sia.
 
 The JSON encoding tries to be flexible in allowing arbitrary encryption and
 encoding schemes. As such, the "masterKey" and "erasureCode" fields are
 encoded as generic JSON objects (in Go, a map[string]interface{}). However,
 these objects must always contain a "name" field that identifies the scheme
-used. They may not be null.
-
-Integer fields must not contain negative values.
+used. They must not be null.
 
 The "permissions" field is encoded as a decimal number (not octal, or a
 symbolic string) and must not exceed 511 (0777 in octal).

--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -1,0 +1,157 @@
+// Package dotsia defines the .sia format. It exposes functions that allow
+// encoding and decoding the format.
+//
+// Specification
+//
+// A .sia file is a gzipped tar archive containing one or more Files. Each
+// File is a JSON representation of the File type defined in this package. For
+// each file object header in the tar archive, only the Size field is
+// populated. A File only contains metadata, not the actual file as uploaded
+// to the Sia network; thus, metadata pertaining to the uploaded file, such as
+// its path and mode bits, are specified inside the File, not the tar header.
+package dotsia
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// A File contains the metadata necessary for retrieving, decoding, and
+// decrypting a file stored on the Sia network.
+type File struct {
+	Path        string
+	Size        uint64
+	SectorSize  uint64
+	MasterKey   crypto.TwofishKey
+	Mode        os.FileMode
+	ErasureCode modules.ErasureCoder
+	Contracts   []Contract
+}
+
+// A Contract represents a file contract made with a host, as well as all of
+// the sectors stored on that host.
+type Contract struct {
+	ID         types.FileContractID
+	NetAddress modules.NetAddress
+	EndHeight  types.BlockHeight
+
+	Sectors []Sector
+}
+
+// A Sector refers to a sector of data stored on a host via its Merkle root.
+// It also specifies the chunk and piece index of the sector, used during
+// erasure coding.
+type Sector struct {
+	Hash  crypto.Hash
+	Chunk uint64
+	Piece uint64
+}
+
+// Encode writes a .sia file to w containing the supplied files.
+func Encode(files []*File, w io.Writer) error {
+	z := gzip.NewWriter(w)
+	t := tar.NewWriter(z)
+
+	for _, f := range files {
+		encFile, err := json.Marshal(f)
+		if err != nil {
+			// should not be possible
+			return err
+		}
+		err = t.WriteHeader(&tar.Header{Size: int64(len(encFile))})
+		if err != nil {
+			return err
+		}
+		_, err = t.Write(encFile)
+		if err != nil {
+			return err
+		}
+	}
+	err := t.Close()
+	if err != nil {
+		return err
+	}
+
+	return z.Close()
+}
+
+// Decode reads a .sia file from r, returning its contents as a slice of
+// Files.
+func Decode(r io.Reader) ([]*File, error) {
+	z, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	t := tar.NewReader(z)
+	dec := json.NewDecoder(t)
+
+	var files []*File
+	for {
+		_, err := t.Next()
+		if err == io.EOF {
+			// end of tar archive
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		f := new(File)
+		err = dec.Decode(f)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, f)
+	}
+
+	err = z.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+// EncodeFile writes a .sia file to the specified filename.
+func EncodeFile(files []*File, filename string) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return Encode(files, f)
+}
+
+// DecodeFile reads a .sia file from the specified filename.
+func DecodeFile(filename string) ([]*File, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return Decode(f)
+}
+
+// EncodeString encodes a .sia file as a base64 string.
+func EncodeString(files []*File) (string, error) {
+	buf := new(bytes.Buffer)
+	err := Encode(files, base64.NewEncoder(base64.URLEncoding, buf))
+	if err != nil {
+		// should not be possible
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// DecodeString decodes a .sia file from a base64 string.
+func DecodeString(str string) ([]*File, error) {
+	buf := bytes.NewBufferString(str)
+	return Decode(base64.NewDecoder(base64.URLEncoding, buf))
+}

--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -274,6 +274,9 @@ func Encode(files []*File, w io.Writer) error {
 
 	// Write each file entry.
 	for _, f := range files {
+		if !f.Validate() {
+			return ErrInvalid
+		}
 		err = writeJSONentry(t, f)
 		if err != nil {
 			return err

--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -145,16 +145,12 @@ const (
 	Version = "0.6.0"
 )
 
+// These errors may be returned when Decode is called on invalid data.
 var (
 	ErrNotSiaFile   = errors.New("not a .sia file")
 	ErrIncompatible = errors.New("file is not compatible with version " + Version)
 	ErrInvalid      = errors.New("file contains invalid values")
 	ErrWrongLen     = errors.New("Hex string is not 64 bytes long")
-
-	currentMetadata = Metadata{
-		Header:  Header,
-		Version: Version,
-	}
 )
 
 // Metadata is the metadata entry present at the beginning of the .sia
@@ -163,6 +159,8 @@ type Metadata struct {
 	Header  string `json:"header"`
 	Version string `json:"version"`
 }
+
+var currentMetadata = Metadata{Header, Version}
 
 // A Hash is a 32-byte checksum, encoded as a 64-byte hex string.
 type Hash [32]byte

--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -274,9 +274,17 @@ func Encode(files []*File, w io.Writer) error {
 
 	// Write each file entry.
 	for _, f := range files {
+		// Convert path separator to /, if necessary.
+		// NOTE: we don't need to do the inverse during Decode; Go treats / as
+		// the separator on all platforms.
+		f.Path = filepath.ToSlash(f.Path)
+
+		// Validate file contents.
 		if !f.Validate() {
 			return ErrInvalid
 		}
+
+		// Write entry.
 		err = writeJSONentry(t, f)
 		if err != nil {
 			return err

--- a/modules/renter/dotsia/format.go
+++ b/modules/renter/dotsia/format.go
@@ -28,10 +28,10 @@ Integer fields must not contain negative values.
 The "permissions" field is encoded as a decimal number (not octal, or a
 symbolic string) and must not exceed 511 (0777 in octal).
 
-The "path" string must be an absolute Unix-style path; that is, it must begin
-with a leading slash and use '/' as its separator. Additionally, paths must
-not end in a slash, and must not contain any occurences of the current
-directory (.) or parent directory (..) elements.
+The "path" string must be a relative Unix-style path; that is, it must not
+begin with a leading slash, and it must use '/' as its separator.
+Additionally, paths must not end in a slash, and must not contain any
+occurences of the current directory (.) or parent directory (..) elements.
 
 The "contracts" array must not be null, but it may be empty. The same rule
 applies to the "sectors" array inside the contract object.
@@ -218,7 +218,7 @@ type Sector struct {
 // docstring. Files returned by Decode are automatically validated.
 func (f *File) Validate() bool {
 	// check path
-	if !filepath.IsAbs(f.Path) || filepath.Clean(f.Path) != f.Path || f.Path == "/" {
+	if filepath.IsAbs(f.Path) || filepath.Clean(f.Path) != f.Path || f.Path == "." {
 		return false
 	}
 	// check permissions

--- a/modules/renter/dotsia/format_test.go
+++ b/modules/renter/dotsia/format_test.go
@@ -2,7 +2,6 @@ package dotsia
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -57,7 +56,7 @@ func TestEncodeDecode(t *testing.T) {
 	b := []byte(savedBuf)
 	b[0] = 0xFF
 	_, err = Decode(bytes.NewReader(b))
-	if err != gzip.ErrHeader {
+	if err != ErrNotSiaFile {
 		t.Fatal("expected header error, got", err)
 	}
 	b = []byte(savedBuf)

--- a/modules/renter/dotsia/format_test.go
+++ b/modules/renter/dotsia/format_test.go
@@ -91,7 +91,7 @@ func TestHashMarshalling(t *testing.T) {
 	invalidJSONBytes := [][]byte{
 		// Invalid JSON.
 		nil,
-		[]byte{},
+		{},
 		[]byte(`"`),
 		// JSON of wrong length.
 		[]byte(""),

--- a/modules/renter/dotsia/format_test.go
+++ b/modules/renter/dotsia/format_test.go
@@ -55,7 +55,7 @@ func makeRandomFile() *File {
 	}
 
 	return &File{
-		Path:        "/random/file",
+		Path:        "random/file",
 		Size:        uint64(entropy[3]),
 		Permissions: os.FileMode(entropy[4]),
 		SectorSize:  uint64(entropy[5]),
@@ -165,7 +165,7 @@ func TestMarshalParity(t *testing.T) {
 func TestValidate(t *testing.T) {
 	// Minimum valid file
 	minimumValid := File{
-		Path:        "/test",
+		Path:        "test",
 		Permissions: 0,
 		MasterKey:   map[string]interface{}{"name": ""},
 		ErasureCode: map[string]interface{}{"name": ""},
@@ -180,17 +180,17 @@ func TestValidate(t *testing.T) {
 		path string
 		ok   bool
 	}{
-		{"relative/path", false},           // not absolute
-		{"///unclean///", false},           // not a clean path
-		{"/directory/../traversal", false}, // not a clean path
-		{"/folder/", false},                // not a clean path
-		{"/./foo", false},                  // not a clean path
-		{".", false},                       // not a clean path
-		{"/", false},                       // empty
+		{"/absolute/path", false},         // absolute path
+		{"unclean///path///", false},      // not a clean path
+		{"directory/../traversal", false}, // not a clean path
+		{"folder/", false},                // not a clean path
+		{"./foo", false},                  // not a clean path
+		{".", false},                      // empty
+		{"/", false},                      // absolute path
 
-		{"/foo", true},         // normal file
-		{"/foo/bar/baz", true}, // normal file
-		{"/.foo", true},        // dotfile
+		{"foo", true},         // normal file
+		{"foo/bar/baz", true}, // normal file
+		{".foo", true},        // dotfile
 	}
 	for i, test := range pathTests {
 		f := minimumValid
@@ -396,7 +396,7 @@ func TestMetadata(t *testing.T) {
 
 	// Minimum valid file
 	minimumValid := &File{
-		Path:        "/test",
+		Path:        "test",
 		Permissions: 0,
 		MasterKey:   map[string]interface{}{"name": ""},
 		ErasureCode: map[string]interface{}{"name": ""},

--- a/modules/renter/dotsia/format_test.go
+++ b/modules/renter/dotsia/format_test.go
@@ -378,6 +378,12 @@ func TestEncodeDecodeString(t *testing.T) {
 			t.Errorf("File %d differs after encoding: %v %v", i, files[i], fs[i])
 		}
 	}
+
+	// try encoding invalid File
+	_, err = EncodeString([]*File{new(File)})
+	if err != ErrInvalid {
+		t.Error("expected ErrInvalid, got", err)
+	}
 }
 
 // TestMetadata tests the metadata validation of the Decode function.
@@ -388,9 +394,18 @@ func TestMetadata(t *testing.T) {
 		currentMetadata = oldMeta
 	}()
 
+	// Minimum valid file
+	minimumValid := &File{
+		Path:        "/test",
+		Permissions: 0,
+		MasterKey:   map[string]interface{}{"name": ""},
+		ErasureCode: map[string]interface{}{"name": ""},
+		Contracts:   []Contract{},
+	}
+
 	// bad version
 	currentMetadata.Version = "foo"
-	str, err := EncodeString([]*File{new(File)})
+	str, err := EncodeString([]*File{minimumValid})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +416,7 @@ func TestMetadata(t *testing.T) {
 
 	// bad header
 	currentMetadata.Header = "foo"
-	str, err = EncodeString([]*File{new(File)})
+	str, err = EncodeString([]*File{minimumValid})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/dotsia/format_test.go
+++ b/modules/renter/dotsia/format_test.go
@@ -1,0 +1,165 @@
+package dotsia
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
+)
+
+type mockWriter func([]byte) (int, error)
+
+func (fn mockWriter) Write(p []byte) (int, error) {
+	return fn(p)
+}
+
+type mockReader func([]byte) (int, error)
+
+func (fn mockReader) Read(p []byte) (int, error) {
+	return fn(p)
+}
+
+// TestEncodeDecode tests the Encode and Decode functions, which are inverses
+// of each other.
+func TestEncodeDecode(t *testing.T) {
+	buf := new(bytes.Buffer)
+	fs := make([]*File, 100)
+	for i := range fs {
+		fs[i] = &File{
+			Size:       uint64(i),
+			Mode:       os.FileMode(i),
+			SectorSize: uint64(i),
+		}
+	}
+	err := Encode(fs, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	savedBuf := buf.String() // used later
+	files, err := Decode(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// verify that files were not changed after encode/decode
+	for i := range files {
+		if files[i].Size != fs[i].Size ||
+			files[i].Mode != fs[i].Mode ||
+			files[i].SectorSize != fs[i].SectorSize {
+			t.Errorf("File %d differs after encoding: %v %v", i, files[i], fs[i])
+		}
+	}
+
+	// try decoding invalid data
+	b := []byte(savedBuf)
+	b[0] = 0xFF
+	_, err = Decode(bytes.NewReader(b))
+	if err != gzip.ErrHeader {
+		t.Fatal("expected header error, got", err)
+	}
+	b = []byte(savedBuf)
+	b[500] = 0xFF
+	_, err = Decode(bytes.NewReader(b))
+	if _, ok := err.(*json.SyntaxError); !ok {
+		t.Fatal("expected syntax error, got", err)
+	}
+
+	// use a mockWriter to simulate write errors
+	w := mockWriter(func([]byte) (int, error) {
+		return 0, os.ErrInvalid
+	})
+	err = Encode(fs, w)
+	if err != os.ErrInvalid {
+		t.Fatal("expected mocked error, got", err)
+	}
+
+	// use a mockReader to simulate read errors
+	r := mockReader(func([]byte) (int, error) {
+		return 0, os.ErrInvalid
+	})
+	_, err = Decode(r)
+	if err != os.ErrInvalid {
+		t.Fatal("expected mocked error, got", err)
+	}
+}
+
+// TestEncodeDecodeFile tests the EncodeFile and DecodeFile functions, which
+// are inverses of each other.
+func TestEncodeDecodeFile(t *testing.T) {
+	fs := make([]*File, 100)
+	for i := range fs {
+		fs[i] = &File{
+			Size:       uint64(i),
+			Mode:       os.FileMode(i),
+			SectorSize: uint64(i),
+		}
+	}
+	dir := build.TempDir("dotsia")
+	err := os.MkdirAll(dir, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := filepath.Join(dir, "TestEncodeDecodeFile")
+	err = EncodeFile(fs, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := DecodeFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// verify that files were not changed after encode/decode
+	for i := range files {
+		if files[i].Size != fs[i].Size ||
+			files[i].Mode != fs[i].Mode ||
+			files[i].SectorSize != fs[i].SectorSize {
+			t.Errorf("File %d differs after encoding: %v %v", i, files[i], fs[i])
+		}
+	}
+
+	// make the file unreadable
+	err = os.Chmod(filename, 0000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = EncodeFile(nil, filename)
+	if !os.IsPermission(err) {
+		t.Fatal("expected permissions error, got", err)
+	}
+	_, err = DecodeFile(filename)
+	if !os.IsPermission(err) {
+		t.Fatal("expected permissions error, got", err)
+	}
+}
+
+// TestEncodeDecodeString tests the EncodeString and DecodeString functions, which
+// are inverses of each other.
+func TestEncodeDecodeString(t *testing.T) {
+	fs := make([]*File, 100)
+	for i := range fs {
+		fs[i] = &File{
+			Size:       uint64(i),
+			Mode:       os.FileMode(i),
+			SectorSize: uint64(i),
+		}
+	}
+	str, err := EncodeString(fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := DecodeString(str)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// verify that files were not changed after encode/decode
+	for i := range files {
+		if files[i].Size != fs[i].Size ||
+			files[i].Mode != fs[i].Mode ||
+			files[i].SectorSize != fs[i].SectorSize {
+			t.Errorf("File %d differs after encoding: %v %v", i, files[i], fs[i])
+		}
+	}
+}


### PR DESCRIPTION
`dotsia` is a package that defines the (new) .sia format and provides functions for encoding/decoding them.

The full specification is in format.go. Here's some design decisions I made:
- After favoring .zip for a while, I finally decide to switch to .tar.gz (my original choice). While .zip is convenient in some aspects, the tradeoffs weren't worth it. Specifically, .zip compresses each file individually, which is a huge loss since all of our files have the same structure. Also, reading a .zip requires that you [know the size in advance](https://golang.org/pkg/archive/zip/#NewReader) (I know, right??).
- I chose not to use any Sia-specific types in the package, to make things as straightforward as possible. This decision may seem a little strange, but hear me out: doing so reduces coupling between the format and the Sia repo. For example, I could have used a `modules.NetAddress` instead of a `string` for the `hostAddress` field. But if we ever decided to add a marshalling method to `NetAddress` (unlikely, I know), it could change how the `dotsia` package encoded that field, which would invisibly break compatibility. Besides, fewer dependencies is always a nice thing.
- I waffled on what to do about the `MasterKey` and `ErasureCode` fields. They are tricky because they need to be generic, which means you can't handle them inside the `dotsia` package. Ideally you would first decode the `name` field and branch on that, but JSON decodes everything at once. You could use `json.RawMessage` to get around this, but it's a pain for callers to work with. Ultimately I just stuck with the default type of `map[string]interface{}`. Since these fields will generally be dead-simple anyway, it shouldn't be too painful to do the necessary typecasting.
- The memory layout of the `File` struct has not changed much, despite the potential savings described in #1025. I think it's favorable to simply rely on compression to minimize any structural differences. It would be prudent, though, to compare different compressed structures with real-world data.
- I put the new package inside the `modules/renter` folder, but it could alternatively live at the top level, or even in its own repo. This might make sense given its decoupling from the rest of the Sia code, but I'm not sure.

Next step is to integrate this package with the renter, replacing most of its persist code in the process. (Actually, next step is to get this branch building...)