### PR TITLE
Make fsync optional when saving a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ vet: release-std
 	go vet $(pkgs)
 
 # will always run on some packages for a while.
-lintpkgs = ./modules/host ./modules ./modules/renter/hostdb ./modules/renter/contractor
+lintpkgs = ./modules/host ./modules ./modules/renter/hostdb ./modules/renter/contractor ./persist
 lint:
 	@for package in $(lintpkgs); do                           \
 		golint -min_confidence=1.0 $$package                  \

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -58,7 +58,7 @@ func (g *Gateway) Close() error {
 
 	// save the latest gateway state
 	id := g.mu.RLock()
-	if err := g.save(); err != nil {
+	if err := g.saveSync(); err != nil {
 		errs = append(errs, fmt.Errorf("save failed: %v", err))
 	}
 	g.mu.RUnlock(id)

--- a/modules/gateway/persist.go
+++ b/modules/gateway/persist.go
@@ -15,13 +15,22 @@ const (
 	logFile = modules.GatewayDir + ".log"
 )
 
-// persistMetadata contains all of the
+// persistMetadata contains the header and version strings that identify the
+// gateway persist file.
 var persistMetadata = persist.Metadata{
 	Header:  "Sia Node List",
 	Version: "0.3.3",
 }
 
-// load pulls the gateway persistent data off disk and into memory.
+// persistData returns the data in the Gateway that will be saved to disk.
+func (g *Gateway) persistData() (nodes []modules.NetAddress) {
+	for node := range g.nodes {
+		nodes = append(nodes, node)
+	}
+	return
+}
+
+// load loads the Gateway's persistent data from disk.
 func (g *Gateway) load() error {
 	var nodes []modules.NetAddress
 	err := persist.LoadFile(persistMetadata, &nodes, filepath.Join(g.persistDir, nodesFile))
@@ -34,21 +43,13 @@ func (g *Gateway) load() error {
 	return nil
 }
 
-// save stores the gateway's persistent data on disk.
+// save stores the Gateway's persistent data on disk.
 func (g *Gateway) save() error {
-	var nodes []modules.NetAddress
-	for node := range g.nodes {
-		nodes = append(nodes, node)
-	}
-	return persist.SaveFile(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile))
+	return persist.SaveFile(persistMetadata, g.persistData(), filepath.Join(g.persistDir, nodesFile))
 }
 
-// saveSync stores the gateway's persistent data on disk, and then syncs to
+// saveSync stores the Gateway's persistent data on disk, and then syncs to
 // disk to minimize the possibility of data loss.
 func (g *Gateway) saveSync() error {
-	var nodes []modules.NetAddress
-	for node := range g.nodes {
-		nodes = append(nodes, node)
-	}
-	return persist.SaveFileSync(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile))
+	return persist.SaveFileSync(persistMetadata, g.persistData(), filepath.Join(g.persistDir, nodesFile))
 }

--- a/modules/gateway/persist.go
+++ b/modules/gateway/persist.go
@@ -10,23 +10,18 @@ import (
 const (
 	// nodesFile is the name of the file that contains all seen nodes.
 	nodesFile = "nodes.json"
+
 	// logFile is the name of the log file.
 	logFile = modules.GatewayDir + ".log"
 )
 
+// persistMetadata contains all of the
 var persistMetadata = persist.Metadata{
 	Header:  "Sia Node List",
 	Version: "0.3.3",
 }
 
-func (g *Gateway) save() error {
-	var nodes []modules.NetAddress
-	for node := range g.nodes {
-		nodes = append(nodes, node)
-	}
-	return persist.SaveFile(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile))
-}
-
+// load pulls the gateway persistent data off disk and into memory.
 func (g *Gateway) load() error {
 	var nodes []modules.NetAddress
 	err := persist.LoadFile(persistMetadata, &nodes, filepath.Join(g.persistDir, nodesFile))
@@ -37,4 +32,23 @@ func (g *Gateway) load() error {
 		g.addNode(node)
 	}
 	return nil
+}
+
+// save stores the gateway's persistent data on disk.
+func (g *Gateway) save() error {
+	var nodes []modules.NetAddress
+	for node := range g.nodes {
+		nodes = append(nodes, node)
+	}
+	return persist.SaveFile(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile))
+}
+
+// saveSync stores the gateway's persistent data on disk, and then syncs to
+// disk to minimize the possibility of data loss.
+func (g *Gateway) saveSync() error {
+	var nodes []modules.NetAddress
+	for node := range g.nodes {
+		nodes = append(nodes, node)
+	}
+	return persist.SaveFileSync(persistMetadata, nodes, filepath.Join(g.persistDir, nodesFile))
 }

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -363,7 +363,7 @@ func (h *Host) Close() (composedError error) {
 
 	// Save the latest host state.
 	h.mu.Lock()
-	err = h.save()
+	err = h.saveSync()
 	h.mu.Unlock()
 	if err != nil {
 		composedError = composeErrors(composedError, err)
@@ -423,7 +423,7 @@ func (h *Host) SetInternalSettings(settings modules.HostInternalSettings) error 
 
 	h.settings = settings
 	h.revisionNumber++
-	return h.save()
+	return h.saveSync()
 }
 
 // InternalSettings returns the settings of a host.

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -171,3 +171,33 @@ func (h *Host) save() error {
 	}
 	return persist.SaveFile(persistMetadata, p, filepath.Join(h.persistDir, settingsFile))
 }
