### PR TITLE
Reduce gateway logging

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -14,7 +14,7 @@ func HttpGET(url string) (resp *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("User-Agent", "Sia-Agent")
+	req.Header.Set("User-Agent", "Sia-Agent")
 	return new(http.Client).Do(req)
 }
 
@@ -24,8 +24,8 @@ func HttpPOST(url string, data string) (resp *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("User-Agent", "Sia-Agent")
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "Sia-Agent")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	return new(http.Client).Do(req)
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -141,9 +141,6 @@ func (srv *Server) initAPI(password string) {
 		router.POST("/miner/header", requirePassword(srv.minerHeaderHandlerPOST, password))
 		router.GET("/miner/start", requirePassword(srv.minerStartHandler, password))
 		router.GET("/miner/stop", requirePassword(srv.minerStopHandler, password))
-		// TODO: doesn't adding authentication break compatibility?
-		router.GET("/miner/headerforwork", requirePassword(srv.minerHeaderHandlerGET, password))  // COMPATv0.4.8
-		router.POST("/miner/submitheader", requirePassword(srv.minerHeaderHandlerPOST, password)) // COMPATv0.4.8
 	}
 
 	// Renter API Calls
@@ -191,8 +188,6 @@ func (srv *Server) initAPI(password string) {
 		router.GET("/wallet/transactions", srv.walletTransactionsHandler)
 		router.GET("/wallet/transactions/:addr", srv.walletTransactionsAddrHandler)
 		router.POST("/wallet/unlock", requirePassword(srv.walletUnlockHandler, password))
-		// TODO: doesn't authentication break compatibility?
-		router.POST("/wallet/encrypt", requirePassword(srv.walletInitHandler, password)) // COMPATv0.4.0
 	}
 
 	// Apply UserAgent middleware and create HTTP server

