### PR TITLE
API authentication

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -141,9 +141,6 @@ func (srv *Server) initAPI(password string) {
 		router.POST("/miner/header", requirePassword(srv.minerHeaderHandlerPOST, password))
 		router.GET("/miner/start", requirePassword(srv.minerStartHandler, password))
 		router.GET("/miner/stop", requirePassword(srv.minerStopHandler, password))
-		// TODO: doesn't adding authentication break compatibility?
-		router.GET("/miner/headerforwork", requirePassword(srv.minerHeaderHandlerGET, password))  // COMPATv0.4.8
-		router.POST("/miner/submitheader", requirePassword(srv.minerHeaderHandlerPOST, password)) // COMPATv0.4.8
 	}
 
 	// Renter API Calls
@@ -190,8 +187,6 @@ func (srv *Server) initAPI(password string) {
 		router.GET("/wallet/transactions", srv.walletTransactionsHandler)
 		router.GET("/wallet/transactions/:addr", srv.walletTransactionsAddrHandler)
 		router.POST("/wallet/unlock", requirePassword(srv.walletUnlockHandler, password))
-		// TODO: doesn't authentication break compatibility?
-		router.POST("/wallet/encrypt", requirePassword(srv.walletInitHandler, password)) // COMPATv0.4.0
 	}
 
 	// Apply UserAgent middleware and create HTTP server

--- a/api/api.go
+++ b/api/api.go
@@ -14,7 +14,7 @@ func HttpGET(url string) (resp *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("User-Agent", "Sia-Agent")
+	req.Header.Set("User-Agent", "Sia-Agent")
 	return new(http.Client).Do(req)
 }
 