+
+// saveSync stores all of the persist data to disk and then syncs to disk.
+func (h *Host) saveSync() error {
+	p := persistence{
+		// RPC Metrics.
+		DownloadCalls:       atomic.LoadUint64(&h.atomicDownloadCalls),
+		ErroredCalls:        atomic.LoadUint64(&h.atomicErroredCalls),
+		FormContractCalls:   atomic.LoadUint64(&h.atomicFormContractCalls),
+		RenewCalls:          atomic.LoadUint64(&h.atomicRenewCalls),
+		ReviseCalls:         atomic.LoadUint64(&h.atomicReviseCalls),
+		RecentRevisionCalls: atomic.LoadUint64(&h.atomicRecentRevisionCalls),
+		SettingsCalls:       atomic.LoadUint64(&h.atomicSettingsCalls),
+		UnrecognizedCalls:   atomic.LoadUint64(&h.atomicUnrecognizedCalls),
+
+		// Consensus Tracking.
+		BlockHeight:  h.blockHeight,
+		RecentChange: h.recentChange,
+
+		// Host Identity.
+		Announced:        h.announced,
+		AutoAddress:      h.autoAddress,
+		FinancialMetrics: h.financialMetrics,
+		PublicKey:        h.publicKey,
+		RevisionNumber:   h.revisionNumber,
+		SecretKey:        h.secretKey,
+		Settings:         h.settings,
+		UnlockHash:       h.unlockHash,
+	}
+	return persist.SaveFileSync(persistMetadata, p, filepath.Join(h.persistDir, settingsFile))
+}

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -40,6 +40,35 @@ type persistence struct {
 	UnlockHash       types.UnlockHash
 }
 
+// persistData returns the data in the Host that will be saved to disk.
+func (h *Host) persistData() persistence {
+	return persistence{
+		// RPC Metrics.
+		DownloadCalls:       atomic.LoadUint64(&h.atomicDownloadCalls),
+		ErroredCalls:        atomic.LoadUint64(&h.atomicErroredCalls),
+		FormContractCalls:   atomic.LoadUint64(&h.atomicFormContractCalls),
+		RenewCalls:          atomic.LoadUint64(&h.atomicRenewCalls),
+		ReviseCalls:         atomic.LoadUint64(&h.atomicReviseCalls),
+		RecentRevisionCalls: atomic.LoadUint64(&h.atomicRecentRevisionCalls),
+		SettingsCalls:       atomic.LoadUint64(&h.atomicSettingsCalls),
+		UnrecognizedCalls:   atomic.LoadUint64(&h.atomicUnrecognizedCalls),
+
+		// Consensus Tracking.
+		BlockHeight:  h.blockHeight,
+		RecentChange: h.recentChange,
+
+		// Host Identity.
+		Announced:        h.announced,
+		AutoAddress:      h.autoAddress,
+		FinancialMetrics: h.financialMetrics,
+		PublicKey:        h.publicKey,
+		RevisionNumber:   h.revisionNumber,
+		SecretKey:        h.secretKey,
+		Settings:         h.settings,
+		UnlockHash:       h.unlockHash,
+	}
+}
+
 // establishDefaults configures the default settings for the host, overwriting
 // any existing settings.
 func (h *Host) establishDefaults() error {
@@ -100,7 +129,7 @@ func (h *Host) initDB() error {
 	})
 }
 
