### PR TITLE
Clean termination of revision loop

### DIFF
--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -291,7 +291,7 @@ func (r *Renter) repairChunks(f *file, handle io.ReaderAt, chunks map[uint64][]u
 		// repeats of other hosts of this chunk.
 		hosts := pool.uniqueHosts(len(pieces), f.chunkHosts(chunk))
 		if len(hosts) == 0 {
-			r.log.Printf("aborting repair of %v: not enough hosts", f.name)
+			r.log.Debugf("aborting repair of %v: host pool is empty", f.name)
 			return
 		}
 		// upload to new hosts
@@ -300,7 +300,10 @@ func (r *Renter) repairChunks(f *file, handle io.ReaderAt, chunks map[uint64][]u
 			if he, ok := err.(hostErrs); ok {
 				// if a specific host failed, remove it from the pool
 				for _, h := range he {
-					r.log.Printf("failed to upload to host %v: %v", h.host, h.err)
+					// only log non-graceful errors
+					if h.err != modules.ErrStopResponse {
+						r.log.Printf("failed to upload to host %v: %v", h.host, h.err)
+					}
 					pool.remove(h.host)
 				}
 			} else {


### PR DESCRIPTION
The host now sends `modules.StopResponse` to the renter when it wishes to gracefully terminate the revision loop. The renter will respect this by disconnecting without error.

I still don't like this. It's bizarre that proper use of the host-renter protocol should require repeatedly disconnecting and reconnecting for no reason. There are many reasons why a host would want to terminate the revision loop: shutdown, changed settings, DoS concerns. But disconnecting for no reason forces the renter to reconnect, and this requires ugly and confusing logic. (The situation is even worse when downloading: due to the way the concerns are separated, there's no easy way to reconnect at all. This means that **files taking longer than 20 minutes to download cannot currently be downloaded**.)
We should ask what we stand to gain from enforcing this hard limit. Assume that the renter will immediately try to reconnect. The gain here is that we have a brief period between disconnect and reconnect, where we can use some criteria to judge whether we should accept the reconnection. But at present (to my knowledge) *no such criteria is implemented*, and if we wanted to implement it, we could do so inside the revision loop, rather than outside.

In short: gracefully terminating with `StopResponse` is fine, but the implication that the renter should immediately reconnect is not.