### PR TITLE
Add a `-v, --verbose` flag to `siac renter`

### DIFF
--- a/siac/main.go
+++ b/siac/main.go
@@ -216,6 +216,7 @@ func main() {
 		renterFilesListCmd, renterFilesLoadCmd, renterFilesLoadASCIICmd,
 		renterFilesRenameCmd, renterFilesShareCmd, renterFilesShareASCIICmd,
 		renterFilesUploadCmd, renterUploadsCmd)
+	renterCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
 	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
 	renterFilesListCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
 


### PR DESCRIPTION
the flag has the same effect as the verbose flag on `siac renter list`