### PR TITLE
Remove the gateway's RelayNode RPC

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -5,8 +5,17 @@ import (
 	"strings"
 )
 
-// Version is the current version of siad.
-const Version = "0.6.1"
+const (
+	// Version is the current version of siad.
+	Version = "0.6.1"
+
+	// MaxEncodedVersionLength is the maximum length of a version string encoded
+	// with the encode package. 100 is much larger than any version number we send
+	// now, but it allows us to send additional information in the version string
+	// later if we choose. For example appending the version string with the HEAD
+	// commit hash.
+	MaxEncodedVersionLength = 100
+)
 
 // IsVersion returns whether str is a valid version number.
 func IsVersion(str string) bool {

--- a/build/version.go
+++ b/build/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version is the current version of siad.
-const Version = "0.6.0"
+const Version = "0.6.1"
 
 // IsVersion returns whether str is a valid version number.
 func IsVersion(str string) bool {

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -349,7 +349,7 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 		// received from the peer is discarded and will be downloaded again if
 		// the parent is found.
 		go func() {
-			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
+			err := cs.gateway.RPC(conn.RPCAddr(), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
 				cs.log.Debugln("WARN: failed to get parents of orphan block:", err)
 			}
@@ -380,7 +380,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	if err == errOrphan {
 		// If the header is an orphan, try to find the parents.
 		go func() {
-			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
+			err := cs.gateway.RPC(conn.RPCAddr(), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
 				cs.log.Debugln("WARN: failed to get parents of orphan header:", err)
 			}
@@ -392,7 +392,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	// If the header is valid and extends the heaviest chain, fetch, accept it,
 	// and broadcast it.
 	go func() {
-		err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlk", cs.threadedReceiveBlock(h.ID()))
+		err := cs.gateway.RPC(conn.RPCAddr(), "SendBlk", cs.threadedReceiveBlock(h.ID()))
 		if err != nil {
 			cs.log.Debugln("WARN: failed to get header's corresponding block:", err)
 		}

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -41,9 +41,13 @@ type (
 	}
 
 	// A PeerConn is the connection type used when communicating with peers during
-	// an RPC. For now it is identical to a net.Conn.
+	// an RPC. It is identical to a net.Conn with the additional RPCAddr method.
+	// This method acts as an identifier for peers and is the address that the
+	// peer can be dialed on. It is also the address that should be used when
+	// calling an RPC on the peer.
 	PeerConn interface {
 		net.Conn
+		RPCAddr() NetAddress
 	}
 
 	// RPCFunc is the type signature of functions that handle RPCs. It is used for

--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -2,9 +2,18 @@ package gateway
 
 import (
 	"net"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // peerConn is a simple type that implements the modules.PeerConn interface.
 type peerConn struct {
 	net.Conn
+	dialbackAddr modules.NetAddress
+}
+
+// RPCAddr implements the RPCAddr method of the modules.PeerConn interface. It
+// is the address that identifies a peer.
+func (pc peerConn) RPCAddr() modules.NetAddress {
+	return pc.dialbackAddr
 }

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -119,7 +119,6 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 
 	// Register RPCs.
 	g.RegisterRPC("ShareNodes", g.shareNodes)
-	g.RegisterRPC("RelayNode", g.relayNode)
 	g.RegisterConnectCall("ShareNodes", g.requestNodes)
 
 	// Load the old node list. If it doesn't exist, no problem, but if it does,

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -34,6 +34,9 @@ func TestAddress(t *testing.T) {
 	}
 	host := modules.NetAddress(g.listener.Addr().String()).Host()
 	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatal("address is not an IP address")
+	}
 	if ip.IsUnspecified() {
 		t.Fatal("expected a non-unspecified address")
 	}

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -12,18 +12,22 @@ import (
 
 const (
 	maxSharedNodes = 10
-	maxAddrLength  = 100
+	maxAddrLength  = 100 // TODO: max NetAddress length is 254 for the hostname (including the trailing dot, 253 without) + 1 for the : + 5 for the port.
 	minPeers       = 3
+)
+
+var (
+	errNodeExists = errors.New("node already added")
 )
 
 // addNode adds an address to the set of nodes on the network.
 func (g *Gateway) addNode(addr modules.NetAddress) error {
 	if _, exists := g.nodes[addr]; exists {
-		return errors.New("node already added")
-	} else if net.ParseIP(addr.Host()) == nil {
-		return errors.New("address is not routable: " + string(addr))
+		return errNodeExists
 	} else if addr.IsValid() != nil {
 		return errors.New("address is not valid: " + string(addr))
+	} else if net.ParseIP(addr.Host()) == nil {
+		return errors.New("address must be an IP address: " + string(addr))
 	}
 	g.nodes[addr] = struct{}{}
 	return nil

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	maxSharedNodes = 10
-	maxAddrLength  = 100 // TODO: max NetAddress length is 254 for the hostname (including the trailing dot, 253 without) + 1 for the : + 5 for the port.
 	minPeers       = 3
 )
 
@@ -77,7 +76,7 @@ func (g *Gateway) shareNodes(conn modules.PeerConn) error {
 // requestNodes is the calling end of the ShareNodes RPC.
 func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	var nodes []modules.NetAddress
-	if err := encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength); err != nil {
 		return err
 	}
 	id := g.mu.Lock()

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -18,11 +18,14 @@ const (
 
 var (
 	errNodeExists = errors.New("node already added")
+	errOurAddress = errors.New("can't add our own address")
 )
 
 // addNode adds an address to the set of nodes on the network.
 func (g *Gateway) addNode(addr modules.NetAddress) error {
-	if _, exists := g.nodes[addr]; exists {
+	if addr == g.myAddr {
+		return errOurAddress
+	} else if _, exists := g.nodes[addr]; exists {
 		return errNodeExists
 	} else if addr.IsValid() != nil {
 		return errors.New("address is not valid: " + string(addr))
@@ -80,8 +83,8 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	id := g.mu.Lock()
 	for _, node := range nodes {
 		err := g.addNode(node)
-		if err != nil {
-			g.log.Printf("WARN: peer '%v' send the invalid addr '%v'", conn.RemoteAddr(), node)
+		if err != nil && err != errNodeExists && err != errOurAddress {
+			g.log.Printf("WARN: peer '%v' sent the invalid addr '%v'", conn.RemoteAddr(), node)
 		}
 	}
 	g.save()
@@ -112,7 +115,7 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 		}
 		return nil
 	}()
-	if err != nil {
+	if err != nil && err != errNodeExists {
 		return err
 	}
 	// relay

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -92,47 +92,6 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	return nil
 }
 
-// relayNode is the recipient end of the RelayNode RPC. It reads a node, adds
-// it to the Gateway's node list, and relays it to each of the Gateway's
-// peers. If the node is already in the node list, it is not relayed.
-func (g *Gateway) relayNode(conn modules.PeerConn) error {
-	// read address
-	var addr modules.NetAddress
-	if err := encoding.ReadObject(conn, &addr, maxAddrLength); err != nil {
-		return err
-	}
-	// add node
-	err := func() error {
-		// We wrap this logic in an anonymous function so we can defer Unlock to
-		// avoid managing locks across branching.
-		id := g.mu.Lock()
-		defer g.mu.Unlock(id)
-		if err := g.addNode(addr); err != nil {
-			return err
-		}
-		if err := g.save(); err != nil {
-			return err
-		}
-		return nil
-	}()
-	if err != nil && err != errNodeExists {
-		return err
-	}
-	// relay
-	peers := g.Peers()
-	go g.Broadcast("RelayNode", addr, peers)
-	return nil
-}
-
-// sendAddress is the calling end of the RelayNode RPC.
-func (g *Gateway) sendAddress(conn modules.PeerConn) error {
-	// don't send if we aren't connectible
-	if g.Address().IsValid() != nil {
-		return errors.New("can't send address without knowing external IP")
-	}
-	return encoding.WriteObject(conn, g.Address())
-}
-
 // threadedNodeManager tries to keep the Gateway's node list healthy. As long
 // as the Gateway has fewer than minNodeListSize nodes, it asks a random peer
 // for more nodes. It also continually pings nodes in order to establish their

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -19,7 +19,7 @@ func TestAddNode(t *testing.T) {
 	if err := g.addNode(dummyNode); err != nil {
 		t.Fatal("addNode failed:", err)
 	}
-	if err := g.addNode(dummyNode); err == nil {
+	if err := g.addNode(dummyNode); err != errNodeExists {
 		t.Error("addNode added duplicate node")
 	}
 	if err := g.addNode("foo"); err == nil {
@@ -30,6 +30,9 @@ func TestAddNode(t *testing.T) {
 	}
 	if err := g.addNode("[::]:9981"); err == nil {
 		t.Error("addNode added unspecified address")
+	}
+	if err := g.addNode(g.myAddr); err != errOurAddress {
+		t.Error("addNode added our own address")
 	}
 }
 

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -167,7 +167,7 @@ func TestShareNodes(t *testing.T) {
 	// SharePeers should now return no peers
 	var nodes []modules.NetAddress
 	err = g1.RPC(g2.Address(), "ShareNodes", func(conn modules.PeerConn) error {
-		return encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength)
+		return encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength)
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +186,7 @@ func TestShareNodes(t *testing.T) {
 		}
 	}
 	err = g1.RPC(g2.Address(), "ShareNodes", func(conn modules.PeerConn) error {
-		return encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength)
+		return encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -196,20 +196,19 @@ func TestShareNodes(t *testing.T) {
 	}
 }
 
-func TestRelayNodes(t *testing.T) {
+// TestNodesAreSharedOnConnect tests that nodes that a gateway has never seen
+// before are added to the node list when connecting to another gateway that
+// has seen said nodes.
+func TestNodesAreSharedOnConnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	g1 := newTestingGateway("TestRelayNodes1", t)
+	g1 := newTestingGateway("TestNodesAreSharedOnConnect1", t)
 	defer g1.Close()
-	g2 := newTestingGateway("TestRelayNodes2", t)
+	g2 := newTestingGateway("TestNodesAreSharedOnConnect2", t)
 	defer g2.Close()
-	g3 := newTestingGateway("TestRelayNodes3", t)
+	g3 := newTestingGateway("TestNodesAreSharedOnConnect3", t)
 	defer g3.Close()
-
-	// normally the Gateway will only register this RPC if has discovered its
-	// IP through external means.
-	g3.RegisterConnectCall("RelayNode", g3.sendAddress)
 
 	// connect g2 to g1
 	err := g2.Connect(g1.Address())
@@ -223,11 +222,11 @@ func TestRelayNodes(t *testing.T) {
 		t.Fatal("couldn't connect:", err)
 	}
 
-	// g2 should have received g3's address from g1
+	// g3 should have received g2's address from g1
 	time.Sleep(200 * time.Millisecond)
-	id := g2.mu.Lock()
-	defer g2.mu.Unlock(id)
-	if _, ok := g2.nodes[g3.Address()]; !ok {
-		t.Fatal("node was not relayed:", g2.nodes)
+	id := g3.mu.Lock()
+	defer g3.mu.Unlock(id)
+	if _, ok := g3.nodes[g2.Address()]; !ok {
+		t.Fatal("node was not shared:", g3.nodes)
 	}
 }

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -223,15 +223,18 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	}
 	// send our version
 	if err := encoding.WriteObject(conn, build.Version); err != nil {
+		conn.Close()
 		return err
 	}
 	// read version ack
 	var remoteVersion string
 	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+		conn.Close()
 		return err
 	}
 	// decide whether to accept this version
 	if remoteVersion == "reject" {
+		conn.Close()
 		return errPeerRejectedConn
 	}
 	// Check that version is acceptable.

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -260,7 +260,15 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 		},
 		sess: muxado.Client(conn),
 	})
+	// addNode must be called after addPeer so that threadedPeerManager doesn't
+	// try to Connect to the node before we do (although in this particular case
+	// it doesn't matter as a lock is held over both calls).
+	err = g.addNode(addr)
 	g.mu.Unlock(id)
+	if err != nil && err != errNodeExists {
+		g.Disconnect(addr)
+		return err
+	}
 
 	// call initRPCs
 	id = g.mu.RLock()

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -148,7 +148,7 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 	//
 	// NOTE: this version must be bumped whenever the gateway or consensus
 	// breaks compatibility.
-	if build.VersionCmp(remoteVersion, "0.4.0") < 0 {
+	if !build.IsVersion(remoteVersion) || build.VersionCmp(remoteVersion, "0.4.0") < 0 {
 		encoding.WriteObject(conn, "reject")
 		conn.Close()
 		g.log.Printf("INFO: %v wanted to connect, but their version (%v) was unacceptable", addr, remoteVersion)
@@ -244,7 +244,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	//
 	// NOTE: this version must be bumped whenever the gateway or consensus
 	// breaks compatibility.
-	if build.VersionCmp(remoteVersion, "0.4.0") < 0 {
+	if !build.IsVersion(remoteVersion) || build.VersionCmp(remoteVersion, "0.4.0") < 0 {
 		conn.Close()
 		return insufficientVersionError(remoteVersion)
 	}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -58,7 +58,7 @@ func (p *peer) open() (modules.PeerConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &peerConn{conn}, nil
+	return &peerConn{conn, p.NetAddress}, nil
 }
 
 func (p *peer) accept() (modules.PeerConn, error) {
@@ -66,7 +66,7 @@ func (p *peer) accept() (modules.PeerConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &peerConn{conn}, nil
+	return &peerConn{conn, p.NetAddress}, nil
 }
 
 // addPeer adds a peer to the Gateway's peer list and spawns a listener thread

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -136,7 +136,7 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 
 	// read version
 	var remoteVersion string
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		conn.Close()
 		g.log.Printf("INFO: %v wanted to connect, but we could not read their version: %v", addr, err)
 		return
@@ -280,7 +280,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	}
 	// read version ack
 	var remoteVersion string
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		conn.Close()
 		return err
 	}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -240,6 +240,7 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 	var err error
 	if build.VersionCmp(remoteVersion, "0.6.1") >= 0 {
 		err = g.addNode(remoteAddr)
+		// TODO: call g.save?
 	}
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
@@ -324,6 +325,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	// try to Connect to the node before we do (although in this particular case
 	// it doesn't matter as a lock is held over both calls).
 	err = g.addNode(addr)
+	// TODO: call g.save?
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
 		g.Disconnect(addr)

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -240,7 +240,9 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 	var err error
 	if build.VersionCmp(remoteVersion, "0.6.1") >= 0 {
 		err = g.addNode(remoteAddr)
-		// TODO: call g.save?
+		if saveErr := g.save(); saveErr != nil {
+			g.log.Printf("WARN: could not save node list: %v", saveErr)
+		}
 	}
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
@@ -325,7 +327,9 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	// try to Connect to the node before we do (although in this particular case
 	// it doesn't matter as a lock is held over both calls).
 	err = g.addNode(addr)
-	// TODO: call g.save?
+	if saveErr := g.save(); saveErr != nil {
+		g.log.Printf("WARN: could not save node list: %v", saveErr)
+	}
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
 		g.Disconnect(addr)

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -297,9 +297,29 @@ func TestConnectRejectsInvalidVersions(t *testing.T) {
 			insufficientVersion: true,
 			msg:                 "Connect should fail when the remote peer's version is ascii gibberish",
 		},
+		{
+			version:             "999.foobar",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is ascii gibberish",
+		},
+		{
+			version:             "foobar.0",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is ascii gibberish",
+		},
 		// Test that Connect fails when the remote peer's version is utf8 gibberish.
 		{
 			version:             "世界",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is utf8 gibberish",
+		},
+		{
+			version:             "999.世界",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is utf8 gibberish",
+		},
+		{
+			version:             "世界.0",
 			insufficientVersion: true,
 			msg:                 "Connect should fail when the remote peer's version is utf8 gibberish",
 		},
@@ -433,9 +453,29 @@ func TestAcceptConnRejectsInvalidVersions(t *testing.T) {
 			versionResponseWant: "reject",
 			msg:                 "acceptConn shouldn't accept a remote peer whose version is ascii giberish",
 		},
+		{
+			remoteVersion:       "999.foobar",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is ascii giberish",
+		},
+		{
+			remoteVersion:       "foobar.0",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is ascii giberish",
+		},
 		// Test that acceptConn fails when the remote peer's version is utf8 gibberish.
 		{
 			remoteVersion:       "世界",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is utf8 giberish",
+		},
+		{
+			remoteVersion:       "999.世界",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is utf8 giberish",
+		},
+		{
+			remoteVersion:       "世界.0",
 			versionResponseWant: "reject",
 			msg:                 "acceptConn shouldn't accept a remote peer whose version is utf8 giberish",
 		},

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -86,7 +86,7 @@ func TestListen(t *testing.T) {
 	}
 	// read ack
 	var ack string
-	if err := encoding.ReadObject(conn, &ack, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &ack, build.MaxEncodedVersionLength); err != nil {
 		t.Fatal(err)
 	} else if ack != "reject" {
 		t.Fatal("gateway should have rejected old version")
@@ -114,7 +114,7 @@ func TestListen(t *testing.T) {
 		t.Fatal("couldn't write version")
 	}
 	// read ack
-	if err := encoding.ReadObject(conn, &ack, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &ack, build.MaxEncodedVersionLength); err != nil {
 		t.Fatal(err)
 	} else if ack == "reject" {
 		t.Fatal("gateway should have given ack")
@@ -285,7 +285,7 @@ func TestConnectRejectsInvalidVersions(t *testing.T) {
 			}
 			// Read remote peer version.
 			var remoteVersion string
-			if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+			if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 				panic(err)
 			}
 			// Write our mock version.
@@ -436,7 +436,7 @@ func (g mockGatewayWithVersion) Connect(addr modules.NetAddress) error {
 	}
 	// read version ack
 	var remoteVersion string
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		return err
 	}
 	// send port

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -197,7 +197,11 @@ func TestConnect(t *testing.T) {
 // addresses.
 func TestConnectRejectsInvalidAddrs(t *testing.T) {
 	g := newTestingGateway("TestConnectRejectsInvalidAddrs", t)
+	defer g.Close()
+
 	g2 := newTestingGateway("TestConnectRejectsInvalidAddrs2", t)
+	defer g2.Close()
+
 	_, g2Port, err := net.SplitHostPort(string(g2.Address()))
 	if err != nil {
 		t.Fatal(err)
@@ -248,6 +252,7 @@ func TestConnectRejectsInvalidVersions(t *testing.T) {
 		t.SkipNow()
 	}
 	g := newTestingGateway("TestConnectRejectsInvalidVersions", t)
+	defer g.Close()
 	// Setup a listener that mocks Gateway.acceptConn, but sends the
 	// version sent over mockVersionChan instead of build.Version.
 	listener, err := net.Listen("tcp", "localhost:0")

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -111,12 +111,10 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 	fn, ok := g.handlers[id]
 	g.mu.RUnlock(lockid)
 	if !ok {
-		g.log.Printf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RemoteAddr(), id)
+		g.log.Debugf("WARN: incoming conn %v requested unknown RPC %q", conn.RemoteAddr(), id)
 		return
 	}
-	if build.DEBUG {
-		g.log.Printf("INFO: incoming conn %v requested RPC \"%v\"", conn.RemoteAddr(), id)
-	}
+	g.log.Debugf("INFO: incoming conn %v requested RPC %q", conn.RemoteAddr(), id)
 
 	// call fn
 	err := fn(conn)
@@ -125,7 +123,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 		err = nil
 	}
 	if err != nil {
-		g.log.Printf("WARN: incoming RPC \"%v\" from conn %v failed: %v", id, conn.RemoteAddr(), err)
+		g.log.Debugf("WARN: incoming RPC %q from conn %v failed: %v", id, conn.RemoteAddr(), err)
 	}
 }
 
@@ -134,7 +132,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 // object and disconnect. This is why Broadcast takes an interface{} instead of
 // an RPCFunc.
 func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) {
-	g.log.Printf("INFO: broadcasting RPC \"%v\" to %v peers", name, len(peers))
+	g.log.Printf("INFO: broadcasting RPC %q to %v peers", name, len(peers))
 
 	// only encode obj once, instead of using WriteObject
 	enc := encoding.Marshal(obj)

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -72,9 +72,6 @@ func (g *Gateway) learnHostname() {
 	g.mu.Unlock(id)
 
 	g.log.Println("INFO: our address is", g.myAddr)
-
-	// now that we know our address, we can start advertising it
-	g.RegisterConnectCall("RelayNode", g.sendAddress)
 }
 
 // forwardPort adds a port mapping to the router.

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -41,7 +41,7 @@ func myExternalIP() (string, error) {
 // learnHostname discovers the external IP of the Gateway. Once the IP has
 // been discovered, it registers the ShareNodes RPC to be called on new
 // connections, advertising the IP to other nodes.
-func (g *Gateway) learnHostname(port string) {
+func (g *Gateway) learnHostname() {
 	if build.Release == "testing" {
 		return
 	}
@@ -61,7 +61,7 @@ func (g *Gateway) learnHostname(port string) {
 		return
 	}
 
-	addr := modules.NetAddress(net.JoinHostPort(host, port))
+	addr := modules.NetAddress(net.JoinHostPort(host, g.port))
 	if err := addr.IsValid(); err != nil {
 		g.log.Printf("WARN: discovered hostname %q is invalid: %v", addr, err)
 		return

--- a/modules/netaddress.go
+++ b/modules/netaddress.go
@@ -9,6 +9,12 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
+// MaxEncodedNetAddressLength is the maximum length of a NetAddress encoded
+// with the encode package. 266 was chosen because the maximum length for the
+// hostname is 254 + 1 for the separating colon + 5 for the port + 8 byte
+// string length prefix.
+const MaxEncodedNetAddressLength = 266
+
 // A NetAddress contains the information needed to contact a peer.
 type NetAddress string
 


### PR DESCRIPTION
The RelayNode RPC allowed any node to add an arbitrary address to the node list of any other node. Even worse, nodes would re-broadcast this new node and so it would quickly propagate across the network. This could be abused by an attacker to maliciously pollute the node lists of all nodes on the network (an eclipse attack).

Now nodes share their port on connect so that the receiving node can add the connecting node to its node list and connect back to them later.

A notable feature necessitated by this change is that inbound connections now store the peer's dialback address instead of the actual `conn.RemoteAddr()`, and therefore `siac gateway list` will show the dialable address of inbound peers.

Also some miscellaneous cleanup.