### PR TITLE
Make fsync optional when saving a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ vet: release-std
 	go vet $(pkgs)
 
 # will always run on some packages for a while.
-lintpkgs = ./modules/host ./modules ./modules/renter/hostdb ./modules/renter/contractor
+lintpkgs = ./modules/host ./modules ./modules/renter/hostdb ./modules/renter/contractor ./persist
 lint:
 	@for package in $(lintpkgs); do                           \
 		golint -min_confidence=1.0 $$package                  \

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -58,7 +58,7 @@ func (g *Gateway) Close() error {
 
 	// save the latest gateway state
 	id := g.mu.RLock()
-	if err := g.save(); err != nil {
+	if err := g.save(true); err != nil {
 		errs = append(errs, fmt.Errorf("save failed: %v", err))
 	}
 	g.mu.RUnlock(id)
@@ -130,7 +130,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 		for _, addr := range modules.BootstrapPeers {
 			g.addNode(addr)
 		}
-		g.save()
+		g.save(false)
 	}
 
 	// Create listener and set address.

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -77,7 +77,7 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	for _, node := range nodes {
 		g.addNode(node)
 	}
-	g.save()
+	g.save(false)
 	g.mu.Unlock(id)
 	return nil
 }
@@ -100,7 +100,7 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 		if err := g.addNode(addr); err != nil {
 			return err
 		}
