### PR TITLE
Add 'RecentRevision' to the list of host RPCs

### DIFF
--- a/doc/File Contract Negotiation.md
+++ b/doc/File Contract Negotiation.md
@@ -6,6 +6,10 @@ untrusted environment. Managing data on Sia happens through several protocols:
 
 + Settings Request - the host sends the renter its settings.
 
++ Revision Request - the renter will send the host a file contract id, and the
+  host will send the most recent file contract revision that it knows of for
+  that file contract, with the signatures.
+
 + File Contract Creation - no data is uploaded during the inital creation of a
   file contract, but funds are allocated so that the file contract can be
   iteratively revised in the future.
@@ -51,8 +55,19 @@ Settings Request
 1. The renter makes an RPC to the host, opening a connection. The connection
    deadline should be at least 120 seconds.
 
-2. The host sends the renter the most recent copy of its internal settings,
-   signed by the host public key. The connection is then closed.
+2. The host sends the renter the most recent copy of its settings, signed by
+   the host public key. The connection is then closed.
+
+Revision Request
+----------------
+
+1. The renter makes an RPC to the host, opening a connection. The connection
+   deadline sould be at least 120 seconds. The renter sends the file contract
+   id for the revision being requested.
+
+2. The host sends the renter the most recent file contract revision, along with
+   the transaction signatures from both the renter and the host. The connection
+   is then closed.
 
 File Contract Creation
 ----------------------
@@ -160,8 +175,9 @@ File Contract Renewal
    because a significant amount of metadata modifications may be necessary on
    the host's end, especially when renewing larger file contracts.
 
-2. The host sends the most recent copy of the settings to the renter. If the
-   host is not accepting new file contracts, the connection is closed.
+2. The host sends the most recent copy of the settings to the renter, along
+   with the most recent file contract revision. If the host is not accepting
+   new file contracts, the connection is closed.
 
 3. The renter either accepts or rejects the settings. If accepted, the renter
    sends an unsigned file contract to the host, containing the same Merkle root
@@ -187,7 +203,10 @@ Data Request
 1. The renter makes an RPC to the host, opening a connection. The connection
    deadline is at least 600 seconds.
 
-2. A loop begins, which will allow the renter to download multiple batches of
+2. The host will send the renter the most recent file contract revision
+   transaction set.
+
+   A loop begins, which will allow the renter to download multiple batches of
    data from the same connection. The host will send the host settings, and the
    most recent file contract revision transaction. If there is no revision yet,
    the host will send a blank transaction. The host is expected to always have

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -30,6 +30,21 @@ package host
 // TODO: 'announced' doesn't tell you if the announcement made it to the
 // blockchain.
 
+// TODO: Need to make sure that the revision exchange for the renter and the
+// host is being handled correctly. For the host, it's not so difficult. The
+// host need only send the most recent revision every time. But, the host
+// should not sign a revision unless the renter has explicitly signed such that
+// the 'WholeTransaction' fields cover only the revision and that the
+// signatures for the revision don't depend on anything else. The renter needs
+// to verify the same when checking on a file contract revision from the host.
+// If the host has submitted a file contract revision where the signatures have
+// signed the whole file contract, there is an issue.
+
+// TODO: there is a mistake in the file contract revision rpc, the host, if it
+// does not have the right file contract id, should be returning an error there
+// to the renter (and not just to it's calling function without informing the
+// renter what's up).
+
 // TODO: clean up all of the magic numbers in the host.
 
 // TODO: host_test.go has commented out tests.
