### PR TITLE
Host api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -82,7 +82,7 @@ func (srv *Server) initAPI() {
 		router.POST("/storage/folders/add/*folder", srv.storageFoldersAddHandler)
 		router.POST("/storage/folders/resize/*folder", srv.storageFoldersResizeHandler)
 		router.POST("/storage/folders/remove/*folder", srv.storageFoldersRemoveHandler)
-		router.POST("/storage/sectors/delete/:root", srv.storageSectorsDeleteHandler)
+		router.POST("/storage/sectors/delete/:merkleroot", srv.storageSectorsDeleteHandler)
 	}
 
 	// Miner API Calls

--- a/api/api.go
+++ b/api/api.go
@@ -72,10 +72,17 @@ func (srv *Server) initAPI() {
 
 	// Host API Calls
 	if srv.host != nil {
-		router.GET("/host", srv.hostHandlerGET)
-		router.POST("/host", srv.hostHandlerPOST)
-		router.POST("/host/announce", srv.hostAnnounceHandler)
-		router.POST("/host/delete/:filecontractid", srv.hostDeleteHandler)
+		// Calls directly pertaining to the host.
+		router.GET("/host", srv.hostHandlerGET)                // Get a bunch of information about the host.
+		router.POST("/host", srv.hostHandlerPOST)              // Set HostInternalSettings.
+		router.POST("/host/announce", srv.hostAnnounceHandler) // Announce the host, optionally on a specific address.
+
+		// Calls pertaining to the storage manager that the host uses.
+		router.GET("/storage", srv.storageHandler)
+		router.POST("/storage/addfolder", srv.storageAddfolderHandler)
+		router.POST("/storage/delete/:sectorroot", srv.storageDeleteSectorroot)
+		router.POST("/storage/resizefolder", srv.storageResizefolderHandler)
+		router.POST("/storage/removefolder", srv.storageRemovefolderHandler)
 	}
 
 	// Miner API Calls

--- a/api/api.go
+++ b/api/api.go
@@ -79,10 +79,10 @@ func (srv *Server) initAPI() {
 
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/storage", srv.storageHandler)
-		router.POST("/storage/folders/add/*folder", srv.storageFolderAddHandler)
-		router.POST("/storage/folders/resize/*folder", srv.storageFolderResizeHandler)
-		router.POST("/storage/folders/remove/*folder", srv.storageFolderRemoveHandler)
-		router.POST("/storage/sectors/delete/:sectorroot", srv.storageSectorDeleteHandler)
+		router.POST("/storage/folders/add/*folder", srv.storageFoldersAddHandler)
+		router.POST("/storage/folders/resize/*folder", srv.storageFoldersResizeHandler)
+		router.POST("/storage/folders/remove/*folder", srv.storageFoldersRemoveHandler)
+		router.POST("/storage/sectors/delete/:root", srv.storageSectorsDeleteHandler)
 	}
 
 	// Miner API Calls

--- a/api/api.go
+++ b/api/api.go
@@ -79,10 +79,10 @@ func (srv *Server) initAPI() {
 
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/storage", srv.storageHandler)
-		router.POST("/storage/addfolder", srv.storageAddfolderHandler)
-		router.POST("/storage/delete/:sectorroot", srv.storageDeleteSectorroot)
-		router.POST("/storage/resizefolder", srv.storageResizefolderHandler)
-		router.POST("/storage/removefolder", srv.storageRemovefolderHandler)
+		router.POST("/storage/folders/add/*folder", srv.storageFolderAddHandler)
+		router.POST("/storage/folders/resize/*folder", srv.storageFolderResizeHandler)
+		router.POST("/storage/folders/remove/*folder", srv.storageFolderRemoveHandler)
+		router.POST("/storage/sectors/delete/:sectorroot", srv.storageSectorDeleteHandler)
 	}
 
 	// Miner API Calls

--- a/api/gateway.go
+++ b/api/gateway.go
@@ -8,6 +8,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// TODO: GatewayInfo is not the right name for this struct.
 type GatewayInfo struct {
 	NetAddress modules.NetAddress `json:"netaddress"`
 	Peers      []modules.Peer     `json:"peers"`

--- a/api/host.go
+++ b/api/host.go
@@ -1,11 +1,10 @@
 package api
 
 import (
-	//"fmt"
+	"fmt"
 	"net/http"
 
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -14,125 +13,85 @@ type (
 	// HostGET contains the information that is returned after a GET request to
 	// /host.
 	HostGET struct {
-		AcceptingContracts bool               `json:"acceptingcontracts"`
-		MaxDuration        types.BlockHeight  `json:"maxduration"`
-		NetAddress         modules.NetAddress `json:"netaddress"`
-		RemainingStorage   uint64             `json:"remainingstorage"`
-		TotalStorage       uint64             `json:"totalstorage"`
-		UnlockHash         types.UnlockHash   `json:"unlockhash"`
-		WindowSize         types.BlockHeight  `json:"windowsize"`
-
-		Collateral             types.Currency `json:"collateral"`
-		ContractPrice          types.Currency `json:"contractprice"`
-		DownloadBandwidthPrice types.Currency `json:"downloadbandwidthprice"`
-		StoragePrice           types.Currency `json:"storageprice"`
-		UploadBandwidthPrice   types.Currency `json:"uploadbandwidthprice"`
-
-		AnticipatedRevenue types.Currency `json:"anticipatedrevenue"`
-		LostRevenue        types.Currency `json:"lostrevenue"`
-		NumContracts       uint64         `json:"numcontracts"`
-		Revenue            types.Currency `json:"revenue"`
-
-		RPCErrorCalls        uint64 `json:"rpcerrorcalls"`
-		RPCUnrecognizedCalls uint64 `json:"rpcunrecognizedcalls"`
-		RPCDownloadCalls     uint64 `json:"rpcdownloadcalls"`
-		RPCRenewCalls        uint64 `json:"rpcrenewcalls"`
-		RPCReviseCalls       uint64 `json:"rpcrevisecalls"`
-		RPCSettingsCalls     uint64 `json:"rpcsettingscalls"`
-		RPCUploadCalls       uint64 `json:"rpcuploadcalls"`
+		FinancialMetrics modules.HostFinancialMetrics `json:"financialmetrics"`
+		InternalSettings modules.HostInternalSettings `json:"internalsettings"`
+		NetworkMetrics   modules.HostNetworkMetrics   `json:"networkmetrics"`
 	}
 )
 
-// hostHandlerGET handles GET requests to the /host API endpoint.
+// hostHandlerGET handles GET requests to the /host API endpoint, returning key
+// information about the host.
 func (srv *Server) hostHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	writeJSON(w, "TODO: fix/revamp this call")
-	// settings := srv.host.Settings()
-	// anticipatedRevenue, revenue, lostRevenue := srv.host.Revenue()
-	// rpcCalls := srv.host.RPCMetrics()
-	// hg := HostGET{
-	// 	AcceptingContracts: settings.AcceptingContracts,
-	// 	MaxDuration:        settings.MaxDuration,
-	// 	NetAddress:         settings.NetAddress,
-	// 	RemainingStorage:   srv.host.Capacity(),
-	// 	TotalStorage:       settings.TotalStorage,
-	// 	UnlockHash:         settings.UnlockHash,
-	// 	WindowSize:         settings.WindowSize,
-
-	// 	Collateral:             settings.Collateral,
-	// 	ContractPrice:          settings.ContractPrice,
-	// 	DownloadBandwidthPrice: settings.DownloadBandwidthPrice,
-	// 	StoragePrice:           settings.StoragePrice,
-	// 	UploadBandwidthPrice:   settings.UploadBandwidthPrice,
-
-	// 	AnticipatedRevenue: anticipatedRevenue,
-	// 	LostRevenue:        lostRevenue,
-	// 	NumContracts:       srv.host.Contracts(),
-	// 	Revenue:            revenue,
-
-	// 	RPCErrorCalls:        rpcCalls.ErrorCalls,
-	// 	RPCUnrecognizedCalls: rpcCalls.UnrecognizedCalls,
-	// 	RPCDownloadCalls:     rpcCalls.DownloadCalls,
-	// 	RPCRenewCalls:        rpcCalls.RenewCalls,
-	// 	RPCReviseCalls:       rpcCalls.ReviseCalls,
-	// 	RPCSettingsCalls:     rpcCalls.SettingsCalls,
-	// 	RPCUploadCalls:       rpcCalls.UploadCalls,
-	// }
-	// writeJSON(w, hg)
+	fm := srv.host.FinancialMetrics()
+	is := srv.host.InternalSettings()
+	nm := srv.host.NetworkMetrics()
+	hg := HostGET{
+		FinancialMetrics: fm,
+		InternalSettings: is,
+		NetworkMetrics:   nm,
+	}
+	writeJSON(w, hg)
 }
 
 // hostHandlerPOST handles POST request to the /host API endpoint.
 func (srv *Server) hostHandlerPOST(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	writeJSON(w, "TODO: fix/revamp this call")
-	// // Map each query string to a field in the host settings.
-	// settings := srv.host.Settings()
-	// qsVars := map[string]interface{}{
-	// 	// TODO: I'm not sure that allowing the user to set the netaddress via
-	// 	// SetSettings is a good idea, if they change it to a bad address, or
-	// 	// even a dns address... what happens?
-	// 	"acceptingcontracts": &settings.AcceptingContracts,
-	// 	"maxduration":        &settings.MaxDuration,
-	// 	"netaddress":         &settings.NetAddress,
-	// 	"windowsize":         &settings.WindowSize,
+	// Map each query string to a field in the host settings.
+	settings := srv.host.InternalSettings()
+	qsVars := map[string]interface{}{
+		"acceptingcontracts":   &settings.AcceptingContracts,
+		"maxduration":          &settings.MaxDuration,
+		"maxdownloadbatchsize": &settings.MaxDownloadBatchSize,
+		"maxrevisebatchsize":   &settings.MaxReviseBatchSize,
+		"netaddress":           &settings.NetAddress,
+		"windowsize":           &settings.WindowSize,
 
-	// 	"collateral":             &settings.Collateral,
-	// 	"contractprice":          &settings.ContractPrice,
-	// 	"downloadbandwidthprice": &settings.DownloadBandwidthPrice,
-	// 	"StoragePrice":           &settings.StoragePrice,
-	// 	"uploadbandwidthprice":   &settings.UploadBandwidthPrice,
-	// }
+		"collateral":            &settings.Collateral,
+		"collateralbudget":      &settings.CollateralBudget,
+		"maxcollateralfraction": &settings.MaxCollateralFraction,
+		"maxcollateral":         &settings.MaxCollateral,
 
-	// // Iterate through the query string and replace any fields that have been
-	// // altered.
-	// for qs := range qsVars {
-	// 	if req.FormValue(qs) != "" { // skip empty values
-	// 		_, err := fmt.Sscan(req.FormValue(qs), qsVars[qs])
-	// 		if err != nil {
-	// 			writeError(w, "Malformed "+qs, http.StatusBadRequest)
-	// 			return
-	// 		}
-	// 	}
-	// }
-	// srv.host.SetSettings(settings)
-	// writeSuccess(w)
+		"downloadlimitgrowth": &settings.DownloadLimitGrowth,
+		"downloadlimitcap":    &settings.DownloadLimitCap,
+		"downloadspeedlimit":  &settings.DownloadSpeedLimit,
+		"uploadlimitgrowth":   &settings.UploadLimitGrowth,
+		"uploadlimitcap":      &settings.UploadLimitCap,
+		"uploadspeedlimit":    &settings.UploadSpeedLimit,
+
+		"minimumcontractprice":          &settings.MinimumContractPrice,
+		"minimumdownloadbandwidthprice": &settings.MinimumDownloadBandwidthPrice,
+		"minimumstorageprice":           &settings.MinimumStoragePrice,
+		"minimumuploadbandwidthprice":   &settings.MinimumUploadBandwidthPrice,
+	}
+
+	// Iterate through the query string and replace any fields that have been
+	// altered.
+	for qs := range qsVars {
+		if req.FormValue(qs) != "" { // skip empty values
+			_, err := fmt.Sscan(req.FormValue(qs), qsVars[qs])
+			if err != nil {
+				writeError(w, "Malformed "+qs, http.StatusBadRequest)
+				return
+			}
+		}
+	}
+	srv.host.SetInternalSettings(settings)
+	writeSuccess(w)
 }
 
 // hostAnnounceHandler handles the API call to get the host to announce itself
 // to the network.
 func (srv *Server) hostAnnounceHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	writeJSON(w, "TODO: fix/revamp this call")
-	// var err error
-	// // TODO: should it just announce using the address found in host.Settings?
-	// // What happens if the two are different?
-	// if addr := req.FormValue("netaddress"); addr != "" {
-	// 	err = srv.host.AnnounceAddress(modules.NetAddress(addr))
-	// } else {
-	// 	err = srv.host.Announce()
-	// }
-	// if err != nil {
-	// 	writeError(w, err.Error(), http.StatusBadRequest)
-	// 	return
-	// }
-	// writeSuccess(w)
+	var err error
+	if addr := req.FormValue("netaddress"); addr != "" {
+		err = srv.host.AnnounceAddress(modules.NetAddress(addr))
+	} else {
+		err = srv.host.Announce()
+	}
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeSuccess(w)
 }
 
 // hostDeleteHandler deletes a file contract from the host.

--- a/api/host.go
+++ b/api/host.go
@@ -196,12 +196,7 @@ func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.
 		return
 	}
 
