### PR TITLE
move race libs to another make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ install:
 
 # release builds and installs release binaries.
 release:
+	go install -tags='debug profile' $(pkgs)
+release-race:
 	go install -race -tags='debug profile' $(pkgs)
 release-std:
 	go install $(pkgs)


### PR DESCRIPTION
`make release` now has the debugger and profiler enabled, but does not
build with the race libraries.

`make release-race` builds with the race libraries.

The primary reason for this change is performance, the race libraries
slow things down significantly and make it difficult to operate on the
production blockchain.