### PR TITLE
Unregister RPC and ConnectCall methods

### DIFF
--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -133,7 +133,7 @@ func assembleAuthenticatedServerTester(requiredPassword string, key crypto.Twofi
 	if err != nil {
 		return nil, err
 	}
-	tp, err := transactionpool.New(cs, g)
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -191,6 +191,14 @@ func (cs *ConsensusSet) Close() error {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
+	if cs.synced {
+		cs.gateway.UnregisterRPC("SendBlocks")
+		cs.gateway.UnregisterRPC("RelayBlock") // COMPATv0.5.1
+		cs.gateway.UnregisterRPC("RelayHeader")
+		cs.gateway.UnregisterRPC("SendBlk")
+		cs.gateway.UnregisterConnectCall("SendBlocks")
+	}
+
 	var errs []error
 	if err := cs.db.Close(); err != nil {
 		errs = append(errs, fmt.Errorf("db.Close failed: %v", err))

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1053,6 +1053,7 @@ func TestRelayHeader(t *testing.T) {
 	defer cst.Close()
 
 	mg := &mockGatewayCallsRPC{
+		Gateway:   cst.cs.gateway,
 		rpcCalled: make(chan string),
 	}
 	cst.cs.gateway = mg

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -78,9 +78,21 @@ type (
 		// supply the given RPC ID.
 		RegisterRPC(string, RPCFunc)
 
+		// UnregisterRPC unregisters an RPC and removes all references to the RPCFunc
+		// supplied in the corresponding RegisterRPC call. References to RPCFuncs
+		// registered with RegisterConnectCall are not removed and should be removed
+		// with UnregisterConnectCall. If the RPC does not exist no action is taken.
+		UnregisterRPC(string)
+
 		// RegisterConnectCall registers an RPC name and function to be called
 		// upon connecting to a peer.
 		RegisterConnectCall(string, RPCFunc)
+
+		// UnregisterConnectCall unregisters an RPC and removes all references to the
+		// RPCFunc supplied in the corresponding RegisterConnectCall call. References
+		// to RPCFuncs registered with RegisterRPC are not removed and should be
+		// removed with UnregisterRPC. If the RPC does not exist no action is taken.
+		UnregisterConnectCall(string)
 
 		// RPC calls an RPC on the given address. RPC cannot be called on an
 		// address that the Gateway is not connected to.

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -57,6 +57,11 @@ func (g *Gateway) Address() modules.NetAddress {
 func (g *Gateway) Close() error {
 	var errs []error
 
+	// Unregister RPCs. Not strictly necessary for clean shutdown in this specific
+	// case, as the handlers should only contain references to the gateway itself,
+	// but do it anyways as an example for other modules to follow.
+	g.UnregisterRPC("ShareNodes")
+	g.UnregisterConnectCall("ShareNodes")
 	// save the latest gateway state
 	id := g.mu.RLock()
 	if err := g.saveSync(); err != nil {

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -69,6 +69,19 @@ func (g *Gateway) RegisterRPC(name string, fn modules.RPCFunc) {
 	g.handlers[handlerName(name)] = fn
 }
 
+// UnregisterRPC unregisters an RPC and removes the corresponding RPCFunc from
+// g.handlers. Future calls to the RPC by peers will fail.
+func (g *Gateway) UnregisterRPC(name string) {
+	id := g.mu.Lock()
+	defer g.mu.Unlock(id)
+	if build.DEBUG {
+		if _, ok := g.handlers[handlerName(name)]; !ok {
+			panic("RPC is not registered: " + name)
+		}
+	}
+	delete(g.handlers, handlerName(name))
+}
+
 // RegisterConnectCall registers a name and RPCFunc to be called on a peer
 // upon connecting.
 func (g *Gateway) RegisterConnectCall(name string, fn modules.RPCFunc) {
@@ -80,6 +93,20 @@ func (g *Gateway) RegisterConnectCall(name string, fn modules.RPCFunc) {
 		}
 	}
 	g.initRPCs[name] = fn
+}
+
+// UnregisterConnectCall unregisters an on-connect call and removes the
+// corresponding RPCFunc from g.initRPCs. Future connections to peers will not
+// trigger the RPC to be called on them.
+func (g *Gateway) UnregisterConnectCall(name string) {
+	id := g.mu.Lock()
+	defer g.mu.Unlock(id)
+	if build.DEBUG {
+		if _, ok := g.initRPCs[name]; !ok {
+			panic("ConnectCall is not registered: " + name)
+		}
+	}
+	delete(g.initRPCs, name)
 }
 
 // listenPeer listens for new streams on a peer connection and serves them via

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -61,7 +61,7 @@ func (g *Gateway) RPC(addr modules.NetAddress, name string, fn modules.RPCFunc) 
 func (g *Gateway) RegisterRPC(name string, fn modules.RPCFunc) {
 	id := g.mu.Lock()
 	defer g.mu.Unlock(id)
-	if build.DEBUG && build.Release != "testing" {
+	if build.DEBUG {
 		if _, ok := g.handlers[handlerName(name)]; ok {
 			panic("refusing to overwrite RPC " + name)
 		}

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -61,10 +61,8 @@ func (g *Gateway) RPC(addr modules.NetAddress, name string, fn modules.RPCFunc) 
 func (g *Gateway) RegisterRPC(name string, fn modules.RPCFunc) {
 	id := g.mu.Lock()
 	defer g.mu.Unlock(id)
-	if build.DEBUG {
-		if _, ok := g.handlers[handlerName(name)]; ok {
-			panic("refusing to overwrite RPC " + name)
-		}
+	if _, ok := g.handlers[handlerName(name)]; ok {
+		build.Critical("RPC already registered: " + name)
 	}
 	g.handlers[handlerName(name)] = fn
 }
@@ -74,10 +72,8 @@ func (g *Gateway) RegisterRPC(name string, fn modules.RPCFunc) {
 func (g *Gateway) UnregisterRPC(name string) {
 	id := g.mu.Lock()
 	defer g.mu.Unlock(id)
-	if build.DEBUG {
-		if _, ok := g.handlers[handlerName(name)]; !ok {
-			panic("RPC is not registered: " + name)
-		}
+	if _, ok := g.handlers[handlerName(name)]; !ok {
+		build.Critical("RPC not registered: " + name)
 	}
 	delete(g.handlers, handlerName(name))
 }
@@ -87,10 +83,8 @@ func (g *Gateway) UnregisterRPC(name string) {
 func (g *Gateway) RegisterConnectCall(name string, fn modules.RPCFunc) {
 	id := g.mu.Lock()
 	defer g.mu.Unlock(id)
-	if build.DEBUG {
-		if _, ok := g.initRPCs[name]; ok {
-			panic("refusing to overwrite RPC " + name)
-		}
+	if _, ok := g.initRPCs[name]; ok {
+		build.Critical("ConnectCall already registered: " + name)
 	}
 	g.initRPCs[name] = fn
 }
@@ -101,10 +95,8 @@ func (g *Gateway) RegisterConnectCall(name string, fn modules.RPCFunc) {
 func (g *Gateway) UnregisterConnectCall(name string) {
 	id := g.mu.Lock()
 	defer g.mu.Unlock(id)
-	if build.DEBUG {
-		if _, ok := g.initRPCs[name]; !ok {
-			panic("ConnectCall is not registered: " + name)
-		}
+	if _, ok := g.initRPCs[name]; !ok {
+		build.Critical("ConnectCall not registered: " + name)
 	}
 	delete(g.initRPCs, name)
 }

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -110,6 +110,7 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string) (*Transa
 }
 
 func (tp *TransactionPool) Close() error {
+	tp.gateway.UnregisterRPC("RelayTransactionSet")
 	tp.consensusSet.Unsubscribe(tp)
 	return tp.db.Close()
 }


### PR DESCRIPTION
Fixes issue #1156 brought up in #1154.

This PR adds two new methods to the gateway `UnregisterRPC` and `UnregisterConnectCall`.

Without these methods the gateway will maintain references to RPCFuncs passed into RegisterRPC and RegisterConnectCall forever. This prevented the GC from cleaning up modules that were closed separately from the gateway. These two methods should primarily be used in the `Close()` method of modules.