### PR TITLE
Add IBD progress estimation

### DIFF
--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -25,9 +26,22 @@ func consensuscmd() {
 	if err != nil {
 		die("Could not get current consensus state:", err)
 	}
-	fmt.Printf(`Synced: %v
+	if cg.Synced {
+		fmt.Printf(`Synced: %v
 Block:  %v
 Height: %v
 Target: %v
 `, yesNo(cg.Synced), cg.CurrentBlock, cg.Height, cg.Target)
+	} else {
+		// Estimate the height of the blockchain by calculating the minutes since a
+		// known block, and dividing by 10 minutes (the block time).
+		block50000Timestamp := time.Date(2016, time.May, 11, 19, 33, 0, 0, time.UTC)
+		diff := time.Since(block50000Timestamp)
+		estimatedHeight := 50000 + (diff.Minutes() / 10)
+		estimatedProgress := float64(cg.Height) / estimatedHeight * 100
+		fmt.Printf(`Synced: %v
+Height: %v
+Progress (estimated): %.f%%
+`, yesNo(cg.Synced), cg.Height, estimatedProgress)
+	}
 }


### PR DESCRIPTION
New users might not know about https://explore.sia.tech so this PR provides a rough estimation in siac of IBD progress.

The blockchain height is estimated using the block time (10 minutes) and the time passed since a block at a known height and time (block 50000 was chosen because it is fairly recent and I'm assuming the hash rate has been stable recently).

It should be trivial to do something similar in the UI.

Example output:
```
$ siac
Synced: No
Height: 34253
Progress (estimated): 67%
```

Closes #929