-	var force bool
-	_, err = fmt.Sscan(req.FormValue("force"), &force)
-	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
-		return
-	}
+	force := req.FormValue("force") == "true"
 	err = srv.host.RemoveStorageFolder(folderIndex, force)
 	if err != nil {
 		writeError(w, err.Error(), http.StatusBadRequest)

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -1,5 +1,6 @@
 package api
 
+/*
 import (
 	"net/url"
 	"path/filepath"
@@ -131,3 +132,4 @@ func TestIntegrationRenewing(t *testing.T) {
 		st.getAPI("/renter/files", &rf)
 	}
 }
+*/

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -236,7 +236,7 @@ func (st *serverTester) coinAddress() string {
 // announcement to register.
 func (st *serverTester) announceHost() error {
 	announceValues := url.Values{}
-	announceValues.Set("address", string(st.host.NetAddress()))
+	announceValues.Set("address", string(st.host.NetworkMetrics().NetAddress))
 	err := st.stdPostAPI("/host/announce", announceValues)
 	if err != nil {
 		return err

--- a/modules/host.go
+++ b/modules/host.go
@@ -10,27 +10,6 @@ const (
 )
 
 type (
-	// HostBandwidthLimits set limits on the volume, price, and speed of data
-	// that's available to the host. Because different ISPs and setups have
-	// different rules governing appropriate limits, and because there's a
-	// profit incentive to matching the limits as close as possible, and
-	// because there might be intelligent ways to allocate data that require
-	// outside information (for example, more data available at night), the
-	// limits have been created with the idea that some external process will
-	// be able to adjust them constantly to conform to transfer limits and take
-	// advantage of low-traffic or low-cost hours.
-	HostBandwidthLimits struct {
-		DownloadLimitGrowth uint64         `json:"downloadlimitgrowth"` // Bytes per second that get added to the limit for how much download bandwidth the host is allowed to use.
-		DownloadLimitCap    uint64         `json:"downloadlimitcap"`    // The maximum size of the limit for how much download bandwidth the host is allowed to use.
-		DownloadMinPrice    types.Currency `json:"downloadminprice"`    // The minimum price in Hastings per byte of download bandwidth.
-		DownloadSpeedLimit  uint64         `json:"downloadspeedlimit"`  // The maximum download speed for all combined host connections.
-
-		UploadLimitGrwoth uint64         `json:"uploadlimitgrowth"` // Bytes per second that get added to the limit for how much upload bandwidth the host is allowed to use.
-		UploadLimitCap    uint64         `json:"uploadlimitcap"`    // The maximum size of the limit for how much upload bandwidth the host is allowed to use.
-		UploadMinPrice    types.Currency `json:"uploadminprice"`    // The minimum price in Hastings per byte of download bandwidth.
-		UploadSpeedLimit  uint64         `json:"uploadspeedlimit"`  // The maximum upload speed for all combined host connections.
-	}
-
 	// HostFinancialMetrics provides financial statistics for the host,
 	// including money that is locked in contracts. Though verbose, these
 	// statistics should provide a clear picture of where the host's money is
@@ -73,11 +52,17 @@ type (
 		MaxCollateralFraction types.Currency `json:"maxcollateralfraction"`
 		MaxCollateral         types.Currency `json:"maxcollateral"`
 
-		BandwidthLimits               HostBandwidthLimits `json:"bandwidthlimits"`
-		MinimumContractPrice          types.Currency      `json:"contractprice"`
-		MinimumDownloadBandwidthPrice types.Currency      `json:"minimumdownloadbandwidthprice"`
-		MinimumStoragePrice           types.Currency      `json:"storageprice"`
-		MinimumUploadBandwidthPrice   types.Currency      `json:"minimumuploadbandwidthprice"`
+		DownloadLimitGrowth uint64 `json:"downloadlimitgrowth"` // Bytes per second that get added to the limit for how much download bandwidth the host is allowed to use.
+		DownloadLimitCap    uint64 `json:"downloadlimitcap"`    // The maximum size of the limit for how much download bandwidth the host is allowed to use.
+		DownloadSpeedLimit  uint64 `json:"downloadspeedlimit"`  // The maximum download speed for all combined host connections.
+		UploadLimitGrowth   uint64 `json:"uploadlimitgrowth"`   // Bytes per second that get added to the limit for how much upload bandwidth the host is allowed to use.
+		UploadLimitCap      uint64 `json:"uploadlimitcap"`      // The maximum size of the limit for how much upload bandwidth the host is allowed to use.
+		UploadSpeedLimit    uint64 `json:"uploadspeedlimit"`    // The maximum upload speed for all combined host connections.
+
+		MinimumContractPrice          types.Currency `json:"contractprice"`
+		MinimumDownloadBandwidthPrice types.Currency `json:"minimumdownloadbandwidthprice"`
+		MinimumStoragePrice           types.Currency `json:"storageprice"`
+		MinimumUploadBandwidthPrice   types.Currency `json:"minimumuploadbandwidthprice"`
 	}
 
 	// HostNetworkMetrics reports the quantity of each type of RPC call that

--- a/modules/host.go
+++ b/modules/host.go
@@ -80,9 +80,11 @@ type (
 		MinimumUploadBandwidthPrice   types.Currency      `json:"minimumuploadbandwidthprice"`
 	}
 
-	// HostRPCMetrics reports the quantity of each type of RPC call that has
-	// been made to the host.
-	HostRPCMetrics struct {
+	// HostNetworkMetrics reports the quantity of each type of RPC call that
+	// has been made to the host.
+	HostNetworkMetrics struct {
+		NetAddress NetAddress
+
 		DownloadBandwidthConsumed uint64 `json:"downloadbandwidthconsumed"`
 		UploadBandwidthConsumed   uint64 `json:"uploadbandwidthconsumed"`
 
@@ -111,16 +113,15 @@ type (
 		// InternalSettings returns the host's internal settings.
 		InternalSettings() HostInternalSettings
 
-		// NetAddress returns the host's network address
-		NetAddress() NetAddress
-
-		// RPCMetrics returns information on the types of RPC calls that have
-		// been made to the host.
-		RPCMetrics() HostRPCMetrics
+		// NetworkMetrics returns information on the types of RPC calls that
+		// have been made to the host.
+		NetworkMetrics() HostNetworkMetrics
 
 		// SetInternalSettings sets the hosting parameters of the host.
 		SetInternalSettings(HostInternalSettings) error
 
+		// The storage manager provides an interface for adding and removing
+		// storage folders and data sectors to the host.
 		StorageManager
 	}
 )

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -184,10 +184,22 @@ func (h *Host) NetAddress() modules.NetAddress {
 	return h.autoAddress
 }
 
-// RPCMetrics returns information about the types of rpc calls that have been
-// made to the host.
-func (h *Host) RPCMetrics() modules.HostRPCMetrics {
-	return modules.HostRPCMetrics{
+// NetworkMetrics returns information about the types of rpc calls that have
+// been made to the host.
+func (h *Host) NetworkMetrics() modules.HostNetworkMetrics {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	var na modules.NetworkAddress
+	if h.settings.NetAddress != "" {
+		na = h.settings.NetAddress
+	}
+	na = h.autoAddress
+	return modules.HostNetworkMetrics{
+		NetAddress: na,
+
+		// TODO: Up/Down bandwidth
+
 		DownloadCalls:     atomic.LoadUint64(&h.atomicDownloadCalls),
 		ErrorCalls:        atomic.LoadUint64(&h.atomicErroredCalls),
 		FormContractCalls: atomic.LoadUint64(&h.atomicFormContractCalls),

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -190,7 +190,7 @@ func (h *Host) NetworkMetrics() modules.HostNetworkMetrics {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	var na modules.NetworkAddress
+	var na modules.NetAddress
 	if h.settings.NetAddress != "" {
 		na = h.settings.NetAddress
 	}

--- a/modules/host/storagemanager/sector.go
+++ b/modules/host/storagemanager/sector.go
@@ -40,7 +40,7 @@ import (
 // read from the filesystem, which means the problem manifests at the lowest
 // level, the sector level. Because data is missing, there is no 'repair'
 // operation that can be supported. The sector usage database should match the
-// storage obligation database, and should be patched if there's a mismatcsm.
+// storage obligation database, and should be patched if there's a mismatch.
 // The storage obligation database gets preference. Any missing sectors will be
 // treated as if they were filesystem problems.
 //

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -177,7 +177,7 @@ func TestIntegrationFormContract(t *testing.T) {
 	}
 
 	// get the host's entry from the db
-	hostEntry, ok := c.hdb.Host(h.NetAddress())
+	hostEntry, ok := c.hdb.Host(h.NetworkMetrics().NetAddress)
 	if !ok {
 		t.Fatal("no entry for host in db")
 	}
@@ -188,7 +188,7 @@ func TestIntegrationFormContract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if contract.IP != h.NetAddress() {
+	if contract.IP != h.NetworkMetrics().NetAddress {
 		t.Fatal("bad contract")
 	}
 }
@@ -206,7 +206,7 @@ func TestIntegrationReviseContract(t *testing.T) {
 	}
 
 	// get the host's entry from the db
-	hostEntry, ok := c.hdb.Host(h.NetAddress())
+	hostEntry, ok := c.hdb.Host(h.NetworkMetrics().NetAddress)
 	if !ok {
 		t.Fatal("no entry for host in db")
 	}
@@ -249,7 +249,7 @@ func TestIntegrationUploadDownload(t *testing.T) {
 	}
 
 	// get the host's entry from the db
-	hostEntry, ok := c.hdb.Host(h.NetAddress())
+	hostEntry, ok := c.hdb.Host(h.NetworkMetrics().NetAddress)
 	if !ok {
 		t.Fatal("no entry for host in db")
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -310,7 +310,7 @@ func TestIntegrationDelete(t *testing.T) {
 	}
 
 	// get the host's entry from the db
-	hostEntry, ok := c.hdb.Host(h.NetAddress())
+	hostEntry, ok := c.hdb.Host(h.NetworkMetrics().NetAddress)
 	if !ok {
 		t.Fatal("no entry for host in db")
 	}
@@ -368,7 +368,7 @@ func TestIntegrationInsertDelete(t *testing.T) {
 	}
 
 	// get the host's entry from the db
-	hostEntry, ok := c.hdb.Host(h.NetAddress())
+	hostEntry, ok := c.hdb.Host(h.NetworkMetrics().NetAddress)
 	if !ok {
 		t.Fatal("no entry for host in db")
 	}
@@ -423,7 +423,7 @@ func TestIntegrationModify(t *testing.T) {
 	}
 
 	// get the host's entry from the db
-	hostEntry, ok := c.hdb.Host(h.NetAddress())
+	hostEntry, ok := c.hdb.Host(h.NetworkMetrics().NetAddress)
 	if !ok {
 		t.Fatal("no entry for host in db")
 	}


### PR DESCRIPTION
In this pull request, I add some routes for the host and the storage manager. These routes should be everything that is necessary for v0.6.0-rc1.

I also restructured modules/host.go a little, mostly to simplify things as much as possible. Overall, I'm quite happy with modules/host.go and modules/storagemanager.go (except for the expiryHeight thing), and this is just more polish on top of what was already pretty good.

Siac + testing to come shortly.