### PR TITLE
fix locking in consensus package

### DIFF
--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -153,18 +153,17 @@ func (cs *ConsensusSet) initializePersistentSubscribe(subscriber modules.Consens
 // As a special case, using an empty id as the start will have all the changes
 // sent to the modules starting with the genesis block.
 func (cs *ConsensusSet) ConsensusSetPersistentSubscribe(subscriber modules.ConsensusSetSubscriber, start modules.ConsensusChangeID) error {
+	cs.mu.Lock()
+	cs.subscribers = append(cs.subscribers, subscriber)
+	cs.mu.Demote()
+	defer cs.mu.DemotedUnlock()
+
 	// Get the input module caught up to the currenct consnesus set.
-	cs.mu.RLock()
 	err := cs.initializePersistentSubscribe(subscriber, start)
-	cs.mu.RUnlock()
 	if err != nil {
 		return err
 	}
-
 	// Only add the module as a subscriber if there was no error.
-	cs.mu.Lock()
-	cs.subscribers = append(cs.subscribers, subscriber)
-	cs.mu.Unlock()
 	return nil
 }
 

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -255,6 +255,9 @@ func validTransaction(tx *bolt.Tx, t types.Transaction) error {
 // is not checked. After the transactions have been validated, a consensus
 // change is returned detailing the diffs that the transaciton set would have.
 func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.ConsensusChange, error) {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+
 	// applyTransaction will apply the diffs from a transaction and store them
 	// in a block node. diffHolder is the blockNode that tracks the temporary
 	// changes. At the end of the function, all changes that were made to the


### PR DESCRIPTION
There were a few locking bugs in the consensus package, places where
the database was being accessed outside of a read lock.

There was one critical place in particular, which was using a readlock
followed by a writelock, when it really needed to be using a single
writelock -> demotelock. This place is likely the cause of the consensus
desynchronizations between the miner + consensus package, has likely
impacted other modules, and since fixing it I have not been able to
trigger the behavior in question.