### PR TITLE
simple hostdb fix

### DIFF
--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -41,11 +41,11 @@ func (hdb *HostDB) load() error {
 	if err != nil {
 		return err
 	}
-	for _, entry := range data.AllHosts {
-		hdb.allHosts[entry.NetAddress] = &entry
+	for i := range data.AllHosts {
+		hdb.allHosts[data.AllHosts[i].NetAddress] = &data.AllHosts[i]
 	}
-	for _, entry := range data.ActiveHosts {
-		hdb.insertNode(&entry)
+	for i := range data.ActiveHosts {
+		hdb.insertNode(&data.AllHosts[i])
 	}
 	hdb.lastChange = data.LastChange
 	return nil


### PR DESCRIPTION
everything I said out-of-band today proposing why the persistence was failing was wrong. I was too quick to make assumptions.

All that was really happening was that pointers were being grabbed from a `for _, object :=` loop, which means that every object actually had the same address, which means the final object overwrote all of the others.

This bug has cropped up a few times, so this is a friendly reminder not to use pointers when doing a `for _, object := ` loop, and if you need pointer then you need to index it via a `for i := range objects` loop