### PR TITLE
Return a descriptive error from /wallet/transactions

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -371,12 +371,12 @@ func (srv *Server) walletTransactionsHandler(w http.ResponseWriter, req *http.Re
 	// Get the start and end blocks.
 	start, err := strconv.Atoi(startheightStr)
 	if err != nil {
-		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "parsing integer value for parameter `startheight` failed: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	end, err := strconv.Atoi(endheightStr)
 	if err != nil {
-		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
+		writeError(w, "parsing integer value for parameter `endheight` failed: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 	confirmedTxns, err := srv.wallet.Transactions(types.BlockHeight(start), types.BlockHeight(end))

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -363,13 +363,20 @@ func (srv *Server) walletTransactionHandler(w http.ResponseWriter, req *http.Req
 
 // walletTransactionsHandler handles API calls to /wallet/transactions.
 func (srv *Server) walletTransactionsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	// If 'startheight' or 'endheight' query parameters don't exist,
+	// return a descriptive error message along with a HTTP 400 Bad Request response code.
+	startheightStr, endheightStr := req.FormValue("startheight"), req.FormValue("endheight")
+	if startheightStr == "" || endheightStr == "" {
+		writeError(w, "startheight and endheight must be provided to a /wallet/transactions call.", http.StatusBadRequest)
+		return
+	}
 	// Get the start and end blocks.
-	start, err := strconv.Atoi(req.FormValue("startheight"))
+	start, err := strconv.Atoi(startheightStr)
 	if err != nil {
 		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	end, err := strconv.Atoi(req.FormValue("endheight"))
+	end, err := strconv.Atoi(endheightStr)
 	if err != nil {
 		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
 		return

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -363,8 +363,6 @@ func (srv *Server) walletTransactionHandler(w http.ResponseWriter, req *http.Req
 
 // walletTransactionsHandler handles API calls to /wallet/transactions.
 func (srv *Server) walletTransactionsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	// If 'startheight' or 'endheight' query parameters don't exist,
-	// return a descriptive error message along with a HTTP 400 Bad Request response code.
 	startheightStr, endheightStr := req.FormValue("startheight"), req.FormValue("endheight")
 	if startheightStr == "" || endheightStr == "" {
 		writeError(w, "startheight and endheight must be provided to a /wallet/transactions call.", http.StatusBadRequest)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -267,11 +267,8 @@ func TestIntegrationWalletTransactionGETid(t *testing.T) {
 	// A call to /wallet/transactions without startheight and endheight parameters
 	// should return a descriptive error message.
 	err = st.getAPI("/wallet/transactions", &wtg)
-	if err == nil {
+	if err == nil || err.Error() != "startheight and endheight must be provided to a /wallet/transactions call.\n"  {
 		t.Error("expecting /wallet/transactions call with empty parameters to error")
-	}
-	if err.Error() != "startheight and endheight must be provided to a /wallet/transactions call.\n" {
-		t.Error("expecting /wallet/transactions call with empty parameters to return descriptive error")
 	}
 
 	// Query the details of the first transaction using

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -264,6 +264,15 @@ func TestIntegrationWalletTransactionGETid(t *testing.T) {
 	if len(wtg.UnconfirmedTransactions) != 0 {
 		t.Error("expecting 0 unconfirmed transactions")
 	}
+	// A call to /wallet/transactions without startheight and endheight parameters
+	// should return a descriptive error message.
+	err = st.getAPI("/wallet/transactions", &wtg)
+	if err == nil {
+		t.Error("expecting /wallet/transactions call with empty parameters to error")
+	}
+	if err.Error() != "startheight and endheight must be provided to a /wallet/transactions call.\n" {
+		t.Error("expecting /wallet/transactions call with empty parameters to return descriptive error")
+	}
 
 	// Query the details of the first transaction using
 	// /wallet/transaction/$(id)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -267,7 +267,7 @@ func TestIntegrationWalletTransactionGETid(t *testing.T) {
 	// A call to /wallet/transactions without startheight and endheight parameters
 	// should return a descriptive error message.
 	err = st.getAPI("/wallet/transactions", &wtg)
-	if err == nil || err.Error() != "startheight and endheight must be provided to a /wallet/transactions call.\n"  {
+	if err == nil || err.Error() != "startheight and endheight must be provided to a /wallet/transactions call.\n" {
 		t.Error("expecting /wallet/transactions call with empty parameters to error")
 	}
 


### PR DESCRIPTION
This PR changes /wallet/transactions to return a descriptive error message if the `startheight` or `endheight` query parameters don't exist.  Previously, a strconv.ParseInt error would be returned, now `startheight and endheight must be provided to a /wallet/transactions call.` is returned, along with a `400 bad request` HTTP status code.