### PR TITLE
Get FormContract working

### DIFF
--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -59,7 +59,7 @@ func GenerateKeyPairDeterministic(entropy [EntropySize]byte) (SecretKey, PublicK
 	return stdKeyGen.generateDeterministic(entropy)
 }
 
-// ReadSignedObject reads a length-prefixed object followed by its signature,
+// ReadSignedObject reads a length-prefixed object prefixed by its signature,
 // and verifies the signature.
 func ReadSignedObject(r io.Reader, obj interface{}, maxLen uint64, pk PublicKey) error {
 	// read the signature
@@ -101,7 +101,7 @@ func VerifyHash(data Hash, pk PublicKey, sig Signature) error {
 	return nil
 }
 
-// WriteSignedObject writes a length-prefixed object followed by its signature.
+// WriteSignedObject writes a length-prefixed object prefixed by its signature.
 func WriteSignedObject(w io.Writer, obj interface{}, sk SecretKey) error {
 	objBytes := encoding.Marshal(obj)
 	sig, err := SignHash(HashBytes(objBytes), sk)

--- a/modules/host.go
+++ b/modules/host.go
@@ -62,9 +62,9 @@ type (
 		NetAddress         NetAddress        `json:"netaddress"`
 		WindowSize         types.BlockHeight `json:"windowsize"`
 
-		Collateral         types.Currency `json:"collateral"`
-		CollateralFraction types.Currency `json:"collateralfraction"`
-		MaxCollateral      types.Currency `json:"maxcollateral"`
+		Collateral            types.Currency `json:"collateral"`
+		MaxCollateralFraction types.Currency `json:"maxcollateralfraction"`
+		MaxCollateral         types.Currency `json:"maxcollateral"`
 
 		BandwidthLimits               HostBandwidthLimits `json:"bandwidthlimits"`
 		MinimumContractPrice          types.Currency      `json:"contractprice"`

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -76,6 +76,10 @@ var (
 	// opportunity cost in being a host.
 	defaultCollateral = types.NewCurrency64(50) // 50 SC / GB / Month
 
+	defaultCollateralFraction = types.NewCurrency64(650e3)
+
+	defaultMaxCollateral = types.NewCurrency64(10000).Mul(types.SiacoinPrecision)
+
 	// defaultWindowSize is the size of the proof of storage window requested
 	// by the host. The host will not delete any obligations until the window
 	// has closed and buried under several confirmations. For release builds,

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -185,7 +185,11 @@ func (h *Host) establishDefaults() error {
 		MaxDuration: defaultMaxDuration,
 		WindowSize:  defaultWindowSize,
 
-		Collateral:                    defaultCollateral,
+		Collateral:            defaultCollateral,
+		MaxCollateralFraction: defaultCollateralFraction,
+		MaxCollateral:         defaultMaxCollateral,
+
+		MinimumStoragePrice:           defaultStoragePrice,
 		MinimumContractPrice:          defaultContractPrice,
 		MinimumDownloadBandwidthPrice: defaultDownloadBandwidthPrice,
 		MinimumUploadBandwidthPrice:   defaultUploadBandwidthPrice,

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -8,6 +8,11 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 )
 
+// acceptNegotiation writes the 'accept' response to conn.
+func acceptNegotiation(conn net.Conn) error {
+	return encoding.WriteObject(conn, modules.AcceptResponse)
+}
+
 // rejectNegotiation will write a rejection response to the connection and
 // return the input error composed with the error received from writing to the
 // connection.

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -1,25 +1,10 @@
 package host
 
 import (
-	"net"
 	"sync/atomic"
 
-	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 )
-
-// acceptNegotiation writes the 'accept' response to conn.
-func acceptNegotiation(conn net.Conn) error {
-	return encoding.WriteObject(conn, modules.AcceptResponse)
-}
-
-// rejectNegotiation will write a rejection response to the connection and
-// return the input error composed with the error received from writing to the
-// connection.
-func rejectNegotiation(conn net.Conn, err error) error {
-	writeErr := encoding.WriteObject(conn, err.Error())
-	return composeErrors(err, writeErr)
-}
 
 // NetAddress returns the address at which the host can be reached.
 func (h *Host) NetAddress() modules.NetAddress {

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -148,14 +148,14 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 		LockedCollateral:     hostPortion,
 		OriginTransactionSet: fullTxnSet,
 	}
-	err = h.lockStorageObligation(so)
-	if err != nil {
-		return nil, err
+	lockErr := h.lockStorageObligation(so)
+	if lockErr != nil {
+		return nil, lockErr
 	}
 	err = h.addStorageObligation(so)
-	err2 := h.unlockStorageObligation(so)
-	if err2 != nil {
-		return nil, err2
+	lockErr = h.unlockStorageObligation(so)
+	if lockErr != nil {
+		return nil, lockErr
 	}
 	if err != nil {
 		// An error here is pretty bad, because the signed file contract has

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -326,7 +326,7 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 		return errWindowStartTooSoon
 	}
 	// WindowEnd must be at least settings.WindowSize blocks after WindowStart.
-	if fc.WindowStart+settings.WindowSize >= fc.WindowEnd {
+	if fc.WindowEnd < fc.WindowStart+settings.WindowSize {
 		return errWindowSizeTooSmall
 	}
 	// ValidProofOutputs and MissedProofOutputs must both have len(2).

--- a/modules/host/negotiatesettings.go
+++ b/modules/host/negotiatesettings.go
@@ -44,9 +44,9 @@ func (h *Host) managedRPCSettings(conn net.Conn) error {
 		UnlockHash:         h.unlockHash,
 		WindowSize:         h.settings.WindowSize,
 
-		Collateral: h.settings.Collateral,
-		// CollateralFraction:
-		// MaxCollateral:
+		Collateral:            h.settings.Collateral,
+		MaxCollateralFraction: h.settings.MaxCollateralFraction,
+		MaxCollateral:         h.settings.MaxCollateral,
 
 		ContractPrice:          h.settings.MinimumContractPrice,
 		DownloadBandwidthPrice: h.settings.MinimumDownloadBandwidthPrice,

--- a/modules/negotiate.go
+++ b/modules/negotiate.go
@@ -174,9 +174,9 @@ type (
 		//
 		// MaxCollateral indicates the maximum number of coins that a host is
 		// willing to put into a file contract.
-		Collateral         types.Currency `json:"collateral"`
-		CollateralFraction types.Currency `json:"collateralfraction"`
-		MaxCollateral      types.Currency `json:"maxcollateral"`
+		Collateral            types.Currency `json:"collateral"`
+		MaxCollateralFraction types.Currency `json:"maxcollateralfraction"`
+		MaxCollateral         types.Currency `json:"maxcollateral"`
 
 		ContractPrice          types.Currency `json:"contractprice"`
 		DownloadBandwidthPrice types.Currency `json:"downloadbandwidthprice"`

--- a/modules/negotiate_test.go
+++ b/modules/negotiate_test.go
@@ -90,3 +90,30 @@ func TestAnnouncementHandling(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// TestNegotiationResponses tests the WriteNegotiationAcceptance,
+// WriteNegotiationRejection, and ReadNegotiationAcceptance functions.
+func TestNegotiationResponses(t *testing.T) {
+	// Write/Read acceptance
+	buf := new(bytes.Buffer)
+	err := WriteNegotiationAcceptance(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ReadNegotiationAcceptance(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write/Read rejection
+	buf.Reset()
+	err = WriteNegotiationRejection(buf, ErrLowBalance)
+	if err != ErrLowBalance {
+		t.Fatal(err)
+	}
+	err = ReadNegotiationAcceptance(buf)
+	// can't compare to ErrLowBalance directly; contents are the same, but pointer is different
+	if err == nil || err.Error() != ErrLowBalance.Error() {
+		t.Fatal(err)
+	}
+}

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -26,7 +26,8 @@ func (newStub) NextAddress() (uc types.UnlockConditions, err error) { return }
 func (newStub) StartTransaction() modules.TransactionBuilder        { return nil }
 
 // transaction pool stubs
-func (newStub) AcceptTransactionSet([]types.Transaction) error { return nil }
+func (newStub) AcceptTransactionSet([]types.Transaction) error      { return nil }
+func (newStub) FeeEstimation() (a types.Currency, b types.Currency) { return }
 
 // hdb stubs
 func (newStub) Host(modules.NetAddress) (settings modules.HostDBEntry, ok bool) { return }

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -30,13 +30,20 @@ type (
 	transactionBuilder interface {
 		AddArbitraryData([]byte) uint64
 		AddFileContract(types.FileContract) uint64
+		AddMinerFee(types.Currency) uint64
+		AddParents([]types.Transaction)
+		AddSiacoinInput(types.SiacoinInput) uint64
+		AddSiacoinOutput(types.SiacoinOutput) uint64
+		AddTransactionSignature(types.TransactionSignature) uint64
 		Drop()
 		FundSiacoins(types.Currency) error
 		Sign(bool) ([]types.Transaction, error)
 		View() (types.Transaction, []types.Transaction)
+		ViewAdded() (parents, coins, funds, signatures []int)
 	}
 	transactionPool interface {
 		AcceptTransactionSet([]types.Transaction) error
+		FeeEstimation() (min types.Currency, max types.Currency)
 	}
 
 	hostDB interface {

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -212,7 +212,7 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 	if !ok {
 		return nil, errors.New("no record of that host")
 	}
-	if host.ContractPrice.Cmp(maxPrice) > 0 {
+	if host.StoragePrice.Cmp(maxPrice) > 0 {
 		return nil, errTooExpensive
 	}
 
@@ -220,8 +220,8 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 	if len(contract.LastRevision.NewValidProofOutputs) != 2 {
 		return nil, errors.New("invalid contract")
 	}
-	if !host.ContractPrice.IsZero() {
-		bytes, errOverflow := contract.LastRevision.NewValidProofOutputs[0].Value.Div(host.ContractPrice).Uint64()
+	if !host.StoragePrice.IsZero() {
+		bytes, errOverflow := contract.LastRevision.NewValidProofOutputs[0].Value.Div(host.StoragePrice).Uint64()
 		if errOverflow == nil && bytes < modules.SectorSize {
 			return nil, errors.New("contract has insufficient capacity")
 		}
@@ -262,7 +262,7 @@ func (c *Contractor) Editor(contract Contract) (Editor, error) {
 
 	he := &hostEditor{
 		contract: contract,
-		price:    host.ContractPrice,
+		price:    host.StoragePrice,
 
 		conn:       conn,
 		contractor: c,

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -1,0 +1,179 @@
+package contractor
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/modules/consensus"
+	"github.com/NebulousLabs/Sia/modules/gateway"
+	"github.com/NebulousLabs/Sia/modules/host"
+	"github.com/NebulousLabs/Sia/modules/miner"
+	"github.com/NebulousLabs/Sia/modules/renter/hostdb"
+	"github.com/NebulousLabs/Sia/modules/transactionpool"
+	modWallet "github.com/NebulousLabs/Sia/modules/wallet"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// newTestingWallet is a helper function that creates a ready-to-use wallet
+// and mines some coins into it.
+func newTestingWallet(testdir string, cs modules.ConsensusSet, tp modules.TransactionPool) (modules.Wallet, error) {
+	w, err := modWallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	if err != nil {
+		return nil, err
+	}
+	key, err := crypto.GenerateTwofishKey()
+	if err != nil {
+		return nil, err
+	}
+	if !w.Encrypted() {
+		_, err = w.Encrypt(key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = w.Unlock(key)
+	if err != nil {
+		return nil, err
+	}
+	// give it some money
+	m, err := miner.New(cs, tp, w, filepath.Join(testdir, modules.MinerDir))
+	if err != nil {
+		return nil, err
+	}
+	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
+		_, err := m.AddBlock()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return w, nil
+}
+
+// newTestingHost is a helper function that creates a ready-to-use host.
+func newTestingHost(testdir string, cs modules.ConsensusSet, tp modules.TransactionPool) (modules.Host, error) {
+	w, err := newTestingWallet(testdir, cs, tp)
+	if err != nil {
+		return nil, err
+	}
+	return host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+}
+
+// newTestingContractor is a helper function that creates a ready-to-use
+// contractor.
+func newTestingContractor(testdir string, cs modules.ConsensusSet, tp modules.TransactionPool) (*Contractor, error) {
+	w, err := newTestingWallet(testdir, cs, tp)
+	if err != nil {
+		return nil, err
+	}
+	hdb, err := hostdb.New(cs, filepath.Join(testdir, "hostdb"))
+	if err != nil {
+		return nil, err
+	}
+	return New(cs, w, tp, hdb, filepath.Join(testdir, "contractor"))
+}
+
+// newTestingTrio creates a Host, Contractor, and TestMiner that can be used
+// for testing host/renter interactions.
+func newTestingTrio(name string) (modules.Host, *Contractor, modules.TestMiner, error) {
+	testdir := build.TempDir("contractor", name)
+
+	// create miner
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cs, err := consensus.New(g, filepath.Join(testdir, modules.ConsensusDir))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	tp, err := transactionpool.New(cs, g)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	w, err := modWallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	key, err := crypto.GenerateTwofishKey()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if !w.Encrypted() {
+		_, err = w.Encrypt(key)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	err = w.Unlock(key)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	m, err := miner.New(cs, tp, w, filepath.Join(testdir, modules.MinerDir))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// create host and contractor, using same consensus set and gateway
+	h, err := newTestingHost(filepath.Join(testdir, "Host"), cs, tp)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	c, err := newTestingContractor(filepath.Join(testdir, "Contractor"), cs, tp)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return h, c, m, nil
+}
+
+// TestIntegrationFormContract tests that the contractor can form contracts
+// with the host module.
+func TestIntegrationFormContract(t *testing.T) {
+	// create host+contractor+miner
+	h, c, m, err := newTestingTrio("TestIngrationFormContract")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure host to accept contracts
+	settings := h.InternalSettings()
+	settings.AcceptingContracts = true
+	err = h.SetInternalSettings(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// announce the host
+	err = h.Announce()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// mine a block, processing the announcement
+	m.AddBlock()
+
+	// wait for hostdb to scan host
+	for len(c.hdb.RandomHosts(1, nil)) == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	// get the host's entry from the db
+	hostEntry, ok := c.hdb.Host(h.NetAddress())
+	if !ok {
+		t.Fatal("no entry for host in db")
+	}
+
+	// form a contract with the host
+	contract, err := c.newContract(hostEntry, 64000, c.blockHeight+100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if contract.IP != h.NetAddress() {
+		t.Fatal("bad contract")
+	}
+}

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -149,7 +149,7 @@ func negotiateContract(conn net.Conn, host modules.HostDBEntry, fc types.FileCon
 // and returns a Contract. The contract is also saved by the HostDB.
 func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endHeight types.BlockHeight) (Contract, error) {
 	// reject hosts that are too expensive
-	if host.ContractPrice.Cmp(maxPrice) > 0 {
+	if host.StoragePrice.Cmp(maxPrice) > 0 {
 		return Contract{}, errTooExpensive
 	}
 
@@ -172,7 +172,7 @@ func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endH
 	duration := endHeight - height
 
 	// create file contract
-	renterCost := host.ContractPrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration)))
+	renterCost := host.StoragePrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration)))
 	payout := renterCost.Add(host.Collateral)
 
 	fc := types.FileContract{
@@ -244,7 +244,7 @@ func (c *Contractor) formContracts(a modules.Allowance) error {
 	// Calculate average host price
 	var sum types.Currency
 	for _, h := range hosts {
-		sum = sum.Add(h.ContractPrice)
+		sum = sum.Add(h.StoragePrice)
 	}
 	avgPrice := sum.Div(types.NewCurrency64(uint64(len(hosts))))
 

--- a/modules/renter/contractor/negotiate.go
+++ b/modules/renter/contractor/negotiate.go
@@ -12,11 +12,18 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+const (
+	// estTxnSize is the estimated size of an encoded file contract
+	// transaction set.
+	estTxnSize = 1024
+)
+
 var (
 	// the contractor will not form contracts above this price
 	maxPrice = modules.StoragePriceToConsensus(500000) // 500k SC / TB / Month
 
-	errTooExpensive = errors.New("host price was too high")
+	errTooExpensive    = errors.New("host price was too high")
+	errSmallCollateral = errors.New("host collateral was too small")
 )
 
 // verifySettings reads a signed HostSettings object from conn, validates the
@@ -48,7 +55,7 @@ func verifySettings(conn net.Conn, host modules.HostDBEntry, hdb hostDB) (module
 
 // negotiateContract establishes a connection to a host and negotiates an
 // initial file contract according to the terms of the host.
-func negotiateContract(conn net.Conn, host modules.HostDBEntry, fc types.FileContract, txnBuilder transactionBuilder, tpool transactionPool) (Contract, error) {
+func negotiateContract(conn net.Conn, host modules.HostDBEntry, fc types.FileContract, txnBuilder transactionBuilder, tpool transactionPool, renterCost types.Currency) (Contract, error) {
 	// allow 30 seconds for negotiation
 	conn.SetDeadline(time.Now().Add(30 * time.Second))
 
@@ -71,48 +78,116 @@ func negotiateContract(conn net.Conn, host modules.HostDBEntry, fc types.FileCon
 	// add UnlockHash to file contract
 	fc.UnlockHash = uc.UnlockHash()
 
+	// calculate transaction fee
+	_, maxFee := tpool.FeeEstimation()
+	fee := maxFee.Mul(types.NewCurrency64(estTxnSize))
+
 	// build transaction containing fc
-	err = txnBuilder.FundSiacoins(fc.Payout)
+	err = txnBuilder.FundSiacoins(renterCost.Add(fee))
 	if err != nil {
 		encoding.WriteObject(conn, "internal error")
 		return Contract{}, err
 	}
 	txnBuilder.AddFileContract(fc)
 
-	// sign the txn
-	signedTxnSet, err := txnBuilder.Sign(false)
-	if err != nil {
-		return Contract{}, err
-	}
+	// add miner fee
+	txnBuilder.AddMinerFee(fee)
+
+	// create the txn
+	txn, parentTxns := txnBuilder.View()
+	txnSet := append(parentTxns, txn)
 
 	// calculate contract ID
-	fcid := signedTxnSet[len(signedTxnSet)-1].FileContractID(0)
+	fcid := txnSet[len(txnSet)-1].FileContractID(0)
 
-	// send acceptance and txn signed by us
+	// send acceptance, txn signed by us, and pubkey
 	if err := encoding.WriteObject(conn, modules.AcceptResponse); err != nil {
-		return Contract{}, errors.New("couldn't send acceptance: " + err.Error())
+		return Contract{}, errors.New("couldn't send initial acceptance: " + err.Error())
 	}
-	if err := encoding.WriteObject(conn, signedTxnSet); err != nil {
+	if err := encoding.WriteObject(conn, txnSet); err != nil {
 		return Contract{}, errors.New("couldn't send the contract signed by us: " + err.Error())
+	}
+	if err := encoding.WriteObject(conn, ourPK); err != nil {
+		return Contract{}, errors.New("couldn't send our public key: " + err.Error())
 	}
 
 	// read acceptance and txn signed by host
 	var response string
-	if err := encoding.ReadObject(conn, &response, 128); err != nil {
+	if err := encoding.ReadObject(conn, &response, modules.MaxErrorSize); err != nil {
 		return Contract{}, errors.New("couldn't read the host's response to our proposed contract: " + err.Error())
 	}
 	if response != modules.AcceptResponse {
 		return Contract{}, errors.New("host rejected proposed contract: " + response)
 	}
-	var hostTxnSet []types.Transaction
-	if err := encoding.ReadObject(conn, &hostTxnSet, types.BlockSizeLimit); err != nil {
-		return Contract{}, errors.New("couldn't read the host's updated contract: " + err.Error())
+	// host now sends any new parent transactions, inputs and outputs that
+	// were added to the transaction
+	var newParents []types.Transaction
+	var newInputs []types.SiacoinInput
+	var newOutputs []types.SiacoinOutput
+	if err := encoding.ReadObject(conn, &newParents, types.BlockSizeLimit); err != nil {
+		return Contract{}, errors.New("couldn't read the host's added parents: " + err.Error())
+	}
+	if err := encoding.ReadObject(conn, &newInputs, types.BlockSizeLimit); err != nil {
+		return Contract{}, errors.New("couldn't read the host's added inputs: " + err.Error())
+	}
+	if err := encoding.ReadObject(conn, &newOutputs, types.BlockSizeLimit); err != nil {
+		return Contract{}, errors.New("couldn't read the host's added outputs: " + err.Error())
 	}
 
-	// TODO: check txn?
+	// merge txnAdditions with txnSet
+	txnBuilder.AddParents(newParents)
+	for _, input := range newInputs {
+		txnBuilder.AddSiacoinInput(input)
+	}
+	for _, output := range newOutputs {
+		txnBuilder.AddSiacoinOutput(output)
+	}
+
+	// sign the txn
+	signedTxnSet, err := txnBuilder.Sign(true)
+	if err != nil {
+		return Contract{}, err
+	}
+
+	// calculate signatures added by the transaction builder
+	var addedSignatures []types.TransactionSignature
+	_, _, _, addedSignatureIndices := txnBuilder.ViewAdded()
+	for _, i := range addedSignatureIndices {
+		addedSignatures = append(addedSignatures, signedTxnSet[len(signedTxnSet)-1].TransactionSignatures[i])
+	}
+
+	// Send acceptance and signatures
+	// TODO: validate new txn
+	if err := encoding.WriteObject(conn, modules.AcceptResponse); err != nil {
+		return Contract{}, errors.New("couldn't send transaction acceptance: " + err.Error())
+	}
+	if err := encoding.WriteObject(conn, addedSignatures); err != nil {
+		return Contract{}, errors.New("couldn't send added signatures: " + err.Error())
+	}
+
+	// Read the host signatures.
+	var acceptStr string
+	err = encoding.ReadObject(conn, &acceptStr, modules.MaxErrorSize)
+	if err != nil {
+		return Contract{}, err
+	}
+	if acceptStr != modules.AcceptResponse {
+		return Contract{}, errors.New(acceptStr)
+	}
+	var hostSigs []types.TransactionSignature
+	if err := encoding.ReadObject(conn, &hostSigs, 2e3); err != nil {
+		return Contract{}, errors.New("couldn't read the host's signatures: " + err.Error())
+	}
+	for _, sig := range hostSigs {
+		txnBuilder.AddTransactionSignature(sig)
+	}
+
+	// Construct the final transaction.
+	txn, parentTxns = txnBuilder.View()
+	txnSet = append(parentTxns, txn)
 
 	// submit to blockchain
-	err = tpool.AcceptTransactionSet(hostTxnSet)
+	err = tpool.AcceptTransactionSet(txnSet)
 	if err == modules.ErrDuplicateTransactionSet {
 		// as long as it made it into the transaction pool, we're good
 		err = nil
@@ -135,7 +210,7 @@ func negotiateContract(conn net.Conn, host modules.HostDBEntry, fc types.FileCon
 			NewWindowStart:        fc.WindowStart,
 			NewWindowEnd:          fc.WindowEnd,
 			NewValidProofOutputs:  []types.SiacoinOutput{fc.ValidProofOutputs[0], fc.ValidProofOutputs[1]},
-			NewMissedProofOutputs: []types.SiacoinOutput{fc.MissedProofOutputs[0], fc.MissedProofOutputs[1]},
+			NewMissedProofOutputs: []types.SiacoinOutput{fc.MissedProofOutputs[0], fc.MissedProofOutputs[1], fc.MissedProofOutputs[2]},
 			NewUnlockHash:         fc.UnlockHash,
 		},
 		LastRevisionTxn: types.Transaction{},
@@ -171,10 +246,23 @@ func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endH
 	}
 	duration := endHeight - height
 
-	// create file contract
-	renterCost := host.StoragePrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration)))
-	payout := renterCost.Add(host.Collateral)
+	// calculate cost to renter and cost to host
+	// TODO: clarify/abstract this math
+	storageAllocation := host.StoragePrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration)))
+	hostCollateral := storageAllocation.Mul(host.MaxCollateralFraction).Div(types.NewCurrency64(1e6).Sub(host.MaxCollateralFraction))
+	if hostCollateral.Cmp(host.MaxCollateral) > 0 {
+		// TODO: check that this isn't too small
+		hostCollateral = host.MaxCollateral
+	}
+	saneCollateral := host.Collateral.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(duration))).Mul(types.NewCurrency64(2)).Div(types.NewCurrency64(3))
+	if hostCollateral.Cmp(saneCollateral) < 0 {
+		return Contract{}, errSmallCollateral
+	}
+	hostPayout := hostCollateral.Add(host.ContractPrice)
+	payout := storageAllocation.Add(hostPayout).Mul(types.NewCurrency64(uint64(10406))).Div(types.NewCurrency64(uint64(10000)))
+	renterCost := payout.Sub(hostCollateral)
 
+	// create file contract
 	fc := types.FileContract{
 		FileSize:       0,
 		FileMerkleRoot: crypto.Hash{}, // no proof possible without data
@@ -185,14 +273,16 @@ func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endH
 		RevisionNumber: 0,
 		ValidProofOutputs: []types.SiacoinOutput{
 			// outputs need to account for tax
-			{Value: types.PostTax(height, renterCost), UnlockHash: ourAddress},
-			// no collateral
-			{Value: types.ZeroCurrency, UnlockHash: host.UnlockHash},
+			{Value: types.PostTax(height, payout).Sub(hostPayout), UnlockHash: ourAddress},
+			// collateral is returned to host
+			{Value: hostPayout, UnlockHash: host.UnlockHash},
 		},
 		MissedProofOutputs: []types.SiacoinOutput{
 			// same as above
-			{Value: types.PostTax(height, renterCost), UnlockHash: ourAddress},
-			// goes to the void, not the renter
+			{Value: types.PostTax(height, payout).Sub(hostPayout), UnlockHash: ourAddress},
+			// same as above
+			{Value: hostPayout, UnlockHash: host.UnlockHash},
+			// once we start doing revisions, we'll move some coins to the host and some to the void
 			{Value: types.ZeroCurrency, UnlockHash: types.UnlockHash{}},
 		},
 	}
@@ -217,7 +307,7 @@ func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endH
 	txnBuilder := c.wallet.StartTransaction()
 
 	// execute negotiation protocol
-	contract, err := negotiateContract(conn, host, fc, txnBuilder, c.tpool)
+	contract, err := negotiateContract(conn, host, fc, txnBuilder, c.tpool, renterCost)
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet
 		return Contract{}, err

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -24,7 +24,7 @@ func (c *Contractor) managedRenew(contract Contract, filesize uint64, newEndHeig
 	host, ok := c.hdb.Host(contract.IP)
 	if !ok {
 		return types.FileContractID{}, errors.New("no record of that host")
-	} else if host.ContractPrice.Cmp(maxPrice) > 0 {
+	} else if host.StoragePrice.Cmp(maxPrice) > 0 {
 		return types.FileContractID{}, errTooExpensive
 	}
 
@@ -48,7 +48,7 @@ func (c *Contractor) managedRenew(contract Contract, filesize uint64, newEndHeig
 	}
 
 	// TODO: what if this isn't enough money??
-	renterCost := host.ContractPrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(newEndHeight - height)))
+	renterCost := host.StoragePrice.Mul(types.NewCurrency64(filesize)).Mul(types.NewCurrency64(uint64(newEndHeight - height)))
 	payout := renterCost // no collateral
 
 	// create file contract
@@ -151,7 +151,7 @@ func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeig
 	var numHosts uint64
 	for _, contract := range contracts {
 		if h, ok := c.hdb.Host(contract.IP); ok {
-			sum = sum.Add(h.ContractPrice)
+			sum = sum.Add(h.StoragePrice)
 			numHosts++
 		}
 	}

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -106,7 +106,7 @@ func (c *Contractor) managedRenew(contract Contract, filesize uint64, newEndHeig
 	txnBuilder := c.wallet.StartTransaction()
 
 	// execute negotiation protocol
-	newContract, err := negotiateContract(conn, host, fc, txnBuilder, c.tpool)
+	newContract, err := negotiateContract(conn, host, fc, txnBuilder, c.tpool, renterCost)
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet
 		return types.FileContractID{}, err

--- a/modules/renter/contractor/upload_test.go
+++ b/modules/renter/contractor/upload_test.go
@@ -62,7 +62,7 @@ func TestEditor(t *testing.T) {
 		},
 	}
 	dbe.AcceptingContracts = true
-	dbe.ContractPrice = types.NewCurrency64(^uint64(0))
+	dbe.StoragePrice = types.NewCurrency64(^uint64(0))
 	hdb.hosts["foo"] = dbe
 	_, err = c.Editor(Contract{IP: "foo"})
 	if err == nil {
@@ -70,7 +70,7 @@ func TestEditor(t *testing.T) {
 	}
 
 	// invalid contract
-	dbe.ContractPrice = types.NewCurrency64(500)
+	dbe.StoragePrice = types.NewCurrency64(500)
 	hdb.hosts["bar"] = dbe
 	_, err = c.Editor(Contract{IP: "bar"})
 	if err == nil {

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -93,7 +93,9 @@ func (hdb *HostDB) threadedProbeHosts() {
 			if err != nil {
 				return err
 			}
-			return encoding.ReadObject(conn, &settings, maxSettingsLen)
+			var pubkey crypto.PublicKey
+			copy(pubkey[:], hostEntry.PublicKey.Key)
+			return crypto.ReadSignedObject(conn, &settings, maxSettingsLen, pubkey)
 		}()
 
 		// Now that network communication is done, lock the hostdb to modify the


### PR DESCRIPTION
The `FormContract` RPC now works. Others are a work in progress. The first host+renter integration test has been written. Some tweaks to the protocol were necessary.
Collateral handling is pretty painful and dangerously opaque. Ideally it could be simplified, but if not, we should at least move some of the logic into a function (perhaps in modules/negotiate.go) and document it extensively.