-// load extrats the save data from disk and populates the host.
+// load loads the Hosts's persistent data from disk.
 func (h *Host) load() error {
 	p := new(persistence)
 	err := h.dependencies.loadFile(persistMetadata, p, filepath.Join(h.persistDir, settingsFile))
@@ -144,60 +173,10 @@ func (h *Host) load() error {
 
 // save stores all of the persist data to disk.
 func (h *Host) save() error {
-	p := persistence{
-		// RPC Metrics.
-		DownloadCalls:       atomic.LoadUint64(&h.atomicDownloadCalls),
-		ErroredCalls:        atomic.LoadUint64(&h.atomicErroredCalls),
-		FormContractCalls:   atomic.LoadUint64(&h.atomicFormContractCalls),
-		RenewCalls:          atomic.LoadUint64(&h.atomicRenewCalls),
-		ReviseCalls:         atomic.LoadUint64(&h.atomicReviseCalls),
-		RecentRevisionCalls: atomic.LoadUint64(&h.atomicRecentRevisionCalls),
-		SettingsCalls:       atomic.LoadUint64(&h.atomicSettingsCalls),
-		UnrecognizedCalls:   atomic.LoadUint64(&h.atomicUnrecognizedCalls),
-
-		// Consensus Tracking.
-		BlockHeight:  h.blockHeight,
-		RecentChange: h.recentChange,
-
-		// Host Identity.
-		Announced:        h.announced,
-		AutoAddress:      h.autoAddress,
-		FinancialMetrics: h.financialMetrics,
-		PublicKey:        h.publicKey,
-		RevisionNumber:   h.revisionNumber,
-		SecretKey:        h.secretKey,
-		Settings:         h.settings,
-		UnlockHash:       h.unlockHash,
-	}
-	return persist.SaveFile(persistMetadata, p, filepath.Join(h.persistDir, settingsFile))
+	return persist.SaveFile(persistMetadata, h.persistData(), filepath.Join(h.persistDir, settingsFile))
 }
 
 // saveSync stores all of the persist data to disk and then syncs to disk.
 func (h *Host) saveSync() error {
-	p := persistence{
-		// RPC Metrics.
-		DownloadCalls:       atomic.LoadUint64(&h.atomicDownloadCalls),
-		ErroredCalls:        atomic.LoadUint64(&h.atomicErroredCalls),
-		FormContractCalls:   atomic.LoadUint64(&h.atomicFormContractCalls),
-		RenewCalls:          atomic.LoadUint64(&h.atomicRenewCalls),
-		ReviseCalls:         atomic.LoadUint64(&h.atomicReviseCalls),
-		RecentRevisionCalls: atomic.LoadUint64(&h.atomicRecentRevisionCalls),
-		SettingsCalls:       atomic.LoadUint64(&h.atomicSettingsCalls),
-		UnrecognizedCalls:   atomic.LoadUint64(&h.atomicUnrecognizedCalls),
-
-		// Consensus Tracking.
-		BlockHeight:  h.blockHeight,
-		RecentChange: h.recentChange,
-
-		// Host Identity.
-		Announced:        h.announced,
-		AutoAddress:      h.autoAddress,
-		FinancialMetrics: h.financialMetrics,
-		PublicKey:        h.publicKey,
-		RevisionNumber:   h.revisionNumber,
-		SecretKey:        h.secretKey,
-		Settings:         h.settings,
-		UnlockHash:       h.unlockHash,
-	}
-	return persist.SaveFileSync(persistMetadata, p, filepath.Join(h.persistDir, settingsFile))
+	return persist.SaveFileSync(persistMetadata, h.persistData(), filepath.Join(h.persistDir, settingsFile))
 }

--- a/modules/host/storagemanager/persist.go
+++ b/modules/host/storagemanager/persist.go
@@ -17,6 +17,15 @@ type persistence struct {
 	StorageFolders []*storageFolder
 }
 
+// persistData returns the data in the StorageManager that will be saved to
+// disk.
+func (sm *StorageManager) persistData() persistence {
+	return persistence{
+		SectorSalt:     sm.sectorSalt,
+		StorageFolders: sm.storageFolders,
+	}
+}
+
 // establishDefaults configures the default settings for the storage manager,
 // overwriting any existing settings.
 func (sm *StorageManager) establishDefaults() error {
@@ -67,18 +76,10 @@ func (sm *StorageManager) load() error {
 
 // save stores all of the persistent data of the storage manager to disk.
 func (sm *StorageManager) save() error {
-	p := persistence{
-		SectorSalt:     sm.sectorSalt,
-		StorageFolders: sm.storageFolders,
-	}
-	return persist.SaveFile(persistMetadata, p, filepath.Join(sm.persistDir, settingsFile))
+	return persist.SaveFile(persistMetadata, sm.persistData(), filepath.Join(sm.persistDir, settingsFile))
 }
 
 // save stores all of the persistent data of the storage manager to disk.
 func (sm *StorageManager) saveSync() error {
-	p := persistence{
-		SectorSalt:     sm.sectorSalt,
-		StorageFolders: sm.storageFolders,
-	}
-	return persist.SaveFileSync(persistMetadata, p, filepath.Join(sm.persistDir, settingsFile))
+	return persist.SaveFileSync(persistMetadata, sm.persistData(), filepath.Join(sm.persistDir, settingsFile))
 }

--- a/modules/host/storagemanager/storagefolders.go
+++ b/modules/host/storagemanager/storagefolders.go
@@ -449,7 +449,7 @@ func (sm *StorageManager) AddStorageFolder(path string, size uint64) error {
 
 	// Add the storage folder to the list of folders for the host.
 	sm.storageFolders = append(sm.storageFolders, newSF)
-	return sm.save()
+	return sm.saveSync()
 }
 
 // ResetStorageFolderHealth will reset the read and write statistics for the
@@ -473,7 +473,7 @@ func (sm *StorageManager) ResetStorageFolderHealth(index int) error {
 	sm.storageFolders[index].FailedWrites = 0
 	sm.storageFolders[index].SuccessfulReads = 0
 	sm.storageFolders[index].SuccessfulWrites = 0
-	return sm.save()
+	return sm.saveSync()
 }
 
 // RemoveStorageFolder removes a storage folder from the host.
@@ -508,7 +508,7 @@ func (sm *StorageManager) RemoveStorageFolder(removalIndex int, force bool) erro
 	// Remove the storage folder from the host and then save the host.
 	sm.storageFolders = append(sm.storageFolders[0:removalIndex], sm.storageFolders[removalIndex+1:]...)
 	removeErr := sm.dependencies.removeFile(filepath.Join(sm.persistDir, removalFolder.uidString()))
-	saveErr := sm.save()
+	saveErr := sm.saveSync()
 	return composeErrors(saveErr, removeErr)
 }
 
@@ -549,7 +549,7 @@ func (sm *StorageManager) ResizeStorageFolder(storageFolderIndex int, newSize ui
 	if resizeFolderSizeConsumed <= newSize {
 		resizeFolder.SizeRemaining = newSize - resizeFolderSizeConsumed
 		resizeFolder.Size = newSize
-		return sm.save()
+		return sm.saveSync()
 	}
 
 	// Calculate the number of sectors that need to be offloaded from the
@@ -569,7 +569,7 @@ func (sm *StorageManager) ResizeStorageFolder(storageFolderIndex int, newSize ui
 	}
 	resizeFolder.Size = newSize
 	resizeFolder.SizeRemaining = 0
-	return sm.save()
+	return sm.saveSync()
 }
 
 // StorageFolders provides information about all of the storage folders in the

--- a/modules/host/storagemanager/storagemanager.go
+++ b/modules/host/storagemanager/storagemanager.go
@@ -88,7 +88,7 @@ func (sm *StorageManager) Close() (composedError error) {
 
 	// Save the latest host state.
 	sm.mu.Lock()
-	err = sm.save()
+	err = sm.saveSync()
 	sm.mu.Unlock()
 	if err != nil {
 		composedError = composeErrors(composedError, err)

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -153,7 +153,7 @@ func (m *Miner) managedSubmitBlock(b types.Block) error {
 		return err
 	}
 	m.persist.Address = uc.UnlockHash()
-	return m.save()
+	return m.saveSync()
 }
 
 // SubmitHeader accepts a block header.

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -200,7 +200,7 @@ func (m *Miner) Close() error {
 	m.cs.Unsubscribe(m)
 
 	var errs []error
-	if err := m.save(); err != nil {
+	if err := m.saveSync(); err != nil {
 		errs = append(errs, fmt.Errorf("save failed: %v", err))
 	}
 	if err := m.log.Close(); err != nil {

--- a/modules/miner/persist.go
+++ b/modules/miner/persist.go
@@ -72,3 +72,8 @@ func (m *Miner) load() error {
 func (m *Miner) save() error {
 	return persist.SaveFile(settingsMetadata, m.persist, filepath.Join(m.persistDir, settingsFile))
 }
+
+// saveSync saves the miner persistence to disk, and then syncs to disk.
+func (m *Miner) saveSync() error {
+	return persist.SaveFileSync(settingsMetadata, m.persist, filepath.Join(m.persistDir, settingsFile))
+}

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -62,6 +62,10 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// the stale rate as low as possible.
 	m.newSourceBlock()
 	m.persist.RecentChange = cc.ID
+	err := m.save()
+	if err != nil {
+		m.log.Println(err)
+	}
 }
 
 // ReceiveUpdatedUnconfirmedTransactions will replace the current unconfirmed

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -57,6 +57,7 @@ type (
 
 	persister interface {
 		save(contractorPersist) error
+		saveSync(contractorPersist) error
 		load(*contractorPersist) error
 	}
 
@@ -91,6 +92,10 @@ type stdPersist struct {
 
 func (p *stdPersist) save(data contractorPersist) error {
 	return persist.SaveFile(p.meta, data, p.filename)
+}
+
+func (p *stdPersist) saveSync(data contractorPersist) error {
+	return persist.SaveFileSync(p.meta, data, p.filename)
 }
 
 func (p *stdPersist) load(data *contractorPersist) error {

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -102,7 +102,7 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 
 	hd.contractor.mu.Lock()
 	hd.contractor.contracts[hd.contract.ID] = hd.contract
-	hd.contractor.save()
+	hd.contractor.saveSync()
 	hd.contractor.mu.Unlock()
 
 	return sector, nil

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -122,7 +122,7 @@ func (he *hostEditor) runRevisionIteration(actions []modules.RevisionAction, rev
 
 	he.contractor.mu.Lock()
 	he.contractor.contracts[he.contract.ID] = he.contract
-	he.contractor.save()
+	he.contractor.saveSync()
 	he.contractor.mu.Unlock()
 
 	return nil

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -311,7 +311,7 @@ func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endH
 	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
 	c.spentTotal = c.spentTotal.Add(fc.Payout)
 	c.cachedAddress = types.UnlockHash{} // clear the cached address
-	c.save()
+	c.saveSync()
 	c.mu.Unlock()
 
 	return contract, nil

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -15,6 +15,21 @@ type contractorPersist struct {
 	SpentTotal  types.Currency
 }
 
+// persistData returns the data in the Contractor that will be saved to disk.
+func (c *Contractor) persistData() contractorPersist {
+	data := contractorPersist{
+		Allowance:   c.allowance,
+		LastChange:  c.lastChange,
+		RenewHeight: c.renewHeight,
+		SpentPeriod: c.spentPeriod,
+		SpentTotal:  c.spentTotal,
+	}
+	for _, contract := range c.contracts {
+		data.Contracts = append(data.Contracts, contract)
+	}
+	return data
+}
+
 // load loads the Contractor persistence data from disk.
 func (c *Contractor) load() error {
 	var data contractorPersist
@@ -33,32 +48,12 @@ func (c *Contractor) load() error {
 	return nil
 }
 
-// save saves the hostdb persistence data to disk.
+// save saves the Contractor persistence data to disk.
 func (c *Contractor) save() error {
-	data := contractorPersist{
-		Allowance:   c.allowance,
-		LastChange:  c.lastChange,
-		RenewHeight: c.renewHeight,
-		SpentPeriod: c.spentPeriod,
-		SpentTotal:  c.spentTotal,
-	}
-	for _, contract := range c.contracts {
-		data.Contracts = append(data.Contracts, contract)
-	}
-	return c.persist.save(data)
+	return c.persist.save(c.persistData())
 }
 
-// saveSync saves the hostdb persistence data to disk and then syncs to disk.
+// saveSync saves the Contractor persistence data to disk and then syncs to disk.
 func (c *Contractor) saveSync() error {
-	data := contractorPersist{
-		Allowance:   c.allowance,
-		LastChange:  c.lastChange,
-		RenewHeight: c.renewHeight,
-		SpentPeriod: c.spentPeriod,
-		SpentTotal:  c.spentTotal,
-	}
-	for _, contract := range c.contracts {
-		data.Contracts = append(data.Contracts, contract)
-	}
-	return c.persist.saveSync(data)
+	return c.persist.saveSync(c.persistData())
 }

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -15,21 +15,6 @@ type contractorPersist struct {
 	SpentTotal  types.Currency
 }
 
-// save saves the hostdb persistence data to disk.
-func (c *Contractor) save() error {
-	data := contractorPersist{
-		Allowance:   c.allowance,
-		LastChange:  c.lastChange,
-		RenewHeight: c.renewHeight,
-		SpentPeriod: c.spentPeriod,
-		SpentTotal:  c.spentTotal,
-	}
-	for _, contract := range c.contracts {
-		data.Contracts = append(data.Contracts, contract)
-	}
-	return c.persist.save(data)
-}
-
 // load loads the Contractor persistence data from disk.
 func (c *Contractor) load() error {
 	var data contractorPersist
@@ -46,4 +31,34 @@ func (c *Contractor) load() error {
 	c.spentPeriod = data.SpentPeriod
 	c.spentTotal = data.SpentTotal
 	return nil
+}
+
+// save saves the hostdb persistence data to disk.
+func (c *Contractor) save() error {
+	data := contractorPersist{
+		Allowance:   c.allowance,
+		LastChange:  c.lastChange,
+		RenewHeight: c.renewHeight,
+		SpentPeriod: c.spentPeriod,
+		SpentTotal:  c.spentTotal,
+	}
+	for _, contract := range c.contracts {
+		data.Contracts = append(data.Contracts, contract)
+	}
+	return c.persist.save(data)
+}
+
+// saveSync saves the hostdb persistence data to disk and then syncs to disk.
+func (c *Contractor) saveSync() error {
+	data := contractorPersist{
+		Allowance:   c.allowance,
+		LastChange:  c.lastChange,
+		RenewHeight: c.renewHeight,
+		SpentPeriod: c.spentPeriod,
+		SpentTotal:  c.spentTotal,
+	}
+	for _, contract := range c.contracts {
+		data.Contracts = append(data.Contracts, contract)
+	}
+	return c.persist.saveSync(data)
 }

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -11,8 +11,9 @@ import (
 // memPersist implements the persister interface in-memory.
 type memPersist contractorPersist
 
-func (m *memPersist) save(data contractorPersist) error { *m = memPersist(data); return nil }
-func (m memPersist) load(data *contractorPersist) error { *data = contractorPersist(m); return nil }
+func (m *memPersist) save(data contractorPersist) error     { *m = memPersist(data); return nil }
+func (m *memPersist) saveSync(data contractorPersist) error { *m = memPersist(data); return nil }
+func (m memPersist) load(data *contractorPersist) error     { *data = contractorPersist(m); return nil }
 
 // TestSaveLoad tests that the contractor can save and load itself.
 func TestSaveLoad(t *testing.T) {

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -118,7 +118,7 @@ func (c *Contractor) managedRenew(contract Contract, filesize uint64, newEndHeig
 	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
 	c.spentTotal = c.spentTotal.Add(fc.Payout)
 	c.cachedAddress = types.UnlockHash{} // clear cachedAddress
-	err = c.save()
+	err = c.saveSync()
 	c.mu.Unlock()
 	if err != nil {
 		c.log.Println("WARN: failed to save the contractor:", err)

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -180,7 +180,7 @@ func (r *Renter) DeleteFile(nickname string) error {
 	}
 	delete(r.files, nickname)
 	os.RemoveAll(filepath.Join(r.persistDir, f.name+ShareExtension))
-	r.save()
+	r.saveSync()
 	r.mu.Unlock(lockID)
 
 	// delete the file's associated contract data.
@@ -260,7 +260,7 @@ func (r *Renter) RenameFile(currentName, newName string) error {
 	// Update the entries in the renter.
 	delete(r.files, currentName)
 	r.files[newName] = file
-	err = r.save()
+	err = r.saveSync()
 	if err != nil {
 		return err
 	}

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -26,6 +26,7 @@ type (
 
 	persister interface {
 		save(hdbPersist) error
+		saveSync(hdbPersist) error
 		load(*hdbPersist) error
 	}
 
@@ -55,6 +56,10 @@ type stdPersist struct {
 }
 
 func (p *stdPersist) save(data hdbPersist) error {
+	return persist.SaveFile(p.meta, data, p.filename)
+}
+
+func (p *stdPersist) saveSync(data hdbPersist) error {
 	return persist.SaveFile(p.meta, data, p.filename)
 }
 

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -24,6 +24,19 @@ func (hdb *HostDB) save() error {
 	return hdb.persist.save(data)
 }
 
+// saveSync saves the hostdb persistence data to disk and then syncs to disk.
+func (hdb *HostDB) saveSync() error {
+	var data hdbPersist
+	for _, entry := range hdb.allHosts {
+		data.AllHosts = append(data.AllHosts, *entry)
+	}
+	for _, node := range hdb.activeHosts {
+		data.ActiveHosts = append(data.ActiveHosts, *node.hostEntry)
+	}
+	data.LastChange = hdb.lastChange
+	return hdb.persist.saveSync(data)
+}
+
 // load loads the hostdb persistence data from disk.
 func (hdb *HostDB) load() error {
 	var data hdbPersist

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -11,8 +11,8 @@ type hdbPersist struct {
 	LastChange  modules.ConsensusChangeID
 }
 
-// save saves the hostdb persistence data to disk.
-func (hdb *HostDB) save() error {
+// persistData returns the data in the hostdb that will be saved to disk.
+func (hdb *HostDB) persistData() hdbPersist {
 	var data hdbPersist
 	for _, entry := range hdb.allHosts {
 		data.AllHosts = append(data.AllHosts, *entry)
@@ -21,20 +21,17 @@ func (hdb *HostDB) save() error {
 		data.ActiveHosts = append(data.ActiveHosts, *node.hostEntry)
 	}
 	data.LastChange = hdb.lastChange
-	return hdb.persist.save(data)
+	return data
+}
+
+// save saves the hostdb persistence data to disk.
+func (hdb *HostDB) save() error {
+	return hdb.persist.save(hdb.persistData())
 }
 
 // saveSync saves the hostdb persistence data to disk and then syncs to disk.
 func (hdb *HostDB) saveSync() error {
-	var data hdbPersist
-	for _, entry := range hdb.allHosts {
-		data.AllHosts = append(data.AllHosts, *entry)
-	}
-	for _, node := range hdb.activeHosts {
-		data.ActiveHosts = append(data.ActiveHosts, *node.hostEntry)
-	}
-	data.LastChange = hdb.lastChange
-	return hdb.persist.saveSync(data)
+	return hdb.persist.saveSync(hdb.persistData())
 }
 
 // load loads the hostdb persistence data from disk.

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -11,8 +11,9 @@ import (
 // memPersist implements the persister interface in-memory.
 type memPersist hdbPersist
 
-func (m *memPersist) save(data hdbPersist) error { *m = memPersist(data); return nil }
-func (m memPersist) load(data *hdbPersist) error { *data = hdbPersist(m); return nil }
+func (m *memPersist) save(data hdbPersist) error     { *m = memPersist(data); return nil }
+func (m *memPersist) saveSync(data hdbPersist) error { *m = memPersist(data); return nil }
+func (m memPersist) load(data *hdbPersist) error     { *data = hdbPersist(m); return nil }
 
 // TestSaveLoad tests that the hostdb can save and load itself.
 func TestSaveLoad(t *testing.T) {

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -186,6 +186,14 @@ func (r *Renter) save() error {
 	return persist.SaveFile(saveMetadata, data, filepath.Join(r.persistDir, PersistFilename))
 }
 
+// saveSync stores the current renter data to disk and then syncs to disk.
+func (r *Renter) saveSync() error {
+	data := struct {
+		Tracking map[string]trackedFile
+	}{r.tracking}
+	return persist.SaveFileSync(saveMetadata, data, filepath.Join(r.persistDir, PersistFilename))
+}
+
 // load fetches the saved renter data from disk.
 func (r *Renter) load() error {
 	// Recursively load all files found in renter directory. Errors

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -74,7 +74,7 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	r.tracking[up.SiaPath] = trackedFile{
 		RepairPath: up.Source,
 	}
-	r.save()
+	r.saveSync()
 	r.mu.Unlock(lockID)
 
 	// Save the .sia file to the renter directory.

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -185,7 +185,7 @@ func (w *Wallet) Lock() error {
 	// calling 'Unlock' again.
 	w.wipeSecrets()
 	w.unlocked = false
-	return w.saveSettings()
+	return nil
 }
 
 // Unlock will decrypt the wallet seed and load all of the addresses into

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -76,6 +76,12 @@ func (w *Wallet) saveSettings() error {
 	return persist.SaveFile(settingsMetadata, w.persist, filepath.Join(w.persistDir, settingsFile))
 }
 
+// saveSettingsSync writes the wallet's settings to the wallet's settings file,
+// replacing the existing file, and then syncs to disk.
+func (w *Wallet) saveSettingsSync() error {
+	return persist.SaveFileSync(settingsMetadata, w.persist, filepath.Join(w.persistDir, settingsFile))
+}
+
 // initSettings creates the settings object at startup. If a settings file
 // exists, the settings file will be loaded into memory. If the settings file
 // does not exist, a new.persist file will be created.
@@ -123,7 +129,7 @@ func (w *Wallet) initPersist() error {
 
 // createBackup creates a backup file at the desired filepath.
 func (w *Wallet) createBackup(backupFilepath string) error {
-	return persist.SaveFile(settingsMetadata, w.persist, backupFilepath)
+	return persist.SaveFileSync(settingsMetadata, w.persist, backupFilepath)
 }
 
 // CreateBackup creates a backup file at the desired filepath.

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -79,7 +79,7 @@ func (w *Wallet) encryptAndSaveSeedFile(masterKey crypto.TwofishKey, seed module
 		return SeedFile{}, err
 	}
 	seedFilename := filepath.Join(w.persistDir, seedFilePrefix+persist.RandomSuffix()+seedFileSuffix)
-	err = persist.SaveFile(seedMetadata, sf, seedFilename)
+	err = persist.SaveFileSync(seedMetadata, sf, seedFilename)
 	if err != nil {
 		return SeedFile{}, err
 	}
@@ -146,7 +146,7 @@ func (w *Wallet) recoverSeed(masterKey crypto.TwofishKey, seed modules.Seed) err
 	// Add the seed file to the wallet's set of tracked seeds and save the
 	// wallet settings.
 	w.persist.AuxiliarySeedFiles = append(w.persist.AuxiliarySeedFiles, seedFile)
-	err = w.saveSettings()
+	err = w.saveSettingsSync()
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (w *Wallet) createSeed(masterKey crypto.TwofishKey, seed modules.Seed) erro
 		spendableKey := generateSpendableKey(seed, i)
 		w.keys[spendableKey.UnlockConditions.UnlockHash()] = spendableKey
 	}
-	return w.saveSettings()
+	return w.saveSettingsSync()
 }
 
 // initPrimarySeed loads the primary seed into the wallet.
@@ -221,7 +221,7 @@ func (w *Wallet) nextPrimarySeedAddress() (types.UnlockConditions, error) {
 	spendableKey := generateSpendableKey(w.primarySeed, w.persist.PrimarySeedProgress+modules.WalletSeedPreloadDepth)
 	w.keys[spendableKey.UnlockConditions.UnlockHash()] = spendableKey
 	w.persist.PrimarySeedProgress++
-	err := w.saveSettings()
+	err := w.saveSettingsSync()
 	if err != nil {
 		return types.UnlockConditions{}, err
 	}

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -168,7 +168,7 @@ func (w *Wallet) loadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 	if err != nil {
 		return err
 	}
-	err = w.saveSettings()
+	err = w.saveSettingsSync()
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string
 			seedsLoaded++
 		}
 	}
-	err = w.saveSettings()
+	err = w.saveSettingsSync()
 	if err != nil {
 		return err
 	}

--- a/persist/boltdb.go
+++ b/persist/boltdb.go
@@ -42,8 +42,8 @@ func (db *BoltDatabase) checkMetadata(md Metadata) error {
 	return err
 }
 
-// updatbMetadata will set the contents of the metadata bucket to be
-// what is stored inside the metadata argument
+// updateMetadata will set the contents of the metadata bucket to the values
+// in db.Metadata.
 func (db *BoltDatabase) updateMetadata(tx *bolt.Tx) error {
 	bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
 	if err != nil {
@@ -60,12 +60,12 @@ func (db *BoltDatabase) updateMetadata(tx *bolt.Tx) error {
 	return nil
 }
 
-// Close saves the bolt database to a file, and updates metadata
+// Close closes the database.
 func (db *BoltDatabase) Close() error {
 	return db.DB.Close()
 }
 
-// OpenDatabase opens a database filename and checks metadata
+// OpenDatabase opens a database and validates its metadata.
 func OpenDatabase(md Metadata, filename string) (*BoltDatabase, error) {
 	// Open the database using a 1 second timeout (without the timeout,
 	// database will potentially hang indefinitely.
@@ -81,7 +81,6 @@ func OpenDatabase(md Metadata, filename string) (*BoltDatabase, error) {
 	}
 	err = boltDB.checkMetadata(md)
 	if err != nil {
-		// Database opening failed, and therefore needs to be closed.
 		db.Close()
 		return nil, err
 	}

--- a/persist/boltdb.go
+++ b/persist/boltdb.go
@@ -13,25 +13,7 @@ type BoltDatabase struct {
 	*bolt.DB
 }
 
-// updateDbMetadata will set the contents of the metadata bucket to be
-// what is stored inside the metadata argument
-func (db *BoltDatabase) updateMetadata(tx *bolt.Tx) error {
-	bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
-	if err != nil {
-		return err
-	}
-	err = bucket.Put([]byte("Header"), []byte(db.Header))
-	if err != nil {
-		return err
-	}
-	err = bucket.Put([]byte("Version"), []byte(db.Version))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// checkDbMetadata confirms that the metadata in the database is
+// checkMetadata confirms that the metadata in the database is
 // correct. If there is no metadata, correct metadata is inserted
 func (db *BoltDatabase) checkMetadata(md Metadata) error {
 	err := db.Update(func(tx *bolt.Tx) error {
@@ -60,7 +42,25 @@ func (db *BoltDatabase) checkMetadata(md Metadata) error {
 	return err
 }
 
-// CloseDatabase saves the bolt database to a file, and updates metadata
+// updatbMetadata will set the contents of the metadata bucket to be
+// what is stored inside the metadata argument
+func (db *BoltDatabase) updateMetadata(tx *bolt.Tx) error {
+	bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
+	if err != nil {
+		return err
+	}
+	err = bucket.Put([]byte("Header"), []byte(db.Header))
+	if err != nil {
+		return err
+	}
+	err = bucket.Put([]byte("Version"), []byte(db.Version))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close saves the bolt database to a file, and updates metadata
 func (db *BoltDatabase) Close() error {
 	return db.DB.Close()
 }

--- a/persist/json.go
+++ b/persist/json.go
@@ -6,27 +6,6 @@ import (
 	"os"
 )
 
-// Save saves json data to a writer.
-func Save(meta Metadata, data interface{}, w io.Writer) error {
-	b, err := json.MarshalIndent(data, "", "\t")
-	if err != nil {
-		return err
-	}
-
-	enc := json.NewEncoder(w)
-	if err := enc.Encode(meta.Header); err != nil {
-		return err
-	}
-	if err := enc.Encode(meta.Version); err != nil {
-		return err
-	}
-	if _, err = w.Write(b); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Load loads json data from a reader.
 func Load(meta Metadata, data interface{}, r io.Reader) error {
 	var header, version string
@@ -50,6 +29,41 @@ func Load(meta Metadata, data interface{}, r io.Reader) error {
 	return nil
 }
 
+// LoadFile loads json data from a file.
+func LoadFile(meta Metadata, data interface{}, filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	err = Load(meta, data, file)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Save saves json data to a writer.
+func Save(meta Metadata, data interface{}, w io.Writer) error {
+	b, err := json.MarshalIndent(data, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(meta.Header); err != nil {
+		return err
+	}
+	if err := enc.Encode(meta.Version); err != nil {
+		return err
+	}
+	if _, err = w.Write(b); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // SaveFile atomically saves json data to a file.
 func SaveFile(meta Metadata, data interface{}, filename string) error {
 	file, err := NewSafeFile(filename)
@@ -64,16 +78,16 @@ func SaveFile(meta Metadata, data interface{}, filename string) error {
 	return file.Commit()
 }
 
-// LoadFile loads json data from a file.
-func LoadFile(meta Metadata, data interface{}, filename string) error {
-	file, err := os.Open(filename)
+// SaveFileSync atomically saves json data to a file and then syncs to disk.
+func SaveFileSync(meta Metadata, data interface{}, filename string) error {
+	file, err := NewSafeFile(filename)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
-	err = Load(meta, data, file)
+	err = Save(meta, data, file)
 	if err != nil {
 		return err
 	}
-	return nil
+	return file.CommitSync()
 }

--- a/persist/json_test.go
+++ b/persist/json_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
+// TestSaveLoad checks that saving and loading data behaves as expected.
 func TestSaveLoad(t *testing.T) {
 	var meta = Metadata{"TestSaveLoad", "0.1"}
 	var saveData int = 3
@@ -58,6 +59,8 @@ func TestSaveLoad(t *testing.T) {
 	}
 }
 
+// TestSaveLoadFile tests that saving and loading a file without fsync properly
+// stores and fetches data.
 func TestSaveLoadFile(t *testing.T) {
 	var meta = Metadata{"TestSaveLoadFile", "0.1"}
 	var saveData int = 3
@@ -65,6 +68,29 @@ func TestSaveLoadFile(t *testing.T) {
 	os.MkdirAll(build.TempDir("persist"), 0777)
 	filename := build.TempDir("persist", "TestSaveLoadFile")
 	err := SaveFile(meta, saveData, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var loadData int
+	err = LoadFile(meta, &loadData, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadData != saveData {
+		t.Fatalf("loaded data (%v) does not match saved data (%v)", loadData, saveData)
+	}
+}
+
+// TestSaveLoadFileSync test that saving and loading a file with fsync properly
+// stores and fetches data.
+func TestSaveLoadFileSync(t *testing.T) {
+	var meta = Metadata{"TestSaveLoadFileFsync", "0.1"}
+	var saveData int = 3
+
+	os.MkdirAll(build.TempDir("persist"), 0777)
+	filename := build.TempDir("persist", "TestSaveLoadFile")
+	err := SaveFileSync(meta, saveData, filename)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/log.go
+++ b/persist/log.go
@@ -26,13 +26,10 @@ func (cf *closeableFile) Close() error {
 	if cf.closed {
 		build.Critical("cannot close the file; already closed")
 	}
-	// Don't sync during testing as it can take too long and causes tests to fail.
-	// TODO: mock the os package so that Sync() is a no-op during testing.
-	if build.Release != "testing" {
-		// Ensure that all data has actually hit the disk.
-		if err := cf.Sync(); err != nil {
-			return err
-		}
+
+	// Ensure that all data has actually hit the disk.
+	if err := cf.Sync(); err != nil {
+		return err
 	}
 	cf.closed = true
 	return cf.File.Close()
@@ -90,7 +87,7 @@ func (l *Logger) Debug(v ...interface{}) {
 	}
 }
 
-// Debug is equivalent to Logger.Printf when build.DEBUG is true. Otherwise it
+// Debugf is equivalent to Logger.Printf when build.DEBUG is true. Otherwise it
 // is a no-op.
 func (l *Logger) Debugf(format string, v ...interface{}) {
 	if build.DEBUG {
@@ -98,8 +95,8 @@ func (l *Logger) Debugf(format string, v ...interface{}) {
 	}
 }
 
-// Debug is equivalent to Logger.Println when build.DEBUG is true. Otherwise it
-// is a no-op.
+// Debugln is equivalent to Logger.Println when build.DEBUG is true. Otherwise
+// it is a no-op.
 func (l *Logger) Debugln(v ...interface{}) {
 	if build.DEBUG {
 		l.Println(v...)

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -60,16 +60,13 @@ func (sf *safeFile) Commit() error {
 }
 
 // CommitSync syncs the file, closes it, and then renames it to the intended
-// final filename. Commit should not be called from a defer if the function it
-// is being called from can return an error.
+// final filename. CommitSync should not be called from a defer if the
+// function it is being called from can return an error.
 func (sf *safeFile) CommitSync() error {
 	if err := sf.Sync(); err != nil {
 		return err
 	}
-	if err := sf.Close(); err != nil {
-		return err
-	}
-	return os.Rename(sf.finalName+"_temp", sf.finalName)
+	return sf.Commit()
 }
 
 // NewSafeFile returns a file that can atomically be written to disk,

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -121,7 +121,7 @@ func TestRelativePathSafeFile(t *testing.T) {
 	}
 	os.Chdir(tmpChdir)
 	defer os.Chdir(wd)
-	err = sf.Commit()
+	err = sf.CommitSync()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fsync is really slow, to the point that it was causing signficant
performance issues. Instead of file saving calling fsync by default for
everything, fsync is only called for user action and for really
important action that pertains to monetary changes or changes to network
contracts. The result should be a significantly faster siad.