### PR TITLE
switch storage folder to query param

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -79,9 +79,9 @@ func (srv *Server) initAPI() {
 
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/storage", srv.storageHandler)
-		router.POST("/storage/folders/add/*folder", srv.storageFoldersAddHandler)
-		router.POST("/storage/folders/remove/*folder", srv.storageFoldersRemoveHandler)
-		router.POST("/storage/folders/resize/*folder", srv.storageFoldersResizeHandler)
+		router.POST("/storage/folders/add", srv.storageFoldersAddHandler)
+		router.POST("/storage/folders/remove", srv.storageFoldersRemoveHandler)
+		router.POST("/storage/folders/resize", srv.storageFoldersResizeHandler)
 		router.POST("/storage/sectors/delete/:merkleroot", srv.storageSectorsDeleteHandler)
 	}
 

--- a/api/host.go
+++ b/api/host.go
@@ -140,8 +140,8 @@ func (srv *Server) storageHandler(w http.ResponseWriter, req *http.Request, _ ht
 }
 
 // storageFoldersAddHandler adds a storage folder to the storage manager.
-func (srv *Server) storageFoldersAddHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	folderPath := ps.ByName("folder")
+func (srv *Server) storageFoldersAddHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	folderPath := req.FormValue("path")
 	var folderSize uint64
 	_, err := fmt.Sscan(req.FormValue("size"), &folderSize)
 	if err != nil {
@@ -157,8 +157,8 @@ func (srv *Server) storageFoldersAddHandler(w http.ResponseWriter, req *http.Req
 }
 
 // storageFoldersResizeHandler resizes a storage folder in the storage manager.
-func (srv *Server) storageFoldersResizeHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	folderPath := ps.ByName("folder")
+func (srv *Server) storageFoldersResizeHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	folderPath := req.FormValue("path")
 	storageFolders := srv.host.StorageFolders()
 	folderIndex, err := folderIndex(folderPath, storageFolders)
 	if err != nil {
@@ -182,8 +182,8 @@ func (srv *Server) storageFoldersResizeHandler(w http.ResponseWriter, req *http.
 
 // storageFoldersRemoveHandler removes a storage folder from the storage
 // manager.
-func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	folderPath := ps.ByName("folder")
+func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	folderPath := req.FormValue("path")
 	storageFolders := srv.host.StorageFolders()
 	folderIndex, err := folderIndex(folderPath, storageFolders)
 	if err != nil {

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -242,8 +242,9 @@ func (st *serverTester) acceptContracts() error {
 // setHostStorage adds a 1 GB folder to the host.
 func (st *serverTester) setHostStorage() error {
 	values := url.Values{}
+	values.Set("path", st.dir)
 	values.Set("size", "1048576")
-	return st.stdPostAPI("/storage/folders/add/"+st.dir, values)
+	return st.stdPostAPI("/storage/folders/add", values)
 }
 
 // announceHost announces the host, mines a block, and waits for the

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/NebulousLabs/Sia/api"
@@ -293,7 +292,7 @@ func hostfolderaddcmd(path, size string) {
 	if err != nil {
 		die("Could not parse size:", err)
 	}
-	err = post("/storage/folders/add"+filepath.ToSlash(abs(path)), "size="+size)
+	err = post("/storage/folders/add", fmt.Sprintf("path=%s&size=%s", abs(path), size))
 	if err != nil {
 		die("Could not add folder:", err)
 	}
@@ -302,7 +301,7 @@ func hostfolderaddcmd(path, size string) {
 
 // hostfolderremovecmd removes a folder from the host.
 func hostfolderremovecmd(path string) {
-	err := post("/storage/folders/remove"+filepath.ToSlash(abs(path)), "")
+	err := post("/storage/folders/remove", "path="+abs(path))
 	if err != nil {
 		die("Could not remove folder:", err)
 	}
@@ -315,7 +314,7 @@ func hostfolderresizecmd(path, newsize string) {
 	if err != nil {
 		die("Could not parse size:", err)
 	}
-	err = post("/storage/folders/resize"+filepath.ToSlash(abs(path)), "newsize="+newsize)
+	err = post("/storage/folders/resize", fmt.Sprintf("path=%s&newsize=%s", abs(path), newsize))
 	if err != nil {
 		die("Could not resize folder:", err)
 	}


### PR DESCRIPTION
this was necessary because Windows-style absolute paths don't work well as URL paths.

absolute paths on Windows don't have a leading slash. So we either get:
```
/storage/folders/addC:/foo/bar
```
which is obviously invalid, or we manually add the slash:
```
/storage/folders/add/C:/foo/bar
```
which works, but now the API sees the path as /C:/foo/bar, which isn't valid. Using a query param seems like the simplest option.