### PR TITLE
hostdb and contractor now save consensus updates correctly

### DIFF
--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -32,4 +32,8 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// }
 
 	c.lastChange = cc.ID
+	err := c.save()
+	if err != nil {
+		c.log.Println(err)
+	}
 }

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -60,7 +60,7 @@ func (p *stdPersist) save(data hdbPersist) error {
 }
 
 func (p *stdPersist) saveSync(data hdbPersist) error {
-	return persist.SaveFile(p.meta, data, p.filename)
+	return persist.SaveFileSync(p.meta, data, p.filename)
 }
 
 func (p *stdPersist) load(data *hdbPersist) error {

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -77,7 +77,7 @@ func (hdb *HostDB) decrementReliability(addr modules.NetAddress, penalty types.C
 	}
 }
 
-// threadedProbeHost tries to fetch the settings of a host. If successful, the
+// threadedProbeHosts tries to fetch the settings of a host. If successful, the
 // host is put in the set of active hosts. If unsuccessful, the host id deleted
 // from the set of active hosts.
 func (hdb *HostDB) threadedProbeHosts() {
@@ -129,6 +129,7 @@ func (hdb *HostDB) threadedProbeHosts() {
 			if _, exists := hdb.activeHosts[hostEntry.NetAddress]; !exists && len(hdb.activeHosts) < maxActiveHosts {
 				hdb.insertNode(hostEntry)
 			}
+			hdb.save()
 		}()
 	}
 }

--- a/modules/renter/hostdb/scan_test.go
+++ b/modules/renter/hostdb/scan_test.go
@@ -51,6 +51,7 @@ func (dial probeDialer) DialTimeout(addr modules.NetAddress, timeout time.Durati
 // TestThreadedProbeHosts tests the threadedProbeHosts method.
 func TestThreadedProbeHosts(t *testing.T) {
 	hdb := bareHostDB()
+	hdb.persist = &memPersist{}
 
 	// create a host to send to threadedProbeHosts
 	sk, pk, err := crypto.GenerateKeyPair()
@@ -121,6 +122,8 @@ func TestThreadedProbeHosts(t *testing.T) {
 // TestThreadedScan tests the threadedScan method.
 func TestThreadedScan(t *testing.T) {
 	hdb := bareHostDB()
+	hdb.persist = &memPersist{}
+
 	// use a real sleeper; this will prevent threadedScan from looping too
 	// quickly.
 	hdb.sleeper = stdSleeper{}

--- a/modules/renter/hostdb/update.go
+++ b/modules/renter/hostdb/update.go
@@ -45,4 +45,10 @@ func (hdb *HostDB) ProcessConsensusChange(cc modules.ConsensusChange) {
 			hdb.insertHost(host)
 		}
 	}
+
+	hdb.lastChange = cc.ID
+	err := hdb.save()
+	if err != nil {
+		hdb.log.Println(err)
+	}
 }

--- a/modules/renter/hostdb/update_test.go
+++ b/modules/renter/hostdb/update_test.go
@@ -62,6 +62,7 @@ func TestFindHostAnnouncements(t *testing.T) {
 func TestReceiveConsensusSetUpdate(t *testing.T) {
 	// create hostdb
 	hdb := bareHostDB()
+	hdb.persist = &memPersist{}
 
 	// Put a host announcement into a block.
 	annBytes, err := makeSignedAnnouncement("foo:1234")


### PR DESCRIPTION
Prior to this PR, the hostdb never saved anywhere at all, so all the persistence code was actually completely untouched in production.

The contractor would not save when it got new consensus updates, which means that if you never used it you would have to rescan the blockchain at startup every time.

Now fixed :)

As of this PR, starting siad on my machine takes 0.2 seconds, which is... amazingly refreshing. I believe everyone will really appreciate having responsive startup.