--- a/api/api.go
+++ b/api/api.go
@@ -8,7 +8,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-// HttpGET is a utility function for making http get requests to sia with a whitelisted user-agent
+// HttpGET is a utility function for making http get requests to sia with a
+// whitelisted user-agent. A non-2xx response does not return an error.
 func HttpGET(url string) (resp *http.Response, err error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -18,7 +19,21 @@ func HttpGET(url string) (resp *http.Response, err error) {
 	return new(http.Client).Do(req)
 }
 
-// HttpPOST is a utility function for making post requests to sia with a whitelisted user-agent
+// HttpGETAuthenticated is a utility function for making authenticated http get
+// requests to sia with a whitelisted user-agent and the supplied password. A
+// non-2xx response does not return an error.
+func HttpGETAuthenticated(url string, password string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Sia-Agent")
+	req.SetBasicAuth("", password)
+	return new(http.Client).Do(req)
+}
+
+// HttpPOST is a utility function for making post requests to sia with a
+// whitelisted user-agent. A non-2xx response does not return an error.
 func HttpPOST(url string, data string) (resp *http.Response, err error) {
 	req, err := http.NewRequest("POST", url, strings.NewReader(data))
 	if err != nil {
@@ -26,6 +41,20 @@ func HttpPOST(url string, data string) (resp *http.Response, err error) {
 	}
 	req.Header.Set("User-Agent", "Sia-Agent")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return new(http.Client).Do(req)
+}
+
+// HttpPOSTAuthenticated is a utility function for making authenticated http
+// post requests to sia with a whitelisted user-agent and the supplied
+// password. A non-2xx response does not return an error.
+func HttpPOSTAuthenticated(url string, data string, password string) (resp *http.Response, err error) {
+	req, err := http.NewRequest("POST", url, strings.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Sia-Agent")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("", password)
 	return new(http.Client).Do(req)
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -70,15 +70,35 @@ func requireUserAgent(h http.Handler, ua string) http.Handler {
 	})
 }
 
-// initAPI determines which functions handle each API call.
-func (srv *Server) initAPI() {
+// requirePassword is middleware that requires a request to authenticate with a
+// password using HTTP basic auth. Usernames are ignored. Empty passwords
+// indicate no authentication is required.
+func requirePassword(h httprouter.Handle, password string) httprouter.Handle {
+	// An empty password is equivalent to no password.
+	if password == "" {
+		return h
+	}
+	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		_, pass, ok := req.BasicAuth()
+		if !ok || pass != password {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"SiaAPI\"")
+			writeError(w, "API authentication failed.", http.StatusUnauthorized)
+			return
+		}
+		h(w, req, ps)
+	}
+}
+
+// initAPI determines which functions handle each API call. An empty string as
+// the password indicates no password.
+func (srv *Server) initAPI(password string) {
 	router := httprouter.New()
 	router.NotFound = http.HandlerFunc(srv.unrecognizedCallHandler) // custom 404
 
 	// Daemon API Calls
 	router.GET("/daemon/constants", srv.daemonConstantsHandler)
 	router.GET("/daemon/version", srv.daemonVersionHandler)
-	router.GET("/daemon/stop", srv.daemonStopHandler)
+	router.GET("/daemon/stop", requirePassword(srv.daemonStopHandler, password))
 
 	// Consensus API Calls
 	if srv.cs != nil {
@@ -95,53 +115,54 @@ func (srv *Server) initAPI() {
 	// Gateway API Calls
 	if srv.gateway != nil {
 		router.GET("/gateway", srv.gatewayHandler)
-		router.POST("/gateway/add/:netaddress", srv.gatewayAddHandler)
-		router.POST("/gateway/remove/:netaddress", srv.gatewayRemoveHandler)
+		router.POST("/gateway/add/:netaddress", requirePassword(srv.gatewayAddHandler, password))
+		router.POST("/gateway/remove/:netaddress", requirePassword(srv.gatewayRemoveHandler, password))
 	}
 
 	// Host API Calls
 	if srv.host != nil {
 		// Calls directly pertaining to the host.
-		router.GET("/host", srv.hostHandlerGET)                // Get a bunch of information about the host.
-		router.POST("/host", srv.hostHandlerPOST)              // Set HostInternalSettings.
-		router.POST("/host/announce", srv.hostAnnounceHandler) // Announce the host, optionally on a specific address.
+		router.GET("/host", srv.hostHandlerGET)                                           // Get a bunch of information about the host.
+		router.POST("/host", requirePassword(srv.hostHandlerPOST, password))              // Set HostInternalSettings.
+		router.POST("/host/announce", requirePassword(srv.hostAnnounceHandler, password)) // Announce the host, optionally on a specific address.
 
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/storage", srv.storageHandler)
-		router.POST("/storage/folders/add", srv.storageFoldersAddHandler)
-		router.POST("/storage/folders/remove", srv.storageFoldersRemoveHandler)
-		router.POST("/storage/folders/resize", srv.storageFoldersResizeHandler)
-		router.POST("/storage/sectors/delete/:merkleroot", srv.storageSectorsDeleteHandler)
+		router.POST("/storage/folders/add", requirePassword(srv.storageFoldersAddHandler, password))
+		router.POST("/storage/folders/remove", requirePassword(srv.storageFoldersRemoveHandler, password))
+		router.POST("/storage/folders/resize", requirePassword(srv.storageFoldersResizeHandler, password))
+		router.POST("/storage/sectors/delete/:merkleroot", requirePassword(srv.storageSectorsDeleteHandler, password))
 	}
 
 	// Miner API Calls
 	if srv.miner != nil {
 		router.GET("/miner", srv.minerHandler)
-		router.GET("/miner/header", srv.minerHeaderHandlerGET)
-		router.POST("/miner/header", srv.minerHeaderHandlerPOST)
-		router.GET("/miner/start", srv.minerStartHandler)
-		router.GET("/miner/stop", srv.minerStopHandler)
-		router.GET("/miner/headerforwork", srv.minerHeaderHandlerGET)  // COMPATv0.4.8
-		router.POST("/miner/submitheader", srv.minerHeaderHandlerPOST) // COMPATv0.4.8
+		router.GET("/miner/header", requirePassword(srv.minerHeaderHandlerGET, password))
+		router.POST("/miner/header", requirePassword(srv.minerHeaderHandlerPOST, password))
+		router.GET("/miner/start", requirePassword(srv.minerStartHandler, password))
+		router.GET("/miner/stop", requirePassword(srv.minerStopHandler, password))
+		// TODO: doesn't adding authentication break compatibility?
+		router.GET("/miner/headerforwork", requirePassword(srv.minerHeaderHandlerGET, password))  // COMPATv0.4.8
+		router.POST("/miner/submitheader", requirePassword(srv.minerHeaderHandlerPOST, password)) // COMPATv0.4.8
 	}
 
 	// Renter API Calls
 	if srv.renter != nil {
 		router.GET("/renter", srv.renterHandler)
 		router.GET("/renter/allowance", srv.renterAllowanceHandlerGET)
-		router.POST("/renter/allowance", srv.renterAllowanceHandlerPOST)
+		router.POST("/renter/allowance", requirePassword(srv.renterAllowanceHandlerPOST, password))
 		router.GET("/renter/downloads", srv.renterDownloadsHandler)
 		router.GET("/renter/files", srv.renterFilesHandler)
 
-		router.POST("/renter/load", srv.renterLoadHandler)
-		router.POST("/renter/loadascii", srv.renterLoadAsciiHandler)
-		router.GET("/renter/share", srv.renterShareHandler)
-		router.GET("/renter/shareascii", srv.renterShareAsciiHandler)
+		router.POST("/renter/load", requirePassword(srv.renterLoadHandler, password))
+		router.POST("/renter/loadascii", requirePassword(srv.renterLoadAsciiHandler, password))
+		router.GET("/renter/share", requirePassword(srv.renterShareHandler, password))
+		router.GET("/renter/shareascii", requirePassword(srv.renterShareAsciiHandler, password))
 
-		router.POST("/renter/delete/*siapath", srv.renterDeleteHandler)
-		router.GET("/renter/download/*siapath", srv.renterDownloadHandler)
-		router.POST("/renter/rename/*siapath", srv.renterRenameHandler)
-		router.POST("/renter/upload/*siapath", srv.renterUploadHandler)
+		router.POST("/renter/delete/*siapath", requirePassword(srv.renterDeleteHandler, password))
+		router.GET("/renter/download/*siapath", requirePassword(srv.renterDownloadHandler, password))
+		router.POST("/renter/rename/*siapath", requirePassword(srv.renterRenameHandler, password))
+		router.POST("/renter/upload/*siapath", requirePassword(srv.renterUploadHandler, password))
 
 		router.GET("/renter/hosts/active", srv.renterHostsActiveHandler)
 		router.GET("/renter/hosts/all", srv.renterHostsAllHandler)
@@ -155,22 +176,23 @@ func (srv *Server) initAPI() {
 	// Wallet API Calls
 	if srv.wallet != nil {
 		router.GET("/wallet", srv.walletHandler)
-		router.POST("/wallet/033x", srv.wallet033xHandler)
-		router.GET("/wallet/address", srv.walletAddressHandler)
+		router.POST("/wallet/033x", requirePassword(srv.wallet033xHandler, password))
+		router.GET("/wallet/address", requirePassword(srv.walletAddressHandler, password))
 		router.GET("/wallet/addresses", srv.walletAddressesHandler)
-		router.GET("/wallet/backup", srv.walletBackupHandler)
-		router.POST("/wallet/init", srv.walletInitHandler)
-		router.POST("/wallet/lock", srv.walletLockHandler)
-		router.POST("/wallet/seed", srv.walletSeedHandler)
-		router.GET("/wallet/seeds", srv.walletSeedsHandler)
-		router.POST("/wallet/siacoins", srv.walletSiacoinsHandler)
-		router.POST("/wallet/siafunds", srv.walletSiafundsHandler)
-		router.POST("/wallet/siagkey", srv.walletSiagkeyHandler)
+		router.GET("/wallet/backup", requirePassword(srv.walletBackupHandler, password))
+		router.POST("/wallet/init", requirePassword(srv.walletInitHandler, password))
+		router.POST("/wallet/lock", requirePassword(srv.walletLockHandler, password))
+		router.POST("/wallet/seed", requirePassword(srv.walletSeedHandler, password))
+		router.GET("/wallet/seeds", requirePassword(srv.walletSeedsHandler, password))
+		router.POST("/wallet/siacoins", requirePassword(srv.walletSiacoinsHandler, password))
+		router.POST("/wallet/siafunds", requirePassword(srv.walletSiafundsHandler, password))
+		router.POST("/wallet/siagkey", requirePassword(srv.walletSiagkeyHandler, password))
 		router.GET("/wallet/transaction/:id", srv.walletTransactionHandler)
 		router.GET("/wallet/transactions", srv.walletTransactionsHandler)
 		router.GET("/wallet/transactions/:addr", srv.walletTransactionsAddrHandler)
-		router.POST("/wallet/unlock", srv.walletUnlockHandler)
-		router.POST("/wallet/encrypt", srv.walletInitHandler) // COMPATv0.4.0
+		router.POST("/wallet/unlock", requirePassword(srv.walletUnlockHandler, password))
+		// TODO: doesn't authentication break compatibility?
+		router.POST("/wallet/encrypt", requirePassword(srv.walletInitHandler, password)) // COMPATv0.4.0
 	}
 
 	// Apply UserAgent middleware and create HTTP server

--- a/api/server.go
+++ b/api/server.go
@@ -35,8 +35,12 @@ type Server struct {
 	wg sync.WaitGroup
 }
 
-// NewServer creates a new API server from the provided modules.
-func NewServer(APIaddr string, requiredUserAgent string, cs modules.ConsensusSet, e modules.Explorer, g modules.Gateway, h modules.Host, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet) (*Server, error) {
+// NewServer creates a new API server from the provided modules. The API will
+// require authentication using HTTP basic auth if the supplied password is not
+// the empty string. Usernames are ignored for authentication. This type of
+// authentication sends passwords in plaintext and should therefore only be
+// used if the APIaddr is localhost.
+func NewServer(APIaddr string, requiredUserAgent string, requiredPassword string, cs modules.ConsensusSet, e modules.Explorer, g modules.Gateway, h modules.Host, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet) (*Server, error) {
 	l, err := net.Listen("tcp", APIaddr)
 	if err != nil {
 		return nil, err
@@ -57,35 +61,9 @@ func NewServer(APIaddr string, requiredUserAgent string, cs modules.ConsensusSet
 	}
 
 	// Register API handlers
-	srv.initAPI()
+	srv.initAPI(requiredPassword)
 
 	return srv, nil
-}
-
-// requirePassword is middleware that requires all requests to authenticate
-// with a password using HTTP basic auth. Usernames are ignored.
-func requirePassword(h http.Handler, password string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		_, pass, ok := req.BasicAuth()
-		if !ok || pass != password {
-			w.Header().Set("WWW-Authenticate", "Basic realm=\"SiaAPI\"")
-			writeError(w, "API authentication failed.", http.StatusUnauthorized)
-			return
-		}
-		h.ServeHTTP(w, req)
-	})
-}
-
-// RequireAuthentication makes a non-authenticated server require
-// authentication with the provided password. Authentication is done with HTTP
-// basic auth with the supplied password. Usernames are ignored during
-// authentication. This type of authentication sends passwords in plaintext and
-// should therefore only be used if the APIaddr is localhost. Calling
-// RequireAuthentication multiple times with different passwords will prevent
-// any API calls, authenticated or not, from succeeding as the server would
-// enforce multiple passwords.
-func (srv *Server) RequireAuthentication(password string) {
-	srv.apiServer.Handler = requirePassword(srv.apiServer.Handler, password)
 }
 
 // Serve listens for and handles API calls. It is a blocking function.

--- a/api/server.go
+++ b/api/server.go
@@ -62,6 +62,32 @@ func NewServer(APIaddr string, requiredUserAgent string, cs modules.ConsensusSet
 	return srv, nil
 }
 
+// requirePassword is middleware that requires all requests to authenticate
+// with a password using HTTP basic auth. Usernames are ignored.
+func requirePassword(h http.Handler, password string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, pass, ok := req.BasicAuth()
+		if !ok || pass != password {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"SiaAPI\"")
+			writeError(w, "API authentication failed.", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, req)
+	})
+}
+
+// RequireAuthentication makes a non-authenticated server require
+// authentication with the provided password. Authentication is done with HTTP
+// basic auth with the supplied password. Usernames are ignored during
+// authentication. This type of authentication sends passwords in plaintext and
+// should therefore only be used if the APIaddr is localhost. Calling
+// RequireAuthentication multiple times with different passwords will prevent
+// any API calls, authenticated or not, from succeeding as the server would
+// enforce multiple passwords.
+func (srv *Server) RequireAuthentication(password string) {
+	srv.apiServer.Handler = requirePassword(srv.apiServer.Handler, password)
+}
+
 // Serve listens for and handles API calls. It is a blocking function.
 func (srv *Server) Serve() error {
 	// Block the Close() method until Serve() has finished.

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -88,7 +88,7 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", "", cs, e, g, h, m, r, tp, w)
 	if err != nil {
 		return nil, err
 	}
@@ -167,11 +167,10 @@ func assembleAuthenticatedServerTester(requiredPassword string, key crypto.Twofi
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", requiredPassword, cs, e, g, h, m, r, tp, w)
 	if err != nil {
 		return nil, err
 	}
-	srv.RequireAuthentication(requiredPassword)
 
 	// Assemble the serverTester.
 	st := &serverTester{
@@ -217,7 +216,7 @@ func assembleExplorerServerTester(testdir string) (*serverTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServer("localhost:0", "", cs, e, g, nil, nil, nil, nil, nil)
+	srv, err := NewServer("localhost:0", "", "", cs, e, g, nil, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -355,7 +355,7 @@ func (st *serverTester) stdGetAPIUA(call string, userAgent string) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Add("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := new(http.Client).Do(req)
 	if err != nil {
 		return err

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -120,6 +120,86 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	return st, nil
 }
 
+// assembleAuthenticatedServerTester creates a bunch of modules and assembles
+// them into a server tester that requires authentication with the given
+// requiredPassword. No directories are created and no blocks are mined.
+func assembleAuthenticatedServerTester(requiredPassword string, key crypto.TwofishKey, testdir string) (*serverTester, error) {
+	// Create the modules.
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
+	if err != nil {
+		return nil, err
+	}
+	cs, err := consensus.New(g, filepath.Join(testdir, modules.ConsensusDir))
+	if err != nil {
+		return nil, err
+	}
+	tp, err := transactionpool.New(cs, g)
+	if err != nil {
+		return nil, err
+	}
+	w, err := wallet.New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	if err != nil {
+		return nil, err
+	}
+	if !w.Encrypted() {
+		_, err = w.Encrypt(key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = w.Unlock(key)
+	if err != nil {
+		return nil, err
+	}
+	m, err := miner.New(cs, tp, w, filepath.Join(testdir, modules.MinerDir))
+	if err != nil {
+		return nil, err
+	}
+	h, err := host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	if err != nil {
+		return nil, err
+	}
+	r, err := renter.New(cs, w, tp, filepath.Join(testdir, modules.RenterDir))
+	if err != nil {
+		return nil, err
+	}
+	e, err := explorer.New(cs, filepath.Join(testdir, modules.ExplorerDir))
+	if err != nil {
+		return nil, err
+	}
+	srv, err := NewServer("localhost:0", "Sia-Agent", cs, e, g, h, m, r, tp, w)
+	if err != nil {
+		return nil, err
+	}
+	srv.RequireAuthentication(requiredPassword)
+
+	// Assemble the serverTester.
+	st := &serverTester{
+		cs:        cs,
+		gateway:   g,
+		host:      h,
+		miner:     m,
+		renter:    r,
+		tpool:     tp,
+		explorer:  e,
+		wallet:    w,
+		walletKey: key,
+
+		server: srv,
+
+		dir: testdir,
+	}
+
+	// TODO: A more reasonable way of listening for server errors.
+	go func() {
+		listenErr := srv.Serve()
+		if listenErr != nil {
+			panic(listenErr)
+		}
+	}()
+	return st, nil
+}
+
 // assembleExplorerServerTester creates all the explorer dependencies and
 // explorer module without creating any directories. The user agent requirement
 // is disabled.
@@ -174,6 +254,33 @@ func createServerTester(name string) (*serverTester, error) {
 		return nil, err
 	}
 	st, err := assembleServerTester(key, testdir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mine blocks until the wallet has confirmed money.
+	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
+		_, err := st.miner.AddBlock()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return st, nil
+}
+
+// createAuthenticatedServerTester creates an authenticated server tester
+// object that is ready for testing, including money in the wallet and all
+// modules initalized.
+func createAuthenticatedServerTester(name string, password string) (*serverTester, error) {
+	// Create the testing directory.
+	testdir := build.TempDir("authenticated-api", name)
+
+	key, err := crypto.GenerateTwofishKey()
+	if err != nil {
+		return nil, err
+	}
+	st, err := assembleAuthenticatedServerTester(password, key, testdir)
 	if err != nil {
 		return nil, err
 	}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -72,7 +72,7 @@ func TestAuthentication(t *testing.T) {
 	}
 	defer st.server.Close()
 
-	testGETURL := "http://" + st.server.listener.Addr().String() + "/daemon/version"
+	testGETURL := "http://" + st.server.listener.Addr().String() + "/wallet/seeds"
 	testPOSTURL := "http://" + st.server.listener.Addr().String() + "/host/announce"
 
 	// Test that unauthenticated API calls fail.

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -54,5 +55,77 @@ func TestReloading(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestAuthenticated tests creating a server that requires authenticated API
+// calls, and then makes (un)authenticated API calls to test the
+// authentication.
+func TestAuthentication(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createAuthenticatedServerTester("TestAuthentication", "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	testGETURL := "http://" + st.server.listener.Addr().String() + "/daemon/version"
+	testPOSTURL := "http://" + st.server.listener.Addr().String() + "/host/announce"
+
+	// Test that unauthenticated API calls fail.
+	// GET
+	resp, err := HttpGET(testGETURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("unauthenticated API call succeeded on a server that requires authentication")
+	}
+	// POST
+	resp, err = HttpPOST(testPOSTURL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("unauthenticated API call succeeded on a server that requires authentication")
+	}
+
+	// Test that authenticated API calls with the wrong password fail.
+	// GET
+	resp, err = HttpGETAuthenticated(testGETURL, "wrong password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("authenticated API call succeeded with an incorrect password")
+	}
+	// POST
+	resp, err = HttpPOSTAuthenticated(testPOSTURL, "", "wrong password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatal("authenticated API call succeeded with an incorrect password")
+	}
+
+	// Test that authenticated API calls with the correct password succeed.
+	// GET
+	resp, err = HttpGETAuthenticated(testGETURL, "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("authenticated API call failed with the correct password")
+	}
+	// POST
+	resp, err = HttpPOSTAuthenticated(testPOSTURL, "", "password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("authenticated API call failed with the correct password")
 	}
 }

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -45,14 +45,6 @@ type (
 		PrimarySeed string `json:"primaryseed"`
 	}
 
-	// WalletEncryptPOST contains the primary seed that gets generated during a
-	// POST call to /wallet/encrypt.
-	//
-	// COMPATv0.4.0
-	WalletEncryptPOST struct {
-		PrimarySeed string `json:"primaryseed"`
-	}
-
 	// WalletSiacoinsPOST contains the transaction sent in the POST call to
 	// /wallet/siafunds.
 	WalletSiacoinsPOST struct {

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -253,7 +253,7 @@ func (srv *Server) walletLockHandler(w http.ResponseWriter, req *http.Request, _
 	writeSuccess(w)
 }
 
-// walletSeedHandler handles API calls to /wallet/seed.
+// walletSeedsHandler handles API calls to /wallet/seeds.
 func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	dictionary := mnemonics.DictionaryID(req.FormValue("dictionary"))
 	if dictionary == "" {
@@ -263,26 +263,26 @@ func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, 
 	// Get the primary seed information.
 	primarySeed, progress, err := srv.wallet.PrimarySeed()
 	if err != nil {
-		writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	primarySeedStr, err := modules.SeedToString(primarySeed, dictionary)
 	if err != nil {
-		writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	// Get the list of seeds known to the wallet.
 	allSeeds, err := srv.wallet.AllSeeds()
 	if err != nil {
-		writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	var allSeedsStrs []string
 	for _, seed := range allSeeds {
 		str, err := modules.SeedToString(seed, dictionary)
 		if err != nil {
-			writeError(w, "error after call to /wallet/seed: "+err.Error(), http.StatusBadRequest)
+			writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
 			return
 		}
 		allSeedsStrs = append(allSeedsStrs, str)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -125,16 +125,16 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	}()
 	defer st.server.Close()
 
-	// Make a call to /wallet/encrypt and get the seed. Provide no encryption
+	// Make a call to /wallet/init and get the seed. Provide no encryption
 	// key so that the encryption key is the seed that gets returned.
-	var wep WalletEncryptPOST
-	err = st.postAPI("/wallet/encrypt", url.Values{}, &wep)
+	var wip WalletInitPOST
+	err = st.postAPI("/wallet/init", url.Values{}, &wip)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Use the seed to call /wallet/unlock.
 	unlockValues := url.Values{}
-	unlockValues.Set("encryptionpassword", wep.PrimarySeed)
+	unlockValues.Set("encryptionpassword", wip.PrimarySeed)
 	err = st.stdPostAPI("/wallet/unlock", unlockValues)
 	if err != nil {
 		t.Fatal(err)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -188,7 +188,7 @@ func TestIntegrationWalletGETSiacoins(t *testing.T) {
 	}
 	sendSiacoinsValues := url.Values{}
 	sendSiacoinsValues.Set("amount", "1234")
-	sendSiacoinsValues.Add("destination", wag.Address.String())
+	sendSiacoinsValues.Set("destination", wag.Address.String())
 	err = st.stdPostAPI("/wallet/siacoins", sendSiacoinsValues)
 	if err != nil {
 		t.Fatal(err)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -40,7 +40,7 @@ func TestIntegrationWalletGETEncrypted(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create wallet:", err)
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", "", cs, nil, g, nil, nil, nil, tp, w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestIntegrationWalletBlankEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := NewServer("localhost:0", "Sia-Agent", cs, nil, g, nil, nil, nil, tp, w)
+	srv, err := NewServer("localhost:0", "Sia-Agent", "", cs, nil, g, nil, nil, nil, tp, w)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/build/version.go
+++ b/build/version.go
@@ -5,8 +5,17 @@ import (
 	"strings"
 )
 
-// Version is the current version of siad.
-const Version = "0.6.1"
+const (
+	// Version is the current version of siad.
+	Version = "0.6.1"
+
+	// MaxEncodedVersionLength is the maximum length of a version string encoded
+	// with the encode package. 100 is much larger than any version number we send
+	// now, but it allows us to send additional information in the version string
+	// later if we choose. For example appending the version string with the HEAD
+	// commit hash.
+	MaxEncodedVersionLength = 100
+)
 
 // IsVersion returns whether str is a valid version number.
 func IsVersion(str string) bool {

--- a/build/version.go
+++ b/build/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version is the current version of siad.
-const Version = "0.6.0"
+const Version = "0.6.1"
 
 // IsVersion returns whether str is a valid version number.
 func IsVersion(str string) bool {

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -349,7 +349,7 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 		// received from the peer is discarded and will be downloaded again if
 		// the parent is found.
 		go func() {
-			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
+			err := cs.gateway.RPC(conn.RPCAddr(), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
 				cs.log.Debugln("WARN: failed to get parents of orphan block:", err)
 			}
@@ -380,7 +380,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	if err == errOrphan {
 		// If the header is an orphan, try to find the parents.
 		go func() {
-			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
+			err := cs.gateway.RPC(conn.RPCAddr(), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
 				cs.log.Debugln("WARN: failed to get parents of orphan header:", err)
 			}
@@ -392,7 +392,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	// If the header is valid and extends the heaviest chain, fetch, accept it,
 	// and broadcast it.
 	go func() {
-		err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlk", cs.threadedReceiveBlock(h.ID()))
+		err := cs.gateway.RPC(conn.RPCAddr(), "SendBlk", cs.threadedReceiveBlock(h.ID()))
 		if err != nil {
 			cs.log.Debugln("WARN: failed to get header's corresponding block:", err)
 		}

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -41,9 +41,13 @@ type (
 	}
 
 	// A PeerConn is the connection type used when communicating with peers during
-	// an RPC. For now it is identical to a net.Conn.
+	// an RPC. It is identical to a net.Conn with the additional RPCAddr method.
+	// This method acts as an identifier for peers and is the address that the
+	// peer can be dialed on. It is also the address that should be used when
+	// calling an RPC on the peer.
 	PeerConn interface {
 		net.Conn
+		RPCAddr() NetAddress
 	}
 
 	// RPCFunc is the type signature of functions that handle RPCs. It is used for

--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -2,9 +2,18 @@ package gateway
 
 import (
 	"net"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // peerConn is a simple type that implements the modules.PeerConn interface.
 type peerConn struct {
 	net.Conn
+	dialbackAddr modules.NetAddress
+}
+
+// RPCAddr implements the RPCAddr method of the modules.PeerConn interface. It
+// is the address that identifies a peer.
+func (pc peerConn) RPCAddr() modules.NetAddress {
+	return pc.dialbackAddr
 }

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -136,7 +136,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	if build.Release == "standard" {
 		for _, addr := range modules.BootstrapPeers {
 			err := g.addNode(addr)
-			if err != nil {
+			if err != nil && err != errNodeExists {
 				g.log.Printf("WARN: failed to add the bootstrap node '%v': %v", addr, err)
 			}
 		}

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -119,7 +119,6 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 
 	// Register RPCs.
 	g.RegisterRPC("ShareNodes", g.shareNodes)
-	g.RegisterRPC("RelayNode", g.relayNode)
 	g.RegisterConnectCall("ShareNodes", g.requestNodes)
 
 	// Load the old node list. If it doesn't exist, no problem, but if it does,

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -34,6 +34,9 @@ func TestAddress(t *testing.T) {
 	}
 	host := modules.NetAddress(g.listener.Addr().String()).Host()
 	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatal("address is not an IP address")
+	}
 	if ip.IsUnspecified() {
 		t.Fatal("expected a non-unspecified address")
 	}

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -12,18 +12,22 @@ import (
 
 const (
 	maxSharedNodes = 10
-	maxAddrLength  = 100
+	maxAddrLength  = 100 // TODO: max NetAddress length is 254 for the hostname (including the trailing dot, 253 without) + 1 for the : + 5 for the port.
 	minPeers       = 3
+)
+
+var (
+	errNodeExists = errors.New("node already added")
 )
 
 // addNode adds an address to the set of nodes on the network.
 func (g *Gateway) addNode(addr modules.NetAddress) error {
 	if _, exists := g.nodes[addr]; exists {
-		return errors.New("node already added")
-	} else if net.ParseIP(addr.Host()) == nil {
-		return errors.New("address is not routable: " + string(addr))
+		return errNodeExists
 	} else if addr.IsValid() != nil {
 		return errors.New("address is not valid: " + string(addr))
+	} else if net.ParseIP(addr.Host()) == nil {
+		return errors.New("address must be an IP address: " + string(addr))
 	}
 	g.nodes[addr] = struct{}{}
 	return nil

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	maxSharedNodes = 10
-	maxAddrLength  = 100 // TODO: max NetAddress length is 254 for the hostname (including the trailing dot, 253 without) + 1 for the : + 5 for the port.
 	minPeers       = 3
 )
 
@@ -77,7 +76,7 @@ func (g *Gateway) shareNodes(conn modules.PeerConn) error {
 // requestNodes is the calling end of the ShareNodes RPC.
 func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	var nodes []modules.NetAddress
-	if err := encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength); err != nil {
 		return err
 	}
 	id := g.mu.Lock()

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -18,11 +18,14 @@ const (
 
 var (
 	errNodeExists = errors.New("node already added")
+	errOurAddress = errors.New("can't add our own address")
 )
 
 // addNode adds an address to the set of nodes on the network.
 func (g *Gateway) addNode(addr modules.NetAddress) error {
-	if _, exists := g.nodes[addr]; exists {
+	if addr == g.myAddr {
+		return errOurAddress
+	} else if _, exists := g.nodes[addr]; exists {
 		return errNodeExists
 	} else if addr.IsValid() != nil {
 		return errors.New("address is not valid: " + string(addr))
@@ -80,8 +83,8 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	id := g.mu.Lock()
 	for _, node := range nodes {
 		err := g.addNode(node)
-		if err != nil {
-			g.log.Printf("WARN: peer '%v' send the invalid addr '%v'", conn.RemoteAddr(), node)
+		if err != nil && err != errNodeExists && err != errOurAddress {
+			g.log.Printf("WARN: peer '%v' sent the invalid addr '%v'", conn.RemoteAddr(), node)
 		}
 	}
 	g.save()
@@ -112,7 +115,7 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 		}
 		return nil
 	}()
-	if err != nil {
+	if err != nil && err != errNodeExists {
 		return err
 	}
 	// relay

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -83,7 +83,7 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	for _, node := range nodes {
 		err := g.addNode(node)
 		if err != nil && err != errNodeExists && err != errOurAddress {
-			g.log.Printf("WARN: peer '%v' sent the invalid addr '%v'", conn.RemoteAddr(), node)
+			g.log.Printf("WARN: peer '%v' sent the invalid addr '%v'", conn.RPCAddr(), node)
 		}
 	}
 	g.save()

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -92,47 +92,6 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	return nil
 }
 
-// relayNode is the recipient end of the RelayNode RPC. It reads a node, adds
-// it to the Gateway's node list, and relays it to each of the Gateway's
-// peers. If the node is already in the node list, it is not relayed.
-func (g *Gateway) relayNode(conn modules.PeerConn) error {
-	// read address
-	var addr modules.NetAddress
-	if err := encoding.ReadObject(conn, &addr, maxAddrLength); err != nil {
-		return err
-	}
-	// add node
-	err := func() error {
-		// We wrap this logic in an anonymous function so we can defer Unlock to
-		// avoid managing locks across branching.
-		id := g.mu.Lock()
-		defer g.mu.Unlock(id)
-		if err := g.addNode(addr); err != nil {
-			return err
-		}
-		if err := g.save(); err != nil {
-			return err
-		}
-		return nil
-	}()
-	if err != nil && err != errNodeExists {
-		return err
-	}
-	// relay
-	peers := g.Peers()
-	go g.Broadcast("RelayNode", addr, peers)
-	return nil
-}
-
-// sendAddress is the calling end of the RelayNode RPC.
-func (g *Gateway) sendAddress(conn modules.PeerConn) error {
-	// don't send if we aren't connectible
-	if g.Address().IsValid() != nil {
-		return errors.New("can't send address without knowing external IP")
-	}
-	return encoding.WriteObject(conn, g.Address())
-}
-
 // threadedNodeManager tries to keep the Gateway's node list healthy. As long
 // as the Gateway has fewer than minNodeListSize nodes, it asks a random peer
 // for more nodes. It also continually pings nodes in order to establish their

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -19,7 +19,7 @@ func TestAddNode(t *testing.T) {
 	if err := g.addNode(dummyNode); err != nil {
 		t.Fatal("addNode failed:", err)
 	}
-	if err := g.addNode(dummyNode); err == nil {
+	if err := g.addNode(dummyNode); err != errNodeExists {
 		t.Error("addNode added duplicate node")
 	}
 	if err := g.addNode("foo"); err == nil {
@@ -30,6 +30,9 @@ func TestAddNode(t *testing.T) {
 	}
 	if err := g.addNode("[::]:9981"); err == nil {
 		t.Error("addNode added unspecified address")
+	}
+	if err := g.addNode(g.myAddr); err != errOurAddress {
+		t.Error("addNode added our own address")
 	}
 }
 

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -167,7 +167,7 @@ func TestShareNodes(t *testing.T) {
 	// SharePeers should now return no peers
 	var nodes []modules.NetAddress
 	err = g1.RPC(g2.Address(), "ShareNodes", func(conn modules.PeerConn) error {
-		return encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength)
+		return encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength)
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +186,7 @@ func TestShareNodes(t *testing.T) {
 		}
 	}
 	err = g1.RPC(g2.Address(), "ShareNodes", func(conn modules.PeerConn) error {
-		return encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength)
+		return encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -196,20 +196,19 @@ func TestShareNodes(t *testing.T) {
 	}
 }
 
-func TestRelayNodes(t *testing.T) {
+// TestNodesAreSharedOnConnect tests that nodes that a gateway has never seen
+// before are added to the node list when connecting to another gateway that
+// has seen said nodes.
+func TestNodesAreSharedOnConnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	g1 := newTestingGateway("TestRelayNodes1", t)
+	g1 := newTestingGateway("TestNodesAreSharedOnConnect1", t)
 	defer g1.Close()
-	g2 := newTestingGateway("TestRelayNodes2", t)
+	g2 := newTestingGateway("TestNodesAreSharedOnConnect2", t)
 	defer g2.Close()
-	g3 := newTestingGateway("TestRelayNodes3", t)
+	g3 := newTestingGateway("TestNodesAreSharedOnConnect3", t)
 	defer g3.Close()
-
-	// normally the Gateway will only register this RPC if has discovered its
-	// IP through external means.
-	g3.RegisterConnectCall("RelayNode", g3.sendAddress)
 
 	// connect g2 to g1
 	err := g2.Connect(g1.Address())
@@ -223,11 +222,11 @@ func TestRelayNodes(t *testing.T) {
 		t.Fatal("couldn't connect:", err)
 	}
 
-	// g2 should have received g3's address from g1
+	// g3 should have received g2's address from g1
 	time.Sleep(200 * time.Millisecond)
-	id := g2.mu.Lock()
-	defer g2.mu.Unlock(id)
-	if _, ok := g2.nodes[g3.Address()]; !ok {
-		t.Fatal("node was not relayed:", g2.nodes)
+	id := g3.mu.Lock()
+	defer g3.mu.Unlock(id)
+	if _, ok := g3.nodes[g2.Address()]; !ok {
+		t.Fatal("node was not shared:", g3.nodes)
 	}
 }

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -223,15 +223,18 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	}
 	// send our version
 	if err := encoding.WriteObject(conn, build.Version); err != nil {
+		conn.Close()
 		return err
 	}
 	// read version ack
 	var remoteVersion string
 	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+		conn.Close()
 		return err
 	}
 	// decide whether to accept this version
 	if remoteVersion == "reject" {
+		conn.Close()
 		return errPeerRejectedConn
 	}
 	// Check that version is acceptable.

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -260,7 +260,15 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 		},
 		sess: muxado.Client(conn),
 	})
+	// addNode must be called after addPeer so that threadedPeerManager doesn't
+	// try to Connect to the node before we do (although in this particular case
+	// it doesn't matter as a lock is held over both calls).
+	err = g.addNode(addr)
 	g.mu.Unlock(id)
+	if err != nil && err != errNodeExists {
+		g.Disconnect(addr)
+		return err
+	}
 
 	// call initRPCs
 	id = g.mu.RLock()

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -148,7 +148,7 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 	//
 	// NOTE: this version must be bumped whenever the gateway or consensus
 	// breaks compatibility.
-	if build.VersionCmp(remoteVersion, "0.4.0") < 0 {
+	if !build.IsVersion(remoteVersion) || build.VersionCmp(remoteVersion, "0.4.0") < 0 {
 		encoding.WriteObject(conn, "reject")
 		conn.Close()
 		g.log.Printf("INFO: %v wanted to connect, but their version (%v) was unacceptable", addr, remoteVersion)
@@ -244,7 +244,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	//
 	// NOTE: this version must be bumped whenever the gateway or consensus
 	// breaks compatibility.
-	if build.VersionCmp(remoteVersion, "0.4.0") < 0 {
+	if !build.IsVersion(remoteVersion) || build.VersionCmp(remoteVersion, "0.4.0") < 0 {
 		conn.Close()
 		return insufficientVersionError(remoteVersion)
 	}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -58,7 +58,7 @@ func (p *peer) open() (modules.PeerConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &peerConn{conn}, nil
+	return &peerConn{conn, p.NetAddress}, nil
 }
 
 func (p *peer) accept() (modules.PeerConn, error) {
@@ -66,7 +66,7 @@ func (p *peer) accept() (modules.PeerConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &peerConn{conn}, nil
+	return &peerConn{conn, p.NetAddress}, nil
 }
 
 // addPeer adds a peer to the Gateway's peer list and spawns a listener thread

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -136,7 +136,7 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 
 	// read version
 	var remoteVersion string
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		conn.Close()
 		g.log.Printf("INFO: %v wanted to connect, but we could not read their version: %v", addr, err)
 		return
@@ -280,7 +280,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	}
 	// read version ack
 	var remoteVersion string
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		conn.Close()
 		return err
 	}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -240,6 +240,7 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 	var err error
 	if build.VersionCmp(remoteVersion, "0.6.1") >= 0 {
 		err = g.addNode(remoteAddr)
+		// TODO: call g.save?
 	}
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
@@ -324,6 +325,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	// try to Connect to the node before we do (although in this particular case
 	// it doesn't matter as a lock is held over both calls).
 	err = g.addNode(addr)
+	// TODO: call g.save?
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
 		g.Disconnect(addr)

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -240,7 +240,9 @@ func (g *Gateway) acceptConn(conn net.Conn) {
 	var err error
 	if build.VersionCmp(remoteVersion, "0.6.1") >= 0 {
 		err = g.addNode(remoteAddr)
-		// TODO: call g.save?
+		if saveErr := g.save(); saveErr != nil {
+			g.log.Printf("WARN: could not save node list: %v", saveErr)
+		}
 	}
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
@@ -325,7 +327,9 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	// try to Connect to the node before we do (although in this particular case
 	// it doesn't matter as a lock is held over both calls).
 	err = g.addNode(addr)
-	// TODO: call g.save?
+	if saveErr := g.save(); saveErr != nil {
+		g.log.Printf("WARN: could not save node list: %v", saveErr)
+	}
 	g.mu.Unlock(id)
 	if err != nil && err != errNodeExists {
 		g.Disconnect(addr)

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -297,9 +297,29 @@ func TestConnectRejectsInvalidVersions(t *testing.T) {
 			insufficientVersion: true,
 			msg:                 "Connect should fail when the remote peer's version is ascii gibberish",
 		},
+		{
+			version:             "999.foobar",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is ascii gibberish",
+		},
+		{
+			version:             "foobar.0",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is ascii gibberish",
+		},
 		// Test that Connect fails when the remote peer's version is utf8 gibberish.
 		{
 			version:             "世界",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is utf8 gibberish",
+		},
+		{
+			version:             "999.世界",
+			insufficientVersion: true,
+			msg:                 "Connect should fail when the remote peer's version is utf8 gibberish",
+		},
+		{
+			version:             "世界.0",
 			insufficientVersion: true,
 			msg:                 "Connect should fail when the remote peer's version is utf8 gibberish",
 		},
@@ -433,9 +453,29 @@ func TestAcceptConnRejectsInvalidVersions(t *testing.T) {
 			versionResponseWant: "reject",
 			msg:                 "acceptConn shouldn't accept a remote peer whose version is ascii giberish",
 		},
+		{
+			remoteVersion:       "999.foobar",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is ascii giberish",
+		},
+		{
+			remoteVersion:       "foobar.0",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is ascii giberish",
+		},
 		// Test that acceptConn fails when the remote peer's version is utf8 gibberish.
 		{
 			remoteVersion:       "世界",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is utf8 giberish",
+		},
+		{
+			remoteVersion:       "999.世界",
+			versionResponseWant: "reject",
+			msg:                 "acceptConn shouldn't accept a remote peer whose version is utf8 giberish",
+		},
+		{
+			remoteVersion:       "世界.0",
 			versionResponseWant: "reject",
 			msg:                 "acceptConn shouldn't accept a remote peer whose version is utf8 giberish",
 		},

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -86,7 +86,7 @@ func TestListen(t *testing.T) {
 	}
 	// read ack
 	var ack string
-	if err := encoding.ReadObject(conn, &ack, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &ack, build.MaxEncodedVersionLength); err != nil {
 		t.Fatal(err)
 	} else if ack != "reject" {
 		t.Fatal("gateway should have rejected old version")
@@ -114,7 +114,7 @@ func TestListen(t *testing.T) {
 		t.Fatal("couldn't write version")
 	}
 	// read ack
-	if err := encoding.ReadObject(conn, &ack, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &ack, build.MaxEncodedVersionLength); err != nil {
 		t.Fatal(err)
 	} else if ack == "reject" {
 		t.Fatal("gateway should have given ack")
@@ -285,7 +285,7 @@ func TestConnectRejectsInvalidVersions(t *testing.T) {
 			}
 			// Read remote peer version.
 			var remoteVersion string
-			if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+			if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 				panic(err)
 			}
 			// Write our mock version.
@@ -436,7 +436,7 @@ func (g mockGatewayWithVersion) Connect(addr modules.NetAddress) error {
 	}
 	// read version ack
 	var remoteVersion string
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		return err
 	}
 	// send port

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -197,7 +197,11 @@ func TestConnect(t *testing.T) {
 // addresses.
 func TestConnectRejectsInvalidAddrs(t *testing.T) {
 	g := newTestingGateway("TestConnectRejectsInvalidAddrs", t)
+	defer g.Close()
+
 	g2 := newTestingGateway("TestConnectRejectsInvalidAddrs2", t)
+	defer g2.Close()
+
 	_, g2Port, err := net.SplitHostPort(string(g2.Address()))
 	if err != nil {
 		t.Fatal(err)
@@ -248,6 +252,7 @@ func TestConnectRejectsInvalidVersions(t *testing.T) {
 		t.SkipNow()
 	}
 	g := newTestingGateway("TestConnectRejectsInvalidVersions", t)
+	defer g.Close()
 	// Setup a listener that mocks Gateway.acceptConn, but sends the
 	// version sent over mockVersionChan instead of build.Version.
 	listener, err := net.Listen("tcp", "localhost:0")

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -111,12 +111,10 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 	fn, ok := g.handlers[id]
 	g.mu.RUnlock(lockid)
 	if !ok {
-		g.log.Printf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RemoteAddr(), id)
+		g.log.Debugf("WARN: incoming conn %v requested unknown RPC %q", conn.RemoteAddr(), id)
 		return
 	}
-	if build.DEBUG {
-		g.log.Printf("INFO: incoming conn %v requested RPC \"%v\"", conn.RemoteAddr(), id)
-	}
+	g.log.Debugf("INFO: incoming conn %v requested RPC %q", conn.RemoteAddr(), id)
 
 	// call fn
 	err := fn(conn)
@@ -125,7 +123,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 		err = nil
 	}
 	if err != nil {
-		g.log.Printf("WARN: incoming RPC \"%v\" from conn %v failed: %v", id, conn.RemoteAddr(), err)
+		g.log.Debugf("WARN: incoming RPC %q from conn %v failed: %v", id, conn.RemoteAddr(), err)
 	}
 }
 
@@ -134,7 +132,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 // object and disconnect. This is why Broadcast takes an interface{} instead of
 // an RPCFunc.
 func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) {
-	g.log.Printf("INFO: broadcasting RPC \"%v\" to %v peers", name, len(peers))
+	g.log.Printf("INFO: broadcasting RPC %q to %v peers", name, len(peers))
 
 	// only encode obj once, instead of using WriteObject
 	enc := encoding.Marshal(obj)

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -107,7 +107,7 @@ func (g *Gateway) listenPeer(p *peer) {
 	for {
 		conn, err := p.accept()
 		if err != nil {
-			g.log.Println("WARN: lost connection to peer", p.NetAddress)
+			g.log.Debugf("WARN: lost connection to peer %q: %v", p.NetAddress, err)
 			break
 		}
 
@@ -130,10 +130,10 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 	fn, ok := g.handlers[id]
 	g.mu.RUnlock(lockid)
 	if !ok {
-		g.log.Debugf("WARN: incoming conn %v requested unknown RPC %q", conn.RemoteAddr(), id)
+		g.log.Debugf("WARN: peer %v requested unknown RPC %q", conn.RPCAddr(), id)
 		return
 	}
-	g.log.Debugf("INFO: incoming conn %v requested RPC %q", conn.RemoteAddr(), id)
+	g.log.Debugf("INFO: peer %v requested RPC %q", conn.RPCAddr(), id)
 
 	// call fn
 	err := fn(conn)
@@ -142,7 +142,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 		err = nil
 	}
 	if err != nil {
-		g.log.Debugf("WARN: incoming RPC %q from conn %v failed: %v", id, conn.RemoteAddr(), err)
+		g.log.Debugf("WARN: incoming RPC %q from peer %v failed: %v", id, conn.RPCAddr(), err)
 	}
 }
 

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -72,9 +72,6 @@ func (g *Gateway) learnHostname() {
 	g.mu.Unlock(id)
 
 	g.log.Println("INFO: our address is", g.myAddr)
-
-	// now that we know our address, we can start advertising it
-	g.RegisterConnectCall("RelayNode", g.sendAddress)
 }
 
 // forwardPort adds a port mapping to the router.

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -41,7 +41,7 @@ func myExternalIP() (string, error) {
 // learnHostname discovers the external IP of the Gateway. Once the IP has
 // been discovered, it registers the ShareNodes RPC to be called on new
 // connections, advertising the IP to other nodes.
-func (g *Gateway) learnHostname(port string) {
+func (g *Gateway) learnHostname() {
 	if build.Release == "testing" {
 		return
 	}
@@ -61,7 +61,7 @@ func (g *Gateway) learnHostname(port string) {
 		return
 	}
 
-	addr := modules.NetAddress(net.JoinHostPort(host, port))
+	addr := modules.NetAddress(net.JoinHostPort(host, g.port))
 	if err := addr.IsValid(); err != nil {
 		g.log.Printf("WARN: discovered hostname %q is invalid: %v", addr, err)
 		return

--- a/modules/netaddress.go
+++ b/modules/netaddress.go
@@ -9,6 +9,12 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
+// MaxEncodedNetAddressLength is the maximum length of a NetAddress encoded
+// with the encode package. 266 was chosen because the maximum length for the
+// hostname is 254 + 1 for the separating colon + 5 for the port + 8 byte
+// string length prefix.
+const MaxEncodedNetAddressLength = 266
+
 // A NetAddress contains the information needed to contact a peer.
 type NetAddress string
 

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -70,13 +70,13 @@ func processConfig(config Config) (Config, error) {
 func startDaemon(config Config) (err error) {
 	// Prompt user for API password.
 	var password string
-	if !config.Siad.NoPassword {
+	if config.Siad.AuthenticateAPI {
 		password, err = speakeasy.Ask("Enter API password: ")
 		if err != nil {
 			return err
 		}
 		if password == "" {
-			return errors.New("password cannot be blank, use the --no-password flag instead")
+			return errors.New("password cannot be blank")
 		}
 		passwordConfirm, err := speakeasy.Ask("Confirm API password: ")
 		if err != nil {

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -168,6 +168,7 @@ func startDaemon(config Config) (err error) {
 	srv, err := api.NewServer(
 		config.Siad.APIaddr,
 		config.Siad.RequiredUserAgent,
+		password,
 		cs,
 		e,
 		g,
@@ -179,9 +180,6 @@ func startDaemon(config Config) (err error) {
 	)
 	if err != nil {
 		return err
-	}
-	if !config.Siad.NoPassword {
-		srv.RequireAuthentication(password)
 	}
 
 	// Bootstrap to the network.

--- a/siad/main.go
+++ b/siad/main.go
@@ -33,6 +33,7 @@ type Config struct {
 		Modules           string
 		NoBootstrap       bool
 		RequiredUserAgent string
+		NoPassword        bool
 
 		Profile    bool
 		ProfileDir string
@@ -155,6 +156,7 @@ func main() {
 	root.Flags().BoolVarP(&globalConfig.Siad.Profile, "profile", "p", false, "enable profiling")
 	root.Flags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
 	root.Flags().StringVarP(&globalConfig.Siad.Modules, "modules", "M", "cghmrtw", "enabled modules, see 'siad modules' for more info")
+	root.Flags().BoolVarP(&globalConfig.Siad.NoPassword, "no-password", "", false, "disable API password protection (not recommended)")
 
 	// Deprecate shorthand flags that aren't commonly used.
 	// COMPATv0.5.2

--- a/siad/main.go
+++ b/siad/main.go
@@ -33,7 +33,7 @@ type Config struct {
 		Modules           string
 		NoBootstrap       bool
 		RequiredUserAgent string
-		NoPassword        bool
+		AuthenticateAPI   bool
 
 		Profile    bool
 		ProfileDir string
@@ -156,7 +156,7 @@ func main() {
 	root.Flags().BoolVarP(&globalConfig.Siad.Profile, "profile", "p", false, "enable profiling")
 	root.Flags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
 	root.Flags().StringVarP(&globalConfig.Siad.Modules, "modules", "M", "cghmrtw", "enabled modules, see 'siad modules' for more info")
-	root.Flags().BoolVarP(&globalConfig.Siad.NoPassword, "no-password", "", false, "disable API password protection (not recommended)")
+	root.Flags().BoolVarP(&globalConfig.Siad.AuthenticateAPI, "authenticate-api", "", false, "enable API password protection")
 
 	// Deprecate shorthand flags that aren't commonly used.
 	// COMPATv0.5.2


### PR DESCRIPTION
Specifically, move "lost connection to peer" logging to Debugf as it could be triggered by a malicious peer.

And replace instances of RemoteAddr in logging with RPCAddr so that the logs are more easily compared with the gateway peer list.

Fixes #1047