### PR TITLE
Fix Transaction Pool Bug

### DIFF
--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -54,7 +54,7 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -32,7 +32,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create consensus set:", err)
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		t.Fatal("Failed to create tpool:", err)
 	}
@@ -97,7 +97,7 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -104,7 +104,7 @@ func blankConsensusSetTester(name string) (*consensusSetTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.ConsensusDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/consensus/processedblock_test.go
+++ b/modules/consensus/processedblock_test.go
@@ -31,7 +31,7 @@ func TestIntegrationMinimumValidChildTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -1,6 +1,8 @@
 package consensus
 
 import (
+	"fmt"
+
 	"github.com/NebulousLabs/Sia/modules"
 
 	"github.com/NebulousLabs/bolt"
@@ -140,11 +142,30 @@ func (cs *ConsensusSet) initializeSubscribe(subscriber modules.ConsensusSetSubsc
 		}
 
 		// Send all remaining consensus changes to the subscriber.
-		for exists {
+		for i := 0; exists; i++ {
 			cc, err := cs.computeConsensusChange(tx, entry)
 			if err != nil {
 				return err
 			}
+
+			// Get the height of the block to print out.
+			if i%1000 == 0 {
+				bid := cc.AppliedBlocks[0].ID()
+				pb, err := getBlockMap(tx, bid)
+				if err == nil {
+					if i == 0 {
+						fmt.Println("A consensus rescan has been requested. This can take a while.")
+					}
+					fmt.Println("Rescan has hit height", pb.Height, "out of", blockHeight(tx))
+				} else {
+					// Didn't get to print for this block, because it was not
+					// recognized in the current path. Try printing for the
+					// next block. Decrement of `i` is okay because it's only
+					// used to decide when to print.
+					i--
+				}
+			}
+
 			subscriber.ProcessConsensusChange(cc)
 			entry, exists = entry.NextEntry(tx)
 		}

--- a/modules/explorer/explorer_test.go
+++ b/modules/explorer/explorer_test.go
@@ -42,7 +42,7 @@ func createExplorerTester(name string) (*explorerTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (et *explorerTester) reorgToBlank() error {
 	if err != nil {
 		return err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(dir, modules.TransactionPoolDir))
 	if err != nil {
 		return err
 	}

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -61,7 +61,7 @@ func (g *Gateway) RPC(addr modules.NetAddress, name string, fn modules.RPCFunc) 
 func (g *Gateway) RegisterRPC(name string, fn modules.RPCFunc) {
 	id := g.mu.Lock()
 	defer g.mu.Unlock(id)
-	if build.DEBUG {
+	if build.DEBUG && build.Release != "testing" {
 		if _, ok := g.handlers[handlerName(name)]; ok {
 			panic("refusing to overwrite RPC " + name)
 		}

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -114,7 +114,7 @@ func blankHostTester(name string) (*hostTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -43,7 +43,7 @@ func createMinerTester(name string) (*minerTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -92,7 +92,7 @@ func newTestingTrio(name string) (modules.Host, *Contractor, modules.TestMiner, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/modules/renter/contractor/negotiate_test.go
+++ b/modules/renter/contractor/negotiate_test.go
@@ -50,7 +50,7 @@ func newContractorTester(name string) (*contractorTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -49,7 +49,7 @@ func newRenterTester(name string) (*renterTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func newContractorTester(name string, hc hostContractor) (*renterTester, error) 
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -6,7 +6,6 @@ package transactionpool
 import (
 	"errors"
 
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -290,19 +289,8 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 	}
 
 	// Notify subscribers and broadcast the transaction set.
-	// NOTE: The transaction set is only broadcast to v0.4.7 peers and above.
-	// v0.4.7-v0.5.1 broadcasted both transaction sets and individual transactions
-	// and those versions act as a bridge between v0.5.2+ and older versions.
-	// COMPATv0.4.6
-	var v047AndAbove []modules.Peer
-	for _, p := range tp.gateway.Peers() {
-		if build.VersionCmp(p.Version, "0.4.7") >= 0 {
-			v047AndAbove = append(v047AndAbove, p)
-		}
-	}
-	go tp.gateway.Broadcast("RelayTransactionSet", ts, v047AndAbove)
+	go tp.gateway.Broadcast("RelayTransactionSet", ts, tp.gateway.Peers())
 	tp.updateSubscribersTransactions()
-
 	return nil
 }
 

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -8,64 +8,6 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// mockGatewayCheckBroadcast is a mock implementation of modules.Gateway that
-// enables testing of selective broadcasting by mocking the Peers and Broadcast
-// methods.
-type mockGatewayCheckBroadcast struct {
-	modules.Gateway
-	peers            []modules.Peer
-	broadcastedPeers chan []modules.Peer
-}
-
-// Peers is a mock implementation of Gateway.Peers that returns the mocked
-// peers.
-func (g *mockGatewayCheckBroadcast) Peers() []modules.Peer {
-	return g.peers
-}
-
-// Broadcast is a mock implementation of Gateway.Broadcast that writes the
-// peers it receives as an argument to the broadcastedPeers channel.
-func (g *mockGatewayCheckBroadcast) Broadcast(_ string, _ interface{}, peers []modules.Peer) {
-	g.broadcastedPeers <- peers
-}
-
-// TestAcceptTransactionSetBroadcasts tests that AcceptTransactionSet only
-// broadcasts to peers v0.4.7 and above.
-func TestAcceptTransactionSetBroadcasts(t *testing.T) {
-	tpt, err := createTpoolTester("TestAcceptTransactionSetBroadcasts")
-	if err != nil {
-		t.Fatal(err)
-	}
-	mockPeers := []modules.Peer{
-		{Version: "0.0.0"},
-		{Version: "0.4.6"},
-		{Version: "0.4.7"},
-		{Version: "9.9.9"},
-	}
-	mg := &mockGatewayCheckBroadcast{
-		Gateway:          tpt.tpool.gateway,
-		peers:            mockPeers,
-		broadcastedPeers: make(chan []modules.Peer),
-	}
-	tpt.tpool.gateway = mg
-
-	go func() {
-		err = tpt.tpool.AcceptTransactionSet([]types.Transaction{{}})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-	broadcastedPeers := <-mg.broadcastedPeers
-	if len(broadcastedPeers) != 2 {
-		t.Fatalf("only 2 peers have version >= v0.4.7, but AcceptTransactionSet relayed the transaction set to %v peers", len(broadcastedPeers))
-	}
-	for _, bp := range broadcastedPeers {
-		if bp.Version != "0.4.7" && bp.Version != "9.9.9" {
-			t.Fatalf("AcceptTransactionSet relayed the transaction to a peer with version < v0.4.7 (%v)", bp.Version)
-		}
-	}
-}
-
 // TestIntegrationAcceptTransactionSet probes the AcceptTransactionSet method
 // of the transaction pool.
 func TestIntegrationAcceptTransactionSet(t *testing.T) {

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -380,3 +380,208 @@ func TestAcceptFCAndConflictingRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestPartialConfirmation checks that the transaction pool correctly accepts a
+// transaction set which has parents that have been accepted by the consensus
+// set but not the whole set has been accepted by the consensus set.
+func TestPartialConfirmation(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	tpt, err := createTpoolTester("TestPartialConfirmation")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create and fund a valid file contract.
+	builder := tpt.wallet.StartTransaction()
+	payout := types.NewCurrency64(1e9)
+	err = builder.FundSiacoins(payout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder.AddFileContract(types.FileContract{
+		WindowStart:        tpt.cs.Height() + 2,
+		WindowEnd:          tpt.cs.Height() + 5,
+		Payout:             payout,
+		ValidProofOutputs:  []types.SiacoinOutput{{Value: types.PostTax(tpt.cs.Height(), payout)}},
+		MissedProofOutputs: []types.SiacoinOutput{{Value: types.PostTax(tpt.cs.Height(), payout)}},
+		UnlockHash:         types.UnlockConditions{}.UnlockHash(),
+	})
+	tSet, err := builder.Sign(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fcid := tSet[len(tSet)-1].FileContractID(0)
+
+	// Create a file contract revision.
+	rSet := []types.Transaction{{
+		FileContractRevisions: []types.FileContractRevision{{
+			ParentID:          fcid,
+			NewRevisionNumber: 2,
+
+			NewWindowStart:        tpt.cs.Height() + 2,
+			NewWindowEnd:          tpt.cs.Height() + 5,
+			NewValidProofOutputs:  []types.SiacoinOutput{{Value: types.PostTax(tpt.cs.Height(), payout)}},
+			NewMissedProofOutputs: []types.SiacoinOutput{{Value: types.PostTax(tpt.cs.Height(), payout)}},
+		}},
+	}}
+
+	// Combine the contract and revision in to a single set.
+	fullSet := append(tSet, rSet...)
+
+	// Get the tSet onto the blockchain.
+	unsolvedBlock, target, err := tpt.miner.BlockForWork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsolvedBlock.Transactions = append(unsolvedBlock.Transactions, tSet...)
+	solvedBlock, solved := tpt.miner.SolveBlock(unsolvedBlock, target)
+	if !solved {
+		t.Fatal("Failed to solve block")
+	}
+	err = tpt.cs.AcceptBlock(solvedBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to get the full set into the transaction pool. The transaction pool
+	// should recognize that the set is partially accepted, and be able to
+	// accept on the the transactions that are new and are not yet on the
+	// blockchain.
+	err = tpt.tpool.AcceptTransactionSet(fullSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPartialConfirmationWeave checks that the transaction pool correctly
+// accepts a transaction set which has parents that have been accepted by the
+// consensus set but not the whole set has been accepted by the consensus set,
+// this time weaving the dependencies, such that the first transaction is not
+// in the consensus set, the second is, and the third has both as dependencies.
+func TestPartialConfirmationWeave(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	tpt, err := createTpoolTester("TestPartialConfirmation")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 1: create an output to the empty address in a tx.
+	// Step 2: create a second output to the empty address in another tx.
+	// Step 3: create a transaction using both those outputs.
+	// Step 4: mine the txn set in step 2
+	// Step 5: Submit the complete set.
+
+	// Create a transaction with a single output to a fully controlled address.
+	emptyUH := types.UnlockConditions{}.UnlockHash()
+	builder1 := tpt.wallet.StartTransaction()
+	funding1 := types.NewCurrency64(1e9)
+	err = builder1.FundSiacoins(funding1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scOutput1 := types.SiacoinOutput{
+		Value:      funding1,
+		UnlockHash: emptyUH,
+	}
+	i1 := builder1.AddSiacoinOutput(scOutput1)
+	tSet1, err := builder1.Sign(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Submit to the transaction pool and mine the block, to minimize
+	// complexity.
+	err = tpt.tpool.AcceptTransactionSet(tSet1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tpt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a second output to the fully controlled address, to fund the
+	// second transaction in the weave.
+	builder2 := tpt.wallet.StartTransaction()
+	funding2 := types.NewCurrency64(2e9)
+	err = builder2.FundSiacoins(funding2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scOutput2 := types.SiacoinOutput{
+		Value:      funding2,
+		UnlockHash: emptyUH,
+	}
+	i2 := builder2.AddSiacoinOutput(scOutput2)
+	tSet2, err := builder2.Sign(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Submit to the transaction pool and mine the block, to minimize
+	// complexity.
+	err = tpt.tpool.AcceptTransactionSet(tSet2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tpt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a passthrough transaction for output1 and output2, so that they
+	// can be used as unconfirmed dependencies.
+	txn1 := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{{
+			ParentID: tSet1[len(tSet1)-1].SiacoinOutputID(i1),
+		}},
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Value:      funding1,
+			UnlockHash: emptyUH,
+		}},
+	}
+	txn2 := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{{
+			ParentID: tSet2[len(tSet2)-1].SiacoinOutputID(i2),
+		}},
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Value:      funding2,
+			UnlockHash: emptyUH,
+		}},
+	}
+
+	// Create a child transaction that depends on inputs from both txn1 and
+	// txn2.
+	child := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{
+			{
+				ParentID: txn1.SiacoinOutputID(0),
+			},
+			{
+				ParentID: txn2.SiacoinOutputID(0),
+			},
+		},
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Value: funding1.Add(funding2),
+		}},
+	}
+
+	// Get txn2 accepted into the consensus set.
+	err = tpt.tpool.AcceptTransactionSet([]types.Transaction{txn2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tpt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to get the set of txn1, txn2, and child accepted into the
+	// transaction pool.
+	err = tpt.tpool.AcceptTransactionSet([]types.Transaction{txn1, txn2, child})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/modules/transactionpool/persist.go
+++ b/modules/transactionpool/persist.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
@@ -60,7 +59,7 @@ func (tp *TransactionPool) initPersist() error {
 	}
 
 	// Create the database and get the most recent consensus change.
-	cc := modules.ConsensusChangeBeginning
+	var cc modules.ConsensusChangeID
 	err = tp.db.Update(func(tx *bolt.Tx) error {
 		// Create the database buckets.
 		buckets := [][]byte{
@@ -126,16 +125,12 @@ func (tp *TransactionPool) transactionConfirmed(tx *bolt.Tx, id types.Transactio
 	if confirmedBytes == nil {
 		return false
 	}
-	if confirmedBytes[0] == 1 {
-		return true
-	}
-	build.Critical("transaction database has an illegal value for a txid")
-	return false
+	return true
 }
 
 // addTransaction adds a transaction to the list of confirmed transactions.
 func (tp *TransactionPool) addTransaction(tx *bolt.Tx, id types.TransactionID) error {
-	return tx.Bucket(bucketConfirmedTransactions).Put(id[:], []byte{1})
+	return tx.Bucket(bucketConfirmedTransactions).Put(id[:], []byte{})
 }
 
 // deleteTransaction deletes a transaction from the list of confirmed

--- a/modules/transactionpool/persist.go
+++ b/modules/transactionpool/persist.go
@@ -1,0 +1,145 @@
+package transactionpool
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
+	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
+)
+
+var (
+	// bucketRecentConsensusChange holds the most recent consensus change seen
+	// by the transaction pool.
+	bucketRecentConsensusChange = []byte("RecentConsensusChange")
+
+	// bucketConfirmedTransactions holds the ids of every transaction that has
+	// been confirmed on the blockchain.
+	bucketConfirmedTransactions = []byte("ConfirmedTransactions")
+
+	// errNilConsensusChange is returned if there is no consensus change in the
+	// database.
+	errNilConsensusChange = errors.New("no consensus change found")
+
+	// fieldRecentConsensusChange is the field in bucketRecentConsensusChange
+	// that holds the value of the most recent consensus change.
+	fieldRecentConsensusChange = []byte("RecentConsensusChange")
+)
+
+// resetDB deletes all consensus related persistence from the transaction pool.
+func (tp *TransactionPool) resetDB(tx *bolt.Tx) error {
+	err := tx.DeleteBucket(bucketConfirmedTransactions)
+	if err != nil {
+		return err
+	}
+	err = tp.putRecentConsensusChange(tx, modules.ConsensusChangeBeginning)
+	if err != nil {
+		return err
+	}
+	_, err = tx.CreateBucket(bucketConfirmedTransactions)
+	return err
+}
+
+// initPersist creates buckets in the database
+func (tp *TransactionPool) initPersist() error {
+	// Create the persist directory if it does not yet exist.
+	err := os.MkdirAll(tp.persistDir, 0700)
+	if err != nil {
+		return err
+	}
+
+	// Open the database file.
+	tp.db, err = persist.OpenDatabase(dbMetadata, filepath.Join(tp.persistDir, dbFilename))
+	if err != nil {
+		return err
+	}
+
+	// Create the database and get the most recent consensus change.
+	cc := modules.ConsensusChangeBeginning
+	err = tp.db.Update(func(tx *bolt.Tx) error {
+		// Create the database buckets.
+		buckets := [][]byte{
+			bucketRecentConsensusChange,
+			bucketConfirmedTransactions,
+		}
+		for _, bucket := range buckets {
+			_, err := tx.CreateBucketIfNotExists(bucket)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Get the recent consensus change.
+		cc, err = tp.getRecentConsensusChange(tx)
+		if err == errNilConsensusChange {
+			return tp.putRecentConsensusChange(tx, modules.ConsensusChangeBeginning)
+		}
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// Subscribe to the consensus set using the most recent consensus change.
+	err = tp.consensusSet.ConsensusSetSubscribe(tp, cc)
+	if err == modules.ErrInvalidConsensusChangeID {
+		// Reset and rescan because the consensus set does not recognize the
+		// provided consensus change id.
+		resetErr := tp.db.Update(func(tx *bolt.Tx) error {
+			return tp.resetDB(tx)
+		})
+		if resetErr != nil {
+			return resetErr
+		}
+		return tp.consensusSet.ConsensusSetSubscribe(tp, modules.ConsensusChangeBeginning)
+	}
+	return err
+}
+
+// getRecentConsensusChange returns the most recent consensus change from the
+// database.
+func (tp *TransactionPool) getRecentConsensusChange(tx *bolt.Tx) (cc modules.ConsensusChangeID, err error) {
+	ccBytes := tx.Bucket(bucketRecentConsensusChange).Get(fieldRecentConsensusChange)
+	if ccBytes == nil {
+		return modules.ConsensusChangeID{}, errNilConsensusChange
+	}
+	copy(cc[:], ccBytes)
+	return cc, nil
+}
+
+// putRecentConsensusChange updates the most recent consensus change seen by
+// the transaction pool.
+func (tp *TransactionPool) putRecentConsensusChange(tx *bolt.Tx, cc modules.ConsensusChangeID) error {
+	return tx.Bucket(bucketRecentConsensusChange).Put(fieldRecentConsensusChange, cc[:])
+}
+
+// transactionConfirmed returns true if the transaction has been confirmed on
+// the blockchain and false if the transaction has not been confirmed on the
+// blockchain.
+func (tp *TransactionPool) transactionConfirmed(tx *bolt.Tx, id types.TransactionID) bool {
+	confirmedBytes := tx.Bucket(bucketConfirmedTransactions).Get(id[:])
+	if confirmedBytes == nil {
+		return false
+	}
+	if confirmedBytes[0] == 1 {
+		return true
+	}
+	build.Critical("transaction database has an illegal value for a txid")
+	return false
+}
+
+// addTransaction adds a transaction to the list of confirmed transactions.
+func (tp *TransactionPool) addTransaction(tx *bolt.Tx, id types.TransactionID) error {
+	return tx.Bucket(bucketConfirmedTransactions).Put(id[:], []byte{1})
+}
+
+// deleteTransaction deletes a transaction from the list of confirmed
+// transactions.
+func (tp *TransactionPool) deleteTransaction(tx *bolt.Tx, id types.TransactionID) error {
+	return tx.Bucket(bucketConfirmedTransactions).Delete(id[:])
+}

--- a/modules/transactionpool/persist_test.go
+++ b/modules/transactionpool/persist_test.go
@@ -1,0 +1,93 @@
+package transactionpool
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
+	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/bolt"
+)
+
+// TestRescan triggers a rescan in the transaction pool, verifying that the
+// rescan code does not cause deadlocks or crashes.
+func TestRescan(t *testing.T) {
+	tpt, err := createTpoolTester("TestRescan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Create a valid transaction set using the wallet.
+	txns, err := tpt.wallet.SendSiacoins(types.NewCurrency64(100), types.UnlockHash{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tpt.tpool.transactionSets) != 1 {
+		t.Error("sending coins did not increase the transaction sets by 1")
+	}
+	// Mine the transaction into a block, so that it's in the consensus set.
+	_, err = tpt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Close the tpool, delete the persistence, then restart the tpool. The
+	// tpool should still recognize the transaction set as a duplicate.
+	persistDir := tpt.tpool.persistDir
+	err = tpt.tpool.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.RemoveAll(persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tpt.tpool, err = New(tpt.cs, tpt.gateway, persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tpt.tpool.AcceptTransactionSet(txns)
+	if err != modules.ErrDuplicateTransactionSet {
+		t.Fatal("expecting modules.ErrDuplicateTransactionSet, got:", err)
+	}
+
+	// Close the tpool, corrupt the database, then restart the tpool. The tpool
+	// should still recognize the transaction set as a duplicate.
+	err = tpt.tpool.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := persist.OpenDatabase(dbMetadata, filepath.Join(persistDir, dbFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = db.Update(func(tx *bolt.Tx) error {
+		ccBytes := tx.Bucket(bucketRecentConsensusChange).Get(fieldRecentConsensusChange)
+		// copy the bytes due to bolt's mmap.
+		newCCBytes := make([]byte, len(ccBytes))
+		copy(newCCBytes, ccBytes)
+		newCCBytes[0]++
+		return tx.Bucket(bucketRecentConsensusChange).Put(fieldRecentConsensusChange, newCCBytes)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = db.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tpt.tpool, err = New(tpt.cs, tpt.gateway, persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tpt.tpool.AcceptTransactionSet(txns)
+	if err != modules.ErrDuplicateTransactionSet {
+		t.Fatal("expecting modules.ErrDuplicateTransactionSet, got:", err)
+	}
+}

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -24,6 +24,8 @@ type tpoolTester struct {
 	miner     modules.TestMiner
 	wallet    modules.Wallet
 	walletKey crypto.TwofishKey
+
+	persistDir string
 }
 
 // createTpoolTester returns a ready-to-use tpool tester, with all modules
@@ -39,7 +41,7 @@ func createTpoolTester(name string) (*tpoolTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := New(cs, g)
+	tp, err := New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}
@@ -73,6 +75,8 @@ func createTpoolTester(name string) (*tpoolTester, error) {
 		miner:     m,
 		wallet:    w,
 		walletKey: key,
+
+		persistDir: testdir,
 	}
 
 	// Mine blocks until there is money in the wallet.
@@ -99,21 +103,22 @@ func TestIntegrationNewNilInputs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	tpDir := filepath.Join(testdir, modules.TransactionPoolDir)
 
 	// Try all combinations of nil inputs.
-	_, err = New(nil, nil)
+	_, err = New(nil, nil, tpDir)
 	if err == nil {
 		t.Error(err)
 	}
-	_, err = New(nil, g)
+	_, err = New(nil, g, tpDir)
 	if err != errNilCS {
 		t.Error(err)
 	}
-	_, err = New(cs, nil)
+	_, err = New(cs, nil, tpDir)
 	if err != errNilGateway {
 		t.Error(err)
 	}
-	_, err = New(cs, g)
+	_, err = New(cs, g, tpDir)
 	if err != nil {
 		t.Error(err)
 	}

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -41,7 +41,7 @@ func createWalletTester(name string) (*walletTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func createBlankWalletTester(name string) (*walletTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func TestNilInputs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -104,7 +104,7 @@ func startDaemon(config Config) (err error) {
 	if strings.Contains(config.Siad.Modules, "t") {
 		i++
 		fmt.Printf("(%d/%d) Loading transaction pool...\n", i, len(config.Siad.Modules))
-		tpool, err = transactionpool.New(cs, g)
+		tpool, err = transactionpool.New(cs, g, filepath.Join(config.Siad.SiaDir, modules.TransactionPoolDir))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The transaction pool was previously experiencing a bug where transaction sets with parents that had been accepted to the blockchain would be rejected as double-spends. This was preventing hosts from getting paid. The transaction pool now keeps a record of all the transactions that have been confirmed on the blockchain, and will remove the parents from a transaction set that have been confirmed.

This behavior should be tested in an rc, but I think this PR is the last code change we need before v0.6.0, the rest should just be adjusting the constants.