### PR TITLE
Renter metrics

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -98,10 +98,11 @@ func (srv *Server) initAPI() {
 
 	// Renter API Calls
 	if srv.renter != nil {
-		router.GET("/renter/downloads", srv.renterDownloadsHandler)
-		router.GET("/renter/files", srv.renterFilesHandler)
+		router.GET("/renter", srv.renterHandler)
 		router.GET("/renter/allowance", srv.renterAllowanceHandlerGET)
 		router.POST("/renter/allowance", srv.renterAllowanceHandlerPOST)
+		router.GET("/renter/downloads", srv.renterDownloadsHandler)
+		router.GET("/renter/files", srv.renterFilesHandler)
 
 		router.POST("/renter/load", srv.renterLoadHandler)
 		router.POST("/renter/loadascii", srv.renterLoadAsciiHandler)

--- a/api/renter.go
+++ b/api/renter.go
@@ -28,29 +28,43 @@ var (
 	}()
 )
 
-// DownloadQueue contains the renter's download queue.
-type RenterDownloadQueue struct {
-	Downloads []modules.DownloadInfo `json:"downloads"`
-}
+type (
+	// RenterGET contains various renter metrics.
+	RenterGET struct {
+		FinancialMetrics modules.RenterFinancialMetrics `json:"financialmetrics"`
+	}
 
-// RenterFiles lists the files known to the renter.
-type RenterFiles struct {
-	Files []modules.FileInfo `json:"files"`
-}
+	// DownloadQueue contains the renter's download queue.
+	RenterDownloadQueue struct {
+		Downloads []modules.DownloadInfo `json:"downloads"`
+	}
 
-// RenterLoad lists files that were loaded into the renter.
-type RenterLoad struct {
-	FilesAdded []string `json:"filesadded"`
-}
+	// RenterFiles lists the files known to the renter.
+	RenterFiles struct {
+		Files []modules.FileInfo `json:"files"`
+	}
 
-// RenterShareASCII contains an ASCII-encoded .sia file.
-type RenterShareASCII struct {
-	ASCIIsia string `json:"asciisia"`
-}
+	// RenterLoad lists files that were loaded into the renter.
+	RenterLoad struct {
+		FilesAdded []string `json:"filesadded"`
+	}
 
-// ActiveHosts lists active hosts on the network.
-type ActiveHosts struct {
-	Hosts []modules.HostDBEntry `json:"hosts"`
+	// RenterShareASCII contains an ASCII-encoded .sia file.
+	RenterShareASCII struct {
+		ASCIIsia string `json:"asciisia"`
+	}
+
+	// ActiveHosts lists active hosts on the network.
+	ActiveHosts struct {
+		Hosts []modules.HostDBEntry `json:"hosts"`
+	}
+)
+
+// renterHandler handles the API call to /renter.
+func (srv *Server) renterHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	writeJSON(w, RenterGET{
+		FinancialMetrics: srv.renter.FinancialMetrics(),
+	})
 }
 
 // renterAllowanceHandlerGET handles the API call to get the allowance.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -65,12 +65,27 @@ type DownloadInfo struct {
 }
 
 // An Allowance dictates how much the Renter is allowed to spend in a given
-// period.
+// period. Note that funds are spent on both storage and bandwidth.
 type Allowance struct {
 	Funds       types.Currency    `json:"funds"`
 	Hosts       uint64            `json:"hosts"`
 	Period      types.BlockHeight `json:"period"`
 	RenewWindow types.BlockHeight `json:"renewwindow"`
+}
+
+// RenterFinancialMetrics contains metrics about how much the Renter has
+// spent on storage, uploads, and downloads.
+type RenterFinancialMetrics struct {
+	// ContractSpending is how much the Renter has paid into file contracts
+	// formed with hosts. Note that some of this money may be returned to the
+	// Renter when the contract ends. To calculate how much will be returned,
+	// subtract the storage, upload, and download metrics from
+	// ContractSpending.
+	ContractSpending types.Currency `json:"contractspending"`
+
+	DownloadSpending types.Currency `json:"downloadspending"`
+	StorageSpending  types.Currency `json:"storagespending"`
+	UploadSpending   types.Currency `json:"uploadspending"`
 }
 
 // A HostDBEntry represents one host entry in the Renter's host DB. It
@@ -104,6 +119,9 @@ type Renter interface {
 
 	// FileList returns information on all of the files stored by the renter.
 	FileList() []FileInfo
+
+	// FinancialMetrics returns the financial metrics of the Renter.
+	FinancialMetrics() RenterFinancialMetrics
 
 	// LoadSharedFiles loads a '.sia' file into the renter. A .sia file may
 	// contain multiple files. The paths of the added files are returned.

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -82,7 +82,6 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 	}
 
 	// read sector data, completing one iteration of the download loop
-	// TODO: optimize this
 	var sectors [][]byte
 	if err := encoding.ReadObject(hd.conn, &sectors, modules.SectorSize+16); err != nil {
 		return nil, err
@@ -102,6 +101,7 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 
 	hd.contractor.mu.Lock()
 	hd.contractor.contracts[hd.contract.ID] = hd.contract
+	hd.contractor.downloadSpending = hd.contractor.downloadSpending.Add(sectorPrice)
 	hd.contractor.saveSync()
 	hd.contractor.mu.Unlock()
 

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -170,6 +170,13 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 		return crypto.Hash{}, err
 	}
 
+	// update spending metrics
+	he.contractor.mu.Lock()
+	he.contractor.storageSpending = he.contractor.storageSpending.Add(sectorStoragePrice)
+	he.contractor.uploadSpending = he.contractor.uploadSpending.Add(sectorBandwidthPrice)
+	he.contractor.save()
+	he.contractor.mu.Unlock()
+
 	return sectorRoot, nil
 }
 
