### PR TITLE
Tpool Fast Start

### DIFF
--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -21,6 +21,16 @@ const (
 )
 
 var (
+	// ConsensusChangeBeginning is a special consensus change id that tells the
+	// consensus set to provide all consensus changes starting from the very
+	// first diff, which includes the genesis block diff.
+	ConsensusChangeBeginning = ConsensusChangeID{}
+
+	// ConsensusChangeRecent is a special consensus change id that tells the
+	// consensus set to provide the most recent consensus change, instead of
+	// starting from a specific value (which many not be known to the caller).
+	ConsensusChangeRecent = ConsensusChangeID{1}
+
 	// ErrBlockKnown is an error indicating that a block is already in the
 	// database.
 	ErrBlockKnown = errors.New("block already present in database")
@@ -170,10 +180,11 @@ type (
 		// run any required closing routines.
 		Close() error
 
-		// ConsensusSetPersistentSubscribe adds a subscriber to the list of
-		// subscribers, and gives them every consensus change that has occured
-		// since the change with the provided id.
-		ConsensusSetPersistentSubscribe(ConsensusSetSubscriber, ConsensusChangeID) error
+		// ConsensusSetSubscribe adds a subscriber to the list of subscribers,
+		// and gives them every consensus change that has occured since the
+		// change with the provided id. There are a few special cases,
+		// described by the ConsensusChangeX variables in this package.
+		ConsensusSetSubscribe(ConsensusSetSubscriber, ConsensusChangeID) error
 
 		// CurrentBlock returns the latest block in the heaviest known
 		// blockchain.

--- a/modules/consensus/changelog_test.go
+++ b/modules/consensus/changelog_test.go
@@ -24,7 +24,7 @@ func TestIntegrationChangeLog(t *testing.T) {
 	// Add a mocked subscriber and check that it receives the correct number of
 	// blocks.
 	ms := newMockSubscriber()
-	cst.cs.ConsensusSetPersistentSubscribe(&ms, modules.ConsensusChangeID{})
+	cst.cs.ConsensusSetSubscribe(&ms, modules.ConsensusChangeID{})
 	if ms.updates[0].AppliedBlocks[0].ID() != cst.cs.blockRoot.Block.ID() {
 		t.Fatal("subscription did not correctly receive the genesis block")
 	}
@@ -35,7 +35,7 @@ func TestIntegrationChangeLog(t *testing.T) {
 	// Create a copy of the subscriber that will subscribe to the consensus at
 	// the tail of the updates.
 	tailSubscriber := ms.copySub()
-	cst.cs.ConsensusSetPersistentSubscribe(&tailSubscriber, tailSubscriber.updates[len(tailSubscriber.updates)-1].ID)
+	cst.cs.ConsensusSetSubscribe(&tailSubscriber, tailSubscriber.updates[len(tailSubscriber.updates)-1].ID)
 	if len(tailSubscriber.updates) != 1 {
 		t.Fatal("subscription resulted in the wrong number of blocks being sent")
 	}
@@ -44,7 +44,7 @@ func TestIntegrationChangeLog(t *testing.T) {
 	behindSubscriber := ms.copySub()
 	cst.addSiafunds()
 	cst.mineSiacoins()
-	cst.cs.ConsensusSetPersistentSubscribe(&behindSubscriber, behindSubscriber.updates[len(behindSubscriber.updates)-1].ID)
+	cst.cs.ConsensusSetSubscribe(&behindSubscriber, behindSubscriber.updates[len(behindSubscriber.updates)-1].ID)
 	if types.BlockHeight(len(behindSubscriber.updates)) != cst.cs.dbBlockHeight()+1 {
 		t.Fatal("subscription resulted in the wrong number of blocks being sent")
 	}

--- a/modules/consensus/changelog_test.go
+++ b/modules/consensus/changelog_test.go
@@ -24,7 +24,7 @@ func TestIntegrationChangeLog(t *testing.T) {
 	// Add a mocked subscriber and check that it receives the correct number of
 	// blocks.
 	ms := newMockSubscriber()
-	cst.cs.ConsensusSetSubscribe(&ms, modules.ConsensusChangeID{})
+	cst.cs.ConsensusSetSubscribe(&ms, modules.ConsensusChangeBeginning)
 	if ms.updates[0].AppliedBlocks[0].ID() != cst.cs.blockRoot.Block.ID() {
 		t.Fatal("subscription did not correctly receive the genesis block")
 	}

--- a/modules/consensus/subscribe_test.go
+++ b/modules/consensus/subscribe_test.go
@@ -47,8 +47,8 @@ func TestUnitInvalidConsensusChangeSubscription(t *testing.T) {
 	defer cst.Close()
 
 	ms := newMockSubscriber()
-	badCCID := modules.ConsensusChangeID{1}
-	err = cst.cs.ConsensusSetPersistentSubscribe(&ms, badCCID)
+	badCCID := modules.ConsensusChangeID{255, 255, 255}
+	err = cst.cs.ConsensusSetSubscribe(&ms, badCCID)
 	if err != modules.ErrInvalidConsensusChangeID {
 		t.Error("consensus set returning the wrong error during an invalid subscription:", err)
 	}
@@ -68,7 +68,7 @@ func TestUnitUnsubscribe(t *testing.T) {
 
 	// Subscribe the mock subscriber to the consensus set.
 	ms := newMockSubscriber()
-	err = cst.cs.ConsensusSetPersistentSubscribe(&ms, modules.ConsensusChangeID{})
+	err = cst.cs.ConsensusSetSubscribe(&ms, modules.ConsensusChangeID{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/subscribe_test.go
+++ b/modules/consensus/subscribe_test.go
@@ -68,7 +68,7 @@ func TestUnitUnsubscribe(t *testing.T) {
 
 	// Subscribe the mock subscriber to the consensus set.
 	ms := newMockSubscriber()
-	err = cst.cs.ConsensusSetSubscribe(&ms, modules.ConsensusChangeID{})
+	err = cst.cs.ConsensusSetSubscribe(&ms, modules.ConsensusChangeBeginning)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -128,7 +128,7 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 		return nil, err
 	}
 
-	err = cs.ConsensusSetSubscribe(e, modules.ConsensusChangeID{})
+	err = cs.ConsensusSetSubscribe(e, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return nil, errors.New("explorer subscription failed: " + err.Error())
 	}

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -128,7 +128,7 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 		return nil, err
 	}
 
-	err = cs.ConsensusSetPersistentSubscribe(e, modules.ConsensusChangeID{})
+	err = cs.ConsensusSetSubscribe(e, modules.ConsensusChangeID{})
 	if err != nil {
 		return nil, errors.New("explorer subscription failed: " + err.Error())
 	}

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -45,7 +45,7 @@ func newAnnouncementFinder(cs modules.ConsensusSet) (*announcementFinder, error)
 	af := &announcementFinder{
 		cs: cs,
 	}
-	err := cs.ConsensusSetSubscribe(af, modules.ConsensusChangeID{})
+	err := cs.ConsensusSetSubscribe(af, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -45,7 +45,7 @@ func newAnnouncementFinder(cs modules.ConsensusSet) (*announcementFinder, error)
 	af := &announcementFinder{
 		cs: cs,
 	}
-	err := cs.ConsensusSetPersistentSubscribe(af, modules.ConsensusChangeID{})
+	err := cs.ConsensusSetSubscribe(af, modules.ConsensusChangeID{})
 	if err != nil {
 		return nil, err
 	}

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -65,7 +65,7 @@ func (h *Host) initRescan() error {
 
 	// Subscribe to the consensus set. This is a blocking call that will not
 	// return until the host has fully caught up to the current block.
-	err = h.cs.ConsensusSetPersistentSubscribe(h, modules.ConsensusChangeID{})
+	err = h.cs.ConsensusSetSubscribe(h, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (h *Host) initRescan() error {
 
 // initConsensusSubscription subscribes the host to the consensus set.
 func (h *Host) initConsensusSubscription() error {
-	err := h.cs.ConsensusSetPersistentSubscribe(h, h.recentChange)
+	err := h.cs.ConsensusSetSubscribe(h, h.recentChange)
 	if err == modules.ErrInvalidConsensusChangeID {
 		// Perform a rescan of the consensus set if the change id that the host
 		// has is unrecognized by the consensus set. This will typically only

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -119,7 +119,7 @@ func (m *Miner) startupRescan() error {
 		defer m.mu.Unlock()
 
 		m.log.Println("Performing a miner rescan.")
-		m.persist.RecentChange = modules.ConsensusChangeID{}
+		m.persist.RecentChange = modules.ConsensusChangeBeginning
 		m.persist.Height = 0
 		m.persist.Target = types.Target{}
 		return m.save()
@@ -130,7 +130,7 @@ func (m *Miner) startupRescan() error {
 
 	// Subscribe to the consensus set. This is a blocking call that will not
 	// return until the miner has fully caught up to the current block.
-	return m.cs.ConsensusSetPersistentSubscribe(m, modules.ConsensusChangeID{})
+	return m.cs.ConsensusSetSubscribe(m, modules.ConsensusChangeID{})
 }
 
 // New returns a ready-to-go miner that is not mining.
@@ -167,7 +167,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 		return nil, errors.New("miner persistence startup failed: " + err.Error())
 	}
 
-	err = m.cs.ConsensusSetPersistentSubscribe(m, m.persist.RecentChange)
+	err = m.cs.ConsensusSetSubscribe(m, m.persist.RecentChange)
 	if err == modules.ErrInvalidConsensusChangeID {
 		// Perform a rescan of the consensus set if the change id is not found.
 		// The id will only be not found if there has been desynchronization

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -130,7 +130,7 @@ func (m *Miner) startupRescan() error {
 
 	// Subscribe to the consensus set. This is a blocking call that will not
 	// return until the miner has fully caught up to the current block.
-	return m.cs.ConsensusSetSubscribe(m, modules.ConsensusChangeID{})
+	return m.cs.ConsensusSetSubscribe(m, modules.ConsensusChangeBeginning)
 }
 
 // New returns a ready-to-go miner that is not mining.

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -172,7 +172,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, d 
 
 	err = cs.ConsensusSetSubscribe(c, c.lastChange)
 	if err == modules.ErrInvalidConsensusChangeID {
-		c.lastChange = modules.ConsensusChangeID{}
+		c.lastChange = modules.ConsensusChangeBeginning
 		// ??? fix things ???
 		// subscribe again using the new ID
 		err = cs.ConsensusSetSubscribe(c, c.lastChange)

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -170,12 +170,12 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, d 
 		return nil, err
 	}
 
-	err = cs.ConsensusSetPersistentSubscribe(c, c.lastChange)
+	err = cs.ConsensusSetSubscribe(c, c.lastChange)
 	if err == modules.ErrInvalidConsensusChangeID {
 		c.lastChange = modules.ConsensusChangeID{}
 		// ??? fix things ???
 		// subscribe again using the new ID
-		err = cs.ConsensusSetPersistentSubscribe(c, c.lastChange)
+		err = cs.ConsensusSetSubscribe(c, c.lastChange)
 	}
 	if err != nil {
 		return nil, errors.New("contractor subscription failed: " + err.Error())

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -17,7 +17,7 @@ import (
 type newStub struct{}
 
 // consensus set stubs
-func (newStub) ConsensusSetPersistentSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error {
+func (newStub) ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error {
 	return nil
 }
 

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -14,7 +14,7 @@ import (
 // interface possible makes it easier to mock these dependencies in testing.
 type (
 	consensusSet interface {
-		ConsensusSetPersistentSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error
+		ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error
 	}
 	// in order to restrict the modules.TransactionBuilder interface, we must
 	// provide a shim to bridge the gap between modules.Wallet and

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -13,7 +13,7 @@ import (
 // interface possible makes it easier to mock these dependencies in testing.
 type (
 	consensusSet interface {
-		ConsensusSetPersistentSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error
+		ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error
 	}
 
 	dialer interface {

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -105,7 +105,7 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*Ho
 
 	err = cs.ConsensusSetSubscribe(hdb, hdb.lastChange)
 	if err == modules.ErrInvalidConsensusChangeID {
-		hdb.lastChange = modules.ConsensusChangeID{}
+		hdb.lastChange = modules.ConsensusChangeBeginning
 		// clear the host sets
 		hdb.activeHosts = make(map[modules.NetAddress]*hostNode)
 		hdb.allHosts = make(map[modules.NetAddress]*hostEntry)

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -103,14 +103,14 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*Ho
 		return nil, err
 	}
 
-	err = cs.ConsensusSetPersistentSubscribe(hdb, hdb.lastChange)
+	err = cs.ConsensusSetSubscribe(hdb, hdb.lastChange)
 	if err == modules.ErrInvalidConsensusChangeID {
 		hdb.lastChange = modules.ConsensusChangeID{}
 		// clear the host sets
 		hdb.activeHosts = make(map[modules.NetAddress]*hostNode)
 		hdb.allHosts = make(map[modules.NetAddress]*hostEntry)
 		// subscribe again using the new ID
-		err = cs.ConsensusSetPersistentSubscribe(hdb, hdb.lastChange)
+		err = cs.ConsensusSetSubscribe(hdb, hdb.lastChange)
 	}
 	if err != nil {
 		return nil, errors.New("hostdb subscription failed: " + err.Error())

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -24,7 +24,7 @@ func bareHostDB() *HostDB {
 type newStub struct{}
 
 // consensus set stubs
-func (newStub) ConsensusSetPersistentSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error {
+func (newStub) ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error {
 	return nil
 }
 

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -84,7 +84,7 @@ func (cs *rescanCS) addBlock(b types.Block) {
 	cs.changes = append(cs.changes, cc)
 }
 
-func (cs *rescanCS) ConsensusSetPersistentSubscribe(s modules.ConsensusSetSubscriber, lastChange modules.ConsensusChangeID) error {
+func (cs *rescanCS) ConsensusSetSubscribe(s modules.ConsensusSetSubscriber, lastChange modules.ConsensusChangeID) error {
 	var start int
 	if lastChange != (modules.ConsensusChangeID{}) {
 		start = -1

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -56,8 +56,7 @@ type (
 		// been sent to the transaction pool. When a new subscriber joins the
 		// transaction pool, all prior consensus changes are sent to the new
 		// subscriber.
-		consensusChangeIndex int
-		subscribers          []modules.TransactionPoolSubscriber
+		subscribers []modules.TransactionPoolSubscriber
 
 		mu demotemutex.DemoteMutex
 	}
@@ -81,11 +80,6 @@ func New(cs modules.ConsensusSet, g modules.Gateway) (*TransactionPool, error) {
 		knownObjects:        make(map[ObjectID]TransactionSetID),
 		transactionSets:     make(map[TransactionSetID][]types.Transaction),
 		transactionSetDiffs: make(map[TransactionSetID]modules.ConsensusChange),
-
-		// The consensus change index is intialized to '-1', which indicates
-		// that no consensus changes have been sent yet. The first consensus
-		// change will then have an index of '0'.
-		consensusChangeIndex: -1,
 	}
 	// Register RPCs
 	// TODO: rename RelayTransactionSet so that the conflicting RPC
@@ -93,7 +87,7 @@ func New(cs modules.ConsensusSet, g modules.Gateway) (*TransactionPool, error) {
 	g.RegisterRPC("RelayTransactionSet", tp.relayTransactionSet)
 
 	// Subscribe the transaction pool to the consensus set.
-	err := cs.ConsensusSetPersistentSubscribe(tp, modules.ConsensusChangeID{})
+	err := cs.ConsensusSetSubscribe(tp, modules.ConsensusChangeRecent)
 	if err != nil {
 		return nil, errors.New("transactionpool subscription failed: " + err.Error())
 	}

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -86,7 +86,6 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 	}
 
 	// Inform subscribers that an update has executed.
-	tp.consensusChangeIndex++
 	tp.mu.Demote()
 	tp.updateSubscribersTransactions()
 	tp.mu.DemotedUnlock()

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -206,7 +206,7 @@ func (w *Wallet) Unlock(masterKey crypto.TwofishKey) error {
 	// Subscribe to the consensus set if this is the first unlock for the
 	// wallet object.
 	if !subscribed {
-		err = w.cs.ConsensusSetPersistentSubscribe(w, modules.ConsensusChangeID{})
+		err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
 		if err != nil {
 			return errors.New("wallet subscription failed: " + err.Error())
 		}


### PR DESCRIPTION
To support the transaction pool's lack of need to actually be aware of any consensus history, I have changed the ConsensusSetSubscribe function to take a few special cases, one of which won't give you any consensus changes, but subscribe you to the beginning. Meaning you may have missed a bunch of updates, but you may not care (as is the case with the transaction pool)

The diff is pretty big because I touched up a few other things as well.