### PR TITLE
Persist log

### DIFF
--- a/modules/consensus/persist.go
+++ b/modules/consensus/persist.go
@@ -63,7 +63,7 @@ func (cs *ConsensusSet) initPersist() error {
 	}
 
 	// Initialize the logger.
-	cs.log, err = persist.NewLogger(filepath.Join(cs.persistDir, logFile))
+	cs.log, err = persist.NewFileLogger(filepath.Join(cs.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -109,7 +109,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	}
 
 	// Create the logger.
-	g.log, err = persist.NewLogger(filepath.Join(g.persistDir, logFile))
+	g.log, err = persist.NewFileLogger(filepath.Join(g.persistDir, logFile))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/host/dependencies.go
+++ b/modules/host/dependencies.go
@@ -112,7 +112,7 @@ func (productionDependencies) mkdirAll(s string, fm os.FileMode) error {
 // newLogger creates a logger that the host can use to log messages and write
 // critical statements.
 func (productionDependencies) newLogger(s string) (*persist.Logger, error) {
-	return persist.NewLogger(s)
+	return persist.NewFileLogger(s)
 }
 
 // openDatabase creates a database that the host can use to interact with large

--- a/modules/host/storagemanager/dependencies.go
+++ b/modules/host/storagemanager/dependencies.go
@@ -103,7 +103,7 @@ func (productionDependencies) mkdirAll(s string, fm os.FileMode) error {
 // newLogger creates a logger that the host can use to log messages and write
 // critical statements.
 func (productionDependencies) newLogger(s string) (*persist.Logger, error) {
-	return persist.NewLogger(s)
+	return persist.NewFileLogger(s)
 }
 
 // openDatabase creates a database that the host can use to interact with large

--- a/modules/miner/persist.go
+++ b/modules/miner/persist.go
@@ -55,7 +55,7 @@ func (m *Miner) initPersist() error {
 	}
 
 	// Add a logger.
-	m.log, err = persist.NewLogger(filepath.Join(m.persistDir, logFile))
+	m.log, err = persist.NewFileLogger(filepath.Join(m.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -3,10 +3,12 @@ package contractor
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -35,7 +37,7 @@ type Contractor struct {
 	// dependencies
 	dialer  dialer
 	hdb     hostDB
-	log     logger
+	log     *persist.Logger
 	persist persister
 	tpool   transactionPool
 	wallet  wallet
@@ -141,7 +143,7 @@ func New(cs consensusSet, wallet walletShim, tpool transactionPool, hdb hostDB, 
 		return nil, err
 	}
 	// Create the logger.
-	logger, err := newLogger(persistDir)
+	logger, err := persist.NewFileLogger(filepath.Join(persistDir, "contractor.log"))
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +153,7 @@ func New(cs consensusSet, wallet walletShim, tpool transactionPool, hdb hostDB, 
 }
 
 // newContractor creates a Contractor using the provided dependencies.
-func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, d dialer, p persister, l logger) (*Contractor, error) {
+func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, d dialer, p persister, l *persist.Logger) (*Contractor, error) {
 	// Create the Contractor object.
 	c := &Contractor{
 		dialer:  d,

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -60,10 +60,6 @@ type (
 		saveSync(contractorPersist) error
 		load(*contractorPersist) error
 	}
-
-	logger interface {
-		Println(...interface{})
-	}
 )
 
 // because wallet is not directly compatible with modules.Wallet (wrong
@@ -110,9 +106,4 @@ func newPersist(dir string) *stdPersist {
 		},
 		filename: filepath.Join(dir, "contractor.json"),
 	}
-}
-
-// newLogger creates a persist.Logger with the standard filename.
-func newLogger(dir string) (*persist.Logger, error) {
-	return persist.NewFileLogger(filepath.Join(dir, "contractor.log"))
 }

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -114,5 +114,5 @@ func newPersist(dir string) *stdPersist {
 
 // newLogger creates a persist.Logger with the standard filename.
 func newLogger(dir string) (*persist.Logger, error) {
-	return persist.NewLogger(filepath.Join(dir, "contractor.log"))
+	return persist.NewFileLogger(filepath.Join(dir, "contractor.log"))
 }

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -79,5 +79,5 @@ func newPersist(dir string) *stdPersist {
 
 // newLogger creates a persist.Logger with the standard filename.
 func newLogger(dir string) (*persist.Logger, error) {
-	return persist.NewLogger(filepath.Join(dir, "hostdb.log"))
+	return persist.NewFileLogger(filepath.Join(dir, "hostdb.log"))
 }

--- a/modules/renter/hostdb/dependencies.go
+++ b/modules/renter/hostdb/dependencies.go
@@ -29,10 +29,6 @@ type (
 		saveSync(hdbPersist) error
 		load(*hdbPersist) error
 	}
-
-	logger interface {
-		Println(...interface{})
-	}
 )
 
 // stdDialer implements the dialer interface via net.DialTimeout.
@@ -75,9 +71,4 @@ func newPersist(dir string) *stdPersist {
 		},
 		filename: filepath.Join(dir, "hostdb.json"),
 	}
-}
-
-// newLogger creates a persist.Logger with the standard filename.
-func newLogger(dir string) (*persist.Logger, error) {
-	return persist.NewFileLogger(filepath.Join(dir, "hostdb.log"))
 }

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -7,9 +7,11 @@ package hostdb
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -30,7 +32,7 @@ var (
 type HostDB struct {
 	// dependencies
 	dialer  dialer
-	log     logger
+	log     *persist.Logger
 	persist persister
 	sleeper sleeper
 
@@ -71,7 +73,7 @@ func New(cs consensusSet, persistDir string) (*HostDB, error) {
 		return nil, err
 	}
 	// Create the logger.
-	logger, err := newLogger(persistDir)
+	logger, err := persist.NewFileLogger(filepath.Join(persistDir, "hostdb.log"))
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +85,7 @@ func New(cs consensusSet, persistDir string) (*HostDB, error) {
 // newHostDB creates a HostDB using the provided dependencies. It loads the old
 // persistence data, spawns the HostDB's scanning threads, and subscribes it to
 // the consensusSet.
-func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l logger) (*HostDB, error) {
+func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l *persist.Logger) (*HostDB, error) {
 	// Create the HostDB object.
 	hdb := &HostDB{
 		dialer:  d,

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -406,7 +406,7 @@ func (r *Renter) initPersist() error {
 	}
 
 	// Initialize the logger.
-	r.log, err = persist.NewLogger(filepath.Join(r.persistDir, logFile))
+	r.log, err = persist.NewFileLogger(filepath.Join(r.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -114,7 +114,7 @@ func (w *Wallet) initPersist() error {
 	}
 
 	// Start logging.
-	w.log, err = persist.NewLogger(filepath.Join(w.persistDir, logFile))
+	w.log, err = persist.NewFileLogger(filepath.Join(w.persistDir, logFile))
 	if err != nil {
 		return err
 	}

--- a/persist/log.go
+++ b/persist/log.go
@@ -2,6 +2,7 @@ package persist
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -9,8 +10,65 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
+// Logger is a wrapper for the standard library logger that enforces logging
+// with the Sia-standard settings. It also supports a Close method, which
+// attempts to close the underlying io.Writer.
+type Logger struct {
+	*log.Logger
+	w io.Writer
+}
+
+// Critical logs a message with a CRITICAL prefix. If debug mode is enabled,
+// it will also write the message to os.Stderr and panic.
+func (l *Logger) Critical(v ...interface{}) {
+	l.Print("CRITICAL:", fmt.Sprintln(v...))
+	build.Critical(v...)
+}
+
+// Debug is equivalent to Logger.Print when build.DEBUG is true. Otherwise it
+// is a no-op.
+func (l *Logger) Debug(v ...interface{}) {
+	if build.DEBUG {
+		l.Print(v...)
+	}
+}
+
+// Debugf is equivalent to Logger.Printf when build.DEBUG is true. Otherwise it
+// is a no-op.
+func (l *Logger) Debugf(format string, v ...interface{}) {
+	if build.DEBUG {
+		l.Printf(format, v...)
+	}
+}
+
+// Debugln is equivalent to Logger.Println when build.DEBUG is true. Otherwise
+// it is a no-op.
+func (l *Logger) Debugln(v ...interface{}) {
+	if build.DEBUG {
+		l.Println(v...)
+	}
+}
+
+// Close logs a shutdown message and closes the Logger's underlying io.Writer,
+// if it is also an io.Closer.
+func (l *Logger) Close() error {
+	l.Println("SHUTDOWN: Logging has terminated.")
+	if c, ok := l.w.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// NewLogger returns a logger that can be closed. Calls should not be made to
+// the logger after 'Close' has been called.
+func NewLogger(w io.Writer) *Logger {
+	l := log.New(w, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile|log.LUTC)
+	l.Println("STARTUP: Logging has started.")
+	return &Logger{l, w}
+}
+
 // closeableFile wraps an os.File to perform sanity checks on its Write and
-// Close methods. When the checks are enable, calls to Write or Close will
+// Close methods. When the checks are enabled, calls to Write or Close will
 // panic if they are called after the file has already been closed.
 type closeableFile struct {
 	*os.File
@@ -46,59 +104,13 @@ func (cf *closeableFile) Write(b []byte) (int, error) {
 	return cf.File.Write(b)
 }
 
-// Logger is a wrapper for the standard library logger that enforces logging
-// into a file with the Sia-standard settings.
-type Logger struct {
-	*log.Logger
-	file *closeableFile
-}
-
-// NewLogger returns a logger that can be closed. Calls should not be made to
-// the logger after 'Close' has been called.
-func NewLogger(logFilename string) (*Logger, error) {
+// NewFileLogger returns a logger that logs to logFilename. The file is opened
+// in append mode, and created if it does not exist.
+func NewFileLogger(logFilename string) (*Logger, error) {
 	logFile, err := os.OpenFile(logFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0660)
 	if err != nil {
 		return nil, err
 	}
 	cf := &closeableFile{File: logFile}
-	l := log.New(cf, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile|log.LUTC)
-	l.Println("STARTUP: Logging has started.")
-	return &Logger{Logger: l, file: cf}, nil
-}
-
-// Close terminates the Logger.
-func (l *Logger) Close() error {
-	l.Println("SHUTDOWN: Logging has terminated.")
-	return l.file.Close()
-}
-
-// Critical logs a message with a CRITICAL prefix. If debug mode is enabled,
-// it will also write the message to os.Stderr and panic.
-func (l *Logger) Critical(v ...interface{}) {
-	l.Print("CRITICAL:", fmt.Sprintln(v...))
-	build.Critical(v...)
-}
-
-// Debug is equivalent to Logger.Print when build.DEBUG is true. Otherwise it
-// is a no-op.
-func (l *Logger) Debug(v ...interface{}) {
-	if build.DEBUG {
-		l.Print(v...)
-	}
-}
-
-// Debugf is equivalent to Logger.Printf when build.DEBUG is true. Otherwise it
-// is a no-op.
-func (l *Logger) Debugf(format string, v ...interface{}) {
-	if build.DEBUG {
-		l.Printf(format, v...)
-	}
-}
-
-// Debugln is equivalent to Logger.Println when build.DEBUG is true. Otherwise
-// it is a no-op.
-func (l *Logger) Debugln(v ...interface{}) {
-	if build.DEBUG {
-		l.Println(v...)
-	}
+	return NewLogger(cf), nil
 }

--- a/persist/log_test.go
+++ b/persist/log_test.go
@@ -22,7 +22,7 @@ func TestLogger(t *testing.T) {
 
 	// Create the logger.
 	logFilename := filepath.Join(testdir, "test.log")
-	fl, err := NewLogger(logFilename)
+	fl, err := NewFileLogger(logFilename)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestLoggerCritical(t *testing.T) {
 
 	// Create the logger.
 	logFilename := filepath.Join(testdir, "test.log")
-	fl, err := NewLogger(logFilename)
+	fl, err := NewFileLogger(logFilename)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -94,7 +94,7 @@ func StartContinuousProfile(profileDir string) {
 	// Continuously log statistics about the running Sia application.
 	go func() {
 		// Create the logger.
-		log, err := persist.NewLogger(filepath.Join(profileDir, "continuousProfiling.log"))
+		log, err := persist.NewFileLogger(filepath.Join(profileDir, "continuousProfiling.log"))
 		if err != nil {
 			fmt.Println("Profile logging failed:", err)
 			return


### PR DESCRIPTION
Change the persist logger to use an `io.Writer` by default, while preserving `Close` functionality