### PR TITLE
Report card fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/con
 
 # fmt calls go fmt on all packages.
 fmt:
-	go fmt $(pkgs)
+	gofmt -s -l -w $(pkgs)
 
 # vet calls go vet on all packages.
 # NOTE: go vet requires packages to be built in order to obtain type info.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ v0.4.7 (patch)
 - Dropped support for v0.3.3.x
 
 v0.4.6 (patch)
-- Removed over-agressive consistency check
+- Removed over-aggressive consistency check
 
 v0.4.5 (patch)
 - Fixed last prominent bug in block database

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Sia 0.6.0
 
 [![Build Status](https://travis-ci.org/NebulousLabs/Sia.svg?branch=master)](https://travis-ci.org/NebulousLabs/Sia)
 [![GoDoc](https://godoc.org/github.com/NebulousLabs/Sia?status.svg)](https://godoc.org/github.com/NebulousLabs/Sia)
+[![Go Report Card](https://goreportcard.com/badge/github.com/NebulousLabs/Sia)](https://goreportcard.com/report/github.com/NebulousLabs/Sia)
 
 Binaries can be found at [our website](http://siacoin.com). Code for the graphical front-end can be found at the [Sia-UI](https://github.com/NebulousLabs/Sia-UI) repo.
 

--- a/api/explorer.go
+++ b/api/explorer.go
@@ -225,7 +225,7 @@ func (srv *Server) buildTransactionSet(txids []types.TransactionID) (txns []Expl
 		// payouts, the block might be the transaction.
 		block, height, exists := srv.explorer.Transaction(txid)
 		if !exists && build.DEBUG {
-			panic("explorer pointing to nonexistant txn")
+			panic("explorer pointing to nonexistent txn")
 		}
 
 		// Check if the block is the transaction.

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -164,7 +164,7 @@ func assembleExplorerServerTester(testdir string) (*serverTester, error) {
 }
 
 // createServerTester creates a server tester object that is ready for testing,
-// including money in the wallet and all modules initalized.
+// including money in the wallet and all modules initialized.
 func createServerTester(name string) (*serverTester, error) {
 	// Create the testing directory.
 	testdir := build.TempDir("api", name)
@@ -189,7 +189,7 @@ func createServerTester(name string) (*serverTester, error) {
 	return st, nil
 }
 
-// createExplorerServerTester creates a server tester object contianing only
+// createExplorerServerTester creates a server tester object containing only
 // the explorer and some presets that match standard explorer setups.
 func createExplorerServerTester(name string) (*serverTester, error) {
 	testdir := build.TempDir("api", name)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -157,7 +157,7 @@ func TestIntegrationWalletGETSiacoins(t *testing.T) {
 	}
 	defer st.server.Close()
 
-	// Check the intial wallet is encrypted, unlocked, and has the siacoins
+	// Check the initial wallet is encrypted, unlocked, and has the siacoins
 	// that got mined.
 	var wg WalletGET
 	err = st.getAPI("/wallet", &wg)

--- a/compatibility/siag_1.0_test.go
+++ b/compatibility/siag_1.0_test.go
@@ -42,7 +42,7 @@ func verifyKeysSiag_1_0(uc types.UnlockConditions, folder string, keyname string
 	}
 	txn := types.Transaction{
 		SiafundInputs: []types.SiafundInput{
-			types.SiafundInput{
+			{
 				UnlockConditions: loadedKeys[0].UnlockConditions,
 			},
 		},

--- a/crypto/encrypt_test.go
+++ b/crypto/encrypt_test.go
@@ -154,7 +154,7 @@ func TestUnitCiphertextUnmarshalInvalidJSON(t *testing.T) {
 	// Test unmarshalling invalid JSON.
 	invalidJSONBytes := [][]byte{
 		nil,
-		[]byte{},
+		{},
 		[]byte("\""),
 	}
 	for _, jsonBytes := range invalidJSONBytes {

--- a/crypto/hash_test.go
+++ b/crypto/hash_test.go
@@ -106,7 +106,7 @@ func TestUnitHashUnmarshalJSON(t *testing.T) {
 	invalidJSONBytes := [][]byte{
 		// Invalid JSON.
 		nil,
-		[]byte{},
+		{},
 		[]byte("\""),
 		// JSON of wrong length.
 		[]byte(""),

--- a/crypto/merkle_test.go
+++ b/crypto/merkle_test.go
@@ -16,7 +16,7 @@ func TestTreeBuilder(t *testing.T) {
 	// function is really for code coverage.
 }
 
-// TestCalculateLeaves probes the CalulateLeaves function.
+// TestCalculateLeaves probes the CalculateLeaves function.
 func TestCalculateLeaves(t *testing.T) {
 	tests := []struct {
 		size, expSegs uint64

--- a/doc/Consensus.md
+++ b/doc/Consensus.md
@@ -259,7 +259,7 @@ output spendable by the 'missed proof spend hash'.
 
 All contracts must have a non-zero payout, 'start' must be before 'end', and
 'start' must be greater than the current height of the blockchain. A storage
-proof is acceptible if it is submitted in the block of height 'end'.
+proof is acceptable if it is submitted in the block of height 'end'.
 
 File contracts are created with a 'Revision Hash', which is the Merkle root of
 an unlock conditions object. A 'file contract revision' can be submitted which

--- a/doc/Encoding.md
+++ b/doc/Encoding.md
@@ -15,7 +15,7 @@ Unmarshal([]byte{3, 0, 0, 0, 0, 0, 0, 0}, &x)
 ```
 
 Note that this leads to some ambiguity. Since an `int64` and a `uint64` are
-both 8 bytes long, it is possible to encode an `int64` and succesfully decode
+both 8 bytes long, it is possible to encode an `int64` and successfully decode
 it as a `uint64`. As a result, it is imperative that *the decoder knows
 exactly what it is decoding*. Developers must rely on context to determine
 what type to decode into.

--- a/doc/File Contract Negotiation.md
+++ b/doc/File Contract Negotiation.md
@@ -12,7 +12,7 @@ untrusted environment. Managing data on Sia happens through several protocols:
   performed to verify that the renter is able to create the signatures to
   modify the file contract revision.
 
-+ File Contract Creation - no data is uploaded during the inital creation of a
++ File Contract Creation - no data is uploaded during the initial creation of a
   file contract, but funds are allocated so that the file contract can be
   iteratively revised in the future.
 
@@ -68,7 +68,7 @@ Revision Request
 ----------------
 
 The renter requests a recent revision from the host. Often, this request
-preceeds modifications. A file contract can only be open for revision with one
+precedes modifications. A file contract can only be open for revision with one
 party at a time. To prevent DoS attacks, the party must authenticate here by
 performing a challenge-response protocol during the revision request. Putting
 this challenge-response requirement in the revision-request can help improve
@@ -76,7 +76,7 @@ privacy, though the host is under no cryptographic or incentive-based
 obligation to preserve the privacy of the revision.
 
 1. The renter makes an RPC to the host, opening a connection. The connection
-   deadline sould be at least 120 seconds. The renter sends the file contract
+   deadline should be at least 120 seconds. The renter sends the file contract
    id for the revision being requested.
 
 2. The host writes 32 bytes of random data that the renter must sign for the

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -70,7 +70,7 @@ type (
 		ProcessConsensusChange(ConsensusChange)
 	}
 
-	// A ConsensusChange enumerates a set of changes that occured to the consensus set.
+	// A ConsensusChange enumerates a set of changes that occurred to the consensus set.
 	ConsensusChange struct {
 		// ID is a unique id for the consensus change derived from the reverted
 		// and applied blocks.
@@ -181,7 +181,7 @@ type (
 		Close() error
 
 		// ConsensusSetSubscribe adds a subscriber to the list of subscribers,
-		// and gives them every consensus change that has occured since the
+		// and gives them every consensus change that has occurred since the
 		// change with the provided id. There are a few special cases,
 		// described by the ConsensusChangeX variables in this package.
 		ConsensusSetSubscribe(ConsensusSetSubscriber, ConsensusChangeID) error

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -149,7 +149,7 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block) (ce changeEntry, err error
 
 		// modules.ErrNonExtendingBlock should be returned if the block does
 		// not extend the current blockchain, however the changes from newChild
-		// should be comitted (which means 'nil' must be returned). A flag is
+		// should be committed (which means 'nil' must be returned). A flag is
 		// set to indicate that modules.ErrNonExtending should be returned.
 		nonExtending = !newNode.heavierThan(currentNode)
 		if nonExtending {

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -222,7 +222,7 @@ func TestUnitValidateHeaderAndBlock(t *testing.T) {
 			block: mockValidBlock,
 			// Create a dosBlocks map where mockValidBlock is marked as a bad block.
 			dosBlocks: map[types.BlockID]struct{}{
-				mockValidBlock.ID(): struct{}{},
+				mockValidBlock.ID(): {},
 			},
 			earliestValidTimestamp: mockValidBlock.Timestamp,
 			marshaler:              parentBlockUnmarshaler,
@@ -355,7 +355,7 @@ func TestUnitValidateHeader(t *testing.T) {
 			header: mockValidBlock.Header(),
 			// Create a dosBlocks map where mockValidBlock is marked as a bad block.
 			dosBlocks: map[types.BlockID]struct{}{
-				mockValidBlock.ID(): struct{}{},
+				mockValidBlock.ID(): {},
 			},
 			blockMapPairs:          serializedParentBlockMap,
 			earliestValidTimestamp: mockValidBlock.Timestamp,

--- a/modules/consensus/accept_txntypes_test.go
+++ b/modules/consensus/accept_txntypes_test.go
@@ -1004,7 +1004,7 @@ func (cst *consensusSetTester) testPaymentChannelBlocks() error {
 		}
 		refundTxn.TransactionSignatures[0].Signature = cryptoSig1[:]
 
-		// Recieving entity never communitcates, funding entity must reclaim
+		// Receiving entity never communitcates, funding entity must reclaim
 		// the 'channelSize' coins that were intended to go to the channel.
 		reclaimUC, err := cst.wallet.NextAddress()
 		reclaimAddr := reclaimUC.UnlockHash()

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -207,7 +207,7 @@ func TestMisuseApplySiacoinOutputs(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Error("no panic occured when misusing applySiacoinInput")
+			t.Error("no panic occurred when misusing applySiacoinInput")
 		}
 	}()
 	cst.cs.applySiacoinOutputs(pb, txn)
@@ -306,7 +306,7 @@ func TestMisuseApplyFileContracts(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Error("no panic occured when misusing applySiacoinInput")
+			t.Error("no panic occurred when misusing applySiacoinInput")
 		}
 	}()
 	cst.cs.applyFileContracts(pb, txn)
@@ -433,7 +433,7 @@ func TestMisuseApplyFileContractRevisions(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r != errNilItem {
-			t.Error("no panic occured when misusing applySiacoinInput")
+			t.Error("no panic occurred when misusing applySiacoinInput")
 		}
 	}()
 	txn := types.Transaction{
@@ -584,7 +584,7 @@ func TestNonexistentStorageProof(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r != errNilItem {
-			t.Error("no panic occured when misusing applySiacoinInput")
+			t.Error("no panic occurred when misusing applySiacoinInput")
 		}
 	}()
 	txn := types.Transaction{
@@ -725,7 +725,7 @@ func TestMisuseApplySiafundInputs(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r != ErrMisuseApplySiafundInput {
-			t.Error("no panic occured when misusing applySiacoinInput")
+			t.Error("no panic occurred when misusing applySiacoinInput")
 			t.Error(r)
 		}
 	}()
@@ -826,7 +826,7 @@ func TestMisuseApplySiafundOutputs(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r != ErrMisuseApplySiafundOutput {
-			t.Error("no panic occured when misusing applySiafundInput")
+			t.Error("no panic occurred when misusing applySiafundInput")
 		}
 	}()
 	cst.cs.applySiafundOutputs(pb, txn)

--- a/modules/consensus/changelog.go
+++ b/modules/consensus/changelog.go
@@ -93,7 +93,7 @@ func appendChangeLog(tx *bolt.Tx, ce changeEntry) error {
 }
 
 // getEntry returns the change entry with a given id, using a bool to indicate
-// existance.
+// existence.
 func getEntry(tx *bolt.Tx, id modules.ConsensusChangeID) (ce changeEntry, exists bool) {
 	var cn changeNode
 	cl := tx.Bucket(ChangeLog)

--- a/modules/consensus/database.go
+++ b/modules/consensus/database.go
@@ -92,7 +92,7 @@ func dbInitialized(tx *bolt.Tx) bool {
 }
 
 // initDB is run if there is no existing consensus database, creating a
-// database with all the required buckets and sane inital values.
+// database with all the required buckets and sane initial values.
 func (cs *ConsensusSet) initDB(tx *bolt.Tx) error {
 	// Create the compononents of the database.
 	err := cs.createConsensusDB(tx)

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -22,7 +22,7 @@ var (
 	errWrongRevertDiffSet            = errors.New("reverting a diff set that isn't the current block")
 )
 
-// commitDiffSetSanity performs a series of sanity checks before commiting a
+// commitDiffSetSanity performs a series of sanity checks before committing a
 // diff set.
 func commitDiffSetSanity(tx *bolt.Tx, pb *processedBlock, dir modules.DiffDirection) {
 	// This function is purely sanity checks.

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -112,7 +112,7 @@ func (cs *ConsensusSet) initializeSubscribe(subscriber modules.ConsensusSetSubsc
 		if start == modules.ConsensusChangeBeginning {
 			// Special case: for modules.ConsensusChangeBeginning, create an
 			// initial node pointing to the genesis block. The subscriber will
-			// recieve the diffs for all blocks in the consensus set, including
+			// receive the diffs for all blocks in the consensus set, including
 			// the genesis block.
 			entry = cs.genesisEntry()
 			exists = true
@@ -153,8 +153,8 @@ func (cs *ConsensusSet) initializeSubscribe(subscriber modules.ConsensusSetSubsc
 }
 
 // ConsensusSetSubscribe adds a subscriber to the list of subscribers, and
-// gives them every consensus change that has occured since the change with the
-// provided id.
+// gives them every consensus change that has occurred since the change with
+// the provided id.
 //
 // As a special case, using an empty id as the start will have all the changes
 // sent to the modules starting with the genesis block.

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -286,7 +286,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	}
 
 	// Set minIBDWaitTime to 1s for just this test because no blocks are
-	// transfered between peers so the wait time can be very short.
+	// transferred between peers so the wait time can be very short.
 	actualMinIBDWaitTime := minIBDWaitTime
 	defer func() {
 		minIBDWaitTime = actualMinIBDWaitTime

--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -64,7 +64,7 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 		persistDir: persistDir,
 	}
 
-	// Intialize the persistent structures, including the database.
+	// Initialize the persistent structures, including the database.
 	err := e.initPersist()
 	if err != nil {
 		return nil, err

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -115,7 +115,7 @@ func TestRandomNode(t *testing.T) {
 		nodes[addr]++
 	}
 	for node, count := range nodes {
-		if count == 0 { // 1-in-200000 chance of occuring naturally
+		if count == 0 { // 1-in-200000 chance of occurring naturally
 			t.Errorf("node %v was never selected", node)
 		}
 	}

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -39,7 +39,7 @@ func TestRPC(t *testing.T) {
 	defer g1.Close()
 
 	if err := g1.RPC("foo.com:123", "", nil); err == nil {
-		t.Fatal("RPC on unconnected peer succeded")
+		t.Fatal("RPC on unconnected peer succeeded")
 	}
 
 	g2 := newTestingGateway("TestRPC2", t)

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -23,9 +23,9 @@ func TestRPCID(t *testing.T) {
 
 func TestHandlerName(t *testing.T) {
 	cases := map[string]rpcID{
-		"":          rpcID{},
-		"foo":       rpcID{'f', 'o', 'o'},
-		"foobarbaz": rpcID{'f', 'o', 'o', 'b', 'a', 'r', 'b', 'a'},
+		"":          {},
+		"foo":       {'f', 'o', 'o'},
+		"foobarbaz": {'f', 'o', 'o', 'b', 'a', 'r', 'b', 'a'},
 	}
 	for s, id := range cases {
 		if hid := handlerName(s); hid != id {
@@ -319,7 +319,7 @@ func TestOutboundAndInboundRPCs(t *testing.T) {
 	// Call the "recv" RPC on g1. We don't know g1's address as g2 sees it, so we
 	// get it from the first address in g2's peer list.
 	var addr modules.NetAddress
-	for p_addr, _ := range g2.peers {
+	for p_addr := range g2.peers {
 		addr = p_addr
 		break
 	}

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -192,7 +192,7 @@ var (
 	// store the heights sorted in numerical order. The action item itself is
 	// an array of file contract ids. The host is able to contextually figure
 	// out what the necessary actions for that item are based on the file
-	// contract id and the associated storage obligation that can be retreived
+	// contract id and the associated storage obligation that can be retrieved
 	// using the id.
 	bucketActionItems = []byte("BucketActionItems")
 

--- a/modules/host/dependencies.go
+++ b/modules/host/dependencies.go
@@ -26,7 +26,7 @@ var (
 )
 
 // These interfaces define the Host's dependencies. Mocking implementation
-// complexity can be reduced by defining each dependency as the minimium
+// complexity can be reduced by defining each dependency as the minimum
 // possible subset of the real dependency.
 type (
 	// dependencies defines all of the dependencies of the Host.

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -170,7 +170,7 @@ type Host struct {
 	// Storage is broken up into sectors. The sectors are distributed across a
 	// set of storage folders using a strategy that tries to create even
 	// distributions, but not aggressively. Uneven distributions could be
-	// manufactured by an attacker given sufficent knowledge about the disk
+	// manufactured by an attacker given sufficient knowledge about the disk
 	// layout (knowledge which should be unavailable), but a limited amount of
 	// damage can be done even with this attack.
 	lockedStorageObligations map[types.FileContractID]struct{} // Which storage obligations are currently being modified.
@@ -279,9 +279,9 @@ func newHost(dependencies dependencies, cs modules.ConsensusSet, tpool modules.T
 		_ = h.log.Close()
 		return nil, err
 	}
-	// After opening the database, it must be initalized. Most commonly,
+	// After opening the database, it must be initialized. Most commonly,
 	// nothing happens. But for new databases, a set of buckets must be
-	// created. Intialization is also a good time to run sanity checks.
+	// created. Initialization is also a good time to run sanity checks.
 	err = h.initDB()
 	if err != nil {
 		_ = h.log.Close()
@@ -289,7 +289,7 @@ func newHost(dependencies dependencies, cs modules.ConsensusSet, tpool modules.T
 		return nil, err
 	}
 
-	// Load the prior persistance structures.
+	// Load the prior persistence structures.
 	err = h.load()
 	if err != nil {
 		_ = h.log.Close()

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -198,7 +198,7 @@ func newHostTester(name string) (*hostTester, error) {
 	return ht, nil
 }
 
-// TestHostInitialization checks that the host intializes to sensisble default
+// TestHostInitialization checks that the host initializes to sensible default
 // values.
 func TestHostInitialization(t *testing.T) {
 	if testing.Short() {

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// errDownloadBadHostValidOutputs is returned if the renter requests a
-	// download and pays an insufficent amount to the host valid addresses.
+	// download and pays an insufficient amount to the host valid addresses.
 	errDownloadBadHostValidOutputs = errors.New("download request rejected for bad host valid outputs")
 
 	// errDownloadBadNewFileMerkleRoot is returned if the renter requests a

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -14,7 +14,7 @@ import (
 var (
 	// errBadModificationIndex is returned if the renter requests a change on a
 	// sector root that is not in the file contract.
-	errBadModificationIndex = errors.New("renter has made a modification that points to a nonexistant sector")
+	errBadModificationIndex = errors.New("renter has made a modification that points to a nonexistent sector")
 
 	// badSectorSize is returned if the renter provides a sector to be inserted
 	// that is the wrong size.

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -98,7 +98,7 @@ func (h *Host) threadedHandleConn(conn net.Conn) {
 	}
 	defer conn.Close()
 
-	// Read a specifier indicating which action is beeing called.
+	// Read a specifier indicating which action is being called.
 	var id types.Specifier
 	if err := encoding.ReadObject(conn, &id, 16); err != nil {
 		atomic.AddUint64(&h.atomicUnrecognizedCalls, 1)

--- a/modules/host/storagemanager/consistency.go
+++ b/modules/host/storagemanager/consistency.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 )
 
-// consistency.go contians a bunch of consistency checks for the host. Because
+// consistency.go contains a bunch of consistency checks for the host. Because
 // a lot of the consistency is checking that different parts of the host match
 // up, it was decided that all consistency checking should go into a single
 // file. As an example, the state of the storage obligations sets the standard

--- a/modules/host/storagemanager/consts.go
+++ b/modules/host/storagemanager/consts.go
@@ -74,7 +74,7 @@ var (
 	// actually frustrate price planning. 32 GB has been chosen as a minimum
 	// for the early days of the network, to allow people to experiment in the
 	// beta, but in the future I think something like 256GB would be much more
-	// appropraite.
+	// appropriate.
 	minimumStorageFolderSize = func() uint64 {
 		if build.Release == "dev" {
 			return 1 << 25 // 32 MiB

--- a/modules/host/storagemanager/dependencies.go
+++ b/modules/host/storagemanager/dependencies.go
@@ -26,7 +26,7 @@ var (
 
 // These interfaces define the StorageManager's dependencies. Mocking
 // implementation complexity can be reduced by defining each dependency as the
-// minimium possible subset of the real dependency.
+// minimum possible subset of the real dependency.
 type (
 	// dependencies defines all of the dependencies of the StorageManager.
 	dependencies interface {

--- a/modules/host/storagemanager/storagefolders.go
+++ b/modules/host/storagemanager/storagefolders.go
@@ -120,7 +120,7 @@ var (
 // files. These files have long, cryptographic names and may take up as much as
 // a gigabyte of space in filesystem overhead, depending on how the filesystem
 // is architected. The host is programmed to gracefully handle full disks, so
-// wihle it might cause the user surprise that the host can't break past 99%
+// while it might cause the user surprise that the host can't break past 99%
 // utilization, there should not be any issues if the user overestimates how
 // much storage is available in the folder they have offered to Sia. The host
 // will put the drive at 100% utilization, which may cause performance

--- a/modules/host/storagemanager/storagefolders_smoke_errors_test.go
+++ b/modules/host/storagemanager/storagefolders_smoke_errors_test.go
@@ -83,7 +83,7 @@ func (faultyRemove) removeFile(s string) error {
 }
 
 // TestStorageFolderTolerance tests the tolerance of storage folders in the
-// presense of disk failures. Disk failures should be recorded, and the
+// presence of disk failures. Disk failures should be recorded, and the
 // failures should be handled gracefully - nonfailing disks should not have
 // problems.
 func TestStorageFolderTolerance(t *testing.T) {

--- a/modules/host/storagemanager/storagefolders_smoke_test.go
+++ b/modules/host/storagemanager/storagefolders_smoke_test.go
@@ -323,7 +323,7 @@ func TestStorageFolderUsage(t *testing.T) {
 	if totalStorage != remainingStorage+modules.SectorSize {
 		t.Fatal("manager is not empty at the moment of creating the in-memory sector usage map")
 	}
-	// Verify that the inital sector usage map was created correctly.
+	// Verify that the initial sector usage map was created correctly.
 	err = smt.sectorUsageCheck(sectorUsageMap)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/host/storagemanager/storagefolders_test.go
+++ b/modules/host/storagemanager/storagefolders_test.go
@@ -130,7 +130,7 @@ func TestAddStorageFolderUIDCollisions(t *testing.T) {
 	// another one repeatedly - enough times to exceed the 256 possible folder
 	// UIDs that can be chosen in the testing environment.
 	for i := 0; i < 300; i++ {
-		// Repalce the very first storage folder.
+		// Replace the very first storage folder.
 		err = smt.sm.RemoveStorageFolder(0, false)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/host/storagemanager/storagefolders_test.go
+++ b/modules/host/storagemanager/storagefolders_test.go
@@ -187,7 +187,7 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// Single valid storage folder.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: minimumStorageFolderSize,
 				},
@@ -197,7 +197,7 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// Single full storage folder.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: 0,
 				},
@@ -207,7 +207,7 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// Single nearly full storage folder.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize - 1,
 				},
@@ -217,11 +217,11 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// Two valid storage folders, first is emptier.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize + 1,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize,
 				},
@@ -231,11 +231,11 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// Two valid storage folders, second is emptier.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize + 1,
 				},
@@ -246,11 +246,11 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// hold a new sector.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize - 1,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize * 5,
 					SizeRemaining: modules.SectorSize,
 				},
@@ -261,11 +261,11 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// percentage.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize * 4,
 					SizeRemaining: modules.SectorSize * 2,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize,
 				},
@@ -276,11 +276,11 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// percentage.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize * 4,
 					SizeRemaining: modules.SectorSize * 2,
 				},
@@ -291,15 +291,15 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// volume.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize * 4,
 					SizeRemaining: modules.SectorSize * 2,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: modules.SectorSize,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize * 4,
 					SizeRemaining: modules.SectorSize * 2,
 				},
@@ -309,15 +309,15 @@ func TestEmptiestStorageFolder(t *testing.T) {
 		// Three storage folders, none have room for a sector.
 		{
 			[]*storageFolder{
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize * 4,
 					SizeRemaining: modules.SectorSize - 1,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize,
 					SizeRemaining: 0,
 				},
-				&storageFolder{
+				{
 					Size:          minimumStorageFolderSize * 4,
 					SizeRemaining: 1,
 				},

--- a/modules/host/storagemanager/storagemanager.go
+++ b/modules/host/storagemanager/storagemanager.go
@@ -133,9 +133,9 @@ func newStorageManager(dependencies dependencies, persistDir string) (*StorageMa
 		_ = sm.log.Close()
 		return nil, err
 	}
-	// After opening the database, it must be initalized. Most commonly,
+	// After opening the database, it must be initialized. Most commonly,
 	// nothing happens. But for new databases, a set of buckets must be
-	// created. Intialization is also a good time to run sanity checks.
+	// created. Initialization is also a good time to run sanity checks.
 	err = sm.initDB()
 	if err != nil {
 		_ = sm.log.Close()
@@ -143,7 +143,7 @@ func newStorageManager(dependencies dependencies, persistDir string) (*StorageMa
 		return nil, err
 	}
 
-	// Load the prior persistance structures.
+	// Load the prior persistence structures.
 	err = sm.load()
 	if err != nil {
 		_ = sm.log.Close()

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -757,7 +757,7 @@ func (h *Host) handleActionItem(so *storageObligation) {
 		h.log.Println(err)
 	}
 
-	// Check if all items have succeded with the required confirmations. Report
+	// Check if all items have succeeded with the required confirmations. Report
 	// success, delete the obligation.
 	//
 	// TODO: This doesn't actually wait enough blocks?

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -14,7 +14,7 @@ import (
 	"github.com/NebulousLabs/bolt"
 )
 
-// initRescan is a helper funtion of initConsensusSubscribe, and is called when
+// initRescan is a helper function of initConsensusSubscribe, and is called when
 // the host and the consensus set have become desynchronized. Desynchronization
 // typically happens if the user is replacing or altering the persistent files
 // in the consensus set or the host.

--- a/modules/host_test.go
+++ b/modules/host_test.go
@@ -94,11 +94,11 @@ func TestUnitStoragePriceConversions(t *testing.T) {
 	if toHuman != 1 {
 		t.Error("rounding is not happening correctly in StoragePriceToHuman")
 	}
-	toHuman, err = StoragePriceToHuman(notOverflow)
+	_, err = StoragePriceToHuman(notOverflow)
 	if err != nil {
 		t.Error(err)
 	}
-	toHuman, err = StoragePriceToHuman(causeOverflow)
+	_, err = StoragePriceToHuman(causeOverflow)
 	if err != types.ErrUint64Overflow {
 		t.Error(err)
 	}
@@ -173,7 +173,7 @@ func TestUnitBandwidthPriceConversions(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	toHuman, err = BandwidthPriceToHuman(causeOverflow)
+	_, err = BandwidthPriceToHuman(causeOverflow)
 	if err != types.ErrUint64Overflow {
 		t.Error(err)
 	}

--- a/modules/miner/cpuminer.go
+++ b/modules/miner/cpuminer.go
@@ -16,7 +16,8 @@ func (m *Miner) threadedMine() {
 	m.mining = true
 	m.mu.Unlock()
 
-	// Solve blocks repeatedly, keeping track of how fast hashing is occuring.
+	// Solve blocks repeatedly, keeping track of how fast hashing is
+	// occurring.
 	cycleStart := time.Now()
 	for {
 		// Kill the thread if mining has been turned off.

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -180,7 +180,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, d 
 		contracts: make(map[types.FileContractID]Contract),
 	}
 
-	// Load the prior persistance structures.
+	// Load the prior persistence structures.
 	err := c.load()
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -94,9 +94,9 @@ func TestNew(t *testing.T) {
 func TestContracts(t *testing.T) {
 	c := &Contractor{
 		contracts: map[types.FileContractID]Contract{
-			{1}: Contract{ID: types.FileContractID{1}, IP: "foo"},
-			{2}: Contract{ID: types.FileContractID{2}, IP: "bar"},
-			{3}: Contract{ID: types.FileContractID{3}, IP: "baz"},
+			{1}: {ID: types.FileContractID{1}, IP: "foo"},
+			{2}: {ID: types.FileContractID{2}, IP: "bar"},
+			{3}: {ID: types.FileContractID{3}, IP: "baz"},
 		},
 	}
 	for _, contract := range c.Contracts() {

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -109,7 +109,7 @@ func newHostDB(cs consensusSet, d dialer, s sleeper, p persister, l *persist.Log
 		scanPool:    make(chan *hostEntry, scanPoolSize),
 	}
 
-	// Load the prior persistance structures.
+	// Load the prior persistence structures.
 	err := hdb.load()
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -54,7 +54,7 @@ func TestActiveHosts(t *testing.T) {
 	h1 := new(hostEntry)
 	h1.NetAddress = "foo"
 	hdb.activeHosts = map[modules.NetAddress]*hostNode{
-		h1.NetAddress: &hostNode{hostEntry: h1},
+		h1.NetAddress: {hostEntry: h1},
 	}
 	if hosts := hdb.ActiveHosts(); len(hosts) != 1 {
 		t.Errorf("wrong number of hosts: expected %v, got %v", 1, len(hosts))
@@ -66,8 +66,8 @@ func TestActiveHosts(t *testing.T) {
 	h2 := new(hostEntry)
 	h2.NetAddress = "bar"
 	hdb.activeHosts = map[modules.NetAddress]*hostNode{
-		h1.NetAddress: &hostNode{hostEntry: h1},
-		h2.NetAddress: &hostNode{hostEntry: h2},
+		h1.NetAddress: {hostEntry: h1},
+		h2.NetAddress: {hostEntry: h2},
 	}
 	if hosts := hdb.ActiveHosts(); len(hosts) != 2 {
 		t.Errorf("wrong number of hosts: expected %v, got %v", 2, len(hosts))
@@ -116,9 +116,9 @@ func TestAveragePrice(t *testing.T) {
 func TestIsOffline(t *testing.T) {
 	hdb := &HostDB{
 		allHosts: map[modules.NetAddress]*hostEntry{
-			"foo.com:1234": &hostEntry{Online: true},
-			"bar.com:1234": &hostEntry{Online: false},
-			"baz.com:1234": &hostEntry{Online: true},
+			"foo.com:1234": {Online: true},
+			"bar.com:1234": {Online: false},
+			"baz.com:1234": {Online: true},
 		},
 		activeHosts: map[modules.NetAddress]*hostNode{
 			"foo.com:1234": nil,

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -32,9 +32,9 @@ func TestSaveLoad(t *testing.T) {
 		host3.NetAddress: &host3,
 	}
 	hdb.activeHosts = map[modules.NetAddress]*hostNode{
-		host1.NetAddress: &hostNode{hostEntry: &host1},
-		host2.NetAddress: &hostNode{hostEntry: &host2},
-		host3.NetAddress: &hostNode{hostEntry: &host3},
+		host1.NetAddress: {hostEntry: &host1},
+		host2.NetAddress: {hostEntry: &host2},
+		host3.NetAddress: {hostEntry: &host3},
 	}
 	hdb.lastChange = modules.ConsensusChangeID{1, 2, 3}
 
@@ -121,9 +121,9 @@ func TestRescan(t *testing.T) {
 		host3.NetAddress: &host3,
 	}
 	hdb.activeHosts = map[modules.NetAddress]*hostNode{
-		host1.NetAddress: &hostNode{hostEntry: &host1},
-		host2.NetAddress: &hostNode{hostEntry: &host2},
-		host3.NetAddress: &hostNode{hostEntry: &host3},
+		host1.NetAddress: {hostEntry: &host1},
+		host2.NetAddress: {hostEntry: &host2},
+		host3.NetAddress: {hostEntry: &host3},
 	}
 
 	// use a bogus change ID

--- a/modules/renter/hostdb/update_test.go
+++ b/modules/renter/hostdb/update_test.go
@@ -31,7 +31,7 @@ func TestFindHostAnnouncements(t *testing.T) {
 	}
 	b := types.Block{
 		Transactions: []types.Transaction{
-			types.Transaction{
+			{
 				ArbitraryData: [][]byte{annBytes},
 			},
 		},

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -397,7 +397,7 @@ func (r *Renter) loadSharedFiles(reader io.Reader) ([]string, error) {
 }
 
 // initPersist handles all of the persistence initialization, such as creating
-// the persistance directory and starting the logger.
+// the persistence directory and starting the logger.
 func (r *Renter) initPersist() error {
 	// Create the perist directory if it does not yet exist.
 	err := os.MkdirAll(r.persistDir, 0700)
@@ -411,7 +411,7 @@ func (r *Renter) initPersist() error {
 		return err
 	}
 
-	// Load the prior persistance structures.
+	// Load the prior persistence structures.
 	err = r.load()
 	if err != nil && !os.IsNotExist(err) {
 		return err

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -162,7 +162,7 @@ func newContractorTester(name string, hc hostContractor) (*renterTester, error) 
 	return rt, nil
 }
 
-// stubHostDB is the minimal implemention of the hostDB interface. It can be
+// stubHostDB is the minimal implementation of the hostDB interface. It can be
 // embedded in other mock hostDB types, removing the need to reimplement all
 // of the hostDB's methods on every mock.
 type stubHostDB struct{}

--- a/modules/storagemanager.go
+++ b/modules/storagemanager.go
@@ -12,7 +12,7 @@ const (
 )
 
 type (
-	// StorageFolderMetadata contians metadata about a storage folder that is
+	// StorageFolderMetadata contains metadata about a storage folder that is
 	// tracked by the storage folder manager.
 	StorageFolderMetadata struct {
 		Capacity          uint64 `json:"capacity"`

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -66,7 +66,7 @@ func relatedObjectIDs(ts []types.Transaction) []ObjectID {
 	}
 
 	var oids []ObjectID
-	for oid, _ := range oidMap {
+	for oid := range oidMap {
 		oids = append(oids, oid)
 	}
 	return oids

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -37,10 +37,10 @@ func TestAcceptTransactionSetBroadcasts(t *testing.T) {
 		t.Fatal(err)
 	}
 	mockPeers := []modules.Peer{
-		modules.Peer{Version: "0.0.0"},
-		modules.Peer{Version: "0.4.6"},
-		modules.Peer{Version: "0.4.7"},
-		modules.Peer{Version: "9.9.9"},
+		{Version: "0.0.0"},
+		{Version: "0.4.6"},
+		{Version: "0.4.7"},
+		{Version: "9.9.9"},
 	}
 	mg := &mockGatewayCheckBroadcast{
 		Gateway:          tpt.tpool.gateway,

--- a/modules/transactionpool/subscribe.go
+++ b/modules/transactionpool/subscribe.go
@@ -23,7 +23,7 @@ func (tp *TransactionPool) updateSubscribersTransactions() {
 
 // TransactionPoolSubscribe adds a subscriber to the transaction pool.
 // Subscribers will receive the full transaction set every time there is a
-// signficant change to the transaction pool.
+// significant change to the transaction pool.
 func (tp *TransactionPool) TransactionPoolSubscribe(subscriber modules.TransactionPoolSubscriber) {
 	tp.mu.Lock()
 	defer tp.mu.Unlock()

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -27,7 +27,7 @@ type (
 	// rejecting them based on internal criteria such as fees and unconfirmed
 	// double spends.
 	TransactionPool struct {
-		// Depedencies of the transaction pool.
+		// Dependencies of the transaction pool.
 		consensusSet modules.ConsensusSet
 		gateway      modules.Gateway
 

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// TestArbDataOnly tries submitting a transaction with only aribtrary data to
+// TestArbDataOnly tries submitting a transaction with only arbitrary data to
 // the transaction pool. Then a block is mined, putting the transaction on the
 // blockchain. The arb data transaction should no longer be in the transaction
 // pool.

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// WalletDir is the directory that contains the wallet persistance.
+	// WalletDir is the directory that contains the wallet persistence.
 	WalletDir = "wallet"
 
 	// SeedChecksumSize is the number of bytes that are used to checksum
@@ -101,7 +101,7 @@ type (
 	}
 
 	// TransactionBuilder is used to construct custom transactions. A transaction
-	// builder is intialized via 'RegisterTransaction' and then can be modified by
+	// builder is initialized via 'RegisterTransaction' and then can be modified by
 	// adding funds or other fields. The transaction is completed by calling
 	// 'Sign', which will sign all inputs added via the 'FundSiacoins' or
 	// 'FundSiafunds' call. All modifications are additive.

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -113,7 +113,7 @@ func TestIntegrationPreEncryption(t *testing.T) {
 		t.Fatal(err)
 	}
 	if w1.Encrypted() {
-		t.Error("wallet is reporting that it has been encrypted when no such action has occured")
+		t.Error("wallet is reporting that it has been encrypted when no such action has occurred")
 	}
 	if w1.Unlocked() {
 		t.Error("new wallet is not being treated as locked")

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -248,7 +248,7 @@ func (w *Wallet) PrimarySeed() (modules.Seed, uint64, error) {
 	return w.primarySeed, w.persist.PrimarySeedProgress, nil
 }
 
-// NextAddress returns an unlock hash that is ready to recieve siacoins or
+// NextAddress returns an unlock hash that is ready to receive siacoins or
 // siafunds. The address is generated using the primary address seed.
 func (w *Wallet) NextAddress() (types.UnlockConditions, error) {
 	w.mu.Lock()

--- a/modules/wallet/transactions_test.go
+++ b/modules/wallet/transactions_test.go
@@ -68,7 +68,7 @@ func TestIntegrationTransactions(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The partial should include one transaction for a block, and 2 for the
-	// send that occured.
+	// send that occurred.
 	if len(txns) != 3 {
 		t.Error(len(txns))
 	}

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -76,9 +76,9 @@ func TestAbsolutePathSafeFile(t *testing.T) {
 }
 
 // TestRelativePathSafeFile tests creating and committing safe files with
-// relative paths. Relative paths are testing to test that calling os.Chdir
-// inbetween creating and committing a safe file doesn't affect the safe file's
-// final path. The relative path tested is relative to the working directory.
+// relative paths. Specifically, we test that calling os.Chdir between creating
+// and committing a safe file doesn't affect the safe file's final path. The
+// relative path tested is relative to the working directory.
 func TestRelativePathSafeFile(t *testing.T) {
 	tmpDir := build.TempDir(persistDir, "TestRelativePathSafeFile")
 	err := os.MkdirAll(tmpDir, 0700)

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -37,7 +37,7 @@ func StartCPUProfile(profileDir, identifier string) error {
 	cpuLock.Unlock()
 
 	// Start profiling into the profile dir, using the identifer. The timestamp
-	// of the start time of the profiling will be included in the filenmae.
+	// of the start time of the profiling will be included in the filename.
 	cpuProfileFile, err := os.Create(filepath.Join(profileDir, "cpu-profile-"+identifier+"-"+time.Now().Format(time.RFC3339Nano)+".prof"))
 	if err != nil {
 		return err

--- a/siac/README.md
+++ b/siac/README.md
@@ -159,7 +159,7 @@ will be overwritten.
 
 * `siac renter share [nickname] [filepath]` writes a .sia file
 pointing to the file specified by `nickname` on the network. The file
-is written to `filepath`. Note that the `.sia` extention will not be
+is written to `filepath`. Note that the `.sia` extension will not be
 automatically added, and must be part of the path.
 
 * `siac renter shareascii [nickname]` writes the .sia file specified

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -147,7 +147,7 @@ Run 'wallet send --help' to see a list of available units.`,
 )
 
 // walletaddresscmd fetches a new address from the wallet that will be able to
-// recieve coins.
+// receive coins.
 func walletaddresscmd() {
 	addr := new(api.WalletAddressGET)
 	err := getAPI("/wallet/address", addr)

--- a/siad/daemon_test.go
+++ b/siad/daemon_test.go
@@ -76,12 +76,12 @@ func TestUnitProcessConfig(t *testing.T) {
 		expectedOutputs [][]string
 	}{
 		inputs: [][]string{
-			[]string{"9980", "9981", "9982", "cghmrtwe"},
-			[]string{":9980", ":9981", ":9982", "CGHMRTWE"},
+			{"9980", "9981", "9982", "cghmrtwe"},
+			{":9980", ":9981", ":9982", "CGHMRTWE"},
 		},
 		expectedOutputs: [][]string{
-			[]string{":9980", ":9981", ":9982", "cghmrtwe"},
-			[]string{":9980", ":9981", ":9982", "cghmrtwe"},
+			{":9980", ":9981", ":9982", "cghmrtwe"},
+			{":9980", ":9981", ":9982", "cghmrtwe"},
 		},
 	}
 	var config Config

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -64,7 +64,7 @@ func TestBlockHeader(t *testing.T) {
 	b.Nonce[2] = 2
 	b.Timestamp = 3
 	b.MinerPayouts = []SiacoinOutput{{Value: NewCurrency64(4)}}
-	b.Transactions = []Transaction{{ArbitraryData: [][]byte{[]byte{'5'}}}}
+	b.Transactions = []Transaction{{ArbitraryData: [][]byte{{'5'}}}}
 
 	id1 := b.ID()
 	id2 := BlockID(crypto.HashBytes(encoding.Marshal(b.Header())))
@@ -176,7 +176,7 @@ func TestBlockCalculateSubsidy(t *testing.T) {
 
 	// Add a single no-fee transaction and check again.
 	txn = Transaction{
-		ArbitraryData: [][]byte{[]byte{'6'}},
+		ArbitraryData: [][]byte{{'6'}},
 	}
 	b.Transactions = append(b.Transactions, txn)
 	if b.CalculateSubsidy(0).Cmp(expected) != 0 {
@@ -199,7 +199,7 @@ func TestBlockCalculateSubsidy(t *testing.T) {
 
 	// Add an empty transaction to the beginning.
 	txn = Transaction{
-		ArbitraryData: [][]byte{[]byte{'7'}},
+		ArbitraryData: [][]byte{{'7'}},
 	}
 	b.Transactions = append([]Transaction{txn}, b.Transactions...)
 	if b.CalculateSubsidy(0).Cmp(expected) != 0 {

--- a/types/currency_test.go
+++ b/types/currency_test.go
@@ -227,7 +227,7 @@ func TestNegativeCurrencyMulRat(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Error("no panic occured when trying to create a negative currency")
+			t.Error("no panic occurred when trying to create a negative currency")
 		}
 	}()
 
@@ -242,7 +242,7 @@ func TestNegativeCurrencySub(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Error("no panic occured when trying to create a negative currency")
+			t.Error("no panic occurred when trying to create a negative currency")
 		}
 	}()
 
@@ -291,7 +291,7 @@ func TestNegativeNewCurrency(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Error("no panic occured when trying to create a negative currency")
+			t.Error("no panic occurred when trying to create a negative currency")
 		}
 	}()
 

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -321,7 +321,7 @@ func TestTransactionValidSignatures(t *testing.T) {
 	}
 	txn.TransactionSignatures[0] = tmpTxn0
 
-	// Try to point to a nonexistant public key.
+	// Try to point to a nonexistent public key.
 	txn.TransactionSignatures[0] = TransactionSignature{PublicKeyIndex: 5}
 	err = txn.validSignatures(10)
 	if err != ErrInvalidPubKeyIndex {

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -11,7 +11,7 @@ func TestUnlockHash(t *testing.T) {
 	uc := UnlockConditions{
 		Timelock: 1,
 		PublicKeys: []SiaPublicKey{
-			SiaPublicKey{
+			{
 				Algorithm: SignatureEntropy,
 				Key:       []byte{'f', 'a', 'k', 'e'},
 			},
@@ -25,22 +25,22 @@ func TestUnlockHash(t *testing.T) {
 // TestSigHash runs the SigHash function of the transaction type.
 func TestSigHash(t *testing.T) {
 	txn := Transaction{
-		SiacoinInputs:         []SiacoinInput{SiacoinInput{}},
-		SiacoinOutputs:        []SiacoinOutput{SiacoinOutput{}},
-		FileContracts:         []FileContract{FileContract{}},
-		FileContractRevisions: []FileContractRevision{FileContractRevision{}},
-		StorageProofs:         []StorageProof{StorageProof{}},
-		SiafundInputs:         []SiafundInput{SiafundInput{}},
-		SiafundOutputs:        []SiafundOutput{SiafundOutput{}},
-		MinerFees:             []Currency{Currency{}},
-		ArbitraryData:         [][]byte{[]byte{'o'}, []byte{'t'}},
+		SiacoinInputs:         []SiacoinInput{{}},
+		SiacoinOutputs:        []SiacoinOutput{{}},
+		FileContracts:         []FileContract{{}},
+		FileContractRevisions: []FileContractRevision{{}},
+		StorageProofs:         []StorageProof{{}},
+		SiafundInputs:         []SiafundInput{{}},
+		SiafundOutputs:        []SiafundOutput{{}},
+		MinerFees:             []Currency{{}},
+		ArbitraryData:         [][]byte{{'o'}, {'t'}},
 		TransactionSignatures: []TransactionSignature{
-			TransactionSignature{
+			{
 				CoveredFields: CoveredFields{
 					WholeTransaction: true,
 				},
 			},
-			TransactionSignature{
+			{
 				CoveredFields: CoveredFields{
 					SiacoinInputs:         []uint64{0},
 					SiacoinOutputs:        []uint64{0},
@@ -101,17 +101,17 @@ func TestTransactionValidCoveredFields(t *testing.T) {
 	// Create a transaction with all fields filled in minimally. The first
 	// check has a legal CoveredFields object with 'WholeTransaction' set.
 	txn := Transaction{
-		SiacoinInputs:         []SiacoinInput{SiacoinInput{}},
-		SiacoinOutputs:        []SiacoinOutput{SiacoinOutput{}},
-		FileContracts:         []FileContract{FileContract{}},
-		FileContractRevisions: []FileContractRevision{FileContractRevision{}},
-		StorageProofs:         []StorageProof{StorageProof{}},
-		SiafundInputs:         []SiafundInput{SiafundInput{}},
-		SiafundOutputs:        []SiafundOutput{SiafundOutput{}},
-		MinerFees:             []Currency{Currency{}},
-		ArbitraryData:         [][]byte{[]byte{'o'}, []byte{'t'}},
+		SiacoinInputs:         []SiacoinInput{{}},
+		SiacoinOutputs:        []SiacoinOutput{{}},
+		FileContracts:         []FileContract{{}},
+		FileContractRevisions: []FileContractRevision{{}},
+		StorageProofs:         []StorageProof{{}},
+		SiafundInputs:         []SiafundInput{{}},
+		SiafundOutputs:        []SiafundOutput{{}},
+		MinerFees:             []Currency{{}},
+		ArbitraryData:         [][]byte{{'o'}, {'t'}},
 		TransactionSignatures: []TransactionSignature{
-			TransactionSignature{
+			{
 				CoveredFields: CoveredFields{
 					WholeTransaction: true,
 				},

--- a/types/target_test.go
+++ b/types/target_test.go
@@ -106,7 +106,7 @@ func TestTargetMul(t *testing.T) {
 	target14[crypto.HashSize-1] = 14
 	target20[crypto.HashSize-1] = 20
 
-	// Multiplying the difficulty of a target at '10' by 5 will yeild a target
+	// Multiplying the difficulty of a target at '10' by 5 will yield a target
 	// of '2'. Similar math follows for the remaining checks.
 	expect2 := target10.MulDifficulty(big.NewRat(5, 1))
 	if expect2 != target2 {
@@ -164,7 +164,7 @@ func TestTargetNegativeIntToTarget(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r != ErrNegativeTarget {
-			t.Error("no panic occured when trying to create a negative target")
+			t.Error("no panic occurred when trying to create a negative target")
 		}
 	}()
 	b := big.NewInt(-3)
@@ -183,7 +183,7 @@ func TestTargetNegativeRatToTarget(t *testing.T) {
 	defer func() {
 		r := recover()
 		if r != ErrNegativeTarget {
-			t.Error("no panic occured when trying to create a negative target")
+			t.Error("no panic occurred when trying to create a negative target")
 		}
 	}()
 	r := big.NewRat(3, -5)

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -445,7 +445,7 @@ func TestTransactionStandaloneValid(t *testing.T) {
 	txn.FileContractRevisions = nil
 
 	// Violate validUnlockConditions
-	txn.SiacoinInputs = []SiacoinInput{SiacoinInput{}}
+	txn.SiacoinInputs = []SiacoinInput{{}}
 	txn.SiacoinInputs[0].UnlockConditions.Timelock = 1
 	err = txn.StandaloneValid(0)
 	if err == nil {


### PR DESCRIPTION
Simple stuff.

I recommend installing [misspell](https://github.com/client9/misspell) and saving the following file as `.git/hooks/pre-commit` in your Sia directory:
```
#!/bin/bash
git diff --cached --name-only | while read FILE; do
	misspell -error "$FILE"
	if [ $? -ne 0 ]; then
		echo "Aborting commit due to typos. Use --no-verify to commit anyway." >&2
		exit 1
	fi
done
```
(Don't forget to make it executable.)

Misspell isn't perfect; there's a lot it doesn't catch. It's designed to fix *common* misspellings, not all possible typos. It doesn't check grammar either. But it's much better than nothing.
Like `gofmt`, misspell can automatically fix typos if you use the `-w` flag. The only reason my git hook script doesn't do this is that sometimes misspell suggests the wrong fix. You should double check the output before using `-w`.