### PR TITLE
Gateway clean shutdown

### DIFF
--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -492,12 +492,12 @@ func TestIntegrationRPCSendBlocks(t *testing.T) {
 
 	for i, tt := range tests {
 		// Create the "remote" peer.
-		remoteCST, err := blankConsensusSetTester(filepath.Join("TestRPCSendBlocks - remote", strconv.Itoa(i)))
+		remoteCST, err := blankConsensusSetTester(filepath.Join("TestIntegrationRPCSendBlocks - remote", strconv.Itoa(i)))
 		if err != nil {
 			t.Fatal(err)
 		}
 		// Create the "local" peer.
-		localCST, err := blankConsensusSetTester(filepath.Join("TestRPCSendBlocks - local", strconv.Itoa(i)))
+		localCST, err := blankConsensusSetTester(filepath.Join("TestIntegrationRPCSendBlocks - local", strconv.Itoa(i)))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -572,8 +572,6 @@ func TestIntegrationRPCSendBlocks(t *testing.T) {
 		}
 
 		// Cleanup.
-		localCST.cs.gateway.Disconnect(remoteCST.cs.gateway.Address())
-		remoteCST.cs.gateway.Disconnect(localCST.cs.gateway.Address())
 		err = localCST.Close()
 		if err != nil {
 			t.Fatal(err)

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -133,6 +133,14 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	if err != nil {
 		return
 	}
+	// Automatically close the listener when g.threads.Stop() is called.
+	g.threads.OnStop(func() {
+		err := g.listener.Close()
+		if err != nil {
+			g.log.Println("WARN: closing the listener failed:", err)
+		}
+	})
+
 	_, port, portErr := net.SplitHostPort(g.listener.Addr().String())
 	if portErr != nil {
 		return nil, portErr

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -24,6 +24,10 @@ func newTestingGateway(name string, t *testing.T) *Gateway {
 // Also tests that the address is not unspecified and is a loopback address.
 // The address must be a loopback address for testing.
 func TestAddress(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestAddress", t)
 	defer g.Close()
 	if g.Address() != g.myAddr {
@@ -43,6 +47,10 @@ func TestAddress(t *testing.T) {
 }
 
 func TestPeers(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestRPC2", t)

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/sync"
 )
 
 // newTestingGateway returns a gateway read to use in a testing environment.
@@ -18,6 +19,25 @@ func newTestingGateway(name string, t *testing.T) *Gateway {
 		t.Fatal(err)
 	}
 	return g
+}
+
+// TestExportedMethodsErrAfterClose tests that exported methods like Close and
+// Connect error with sync.ErrStopped after the gateway has been closed.
+func TestExportedMethodsErrAfterClose(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	g := newTestingGateway("TestCloseErrsSecondTime", t)
+	if err := g.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Close(); err != sync.ErrStopped {
+		t.Fatalf("expected %q, got %q", sync.ErrStopped, err)
+	}
+	if err := g.Connect("localhost:1234"); err != sync.ErrStopped {
+		t.Fatalf("expected %q, got %q", sync.ErrStopped, err)
+	}
 }
 
 // TestAddress tests that Gateway.Address returns the address of its listener.

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -55,7 +55,7 @@ func (g *Gateway) randomNode() (modules.NetAddress, error) {
 // shareNodes is the receiving end of the ShareNodes RPC. It writes up to 10
 // randomly selected nodes to the caller.
 func (g *Gateway) shareNodes(conn modules.PeerConn) error {
-	id := g.mu.RLock()
+	g.mu.RLock()
 	var nodes []modules.NetAddress
 	for node := range g.nodes {
 		if len(nodes) == maxSharedNodes {
@@ -63,7 +63,7 @@ func (g *Gateway) shareNodes(conn modules.PeerConn) error {
 		}
 		nodes = append(nodes, node)
 	}
-	g.mu.RUnlock(id)
+	g.mu.RUnlock()
 	return encoding.WriteObject(conn, nodes)
 }
 
@@ -73,7 +73,7 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	if err := encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength); err != nil {
 		return err
 	}
-	id := g.mu.Lock()
+	g.mu.Lock()
 	for _, node := range nodes {
 		err := g.addNode(node)
 		if err != nil {
@@ -81,7 +81,7 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 		}
 	}
 	g.save()
-	g.mu.Unlock(id)
+	g.mu.Unlock()
 	return nil
 }
 
@@ -98,8 +98,8 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 	err := func() error {
 		// We wrap this logic in an anonymous function so we can defer Unlock to
 		// avoid managing locks across branching.
-		id := g.mu.Lock()
-		defer g.mu.Unlock(id)
+		g.mu.Lock()
+		defer g.mu.Unlock()
 		if err := g.addNode(addr); err != nil {
 			return err
 		}
@@ -142,10 +142,10 @@ func (g *Gateway) threadedNodeManager() {
 			return
 		}
 
-		id := g.mu.RLock()
+		g.mu.RLock()
 		numNodes := len(g.nodes)
 		peer, err := g.randomPeer()
-		g.mu.RUnlock(id)
+		g.mu.RUnlock()
 		if err != nil {
 			// can't do much until we have peers
 			continue
@@ -156,9 +156,9 @@ func (g *Gateway) threadedNodeManager() {
 		}
 
 		// find an untested node to check
-		id = g.mu.RLock()
+		g.mu.RLock()
 		node, err := g.randomNode()
-		g.mu.RUnlock(id)
+		g.mu.RUnlock()
 		if err != nil {
 			continue
 		}
@@ -166,10 +166,10 @@ func (g *Gateway) threadedNodeManager() {
 		// try to connect
 		conn, err := net.DialTimeout("tcp", string(node), dialTimeout)
 		if err != nil {
-			id = g.mu.Lock()
+			g.mu.Lock()
 			g.removeNode(node)
 			g.save()
-			g.mu.Unlock(id)
+			g.mu.Unlock()
 			continue
 		}
 		// if connection succeeds, supply an unacceptable version to ensure

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -113,7 +113,11 @@ func (g *Gateway) relayNode(conn modules.PeerConn) error {
 	}
 	// relay
 	peers := g.Peers()
-	go g.Broadcast("RelayNode", addr, peers)
+	g.closeWG.Add(1)
+	go func() {
+		defer g.closeWG.Done()
+		g.Broadcast("RelayNode", addr, peers)
+	}()
 	return nil
 }
 

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -12,6 +12,10 @@ import (
 const dummyNode = "111.111.111.111:1111"
 
 func TestAddNode(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestAddNode", t)
 	defer g.Close()
 	id := g.mu.Lock()
@@ -34,6 +38,10 @@ func TestAddNode(t *testing.T) {
 }
 
 func TestRemoveNode(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestRemoveNode", t)
 	defer g.Close()
 	id := g.mu.Lock()
@@ -50,6 +58,10 @@ func TestRemoveNode(t *testing.T) {
 }
 
 func TestRandomNode(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestRandomNode", t)
 	defer g.Close()
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -13,8 +13,6 @@ import (
 )
 
 const (
-	// the gateway will abort a connection attempt after this long
-	dialTimeout = 2 * time.Minute
 	// the gateway will not accept inbound connections above this threshold
 	fullyConnectedThreshold = 128
 	// the gateway will ask for more addresses below this threshold
@@ -31,6 +29,19 @@ var (
 			return 3 * time.Second
 		case "testing":
 			return 10 * time.Millisecond
+		default:
+			panic("unrecognized build.Release")
+		}
+	}()
+	// the gateway will abort a connection attempt after this long
+	dialTimeout = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 2 * time.Minute
+		case "standard":
+			return 2 * time.Minute
+		case "testing":
+			return 2 * time.Second
 		default:
 			panic("unrecognized build.Release")
 		}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -334,7 +334,10 @@ func (g *Gateway) threadedPeerManager() {
 			g.closeWG.Add(1)
 			go func() {
 				defer g.closeWG.Done()
-				g.Connect(addr)
+				connectErr := g.Connect(addr)
+				if connectErr != nil {
+					g.log.Debugln("WARN: automatic connect failed:", connectErr)
+				}
 			}()
 		}
 		select {

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -132,7 +132,11 @@ func (g *Gateway) listen() {
 		// will accept new connections. The intent here is to prevent new
 		// incoming connections from kicking out old ones before they have a
 		// chance to request additional nodes.
-		time.Sleep(acceptInterval)
+		select {
+		case <-time.After(acceptInterval):
+		case <-g.closeChan:
+			return
+		}
 	}
 }
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -117,18 +117,6 @@ func (g *Gateway) threadedListen() {
 	}
 	defer g.threads.Done()
 
-	// Shutdown the listener when the stop signal is received.
-	if g.threads.Add() != nil {
-		return
-	}
-	go func() {
-		defer g.threads.Done()
-		<-g.threads.StopChan()
-		if err := g.listener.Close(); err != nil {
-			g.log.Printf("WARN: listener.Close failed: %v", err)
-		}
-	}()
-
 	for {
 		conn, err := g.listener.Accept()
 		if err != nil {

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -31,8 +31,8 @@ func TestAddPeer(t *testing.T) {
 
 	g := newTestingGateway("TestAddPeer", t)
 	defer g.Close()
-	id := g.mu.Lock()
-	defer g.mu.Unlock(id)
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	g.addPeer(&peer{
 		Peer: modules.Peer{
 			NetAddress: "foo.com:123",
@@ -51,8 +51,8 @@ func TestRandomInboundPeer(t *testing.T) {
 
 	g := newTestingGateway("TestRandomInboundPeer", t)
 	defer g.Close()
-	id := g.mu.Lock()
-	defer g.mu.Unlock(id)
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	_, err := g.randomInboundPeer()
 	if err != errNoPeers {
 		t.Fatal("expected errNoPeers, got", err)
@@ -123,18 +123,18 @@ func TestListen(t *testing.T) {
 	// g should add the peer
 	var ok bool
 	for !ok {
-		id := g.mu.RLock()
+		g.mu.RLock()
 		_, ok = g.peers[addr]
-		g.mu.RUnlock(id)
+		g.mu.RUnlock()
 	}
 
 	muxado.Client(conn).Close()
 
 	// g should remove the peer
 	for ok {
-		id := g.mu.RLock()
+		g.mu.RLock()
 		_, ok = g.peers[addr]
-		g.mu.RUnlock(id)
+		g.mu.RUnlock()
 	}
 
 	// uncompliant connect
@@ -160,9 +160,9 @@ func TestConnect(t *testing.T) {
 	defer bootstrap.Close()
 
 	// give it a node
-	id := bootstrap.mu.Lock()
+	bootstrap.mu.Lock()
 	bootstrap.addNode(dummyNode)
-	bootstrap.mu.Unlock(id)
+	bootstrap.mu.Unlock()
 
 	// create peer who will connect to bootstrap
 	g := newTestingGateway("TestConnect2", t)
@@ -194,11 +194,11 @@ func TestConnect(t *testing.T) {
 	}
 	// g should have the node
 	time.Sleep(100 * time.Millisecond)
-	id = g.mu.RLock()
+	g.mu.RLock()
 	if _, ok := g.nodes[dummyNode]; !ok {
 		t.Fatal("bootstrapper should have received dummyNode:", g.nodes)
 	}
-	g.mu.RUnlock(id)
+	g.mu.RUnlock()
 }
 
 // TestConnectRejects tests that Gateway.Connect only accepts peers with
@@ -494,14 +494,14 @@ func TestDisconnect(t *testing.T) {
 	if err != nil {
 		t.Fatal("dial failed:", err)
 	}
-	id := g.mu.Lock()
+	g.mu.Lock()
 	g.addPeer(&peer{
 		Peer: modules.Peer{
 			NetAddress: "foo.com:123",
 		},
 		sess: muxado.Client(conn),
 	})
-	g.mu.Unlock(id)
+	g.mu.Unlock()
 	if err := g.Disconnect("foo.com:123"); err != nil {
 		t.Fatal("disconnect failed:", err)
 	}
@@ -520,16 +520,16 @@ func TestPeerManager(t *testing.T) {
 	defer g2.Close()
 
 	// g1's node list should only contain g2
-	id := g1.mu.Lock()
+	g1.mu.Lock()
 	g1.nodes = map[modules.NetAddress]struct{}{}
 	g1.nodes[g2.Address()] = struct{}{}
-	g1.mu.Unlock(id)
+	g1.mu.Unlock()
 
 	// when peerManager wakes up, it should connect to g2.
 	time.Sleep(6 * time.Second)
 
-	id = g1.mu.RLock()
-	defer g1.mu.RUnlock(id)
+	g1.mu.RLock()
+	defer g1.mu.RUnlock()
 	if len(g1.peers) != 1 || g1.peers[g2.Address()] == nil {
 		t.Fatal("gateway did not connect to g2:", g1.peers)
 	}

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -25,6 +25,10 @@ func (dc *dummyConn) Close() error { return nil }
 func (dc *dummyConn) SetWriteDeadline(time.Time) error { return nil }
 
 func TestAddPeer(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestAddPeer", t)
 	defer g.Close()
 	id := g.mu.Lock()
@@ -41,6 +45,10 @@ func TestAddPeer(t *testing.T) {
 }
 
 func TestRandomInboundPeer(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestRandomInboundPeer", t)
 	defer g.Close()
 	id := g.mu.Lock()
@@ -458,6 +466,10 @@ func TestAcceptConnRejects(t *testing.T) {
 }
 
 func TestDisconnect(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestDisconnect", t)
 	defer g.Close()
 

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -169,9 +169,11 @@ func TestConnect(t *testing.T) {
 	defer g.Close()
 
 	// first simulate a "bad" connect, where bootstrap won't share its nodes
+	bootstrap.mu.Lock()
 	bootstrap.handlers[handlerName("ShareNodes")] = func(modules.PeerConn) error {
 		return nil
 	}
+	bootstrap.mu.Unlock()
 	// connect
 	err := g.Connect(bootstrap.Address())
 	if err != nil {
@@ -187,7 +189,9 @@ func TestConnect(t *testing.T) {
 	bootstrap.Disconnect(g.Address())
 
 	// now restore the correct ShareNodes RPC and try again
+	bootstrap.mu.Lock()
 	bootstrap.handlers[handlerName("ShareNodes")] = bootstrap.shareNodes
+	bootstrap.mu.Unlock()
 	err = g.Connect(bootstrap.Address())
 	if err != nil {
 		t.Fatal(err)

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -10,10 +10,10 @@ func TestLoad(t *testing.T) {
 	}
 
 	g := newTestingGateway("TestLoad", t)
-	id := g.mu.Lock()
+	g.mu.Lock()
 	g.addNode(dummyNode)
 	g.save()
-	g.mu.Unlock(id)
+	g.mu.Unlock()
 	g.Close()
 
 	g2, err := New("localhost:0", g.persistDir)

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -5,6 +5,10 @@ import (
 )
 
 func TestLoad(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g := newTestingGateway("TestLoad", t)
 	id := g.mu.Lock()
 	g.addNode(dummyNode)

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -112,7 +112,11 @@ func (g *Gateway) listenPeer(p *peer) {
 		}
 
 		// it is the handler's responsibility to close the connection
-		go g.threadedHandleConn(conn)
+		g.closeWG.Add(1)
+		go func() {
+			defer g.closeWG.Done()
+			g.threadedHandleConn(conn)
+		}()
 	}
 	g.Disconnect(p.NetAddress)
 }

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -172,7 +172,11 @@ func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) 
 			err := g.RPC(addr, name, fn)
 			if err != nil {
 				// try one more time before giving up
-				time.Sleep(10 * time.Second)
+				select {
+				case <-time.After(10 * time.Second):
+				case <-g.closeChan:
+					return
+				}
 				g.RPC(addr, name, fn)
 			}
 			wg.Done()

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -198,9 +198,10 @@ func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) 
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(len(peers))
 	for _, p := range peers {
+		wg.Add(1)
 		go func(addr modules.NetAddress) {
+			defer wg.Done()
 			err := g.RPC(addr, name, fn)
 			if err != nil {
 				g.log.Debugf("WARN: broadcasting RPC %q to peer %q failed (attempting again in 10 seconds): %v", name, addr, err)
@@ -215,7 +216,6 @@ func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) 
 					g.log.Debugf("WARN: broadcasting RPC %q to peer %q failed twice: %v", name, addr, err)
 				}
 			}
-			wg.Done()
 		}(p.NetAddress)
 	}
 	wg.Wait()

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -168,6 +168,10 @@ func TestUnregisterConnectCallPanics(t *testing.T) {
 }
 
 func TestRPC(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 
@@ -240,6 +244,10 @@ func TestRPC(t *testing.T) {
 }
 
 func TestThreadedHandleConn(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g1 := newTestingGateway("TestThreadedHandleConn1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestThreadedHandleConn2", t)
@@ -300,6 +308,10 @@ func TestThreadedHandleConn(t *testing.T) {
 // TestBroadcast tests that calling broadcast with a slice of peers only
 // broadcasts to those peers.
 func TestBroadcast(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g1 := newTestingGateway("TestBroadcast1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestBroadcast2", t)
@@ -420,6 +432,10 @@ func TestBroadcast(t *testing.T) {
 // TestOutboundAndInboundRPCs tests that both inbound and outbound connections
 // can successfully make RPC calls.
 func TestOutboundAndInboundRPCs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestRPC2", t)
@@ -465,6 +481,10 @@ func TestOutboundAndInboundRPCs(t *testing.T) {
 
 // TestCallingRPCFromRPC tests that calling an RPC from an RPC works.
 func TestCallingRPCFromRPC(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	g1 := newTestingGateway("TestCallingRPCFromRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestCallingRPCFromRPC2", t)

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -67,9 +67,9 @@ func (g *Gateway) learnHostname(port string) {
 		return
 	}
 
-	id := g.mu.Lock()
+	g.mu.Lock()
 	g.myAddr = addr
-	g.mu.Unlock(id)
+	g.mu.Unlock()
 
 	g.log.Println("INFO: our address is", g.myAddr)
 


### PR DESCRIPTION
I chose to put the `wg.Add(1)` `wg.Done()`s on the calling side because they are not necessarily called from goroutines. The godocs also suggest putting the `Add` outside the goroutine. It also makes it easy to visually check that all goroutines have a corresponding `Add` and `Done`.