### PR TITLE
sync.ThreadGroup

### DIFF
--- a/sync/threadgroup.go
+++ b/sync/threadgroup.go
@@ -1,0 +1,67 @@
+package sync
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrStopped is returned by ThreadGroup methods if Stop has already been
+// called.
+var ErrStopped = errors.New("ThreadGroup already stopped")
+
+// ThreadGroup is a sync.WaitGroup with additional functionality for
+// facilitating clean shutdown. Namely, it provides a StopChan method for
+// notifying callers when shutdown occurrs. Another key difference is that a
+// ThreadGroup is only intended be used once; as such, its Add and Stop
+// methods return errors if Stop has already been called.
+type ThreadGroup struct {
+	stopChan chan struct{}
+	chanOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// StopChan provides read-only access to the ThreadGroup's stopChan. Callers
+// should select on StopChan in order to interrupt long-running reads (such as
+// time.After).
+func (tg *ThreadGroup) StopChan() <-chan struct{} {
+	// Initialize tg.stopChan if it is nil; this makes an unitialized
+	// ThreadGroup valid. (Otherwise, a NewThreadGroup function would be
+	// necessary.)
+	tg.chanOnce.Do(func() { tg.stopChan = make(chan struct{}) })
+	return tg.stopChan
+}
+
+// IsStopped returns true if Stop has been called.
+func (tg *ThreadGroup) IsStopped() bool {
+	select {
+	case <-tg.StopChan():
+		return true
+	default:
+		return false
+	}
+}
+
+// Add adds delta to the ThreadGroup counter.
+func (tg *ThreadGroup) Add(delta int) error {
+	if tg.IsStopped() {
+		return ErrStopped
+	}
+	tg.wg.Add(delta)
+	return nil
+}
+
+// Done decrements the ThreadGroup counter.
+func (tg *ThreadGroup) Done() {
+	tg.wg.Done()
+}
+
+// Stop closes the Threadgroup's stopChan and blocks until the counter is
+// zero.
+func (tg *ThreadGroup) Stop() error {
+	if tg.IsStopped() {
+		return ErrStopped
+	}
+	close(tg.stopChan)
+	tg.wg.Wait()
+	return nil
+}

--- a/sync/threadgroup.go
+++ b/sync/threadgroup.go
@@ -42,14 +42,14 @@ func (tg *ThreadGroup) IsStopped() bool {
 	}
 }
 
-// Add adds delta to the ThreadGroup counter.
-func (tg *ThreadGroup) Add(delta int) error {
+// Add increments the ThreadGroup counter.
+func (tg *ThreadGroup) Add() error {
 	tg.mu.Lock()
 	defer tg.mu.Unlock()
 	if tg.IsStopped() {
 		return ErrStopped
 	}
-	tg.wg.Add(delta)
+	tg.wg.Add(1)
 	return nil
 }
 

--- a/sync/threadgroup_test.go
+++ b/sync/threadgroup_test.go
@@ -9,11 +9,12 @@ import (
 // TestThreadGroup tests normal operation of a ThreadGroup.
 func TestThreadGroup(t *testing.T) {
 	var tg ThreadGroup
-	err := tg.Add(10)
-	if err != nil {
-		t.Fatal(err)
-	}
 	for i := 0; i < 10; i++ {
+		err := tg.Add()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		go func() {
 			defer tg.Done()
 			select {
@@ -23,7 +24,7 @@ func TestThreadGroup(t *testing.T) {
 		}()
 	}
 	start := time.Now()
-	err = tg.Stop()
+	err := tg.Stop()
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatal(err)
@@ -53,7 +54,7 @@ func TestThreadGroupStop(t *testing.T) {
 	}
 
 	// Add and Stop should return errors
-	err = tg.Add(1)
+	err = tg.Add()
 	if err != ErrStopped {
 		t.Fatal("expected ErrStopped, got", err)
 	}
@@ -68,7 +69,7 @@ func TestThreadGroupConcurrentAdd(t *testing.T) {
 	var tg ThreadGroup
 	for i := 0; i < 10; i++ {
 		go func() {
-			err := tg.Add(1)
+			err := tg.Add()
 			if err != nil {
 				return
 			}
@@ -108,7 +109,7 @@ func TestThreadGroupOnce(t *testing.T) {
 	}
 
 	tg = new(ThreadGroup)
-	tg.Add(1)
+	tg.Add()
 	if tg.stopChan == nil {
 		t.Error("stopChan should have been initialized by Add")
 	}
@@ -127,7 +128,7 @@ func TestThreadGroupRace(t *testing.T) {
 	go tg.IsStopped()
 	go tg.StopChan()
 	go func() {
-		if tg.Add(1) == nil {
+		if tg.Add() == nil {
 			tg.Done()
 		}
 	}()
@@ -140,7 +141,7 @@ func TestThreadGroupRace(t *testing.T) {
 func BenchmarkThreadGroup(b *testing.B) {
 	var tg ThreadGroup
 	for i := 0; i < b.N; i++ {
-		tg.Add(1)
+		tg.Add()
 		go tg.Done()
 	}
 	tg.Stop()

--- a/sync/threadgroup_test.go
+++ b/sync/threadgroup_test.go
@@ -89,7 +89,7 @@ func TestThreadGroupConcurrentAdd(t *testing.T) {
 // TestThreadGroupOnce tests that a zero-valued ThreadGroup's stopChan is
 // properly initialized.
 func TestThreadGroupOnce(t *testing.T) {
-	var tg ThreadGroup
+	tg := new(ThreadGroup)
 	if tg.stopChan != nil {
 		t.Error("expected nil stopChan")
 	}
@@ -100,26 +100,26 @@ func TestThreadGroupOnce(t *testing.T) {
 		t.Error("stopChan should have been initialized by StopChan")
 	}
 
-	tg = ThreadGroup{}
+	tg = new(ThreadGroup)
 	tg.IsStopped()
 	if tg.stopChan == nil {
 		t.Error("stopChan should have been initialized by IsStopped")
 	}
 
-	tg = ThreadGroup{}
+	tg = new(ThreadGroup)
 	tg.Add(1)
 	if tg.stopChan == nil {
 		t.Error("stopChan should have been initialized by Add")
 	}
 
-	tg = ThreadGroup{}
+	tg = new(ThreadGroup)
 	tg.Stop()
 	if tg.stopChan == nil {
 		t.Error("stopChan should have been initialized by Stop")
 	}
 
 	// try to trigger the race detector
-	tg = ThreadGroup{}
+	tg = new(ThreadGroup)
 	go tg.IsStopped()
 	go tg.Add(1)
 	err := tg.Stop()


### PR DESCRIPTION
Example usage:
```go
type module struct {
	threads sync.ThreadGroup
	log     *persist.Logger
}

func NewModule() module {
	return module{
		log: persist.NewLogger(),
	}
}

func (m *module) DoSomething() error {
	err := m.threads.Add(1)
	if err != nil {
		return errors.New("Module is closed")
	}
	defer m.threads.Done()

	for {
		select {
		case <-time.After(1 * time.Second):
			// do some work

		case <-m.threads.StopChan():
			return nil
		}
	}

	// alternatively:
	for {
		if m.threads.IsStopped() {
			return nil
		}
		// do some work
	}
}

func (m *module) Close() error {
	err := m.threads.Stop()
	if err != nil {
		return errors.New("Module already closed")
	}
	return m.log.Close()
}
```