@@ -265,6 +272,12 @@ func (he *hostEditor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newDat
 	if err := he.runRevisionIteration(actions, rev, newRoots, height); err != nil {
 		return err
 	}
+
+	// update spending metrics
+	he.contractor.mu.Lock()
+	he.contractor.uploadSpending = he.contractor.uploadSpending.Add(sectorPrice)
+	he.contractor.save()
+	he.contractor.mu.Unlock()
 
 	return nil
 }

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -308,8 +308,6 @@ func (c *Contractor) newContract(host modules.HostDBEntry, filesize uint64, endH
 
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
-	c.spentTotal = c.spentTotal.Add(fc.Payout)
 	c.cachedAddress = types.UnlockHash{} // clear the cached address
 	c.saveSync()
 	c.mu.Unlock()

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -12,19 +12,22 @@ type contractorPersist struct {
 	Contracts   []Contract
 	LastChange  modules.ConsensusChangeID
 	RenewHeight types.BlockHeight
-	SpentPeriod types.Currency
-	SpentTotal  types.Currency
+	// metrics
+	DownloadSpending types.Currency
+	StorageSpending  types.Currency
+	UploadSpending   types.Currency
 }
 
 // persistData returns the data in the Contractor that will be saved to disk.
 func (c *Contractor) persistData() contractorPersist {
 	data := contractorPersist{
-		Allowance:   c.allowance,
-		BlockHeight: c.blockHeight,
-		LastChange:  c.lastChange,
-		RenewHeight: c.renewHeight,
-		SpentPeriod: c.spentPeriod,
-		SpentTotal:  c.spentTotal,
+		Allowance:        c.allowance,
+		BlockHeight:      c.blockHeight,
+		LastChange:       c.lastChange,
+		RenewHeight:      c.renewHeight,
+		DownloadSpending: c.downloadSpending,
+		StorageSpending:  c.storageSpending,
+		UploadSpending:   c.uploadSpending,
 	}
 	for _, contract := range c.contracts {
 		data.Contracts = append(data.Contracts, contract)
@@ -46,8 +49,9 @@ func (c *Contractor) load() error {
 	}
 	c.lastChange = data.LastChange
 	c.renewHeight = data.RenewHeight
-	c.spentPeriod = data.SpentPeriod
-	c.spentTotal = data.SpentTotal
+	c.downloadSpending = data.DownloadSpending
+	c.storageSpending = data.StorageSpending
+	c.uploadSpending = data.UploadSpending
 	return nil
 }
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -115,8 +115,6 @@ func (c *Contractor) managedRenew(contract Contract, filesize uint64, newEndHeig
 	// update host contract
 	c.mu.Lock()
 	c.contracts[newContract.ID] = newContract
-	c.spentPeriod = c.spentPeriod.Add(fc.Payout)
-	c.spentTotal = c.spentTotal.Add(fc.Payout)
 	c.cachedAddress = types.UnlockHash{} // clear cachedAddress
 	err = c.saveSync()
 	c.mu.Unlock()

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -45,6 +45,9 @@ type hostContractor interface {
 	// modified.
 	Editor(contractor.Contract) (contractor.Editor, error)
 
+	// FinancialMetrics returns the financial metrics of the contractor.
+	FinancialMetrics() modules.RenterFinancialMetrics
+
 	// Downloader creates a Downloader from the specified contract, allowing
 	// the retrieval of sectors.
 	Downloader(contractor.Contract) (contractor.Downloader, error)
@@ -122,6 +125,9 @@ func (r *Renter) AllHosts() []modules.HostDBEntry    { return r.hostDB.AllHosts(
 // contractor passthroughs
 func (r *Renter) Allowance() modules.Allowance           { return r.hostContractor.Allowance() }
 func (r *Renter) SetAllowance(a modules.Allowance) error { return r.hostContractor.SetAllowance(a) }
+func (r *Renter) FinancialMetrics() modules.RenterFinancialMetrics {
+	return r.hostContractor.FinancialMetrics()
+}
 
 // enforce that Renter satisfies the modules.Renter interface
 var _ modules.Renter = (*Renter)(nil)

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -179,5 +179,6 @@ type stubContractor struct{}
 func (stubContractor) SetAllowance(modules.Allowance) error                          { return nil }
 func (stubContractor) Allowance() modules.Allowance                                  { return modules.Allowance{} }
 func (stubContractor) Contracts() []contractor.Contract                              { return nil }
+func (stubContractor) FinancialMetrics() (m modules.RenterFinancialMetrics)          { return }
 func (stubContractor) Editor(contractor.Contract) (contractor.Editor, error)         { return nil, nil }
 func (stubContractor) Downloader(contractor.Contract) (contractor.Downloader, error) { return nil, nil }

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -42,6 +42,10 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("nicknames cannot begin with /")
 	}
 
+	if !r.wallet.Unlocked() {
+		return errors.New("wallet must be unlocked before uploading")
+	}
+
 	// Check for a nickname conflict.
 	lockID := r.mu.RLock()
 	_, exists := r.files[up.SiaPath]


### PR DESCRIPTION
Adds spending metrics to the renter, including storage, upload, download, and total paid into contracts. (From these, you can calculate how much will be returned to the renter when its contracts end.)

For now, only historical totals are given. So you can't view how much you spent within, e.g. the last renewal period. I don't think contracts are ever cleared from the contractor (even after they expire). We should address these issues when we implement renewal.

I don't like threading calls through the renter to the contractor. I'm eager to make the contractor a "first-class citizen" with its own API routes. This would allow you to easily inspect individual contracts. It's also a necessity for low-level renter integrations.