### PR TITLE
fix race condition in hostdb

### DIFF
--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -103,12 +103,6 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*Ho
 		return nil, err
 	}
 
-	// Begin listening to consensus and looking for hosts.
-	for i := 0; i < scanningThreads; i++ {
-		go hdb.threadedProbeHosts()
-	}
-	go hdb.threadedScan()
-
 	err = cs.ConsensusSetPersistentSubscribe(hdb, hdb.lastChange)
 	if err == modules.ErrInvalidConsensusChangeID {
 		hdb.lastChange = modules.ConsensusChangeID{}
@@ -122,5 +116,10 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*Ho
 		return nil, errors.New("hostdb subscription failed: " + err.Error())
 	}
 
+	// Begin listening to consensus and looking for hosts.
+	for i := 0; i < scanningThreads; i++ {
+		go hdb.threadedProbeHosts()
+	}
+	go hdb.threadedScan()
 	return hdb, nil
 }


### PR DESCRIPTION
The hostdb previously would spin up some goroutines to do scanning
before it would finish fetching all of the updates from the consensus
set. Because the hostdb does not grab a lock during the call to `New`,
this resulted in a race condition. The startup order is now correct, and
the goroutines are not spun up until the hostdb has received all of the
consensus changes.

The hostdb should probably not have been scanning hosts before getting
all of the blocks anyway.