@@ -24,8 +24,8 @@ func HttpPOST(url string, data string) (resp *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("User-Agent", "Sia-Agent")
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "Sia-Agent")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	return new(http.Client).Do(req)
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -8,7 +8,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-// HttpGET is a utility function for making http get requests to sia with a whitelisted user-agent
+// HttpGET is a utility function for making http get requests to sia with a
+// whitelisted user-agent. A non-2xx response does not return an error.
 func HttpGET(url string) (resp *http.Response, err error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -18,7 +19,21 @@ func HttpGET(url string) (resp *http.Response, err error) {
 	return new(http.Client).Do(req)
 }
 
-// HttpPOST is a utility function for making post requests to sia with a whitelisted user-agent
+// HttpGETAuthenticated is a utility function for making authenticated http get
+// requests to sia with a whitelisted user-agent and the supplied password. A
+// non-2xx response does not return an error.
+func HttpGETAuthenticated(url string, password string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Sia-Agent")
+	req.SetBasicAuth("", password)
+	return new(http.Client).Do(req)
+}
+
+// HttpPOST is a utility function for making post requests to sia with a
+// whitelisted user-agent. A non-2xx response does not return an error.
 func HttpPOST(url string, data string) (resp *http.Response, err error) {
 	req, err := http.NewRequest("POST", url, strings.NewReader(data))
 	if err != nil {
@@ -26,6 +41,20 @@ func HttpPOST(url string, data string) (resp *http.Response, err error) {
 	}
 	req.Header.Set("User-Agent", "Sia-Agent")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return new(http.Client).Do(req)
+}
+
+// HttpPOSTAuthenticated is a utility function for making authenticated http
+// post requests to sia with a whitelisted user-agent and the supplied
+// password. A non-2xx response does not return an error.
+func HttpPOSTAuthenticated(url string, data string, password string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("POST", url, strings.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Sia-Agent")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("", password)
 	return new(http.Client).Do(req)
 }
 

--- a/api/server.go
+++ b/api/server.go
@@ -35,8 +35,12 @@ type Server struct {
 	wg sync.WaitGroup
 }
 
-// NewServer creates a new API server from the provided modules.
-func NewServer(APIaddr string, requiredUserAgent string, cs modules.ConsensusSet, e modules.Explorer, g modules.Gateway, h modules.Host, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet) (*Server, error) {
+// NewServer creates a new API server from the provided modules. The API will
+// require authentication using HTTP basic auth if the supplied password is not
+// the empty string. Usernames are ignored for authentication. This type of
+// authentication sends passwords in plaintext and should therefore only be
+// used if the APIaddr is localhost.
+func NewServer(APIaddr string, requiredUserAgent string, requiredPassword string, cs modules.ConsensusSet, e modules.Explorer, g modules.Gateway, h modules.Host, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet) (*Server, error) {
 	l, err := net.Listen("tcp", APIaddr)
 	if err != nil {
 		return nil, err
@@ -57,35 +61,9 @@ func NewServer(APIaddr string, requiredUserAgent string, cs modules.ConsensusSet
 	}
 
 	// Register API handlers
-	srv.initAPI()
+	srv.initAPI(requiredPassword)
 
 	return srv, nil
-}
-
-// requirePassword is middleware that requires all requests to authenticate
-// with a password using HTTP basic auth. Usernames are ignored.
-func requirePassword(h http.Handler, password string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		_, pass, ok := req.BasicAuth()
-		if !ok || pass != password {
-			w.Header().Set("WWW-Authenticate", "Basic realm=\"SiaAPI\"")
-			writeError(w, "API authentication failed.", http.StatusUnauthorized)
-			return
-		}
-		h.ServeHTTP(w, req)
-	})
-}
-
-// RequireAuthentication makes a non-authenticated server require
-// authentication with the provided password. Authentication is done with HTTP
-// basic auth with the supplied password. Usernames are ignored during
-// authentication. This type of authentication sends passwords in plaintext and
-// should therefore only be used if the APIaddr is localhost. Calling
-// RequireAuthentication multiple times with different passwords will prevent
-// any API calls, authenticated or not, from succeeding as the server would
-// enforce multiple passwords.
-func (srv *Server) RequireAuthentication(password string) {
-	srv.apiServer.Handler = requirePassword(srv.apiServer.Handler, password)
 }
 
 // Serve listens for and handles API calls. It is a blocking function.

--- a/api/server.go
+++ b/api/server.go
@@ -62,6 +62,32 @@ func NewServer(APIaddr string, requiredUserAgent string, cs modules.ConsensusSet
 	return srv, nil
 }
 
+// requirePassword is middleware that requires all requests to authenticate
+// with a password using HTTP basic auth. Usernames are ignored.
+func requirePassword(h http.Handler, password string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, pass, ok := req.BasicAuth()
+		if !ok || pass != password {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"SiaAPI\"")
+			writeError(w, "API authentication failed.", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, req)
+	})
+}
+
+// RequireAuthentication makes a non-authenticated server require
+// authentication with the provided password. Authentication is done with HTTP
+// basic auth with the supplied password. Usernames are ignored during
+// authentication. This type of authentication sends passwords in plaintext and
+// should therefore only be used if the APIaddr is localhost. Calling
+// RequireAuthentication multiple times with different passwords will prevent
+// any API calls, authenticated or not, from succeeding as the server would
+// enforce multiple passwords.
+func (srv *Server) RequireAuthentication(password string) {
+	srv.apiServer.Handler = requirePassword(srv.apiServer.Handler, password)
+}
+
 // Serve listens for and handles API calls. It is a blocking function.
 func (srv *Server) Serve() error {
 	// Block the Close() method until Serve() has finished.

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -88,7 +88,7 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", "", cs, e, g, h, m, r, tp, w)
 	if err != nil {
 		return nil, err
 	}
@@ -167,11 +167,10 @@ func assembleAuthenticatedServerTester(requiredPassword string, key crypto.Twofi
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", requiredPassword, cs, e, g, h, m, r, tp, w)
 	if err != nil {
 		return nil, err
 	}
-	srv.RequireAuthentication(requiredPassword)
 
 	// Assemble the serverTester.
 	st := &serverTester{
@@ -217,7 +216,7 @@ func assembleExplorerServerTester(testdir string) (*serverTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer("localhost:0", "", cs, e, g, nil, nil, nil, nil, nil)
+	srv, err := NewServer("localhost:0", "", "", cs, e, g, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -345,7 +345,7 @@ func (st *serverTester) stdGetAPIUA(call string, userAgent string) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Add("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := new(http.Client).Do(req)
 	if err != nil {
 		return err

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -120,6 +120,86 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	return st, nil
 }
 
+// assembleAuthenticatedServerTester creates a bunch of modules and assembles
+// them into a server tester that requires authentication with the given
+// requiredPassword. No directories are created and no blocks are mined.
+func assembleAuthenticatedServerTester(requiredPassword string, key crypto.TwofishKey, testdir string) (*serverTester, error) {
+	// Create the modules.
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
+	if err != nil {
+		return nil, err
+	}
+	cs, err := consensus.New(g, filepath.Join(testdir, modules.ConsensusDir))
+	if err != nil {
+		return nil, err
+	}
+	tp, err := transactionpool.New(cs, g)
+	if err != nil {
+		return nil, err
+	}
+	w, err := wallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	if err != nil {
+		return nil, err
+	}
+	if !w.Encrypted() {
+		_, err = w.Encrypt(key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = w.Unlock(key)
+	if err != nil {
+		return nil, err
+	}
+	m, err := miner.New(cs, tp, w, filepath.Join(testdir, modules.MinerDir))
+	if err != nil {
+		return nil, err
+	}
+	h, err := host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	if err != nil {
+		return nil, err
+	}
+	r, err := renter.New(cs, w, tp, filepath.Join(testdir, modules.RenterDir))
+	if err != nil {
+		return nil, err
+	}
+	e, err := explorer.New(cs, filepath.Join(testdir, modules.ExplorerDir))
+	if err != nil {
+		return nil, err
+	}
+	srv, err := NewServer("localhost:0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
+	if err != nil {
+		return nil, err
+	}
+	srv.RequireAuthentication(requiredPassword)
+
+	// Assemble the serverTester.
+	st := &serverTester{
+		cs:        cs,
+		gateway:   g,
+		host:      h,
+		miner:     m,
+		renter:    r,
+		tpool:     tp,
+		explorer:  e,
+		wallet:    w,
+		walletKey: key,
+
+		server: srv,
+
+		dir: testdir,
+	}
+
+	// TODO: A more reasonable way of listening for server errors.
+	go func() {
+		listenErr := srv.Serve()
+		if listenErr != nil {
+			panic(listenErr)
+		}
+	}()
+	return st, nil
+}
+
 // assembleExplorerServerTester creates all the explorer dependencies and
 // explorer module without creating any directories. The user agent requirement
 // is disabled.
@@ -174,6 +254,33 @@ func createServerTester(name string) (*serverTester, error) {
 		return nil, err
 	}
 	st, err := assembleServerTester(key, testdir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mine blocks until the wallet has confirmed money.
+	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
+		_, err := st.miner.AddBlock()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return st, nil
+}
+
+// createAuthenticatedServerTester creates an authenticated server tester
+// object that is ready for testing, including money in the wallet and all
+// modules initalized.
+func createAuthenticatedServerTester(name string, password string) (*serverTester, error) {
+	// Create the testing directory.
+	testdir := build.TempDir("authenticated-api", name)
+
+	key, err := crypto.GenerateTwofishKey()
+	if err != nil {
+		return nil, err
+	}
+	st, err := assembleAuthenticatedServerTester(password, key, testdir)
 	if err != nil {
 		return nil, err
 	}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -72,7 +72,7 @@ func TestAuthentication(t *testing.T) {
 	}
 	defer st.server.Close()
 
-	testGETURL := "http://" + st.server.listener.Addr().String() + "/daemon/version"
+	testGETURL := "http://" + st.server.listener.Addr().String() + "/wallet/seeds"
 	testPOSTURL := "http://" + st.server.listener.Addr().String() + "/host/announce"
 
 	// Test that unauthenticated API calls fail.

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -54,5 +55,77 @@ func TestReloading(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestAuthenticated tests creating a server that requires authenticated API
+// calls, and then makes (un)authenticated API calls to test the
+// authentication.
+func TestAuthentication(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createAuthenticatedServerTester("TestAuthentication", "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	testGETURL := "http://" + st.server.listener.Addr().String() + "/daemon/version"
+	testPOSTURL := "http://" + st.server.listener.Addr().String() + "/host/announce"
+
+	// Test that unauthenticated API calls fail.
+	// GET
+	resp, err := HttpGET(testGETURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("unauthenticated API call succeeded on a server that requires authentication")
+	}
+	// POST
+	resp, err = HttpPOST(testPOSTURL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("unauthenticated API call succeeded on a server that requires authentication")
+	}
+
+	// Test that authenticated API calls with the wrong password fail.
+	// GET
+	resp, err = HttpGETAuthenticated(testGETURL, "wrong password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("authenticated API call succeeded with an incorrect password")
+	}
+	// POST
+	resp, err = HttpPOSTAuthenticated(testPOSTURL, "", "wrong password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("authenticated API call succeeded with an incorrect password")
+	}
+
+	// Test that authenticated API calls with the correct password succeed.
+	// GET
+	resp, err = HttpGETAuthenticated(testGETURL, "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("authenticated API call failed with the correct password")
+	}
+	// POST
+	resp, err = HttpPOSTAuthenticated(testPOSTURL, "", "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("authenticated API call failed with the correct password")
 	}
 }

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -45,14 +45,6 @@ type (
 		PrimarySeed string `json:"primaryseed"`
 	}
 
-	// WalletEncryptPOST contains the primary seed that gets generated during a
-	// POST call to /wallet/encrypt.
-	//
-	// COMPATv0.4.0
-	WalletEncryptPOST struct {
-		PrimarySeed string `json:"primaryseed"`
-	}
-
 	// WalletSiacoinsPOST contains the transaction sent in the POST call to
 	// /wallet/siafunds.
 	WalletSiacoinsPOST struct {

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -253,7 +253,7 @@ func (srv *Server) walletLockHandler(w http.ResponseWriter, req *http.Request, _
 	writeSuccess(w)
 }
 
-// walletSeedHandler handles API calls to /wallet/seed.
+// walletSeedsHandler handles API calls to /wallet/seeds.
 func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	dictionary := mnemonics.DictionaryID(req.FormValue("dictionary"))
 	if dictionary == "" {
@@ -263,26 +263,26 @@ func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, 
 	// Get the primary seed information.
 	primarySeed, progress, err := srv.wallet.PrimarySeed()
 	if err != nil {
-		writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	primarySeedStr, err := modules.SeedToString(primarySeed, dictionary)
 	if err != nil {
-		writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Get the list of seeds known to the wallet.
 	allSeeds, err := srv.wallet.AllSeeds()
 	if err != nil {
-		writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	var allSeedsStrs []string
 	for _, seed := range allSeeds {
 		str, err := modules.SeedToString(seed, dictionary)
 		if err != nil {
-			writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+			writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 			return
 		}
 		allSeedsStrs = append(allSeedsStrs, str)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -125,16 +125,16 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	}()
 	defer st.server.Close()
 
-	// Make a call to /wallet/encrypt and get the seed. Provide no encryption
+	// Make a call to /wallet/init and get the seed. Provide no encryption
 	// key so that the encryption key is the seed that gets returned.
-	var wep WalletEncryptPOST
-	err = st.postAPI("/wallet/encrypt", url.Values{}, &wep)
+	var wip WalletInitPOST
+	err = st.postAPI("/wallet/init", url.Values{}, &wip)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Use the seed to call /wallet/unlock.
 	unlockValues := url.Values{}
-	unlockValues.Set("encryptionpassword", wep.PrimarySeed)
+	unlockValues.Set("encryptionpassword", wip.PrimarySeed)
 	err = st.stdPostAPI("/wallet/unlock", unlockValues)
 	if err != nil {
 		t.Fatal(err)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -188,7 +188,7 @@ func TestIntegrationWalletGETSiacoins(t *testing.T) {
 	}
 	sendSiacoinsValues := url.Values{}
 	sendSiacoinsValues.Set("amount", "1234")
-	sendSiacoinsValues.Add("destination", wag.Address.String())
+	sendSiacoinsValues.Set("destination", wag.Address.String())
 	err = st.stdPostAPI("/wallet/siacoins", sendSiacoinsValues)
 	if err != nil {
 		t.Fatal(err)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -40,7 +40,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create wallet:", err)
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", "", cs, nil, g, nil, nil, nil, tp, w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", "", cs, nil, g, nil, nil, nil, tp, w)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -70,13 +70,13 @@ func processConfig(config Config) (Config, error) {
 func startDaemon(config Config) (err error) {
 	// Prompt user for API password.
 	var password string
-	if !config.Siad.NoPassword {
+	if config.Siad.AuthenticateAPI {
 		password, err = speakeasy.Ask("Enter API password: ")
 		if err != nil {
 			return err
 		}
 		if password == "" {
-			return errors.New("password cannot be blank, use the --no-password flag instead")
+			return errors.New("password cannot be blank")
 		}
 		passwordConfirm, err := speakeasy.Ask("Confirm API password: ")
 		if err != nil {

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -168,6 +168,7 @@ func startDaemon(config Config) (err error) {
 	srv, err := api.NewServer(
 		config.Siad.APIaddr,
 		config.Siad.RequiredUserAgent,
+		password,
 		cs,
 		e,
 		g,
@@ -179,9 +180,6 @@ func startDaemon(config Config) (err error) {
 	)
 	if err != nil {
 		return err
-	}
-	if !config.Siad.NoPassword {
-		srv.RequireAuthentication(password)
 	}
 
 	// Bootstrap to the network.

--- a/siad/main.go
+++ b/siad/main.go
@@ -33,6 +33,7 @@ type Config struct {
 		Modules           string
 		NoBootstrap       bool
 		RequiredUserAgent string
+		NoPassword        bool
 
 		Profile    bool
 		ProfileDir string
@@ -146,6 +147,7 @@ func main() {
 	root.Flags().BoolVarP(&globalConfig.Siad.Profile, "profile", "p", false, "enable profiling")
 	root.Flags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
 	root.Flags().StringVarP(&globalConfig.Siad.Modules, "modules", "M", "cghmrtw", "enabled modules, see 'siad modules' for more info")
+	root.Flags().BoolVarP(&globalConfig.Siad.NoPassword, "no-password", "", false, "disable API password protection (not recommended)")
 
 	// Deprecate shorthand flags that aren't commonly used.
 	// COMPATv0.5.2

--- a/siad/main.go
+++ b/siad/main.go
@@ -33,7 +33,7 @@ type Config struct {
 		Modules           string
 		NoBootstrap       bool
 		RequiredUserAgent string
-		NoPassword        bool
+		AuthenticateAPI   bool
 
 		Profile    bool
 		ProfileDir string
@@ -147,7 +147,7 @@ func main() {
 	root.Flags().BoolVarP(&globalConfig.Siad.Profile, "profile", "p", false, "enable profiling")
 	root.Flags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
 	root.Flags().StringVarP(&globalConfig.Siad.Modules, "modules", "M", "cghmrtw", "enabled modules, see 'siad modules' for more info")
-	root.Flags().BoolVarP(&globalConfig.Siad.NoPassword, "no-password", "", false, "disable API password protection (not recommended)")
+	root.Flags().BoolVarP(&globalConfig.Siad.AuthenticateAPI, "authenticate-api", "", false, "enable API password protection")
 
 	// Deprecate shorthand flags that aren't commonly used.
 	// COMPATv0.5.2


### PR DESCRIPTION
Authentication is implemented with [HTTP basic auth](https://tools.ietf.org/html/rfc2617#section-2). Passwords are sent in plaintext. Therefore API authentication should only be used if the API is only exposed over localhost. In the future, TLS can be used to encrypt API calls which will make it safe to use API authentication elsewhere.

It is safe to send passwords in plaintext over localhost as only root should be able to sniff localhost.

Authentication is enabled in siad by default. The `--no-password` flag can be used to disable it.