### PR TITLE
performance and correctness updates to miner

### DIFF
--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -27,7 +27,10 @@ func (m *Miner) blockForWork() types.Block {
 	}
 
 	// Update the address + payouts.
-	_ = m.checkAddress() // Err is ignored - address generation failed but can't do anything about it (log maybe).
+	err := m.checkAddress()
+	if err != nil {
+		m.log.Println(err)
+	}
 	b.MinerPayouts = []types.SiacoinOutput{{Value: b.CalculateSubsidy(m.persist.Height + 1), UnlockHash: m.persist.Address}}
 
 	// Add an arb-data txn to the block to create a unique merkle root.


### PR DESCRIPTION
During IBD and loading, some hashing in the miner module was causing
visible slowdown. While investigating other potential sources of
slowdown, I also discovered some locking misuse.

Removing the hashes resulted in about a 10% speedup for the miner accepting an average sized block (where average was defined by using the real chain). `FindBlock` had an outright deadlock in it.  An unchecked error is now checked because the miner now has a logger that can record the error.