### PR TITLE
tweaks to get formcontract working

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -19,7 +19,7 @@ var (
 			return 2
 		}
 		if build.Release == "standard" {
-			return 4
+			return 2
 		}
 		if build.Release == "testing" {
 			return 1

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -75,7 +75,7 @@ var (
 	// file contract opens too soon into the future - the host needs time to
 	// submit the file contract and all revisions to the blockchain before the
 	// storage proof window opens.
-	errWindowStartTooSoon = errors.New("the storage proof window is opening to soon")
+	errWindowStartTooSoon = errors.New("the storage proof window is opening too soon")
 )
 
 // contractCollateral returns the amount of collateral that the host is
@@ -363,6 +363,7 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	// WindowStart must be at least revisionSubmissionBuffer blocks into the
 	// future.
 	if fc.WindowStart <= blockHeight+revisionSubmissionBuffer {
+		h.log.Debugf("A renter tried to form a contract that had a window start which was too soon. The contract started at %v, the current height is %v, the revisionSubmissionBuffer is %v, and the comparison was %v <= %v\n", fc.WindowStart, blockHeight, revisionSubmissionBuffer, fc.WindowStart, blockHeight+revisionSubmissionBuffer)
 		return errWindowStartTooSoon
 	}
 	// WindowEnd must be at least settings.WindowSize blocks after

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -8,6 +8,7 @@ import (
 // contractorPersist defines what Contractor data persists across sessions.
 type contractorPersist struct {
 	Allowance   modules.Allowance
+	BlockHeight types.BlockHeight
 	Contracts   []Contract
 	LastChange  modules.ConsensusChangeID
 	RenewHeight types.BlockHeight
@@ -19,6 +20,7 @@ type contractorPersist struct {
 func (c *Contractor) persistData() contractorPersist {
 	data := contractorPersist{
 		Allowance:   c.allowance,
+		BlockHeight: c.blockHeight,
 		LastChange:  c.lastChange,
 		RenewHeight: c.renewHeight,
 		SpentPeriod: c.spentPeriod,
@@ -38,6 +40,7 @@ func (c *Contractor) load() error {
 		return err
 	}
 	c.allowance = data.Allowance
+	c.blockHeight = data.BlockHeight
 	for _, contract := range data.Contracts {
 		c.contracts[contract.ID] = contract
 	}

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -4,6 +4,16 @@
 // set of hosts it has found and updates who is online.
 package hostdb
 
+// TODO: There should be some mechanism that detects if the number of active
+// hosts is low. Then either the user can be informed, or the hostdb can start
+// scanning hosts that have been offline for a while and are no longer
+// prioritized by the scan loop.
+
+// TODO: There should be some mechanism for detecting if the hostdb cannot
+// connect to the internet. If it cannot, hosts should not be penalized for
+// appearing to be offline, because they may not actually be offline and it'll
+// unfairly over-penalize the hosts with the highest uptime.
+
 import (
 	"errors"
 	"os"

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -30,7 +30,7 @@ var (
 		if build.Release == "testing" {
 			return 8
 		}
-		return 6 // RC; orig value: 20
+		return 1 // RC; orig value: 20
 	}()
 )
 


### PR DESCRIPTION
repaircontract is still failing because it thinks that there aren't
enough hosts.

There are 4 hosts in the host database, though I think contracts have only been formed with 2 of them? It might be getting confused because the contracts haven't made it into the blockchain?

@lukechampine can you investigate?