@@ -89,13 +104,14 @@ var (
 type Host struct {
 	// RPC Metrics - atomic variables need to be placed at the top to preserve
 	// compatibility with 32bit systems.
-	atomicDownloadCalls     uint64
-	atomicErroredCalls      uint64
-	atomicFormContractCalls uint64
-	atomicRenewCalls        uint64
-	atomicReviseCalls       uint64
-	atomicSettingsCalls     uint64
-	atomicUnrecognizedCalls uint64
+	atomicDownloadCalls        uint64
+	atomicErroredCalls         uint64
+	atomicFormContractCalls    uint64
+	atomicRenewCalls           uint64
+	atomicReviseCalls          uint64
+	atomicRevisionRequestCalls uint64
+	atomicSettingsCalls        uint64
+	atomicUnrecognizedCalls    uint64
 
 	// Dependencies.
 	cs     modules.ConsensusSet

--- a/modules/host/negotiaterecentrevision.go
+++ b/modules/host/negotiaterecentrevision.go
@@ -1,0 +1,74 @@
+package host
+
+import (
+	"net"
+	"time"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
+)
+
+// managedSendRecentRevision sends the most recent known file contract
+// revision, including signatures, to the renter, for the file contract with
+// the input id.
+func (h *Host) managedRPCRevisionRequest(conn net.Conn) (types.FileContractID, error) {
+	// Set the negotiation deadline.
+	conn.SetDeadline(time.Now().Add(modules.NegotiateRevisionRequestTime))
+
+	// Receive the file contract id from the renter.
+	var fcid types.FileContractID
+	err := encoding.ReadObject(conn, &fcid, uint64(len(fcid)))
+	if err != nil {
+		return types.FileContractID{}, err
+	}
+
+	// Fetch the storage obligation with the file contract revision
+	// transaction.
+	var so *storageObligation
+	err = h.db.Update(func(tx *bolt.Tx) error {
+		fso, err := getStorageObligation(tx, fcid)
+		so = &fso
+		return err
+	})
+	if err != nil {
+		return types.FileContractID{}, composeErrors(err, modules.WriteNegotiationRejection(conn, err))
+	}
+
+	// Send the most recent file contract revision.
+	revisionTxn := so.RevisionTransactionSet[len(so.RevisionTransactionSet)-1]
+	recentRevision := revisionTxn.FileContractRevisions[0]
+	// Find all of the signatures on the file contract revision. There should be two.
+	var revisionSigs []types.TransactionSignature
+	for _, sig := range revisionTxn.TransactionSignatures {
+		if sig.ParentID == crypto.Hash(fcid) {
+			revisionSigs = append(revisionSigs, sig)
+		}
+	}
+
+	// Sanity check - verify that the host has a valid revision and set of
+	// signatures.
+	h.mu.RLock()
+	blockHeight := h.blockHeight
+	h.mu.RUnlock()
+	err = modules.VerifyFileContractRevisionTransactionSignatures(recentRevision, revisionSigs, blockHeight)
+	if err != nil {
+		h.log.Critical("host is inconsistend, bad file contract revision transaction", err)
+		return types.FileContractID{}, err
+	}
+
+	// Send the file contract revision and the corresponding signatures to the
+	// renter.
+	err = encoding.WriteObject(conn, revisionTxn)
+	if err != nil {
+		return types.FileContractID{}, err
+	}
+	err = encoding.WriteObject(conn, revisionSigs)
+	if err != nil {
+		return types.FileContractID{}, err
+	}
+	return fcid, nil
+}

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -117,6 +117,9 @@ func (h *Host) threadedHandleConn(conn net.Conn) {
 	case modules.RPCReviseContract:
 		atomic.AddUint64(&h.atomicReviseCalls, 1)
 		err = h.managedRPCReviseContract(conn)
+	case modules.RPCRevisionRequest:
+		atomic.AddUint64(&h.atomicRevisionRequestCalls, 1)
+		_, err = h.managedRPCRevisionRequest(conn)
 	case modules.RPCSettings:
 		atomic.AddUint64(&h.atomicSettingsCalls, 1)
 		err = h.managedRPCSettings(conn)

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -17,13 +17,14 @@ import (
 // persistence is the data that is kept when the host is restarted.
 type persistence struct {
 	// RPC Metrics.
-	DownloadCalls     uint64
-	ErroredCalls      uint64
-	FormContractCalls uint64
-	RenewCalls        uint64
-	ReviseCalls       uint64
-	SettingsCalls     uint64
-	UnrecognizedCalls uint64
+	DownloadCalls        uint64
+	ErroredCalls         uint64
+	FormContractCalls    uint64
+	RenewCalls           uint64
+	ReviseCalls          uint64
+	RevisionRequestCalls uint64
+	SettingsCalls        uint64
+	UnrecognizedCalls    uint64
 
 	// Consensus Tracking.
 	BlockHeight  types.BlockHeight
@@ -125,6 +126,7 @@ func (h *Host) load() error {
 	atomic.StoreUint64(&h.atomicFormContractCalls, p.FormContractCalls)
 	atomic.StoreUint64(&h.atomicRenewCalls, p.RenewCalls)
 	atomic.StoreUint64(&h.atomicReviseCalls, p.ReviseCalls)
+	atomic.StoreUint64(&h.atomicRevisionRequestCalls, p.RevisionRequestCalls)
 	atomic.StoreUint64(&h.atomicSettingsCalls, p.SettingsCalls)
 	atomic.StoreUint64(&h.atomicUnrecognizedCalls, p.UnrecognizedCalls)
 
@@ -157,13 +159,14 @@ func (h *Host) load() error {
 func (h *Host) save() error {
 	p := persistence{
 		// RPC Metrics.
-		DownloadCalls:     atomic.LoadUint64(&h.atomicDownloadCalls),
-		ErroredCalls:      atomic.LoadUint64(&h.atomicErroredCalls),
-		FormContractCalls: atomic.LoadUint64(&h.atomicFormContractCalls),
-		RenewCalls:        atomic.LoadUint64(&h.atomicRenewCalls),
-		ReviseCalls:       atomic.LoadUint64(&h.atomicReviseCalls),
-		SettingsCalls:     atomic.LoadUint64(&h.atomicSettingsCalls),
-		UnrecognizedCalls: atomic.LoadUint64(&h.atomicUnrecognizedCalls),
+		DownloadCalls:        atomic.LoadUint64(&h.atomicDownloadCalls),
+		ErroredCalls:         atomic.LoadUint64(&h.atomicErroredCalls),
+		FormContractCalls:    atomic.LoadUint64(&h.atomicFormContractCalls),
+		RenewCalls:           atomic.LoadUint64(&h.atomicRenewCalls),
+		ReviseCalls:          atomic.LoadUint64(&h.atomicReviseCalls),
+		RevisionRequestCalls: atomic.LoadUint64(&h.atomicRevisionRequestCalls),
+		SettingsCalls:        atomic.LoadUint64(&h.atomicSettingsCalls),
+		UnrecognizedCalls:    atomic.LoadUint64(&h.atomicUnrecognizedCalls),
 
 		// Consensus Tracking.
 		BlockHeight:  h.blockHeight,


### PR DESCRIPTION
'RecentRevision' allows a renter to request a recent file contract
revision from the host. The host will return the revision and the
signatures for the revision. A helper function has been added to the
modules package which verifies that the revision + signatures are valid
and follow protocol.