-		if err := g.save(); err != nil {
+		if err := g.save(false); err != nil {
 			return err
 		}
 		return nil
@@ -161,7 +161,7 @@ func (g *Gateway) threadedNodeManager() {
 		if err != nil {
 			id = g.mu.Lock()
 			g.removeNode(node)
-			g.save()
+			g.save(false)
 			g.mu.Unlock(id)
 			continue
 		}

--- a/modules/gateway/persist.go
+++ b/modules/gateway/persist.go
@@ -19,12 +19,12 @@ var persistMetadata = persist.Metadata{
 	Version: "0.3.3",
 }
 
-func (g *Gateway) save() error {
+func (g *Gateway) save(fsync bool) error {
 	var nodes []modules.NetAddress
 	for node := range g.nodes {
 		nodes = append(nodes, node)
 	}
-	return persist.SaveFile(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile))
+	return persist.SaveFile(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile), fsync)
 }
 
 func (g *Gateway) load() error {

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -8,7 +8,7 @@ func TestLoad(t *testing.T) {
 	g := newTestingGateway("TestLoad", t)
 	id := g.mu.Lock()
 	g.addNode(dummyNode)
-	g.save()
+	g.save(false)
 	g.mu.Unlock(id)
 	g.Close()
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -208,7 +208,7 @@ func (h *Host) checkUnlockHash() error {
 		// the host will be using this unlock hash to establish identity, and
 		// losing it will mean silently losing part of the host identity.
 		h.unlockHash = uc.UnlockHash()
-		err = h.save()
+		err = h.save(false)
 		if err != nil {
 			return err
 		}
@@ -363,7 +363,7 @@ func (h *Host) Close() (composedError error) {
 
 	// Save the latest host state.
 	h.mu.Lock()
-	err = h.save()
+	err = h.save(true)
 	h.mu.Unlock()
 	if err != nil {
 		composedError = composeErrors(composedError, err)
@@ -414,7 +414,7 @@ func (h *Host) SetInternalSettings(settings modules.HostInternalSettings) error 
 
 	h.settings = settings
 	h.revisionNumber++
-	return h.save()
+	return h.save(true)
 }
 
 // InternalSettings returns the settings of a host.

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -77,7 +77,7 @@ func (h *Host) establishDefaults() error {
 	if err != nil {
 		return err
 	}
-	return h.save()
+	return h.save(false)
 }
 
 // initDB will check that the database has been initialized and if not, will
@@ -143,7 +143,7 @@ func (h *Host) load() error {
 }
 
 // save stores all of the persist data to disk.
-func (h *Host) save() error {
+func (h *Host) save(fsync bool) error {
 	p := persistence{
 		// RPC Metrics.
 		DownloadCalls:       atomic.LoadUint64(&h.atomicDownloadCalls),
@@ -169,5 +169,5 @@ func (h *Host) save() error {
 		Settings:         h.settings,
 		UnlockHash:       h.unlockHash,
 	}
-	return persist.SaveFile(persistMetadata, p, filepath.Join(h.persistDir, settingsFile))
+	return persist.SaveFile(persistMetadata, p, filepath.Join(h.persistDir, settingsFile), fsync)
 }

--- a/modules/host/storagemanager/persist.go
+++ b/modules/host/storagemanager/persist.go
@@ -61,10 +61,10 @@ func (sm *StorageManager) load() error {
 }
 
 // save stores all of the persistent data of the storage manager to disk.
-func (sm *StorageManager) save() error {
+func (sm *StorageManager) save(fsync bool) error {
 	p := persistence{
 		SectorSalt:     sm.sectorSalt,
 		StorageFolders: sm.storageFolders,
 	}
-	return persist.SaveFile(persistMetadata, p, filepath.Join(sm.persistDir, settingsFile))
+	return persist.SaveFile(persistMetadata, p, filepath.Join(sm.persistDir, settingsFile), fsync)
 }

--- a/modules/host/storagemanager/sector.go
+++ b/modules/host/storagemanager/sector.go
@@ -228,7 +228,7 @@ func (sm *StorageManager) AddSector(sectorRoot crypto.Hash, expiryHeight types.B
 	if err != nil {
 		return err
 	}
-	return sm.save()
+	return sm.save(false)
 }
 
 // ReadSector will pull a sector from disk into memory.
@@ -337,7 +337,7 @@ func (sm *StorageManager) RemoveSector(sectorRoot crypto.Hash, expiryHeight type
 		}
 		folder.SizeRemaining += modules.SectorSize
 		folder.SuccessfulWrites++
-		err = sm.save()
+		err = sm.save(false)
 		if err != nil {
 			return err
 		}
@@ -396,7 +396,7 @@ func (sm *StorageManager) DeleteSector(sectorRoot crypto.Hash) error {
 		}
 		folder.SizeRemaining += modules.SectorSize
 		folder.SuccessfulWrites++
-		err = sm.save()
+		err = sm.save(false)
 		if err != nil {
 			return err
 		}

--- a/modules/host/storagemanager/storagefolders.go
+++ b/modules/host/storagemanager/storagefolders.go
@@ -446,7 +446,7 @@ func (sm *StorageManager) AddStorageFolder(path string, size uint64) error {
 
 	// Add the storage folder to the list of folders for the host.
 	sm.storageFolders = append(sm.storageFolders, newSF)
-	return sm.save()
+	return sm.save(true)
 }
 
 // ResetStorageFolderHealth will reset the read and write statistics for the
@@ -470,7 +470,7 @@ func (sm *StorageManager) ResetStorageFolderHealth(index int) error {
 	sm.storageFolders[index].FailedWrites = 0
 	sm.storageFolders[index].SuccessfulReads = 0
 	sm.storageFolders[index].SuccessfulWrites = 0
-	return sm.save()
+	return sm.save(false)
 }
 
 // RemoveStorageFolder removes a storage folder from the host.
@@ -505,7 +505,7 @@ func (sm *StorageManager) RemoveStorageFolder(removalIndex int, force bool) erro
 	// Remove the storage folder from the host and then save the host.
 	sm.storageFolders = append(sm.storageFolders[0:removalIndex], sm.storageFolders[removalIndex+1:]...)
 	removeErr := sm.dependencies.removeFile(filepath.Join(sm.persistDir, removalFolder.uidString()))
-	saveErr := sm.save()
+	saveErr := sm.save(true)
 	return composeErrors(saveErr, removeErr)
 }
 
@@ -546,7 +546,7 @@ func (sm *StorageManager) ResizeStorageFolder(storageFolderIndex int, newSize ui
 	if resizeFolderSizeConsumed <= newSize {
 		resizeFolder.SizeRemaining = newSize - resizeFolderSizeConsumed
 		resizeFolder.Size = newSize
-		return sm.save()
+		return sm.save(true)
 	}
 
 	// Calculate the number of sectors that need to be offloaded from the
@@ -566,7 +566,7 @@ func (sm *StorageManager) ResizeStorageFolder(storageFolderIndex int, newSize ui
 	}
 	resizeFolder.Size = newSize
 	resizeFolder.SizeRemaining = 0
-	return sm.save()
+	return sm.save(true)
 }
 
 // StorageFolders provides information about all of the storage folders in the

--- a/modules/host/storagemanager/storagemanager.go
+++ b/modules/host/storagemanager/storagemanager.go
@@ -88,7 +88,7 @@ func (sm *StorageManager) Close() (composedError error) {
 
 	// Save the latest host state.
 	sm.mu.Lock()
-	err = sm.save()
+	err = sm.save(true)
 	sm.mu.Unlock()
 	if err != nil {
 		composedError = composeErrors(composedError, err)

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -57,7 +57,7 @@ func (h *Host) initRescan() error {
 			return err
 		}
 
-		return h.save()
+		return h.save(false)
 	}()
 	if err != nil {
 		return err
@@ -292,7 +292,7 @@ func (h *Host) ProcessConsensusChange(cc modules.ConsensusChange) {
 	h.recentChange = cc.ID
 
 	// Save the host.
-	err = h.save()
+	err = h.save(false)
 	if err != nil {
 		h.log.Println("ERROR: could not save during ProcessConsensusChange:", err)
 	}

--- a/modules/host/upnp.go
+++ b/modules/host/upnp.go
@@ -78,7 +78,7 @@ func (h *Host) managedLearnHostname() {
 		h.log.Debugln(err)
 	}
 	h.autoAddress = autoAddress
-	err = h.save()
+	err = h.save(false)
 	if err != nil {
 		h.log.Println(err)
 	}

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -150,7 +150,7 @@ func (m *Miner) managedSubmitBlock(b types.Block) error {
 		return err
 	}
 	m.persist.Address = uc.UnlockHash()
-	return m.save()
+	return m.save(true)
 }
 
 // SubmitHeader accepts a block header.

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -122,7 +122,7 @@ func (m *Miner) startupRescan() error {
 		m.persist.RecentChange = modules.ConsensusChangeID{}
 		m.persist.Height = 0
 		m.persist.Target = types.Target{}
-		return m.save()
+		return m.save(false)
 	}()
 	if err != nil {
 		return err
@@ -183,7 +183,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 	m.tpool.TransactionPoolSubscribe(m)
 
 	// Save after synchronizing with consensus
-	err = m.save()
+	err = m.save(false)
 	if err != nil {
 		return nil, errors.New("miner could not save during startup: " + err.Error())
 	}
@@ -200,7 +200,7 @@ func (m *Miner) Close() error {
 	m.cs.Unsubscribe(m)
 
 	var errs []error
-	if err := m.save(); err != nil {
+	if err := m.save(true); err != nil {
 		errs = append(errs, fmt.Errorf("save failed: %v", err))
 	}
 	if err := m.log.Close(); err != nil {

--- a/modules/miner/persist.go
+++ b/modules/miner/persist.go
@@ -39,7 +39,7 @@ func (m *Miner) initSettings() error {
 	filename := filepath.Join(m.persistDir, settingsFile)
 	_, err := os.Stat(filename)
 	if os.IsNotExist(err) {
-		return m.save()
+		return m.save(false)
 	} else if err != nil {
 		return err
 	}
@@ -69,6 +69,6 @@ func (m *Miner) load() error {
 }
 
 // save saves the miner persistence to disk.
-func (m *Miner) save() error {
-	return persist.SaveFile(settingsMetadata, m.persist, filepath.Join(m.persistDir, settingsFile))
+func (m *Miner) save(fsync bool) error {
+	return persist.SaveFile(settingsMetadata, m.persist, filepath.Join(m.persistDir, settingsFile), fsync)
 }

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -57,6 +57,10 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// the stale rate as low as possible.
 	m.newSourceBlock()
 	m.persist.RecentChange = cc.ID
+	err := m.save(false)
+	if err != nil {
+		m.log.Println(err)
+	}
 }
 
 // ReceiveUpdatedUnconfirmedTransactions will replace the current unconfirmed

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -56,7 +56,7 @@ type (
 	}
 
 	persister interface {
-		save(contractorPersist) error
+		save(contractorPersist, bool) error
 		load(*contractorPersist) error
 	}
 
@@ -89,8 +89,8 @@ type stdPersist struct {
 	filename string
 }
 
-func (p *stdPersist) save(data contractorPersist) error {
-	return persist.SaveFile(p.meta, data, p.filename)
+func (p *stdPersist) save(data contractorPersist, fsync bool) error {
+	return persist.SaveFile(p.meta, data, p.filename, fsync)
 }
 
 func (p *stdPersist) load(data *contractorPersist) error {

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -102,7 +102,7 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 
 	hd.contractor.mu.Lock()
 	hd.contractor.contracts[hd.contract.ID] = hd.contract
-	hd.contractor.save()
+	hd.contractor.save(false)
 	hd.contractor.mu.Unlock()
 
 	return sector, nil

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -122,7 +122,7 @@ func (he *hostEditor) runRevisionIteration(actions []modules.RevisionAction, rev
 
 	he.contractor.mu.Lock()
 	he.contractor.contracts[he.contract.ID] = he.contract
-	he.contractor.save()
+	he.contractor.save(false)
 	he.contractor.mu.Unlock()
 
 	return nil

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -311,7 +311,7 @@ func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endH
 	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
 	c.spentTotal = c.spentTotal.Add(fc.Payout)
 	c.cachedAddress = types.UnlockHash{} // clear the cached address
-	c.save()
+	c.save(true)
 	c.mu.Unlock()
 
 	return contract, nil

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -16,7 +16,7 @@ type contractorPersist struct {
 }
 
 // save saves the hostdb persistence data to disk.
-func (c *Contractor) save() error {
+func (c *Contractor) save(fsync bool) error {
 	data := contractorPersist{
 		Allowance:   c.allowance,
 		LastChange:  c.lastChange,
@@ -27,7 +27,7 @@ func (c *Contractor) save() error {
 	for _, contract := range c.contracts {
 		data.Contracts = append(data.Contracts, contract)
 	}
-	return c.persist.save(data)
+	return c.persist.save(data, fsync)
 }
 
 // load loads the Contractor persistence data from disk.

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -11,8 +11,8 @@ import (
 // memPersist implements the persister interface in-memory.
 type memPersist contractorPersist
 
-func (m *memPersist) save(data contractorPersist) error { *m = memPersist(data); return nil }
-func (m memPersist) load(data *contractorPersist) error { *data = contractorPersist(m); return nil }
+func (m *memPersist) save(data contractorPersist, fsync bool) error { *m = memPersist(data); return nil }
+func (m memPersist) load(data *contractorPersist) error             { *data = contractorPersist(m); return nil }
 
 // TestSaveLoad tests that the contractor can save and load itself.
 func TestSaveLoad(t *testing.T) {
@@ -29,7 +29,7 @@ func TestSaveLoad(t *testing.T) {
 		{2}: {IP: "baz"},
 	}
 	// save and reload
-	err := c.save()
+	err := c.save(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestSaveLoad(t *testing.T) {
 	os.MkdirAll(build.TempDir("contractor", "TestSaveLoad"), 0700)
 
 	// save and reload
-	err = c.save()
+	err = c.save(false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -118,7 +118,7 @@ func (c *Contractor) managedRenew(contract Contract, filesize uint64, newEndHeig
 	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
 	c.spentTotal = c.spentTotal.Add(fc.Payout)
 	c.cachedAddress = types.UnlockHash{} // clear cachedAddress
-	err = c.save()
+	err = c.save(true)
 	c.mu.Unlock()
 	if err != nil {
 		c.log.Println("WARN: failed to save the contractor:", err)

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -180,7 +180,7 @@ func (r *Renter) DeleteFile(nickname string) error {
 	}
 	delete(r.files, nickname)
 	os.RemoveAll(filepath.Join(r.persistDir, f.name+ShareExtension))
-	r.save()
+	r.save(true)
 	r.mu.Unlock(lockID)
 
 	// delete the file's associated contract data.
@@ -260,7 +260,7 @@ func (r *Renter) RenameFile(currentName, newName string) error {
 	// Update the entries in the renter.
 	delete(r.files, currentName)
 	r.files[newName] = file
-	err = r.save()
+	err = r.save(true)
 	if err != nil {
 		return err
 	}

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -25,7 +25,7 @@ type (
 	}
 
 	persister interface {
-		save(hdbPersist) error
+		save(hdbPersist, bool) error
 		load(*hdbPersist) error
 	}
 
@@ -54,8 +54,8 @@ type stdPersist struct {
 	filename string
 }
 
-func (p *stdPersist) save(data hdbPersist) error {
-	return persist.SaveFile(p.meta, data, p.filename)
+func (p *stdPersist) save(data hdbPersist, fsync bool) error {
+	return persist.SaveFile(p.meta, data, p.filename, fsync)
 }
 
 func (p *stdPersist) load(data *hdbPersist) error {

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -12,7 +12,7 @@ type hdbPersist struct {
 }
 
 // save saves the hostdb persistence data to disk.
-func (hdb *HostDB) save() error {
+func (hdb *HostDB) save(fsync bool) error {
 	var data hdbPersist
 	for _, entry := range hdb.allHosts {
 		data.AllHosts = append(data.AllHosts, *entry)
@@ -21,7 +21,7 @@ func (hdb *HostDB) save() error {
 		data.ActiveHosts = append(data.ActiveHosts, *node.hostEntry)
 	}
 	data.LastChange = hdb.lastChange
-	return hdb.persist.save(data)
+	return hdb.persist.save(data, fsync)
 }
 
 // load loads the hostdb persistence data from disk.

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -11,8 +11,8 @@ import (
 // memPersist implements the persister interface in-memory.
 type memPersist hdbPersist
 
-func (m *memPersist) save(data hdbPersist) error { *m = memPersist(data); return nil }
-func (m memPersist) load(data *hdbPersist) error { *data = hdbPersist(m); return nil }
+func (m *memPersist) save(data hdbPersist, fsync bool) error { *m = memPersist(data); return nil }
+func (m memPersist) load(data *hdbPersist) error             { *data = hdbPersist(m); return nil }
 
 // TestSaveLoad tests that the hostdb can save and load itself.
 func TestSaveLoad(t *testing.T) {
@@ -38,7 +38,7 @@ func TestSaveLoad(t *testing.T) {
 	hdb.lastChange = modules.ConsensusChangeID{1, 2, 3}
 
 	// save and reload
-	err := hdb.save()
+	err := hdb.save(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestRescan(t *testing.T) {
 	hdb.lastChange = modules.ConsensusChangeID{1, 2, 3}
 
 	// save the hostdb
-	err := hdb.save()
+	err := hdb.save(false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -175,15 +175,15 @@ func (r *Renter) saveFile(f *file) error {
 	}
 
 	// Commit the SafeFile.
-	return handle.Commit()
+	return handle.Commit(false)
 }
 
 // save stores the current renter data to disk.
-func (r *Renter) save() error {
+func (r *Renter) save(fsync bool) error {
 	data := struct {
 		Tracking map[string]trackedFile
 	}{r.tracking}
-	return persist.SaveFile(saveMetadata, data, filepath.Join(r.persistDir, PersistFilename))
+	return persist.SaveFile(saveMetadata, data, filepath.Join(r.persistDir, PersistFilename), fsync)
 }
 
 // load fetches the saved renter data from disk.

--- a/modules/renter/persist_test.go
+++ b/modules/renter/persist_test.go
@@ -201,7 +201,7 @@ func TestRenterSaveLoad(t *testing.T) {
 	rt.renter.saveFile(f2)
 	rt.renter.saveFile(f3)
 
-	err = rt.renter.save() // save metadata
+	err = rt.renter.save(false) // save metadata
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -74,7 +74,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	r.tracking[up.SiaPath] = trackedFile{
 		RepairPath: up.Source,
 	}
-	r.save()
+	r.save(true)
 	r.mu.Unlock(lockID)
 
 	// Save the .sia file to the renter directory.

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -75,7 +75,7 @@ func (w *Wallet) initEncryption(masterKey crypto.TwofishKey) (modules.Seed, erro
 	if err != nil {
 		return modules.Seed{}, err
 	}
-	err = w.saveSettings()
+	err = w.saveSettings(false)
 	if err != nil {
 		return modules.Seed{}, err
 	}
@@ -185,7 +185,7 @@ func (w *Wallet) Lock() error {
 	// calling 'Unlock' again.
 	w.wipeSecrets()
 	w.unlocked = false
-	return w.saveSettings()
+	return nil
 }
 
 // Unlock will decrypt the wallet seed and load all of the addresses into

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -72,8 +72,8 @@ func (w *Wallet) loadSettings() error {
 
 // saveSettings writes the wallet's settings to the wallet's settings file,
 // replacing the existing file.
-func (w *Wallet) saveSettings() error {
-	return persist.SaveFile(settingsMetadata, w.persist, filepath.Join(w.persistDir, settingsFile))
+func (w *Wallet) saveSettings(fsync bool) error {
+	return persist.SaveFile(settingsMetadata, w.persist, filepath.Join(w.persistDir, settingsFile), fsync)
 }
 
 // initSettings creates the settings object at startup. If a settings file
@@ -88,7 +88,7 @@ func (w *Wallet) initSettings() error {
 		if err != nil {
 			return err
 		}
-		return w.saveSettings()
+		return w.saveSettings(false)
 	} else if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (w *Wallet) initPersist() error {
 
 // createBackup creates a backup file at the desired filepath.
 func (w *Wallet) createBackup(backupFilepath string) error {
-	return persist.SaveFile(settingsMetadata, w.persist, backupFilepath)
+	return persist.SaveFile(settingsMetadata, w.persist, backupFilepath, true)
 }
 
 // CreateBackup creates a backup file at the desired filepath.

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -79,7 +79,7 @@ func (w *Wallet) encryptAndSaveSeedFile(masterKey crypto.TwofishKey, seed module
 		return SeedFile{}, err
 	}
 	seedFilename := filepath.Join(w.persistDir, seedFilePrefix+persist.RandomSuffix()+seedFileSuffix)
-	err = persist.SaveFile(seedMetadata, sf, seedFilename)
+	err = persist.SaveFile(seedMetadata, sf, seedFilename, true)
 	if err != nil {
 		return SeedFile{}, err
 	}
@@ -146,7 +146,7 @@ func (w *Wallet) recoverSeed(masterKey crypto.TwofishKey, seed modules.Seed) err
 	// Add the seed file to the wallet's set of tracked seeds and save the
 	// wallet settings.
 	w.persist.AuxiliarySeedFiles = append(w.persist.AuxiliarySeedFiles, seedFile)
-	err = w.saveSettings()
+	err = w.saveSettings(true)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (w *Wallet) createSeed(masterKey crypto.TwofishKey, seed modules.Seed) erro
 		spendableKey := generateSpendableKey(seed, i)
 		w.keys[spendableKey.UnlockConditions.UnlockHash()] = spendableKey
 	}
-	return w.saveSettings()
+	return w.saveSettings(true)
 }
 
 // initPrimarySeed loads the primary seed into the wallet.
@@ -221,7 +221,7 @@ func (w *Wallet) nextPrimarySeedAddress() (types.UnlockConditions, error) {
 	spendableKey := generateSpendableKey(w.primarySeed, w.persist.PrimarySeedProgress+modules.WalletSeedPreloadDepth)
 	w.keys[spendableKey.UnlockConditions.UnlockHash()] = spendableKey
 	w.persist.PrimarySeedProgress++
-	err := w.saveSettings()
+	err := w.saveSettings(true)
 	if err != nil {
 		return types.UnlockConditions{}, err
 	}

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -168,7 +168,7 @@ func (w *Wallet) loadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 	if err != nil {
 		return err
 	}
-	err = w.saveSettings()
+	err = w.saveSettings(true)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string
 			seedsLoaded++
 		}
 	}
-	err = w.saveSettings()
+	err = w.saveSettings(true)
 	if err != nil {
 		return err
 	}

--- a/persist/boltdb.go
+++ b/persist/boltdb.go
@@ -13,7 +13,7 @@ type BoltDatabase struct {
 	*bolt.DB
 }
 
-// updateDbMetadata will set the contents of the metadata bucket to be
+// updatbMetadata will set the contents of the metadata bucket to be
 // what is stored inside the metadata argument
 func (db *BoltDatabase) updateMetadata(tx *bolt.Tx) error {
 	bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
@@ -31,7 +31,7 @@ func (db *BoltDatabase) updateMetadata(tx *bolt.Tx) error {
 	return nil
 }
 
-// checkDbMetadata confirms that the metadata in the database is
+// checkMetadata confirms that the metadata in the database is
 // correct. If there is no metadata, correct metadata is inserted
 func (db *BoltDatabase) checkMetadata(md Metadata) error {
 	err := db.Update(func(tx *bolt.Tx) error {
@@ -60,7 +60,7 @@ func (db *BoltDatabase) checkMetadata(md Metadata) error {
 	return err
 }
 
-// CloseDatabase saves the bolt database to a file, and updates metadata
+// Close saves the bolt database to a file, and updates metadata
 func (db *BoltDatabase) Close() error {
 	return db.DB.Close()
 }

--- a/persist/json.go
+++ b/persist/json.go
@@ -51,7 +51,7 @@ func Load(meta Metadata, data interface{}, r io.Reader) error {
 }
 
 // SaveFile atomically saves json data to a file.
-func SaveFile(meta Metadata, data interface{}, filename string) error {
+func SaveFile(meta Metadata, data interface{}, filename string, fsync bool) error {
 	file, err := NewSafeFile(filename)
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func SaveFile(meta Metadata, data interface{}, filename string) error {
 	if err != nil {
 		return err
 	}
-	return file.Commit()
+	return file.Commit(fsync)
 }
 
 // LoadFile loads json data from a file.

--- a/persist/json_test.go
+++ b/persist/json_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
+// TestSaveLoad checks that saving and loading data behaves as expected.
 func TestSaveLoad(t *testing.T) {
 	var meta = Metadata{"TestSaveLoad", "0.1"}
 	var saveData int = 3
@@ -58,13 +59,38 @@ func TestSaveLoad(t *testing.T) {
 	}
 }
 
+// TestSaveLoadFile tests that saving and loading a file without fsync properly
+// stores and fetches data.
 func TestSaveLoadFile(t *testing.T) {
 	var meta = Metadata{"TestSaveLoadFile", "0.1"}
 	var saveData int = 3
 
 	os.MkdirAll(build.TempDir("persist"), 0777)
 	filename := build.TempDir("persist", "TestSaveLoadFile")
-	err := SaveFile(meta, saveData, filename)
+	err := SaveFile(meta, saveData, filename, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var loadData int
+	err = LoadFile(meta, &loadData, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadData != saveData {
+		t.Fatalf("loaded data (%v) does not match saved data (%v)", loadData, saveData)
+	}
+}
+
+// TestSaveLoadFileFsync test that saving and loading a file with fsync
+// properly stores and fetches data.
+func TestSaveLoadFileFsync(t *testing.T) {
+	var meta = Metadata{"TestSaveLoadFileFsync", "0.1"}
+	var saveData int = 3
+
+	os.MkdirAll(build.TempDir("persist"), 0777)
+	filename := build.TempDir("persist", "TestSaveLoadFile")
+	err := SaveFile(meta, saveData, filename, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/log.go
+++ b/persist/log.go
@@ -90,7 +90,7 @@ func (l *Logger) Debug(v ...interface{}) {
 	}
 }
 
-// Debug is equivalent to Logger.Printf when build.DEBUG is true. Otherwise it
+// Debugf is equivalent to Logger.Printf when build.DEBUG is true. Otherwise it
 // is a no-op.
 func (l *Logger) Debugf(format string, v ...interface{}) {
 	if build.DEBUG {
@@ -98,8 +98,8 @@ func (l *Logger) Debugf(format string, v ...interface{}) {
 	}
 }
 
-// Debug is equivalent to Logger.Println when build.DEBUG is true. Otherwise it
-// is a no-op.
+// Debugln is equivalent to Logger.Println when build.DEBUG is true. Otherwise
+// it is a no-op.
 func (l *Logger) Debugln(v ...interface{}) {
 	if build.DEBUG {
 		l.Println(v...)

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-
-	"github.com/NebulousLabs/Sia/build"
 )
 
 const (
@@ -54,10 +52,10 @@ type safeFile struct {
 // Commit syncs the file, closes it, and then renames it to the intended final
 // filename. Commit should not be called from a defer if the function it is
 // being called from can return an error.
-func (sf *safeFile) Commit() error {
+func (sf *safeFile) Commit(fsync bool) error {
 	// Don't sync during testing as it can take too long and causes tests to fail.
 	// TODO: mock the os package so that Sync() is a no-op during testing.
-	if build.Release != "testing" {
+	if fsync {
 		if err := sf.Sync(); err != nil {
 			return err
 		}

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -60,7 +60,7 @@ func TestAbsolutePathSafeFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = sf.Commit()
+	err = sf.Commit(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestRelativePathSafeFile(t *testing.T) {
 	}
 	os.Chdir(tmpChdir)
 	defer os.Chdir(wd)
-	err = sf.Commit()
+	err = sf.Commit(false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fsync is really slow, to the point that it was causing signficant
performance issues. Instead of file saving calling fsync by default for
everything, fsync is only called for user action and for really
important action that pertains to monetary changes or changes to network
contracts. The result should be a significantly faster siad.

Further investigation has led me to believe that the bottleneck for some of the startup is actually not I/O, and not fsync, but instead is hashing. I also remember making this conclusion before. Regardless, we do a lot less fsync now, only during important calls. This might be worth looking over to figure out where I made what decisions, and to dispute any that you disagree with.