### PR TITLE
More persist/boltdb.go testing

### DIFF
--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -258,10 +258,7 @@ func TestErrTxNotWritable(t *testing.T) {
 		}
 		// Should return an error because updateMetadata is being called from
 		// a read-only transaction.
-		err = db.View(func(tx *bolt.Tx) error {
-			err = boltDB.updateMetadata(tx)
-			return err
-		})
+		err = db.View(boltDB.updateMetadata)
 		if err != bolt.ErrTxNotWritable {
 			t.Errorf("updateMetadata returned wrong error for input %v, filename %v; expected tx not writable, got %v", in.md, dbFilename, err)
 		}

--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -1,5 +1,3 @@
-// Borrowed weird strings from https://github.com/minimaxir/big-list-of-naughty-strings
-
 package persist
 
 import (
@@ -12,7 +10,11 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/bolt"
 )
-
+ 
+// testInputs and testFilenames are global variables because most tests require
+// a variety of metadata and filename inputs (although only TestCheckMetadata 
+// and TestIntegratedCheckMetadata use testInput.newMd and testInput.err). 
+// Weird strings are from https://github.com/minimaxir/big-ltist-of-naughty-strings
 var (
     testInputs = []struct{
         md		Metadata
@@ -42,7 +44,6 @@ var (
 		{Metadata{"\n\n","Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ ̖t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, Metadata{"\n\n","Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, ErrBadVersion},
     }
 
-
     testFilenames = []string{
 		" ",
 		"_",
@@ -60,6 +61,7 @@ var (
 		"%s",
     }
 )
+
 
 // TestOpenDatabase tests calling OpenDatabase on the following types of
 // database:
@@ -123,7 +125,7 @@ func TestOpenDatabase(t *testing.T) {
 			for _, testBucket := range testBuckets {
 				_, err := tx.CreateBucketIfNotExists(testBucket)
 				if err != nil {
-					t.Fatalf("db.Update failed on bucket name %v for metadata %v, filename %v; error was", testBucket, in.md, dbFilename,  err)
+					t.Fatalf("db.Update failed on bucket name %v for metadata %v, filename %v; error was %v", testBucket, in.md, dbFilename, err)
 					return err
 				}
 			}
@@ -221,8 +223,8 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 		dbFilename = "Fake Filename"
 	)
 
-	// Create a folder for the database file. If a folder by that
-	// name exists already, it will be replaced by an empty folder.
+	// Create a folder for the database file. If a folder by that name exists 
+	// already, it will be replaced by an empty folder.
 	testDir := build.TempDir(persistDir, "TestErrPermissionOpenDatabase")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
@@ -256,8 +258,8 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 }
 
 
-// TestErrTxNotWritable checks that updateMetadata returns an error
-// when called from a read-only transaction.
+// TestErrTxNotWritable checks that updateMetadata returns an error when called 
+// from a read-only transaction.
 func TestErrTxNotWritable(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -299,8 +301,9 @@ func TestErrTxNotWritable(t *testing.T) {
 	}
 }
 
-// TestErrDatabaseNotOpen tests that checkMetadata returns an error
-// when called on a BoltDatabase that is closed.
+
+// TestErrDatabaseNotOpen tests that checkMetadata returns an error when called 
+// on a BoltDatabase that is closed.
 func TestErrDatabaseNotOpen(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -342,8 +345,9 @@ func TestErrDatabaseNotOpen(t *testing.T) {
 	}
 }
 
-// TestErrCheckMetadata tests that checkMetadata returns an error
-// when called on a BoltDatabase whose metadata has been changed.
+
+// TestErrCheckMetadata tests that checkMetadata returns an error when called 
+// on a BoltDatabase whose metadata has been changed.
 func TestErrCheckMetadata(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -413,8 +417,8 @@ func TestErrCheckMetadata(t *testing.T) {
 
 
 // TestErrIntegratedCheckMetadata checks that checkMetadata returns an error
-// within OpenDatabase when OpenDatabase is called on a BoltDatabase that 
-// has already been set up with different metadata.
+// within OpenDatabase when OpenDatabase is called on a BoltDatabase that has 
+// already been set up with different metadata.
 func TestErrIntegratedCheckMetadata(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -427,8 +431,8 @@ func TestErrIntegratedCheckMetadata(t *testing.T) {
 	}
 
 	for i, in := range testInputs {
-	dbFilename := testFilenames[i%len(testFilenames)]	
-	dbFilepath := filepath.Join(testDir, dbFilename)
+		dbFilename := testFilenames[i%len(testFilenames)]	
+		dbFilepath := filepath.Join(testDir, dbFilename)
 
 		boltDB, err := OpenDatabase(in.md, dbFilepath)
 		if err != nil {
@@ -442,7 +446,7 @@ func TestErrIntegratedCheckMetadata(t *testing.T) {
 
 		boltDB, err = OpenDatabase(in.newMd, dbFilepath)
 		if err != in.err {
-			t.Error("expected error %v for input %v and filename %v; got %v instead", in, dbFilename, err)
+			t.Errorf("expected error %v for input %v and filename %v; got %v instead", in.err, in, dbFilename, err)
 		}
 
 		err = os.Remove(dbFilepath)

--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -10,41 +10,41 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/bolt"
 )
- 
+
 // testInputs and testFilenames are global variables because most tests require
-// a variety of metadata and filename inputs (although only TestCheckMetadata 
-// and TestIntegratedCheckMetadata use testInput.newMd and testInput.err). 
+// a variety of metadata and filename inputs (although only TestCheckMetadata
+// and TestIntegratedCheckMetadata use testInput.newMd and testInput.err).
 // Weird strings are from https://github.com/minimaxir/big-ltist-of-naughty-strings
 var (
-    testInputs = []struct{
-        md		Metadata
-        newMd	Metadata
-        err     error
-    }{
+	testInputs = []struct {
+		md    Metadata
+		newMd Metadata
+		err   error
+	}{
 		{Metadata{"1sadf23", "12253"}, Metadata{"1sa-df23", "12253"}, ErrBadHeader},
 		{Metadata{"$@#$%^&", "$@#$%^&"}, Metadata{"$@#$%^&", "$@#$%!^&"}, ErrBadVersion},
 		{Metadata{"//", "//"}, Metadata{"////", "//"}, ErrBadHeader},
 		{Metadata{":]", ":)"}, Metadata{":]", ":("}, ErrBadVersion},
-		{Metadata{"¯|_(ツ)_|¯","_|¯(ツ)¯|_"}, Metadata{"¯|_(ツ)_|¯","_|¯(ツ)_|¯"}, ErrBadVersion},
+		{Metadata{"¯|_(ツ)_|¯", "_|¯(ツ)¯|_"}, Metadata{"¯|_(ツ)_|¯", "_|¯(ツ)_|¯"}, ErrBadVersion},
 		{Metadata{"世界", "怎么办呢"}, Metadata{"世界", "怎么好呢"}, ErrBadVersion},
-		{Metadata{"     ","     "}, Metadata{"\t","     "}, ErrBadHeader},
-        {Metadata{"",""}, Metadata{"asdf",""}, ErrBadHeader},
-        {Metadata{"","_"}, Metadata{"",""}, ErrBadVersion},
-        {Metadata{"%&*","#@$"}, Metadata{"","#@$"}, ErrBadHeader},
-        {Metadata{"a.sdf","0.30.2"}, Metadata{"a.sdf", "0.3.02" }, ErrBadVersion},
-        {Metadata{"/","/"}, Metadata{"//","/"}, ErrBadHeader},
-        {Metadata{"%*.*s","%d"}, Metadata{"%*.*s","%    d"}, ErrBadVersion},
-        {Metadata{" ",""}, Metadata{"   ",""}, ErrBadHeader},
-        {Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","␢undefined"}, ErrBadVersion},
-        {Metadata{" ","  "}, Metadata{"  ","  "}, ErrBadHeader},
-        {Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"},Metadata{"\xF0\x9F\x98\x8F"," \xF0\x9F\x98\xBE"}, ErrBadVersion},
-        {Metadata{"'",""}, Metadata{"`",""}, ErrBadHeader},
-        {Metadata{"","-"}, Metadata{"","-␡"}, ErrBadVersion},
-		{Metadata{"<foo val=“bar” />","(ﾉಥ益ಥ ┻━┻"}, Metadata{"<foo val=“bar” />","(ﾉ\nಥ益ಥ ┻━┻"}, ErrBadVersion},
-		{Metadata{"\n\n","Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ ̖t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, Metadata{"\n\n","Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, ErrBadVersion},
-    }
+		{Metadata{"     ", "     "}, Metadata{"\t", "     "}, ErrBadHeader},
+		{Metadata{"", ""}, Metadata{"asdf", ""}, ErrBadHeader},
+		{Metadata{"", "_"}, Metadata{"", ""}, ErrBadVersion},
+		{Metadata{"%&*", "#@$"}, Metadata{"", "#@$"}, ErrBadHeader},
+		{Metadata{"a.sdf", "0.30.2"}, Metadata{"a.sdf", "0.3.02"}, ErrBadVersion},
+		{Metadata{"/", "/"}, Metadata{"//", "/"}, ErrBadHeader},
+		{Metadata{"%*.*s", "%d"}, Metadata{"%*.*s", "%    d"}, ErrBadVersion},
+		{Metadata{" ", ""}, Metadata{"   ", ""}, ErrBadHeader},
+		{Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢", "undefined"}, Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢", "␢undefined"}, ErrBadVersion},
+		{Metadata{" ", "  "}, Metadata{"  ", "  "}, ErrBadHeader},
+		{Metadata{"\xF0\x9F\x98\x8F", "\xF0\x9F\x98\xBE"}, Metadata{"\xF0\x9F\x98\x8F", " \xF0\x9F\x98\xBE"}, ErrBadVersion},
+		{Metadata{"'", ""}, Metadata{"`", ""}, ErrBadHeader},
+		{Metadata{"", "-"}, Metadata{"", "-␡"}, ErrBadVersion},
+		{Metadata{"<foo val=“bar” />", "(ﾉಥ益ಥ ┻━┻"}, Metadata{"<foo val=“bar” />", "(ﾉ\nಥ益ಥ ┻━┻"}, ErrBadVersion},
+		{Metadata{"\n\n", "Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ ̖t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, Metadata{"\n\n", "Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, ErrBadVersion},
+	}
 
-    testFilenames = []string{
+	testFilenames = []string{
 		" ",
 		"_",
 		"-",
@@ -59,9 +59,8 @@ var (
 		",.;'[]-=",
 		"A:",
 		"%s",
-    }
+	}
 )
-
 
 // TestOpenDatabase tests calling OpenDatabase on the following types of
 // database:
@@ -93,10 +92,10 @@ func TestOpenDatabase(t *testing.T) {
 	// Create a folder for the database file. If a folder by that name exists
 	// already, it will be replaced by an empty folder.
 	testDir := build.TempDir(persistDir, "TestOpenNewDatabase")
-		err := os.MkdirAll(testDir, 0700)
-		if err != nil {
-			t.Fatal(err)
-		}
+	err := os.MkdirAll(testDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for i, in := range testInputs {
 		dbFilename := testFilenames[i%len(testFilenames)]
@@ -125,23 +124,28 @@ func TestOpenDatabase(t *testing.T) {
 			for _, testBucket := range testBuckets {
 				_, err := tx.CreateBucketIfNotExists(testBucket)
 				if err != nil {
-					t.Fatalf("db.Update failed on bucket name %v for metadata %v, filename %v; error was %v", testBucket, in.md, dbFilename, err)
+					t.Errorf("db.Update failed on bucket name %v for metadata %v, filename %v; error was %v", testBucket, in.md, dbFilename, err)
 					return err
 				}
 			}
 			return nil
 		})
+
 		if err != nil {
+			t.Fatal(err)
 		}
 
 		// Make sure CreateBucketIfNotExists method handles invalid (nil)
 		// bucket name.
 		err = db.Update(func(tx *bolt.Tx) error {
 			_, err := tx.CreateBucketIfNotExists(nil)
-			return err				
+			return err
 		})
+
+		//
 		if err != bolt.ErrBucketNameRequired {
-			t.Fatalf("the CreateBucketIfNotExists method returned wrong error when fed nil byteslice (metadata was %v, filename was %v); expected %v, got %v", in.md, dbFilename, bolt.ErrBucketNameRequired, err)
+			t.Errorf("the CreateBucketIfNotExists method returned wrong error when fed nil byteslice (metadata was %v, filename was %v); expected %v, got %v", in.md, dbFilename, bolt.ErrBucketNameRequired, err)
+			continue
 		}
 
 		// Fill each bucket with a random number (0-9, inclusive) of key/value
@@ -158,15 +162,17 @@ func TestOpenDatabase(t *testing.T) {
 					rand.Read(v)
 					err := b.Put(k, v)
 					if err != nil {
+						t.Errorf("db.Update failed to fill bucket %v for metadata %v, filename %v; error was %v", testBucket, in.md, dbFilename, err)
 						return err
 					}
-				}	
+				}
 			}
-		return nil
-		})		
+			return nil
+		})
+
 		if err != nil {
 			t.Fatal(err)
-		}	
+		}
 
 		// Close the newly-filled database.
 		err = db.Close()
@@ -208,7 +214,6 @@ func TestOpenDatabase(t *testing.T) {
 	}
 }
 
-
 // TestErrPermissionOpenDatabase tests calling OpenDatabase on a database file
 // with the wrong filemode (< 0600), which should result in an os.ErrPermission
 // error.
@@ -223,7 +228,7 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 		dbFilename = "Fake Filename"
 	)
 
-	// Create a folder for the database file. If a folder by that name exists 
+	// Create a folder for the database file. If a folder by that name exists
 	// already, it will be replaced by an empty folder.
 	testDir := build.TempDir(persistDir, "TestErrPermissionOpenDatabase")
 	err := os.MkdirAll(testDir, 0700)
@@ -238,8 +243,8 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 	for _, mode := range badFileModes {
 		// Create a file named dbFilename in directory testDir with the wrong
 		// permissions (mode < 0600).
-		_, err := os.OpenFile(dbFilepath, os.O_RDWR|os.O_CREATE, mode) 
-		if err != nil { 
+		_, err := os.OpenFile(dbFilepath, os.O_RDWR|os.O_CREATE, mode)
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -254,11 +259,10 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-	}        
+	}
 }
 
-
-// TestErrTxNotWritable checks that updateMetadata returns an error when called 
+// TestErrTxNotWritable checks that updateMetadata returns an error when called
 // from a read-only transaction.
 func TestErrTxNotWritable(t *testing.T) {
 	if testing.Short() {
@@ -282,18 +286,23 @@ func TestErrTxNotWritable(t *testing.T) {
 
 		boltDB := &BoltDatabase{
 			Metadata: in.md,
-			DB: db,
+			DB:       db,
 		}
 
-		tx, err := db.Begin(false)
-		// Should return an error since tx is a read-only transaction.
-		err = boltDB.updateMetadata(tx)
+		err = db.View(func(tx *bolt.Tx) error {
+			err = boltDB.updateMetadata(tx)
+			return err
+		})
+
 		if err != bolt.ErrTxNotWritable {
 			t.Errorf("updateMetadata returned wrong error for input %v, filename %v; expected tx not writable, got %v", in.md, dbFilename, err)
 		}
 
-		tx.Commit()
-		boltDB.Close()
+		err = boltDB.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		err = os.Remove(dbFilepath)
 		if err != nil {
 			t.Fatal(err)
@@ -301,8 +310,7 @@ func TestErrTxNotWritable(t *testing.T) {
 	}
 }
 
-
-// TestErrDatabaseNotOpen tests that checkMetadata returns an error when called 
+// TestErrDatabaseNotOpen tests that checkMetadata returns an error when called
 // on a BoltDatabase that is closed.
 func TestErrDatabaseNotOpen(t *testing.T) {
 	if testing.Short() {
@@ -316,7 +324,7 @@ func TestErrDatabaseNotOpen(t *testing.T) {
 	}
 
 	dbFilepath := filepath.Join(testDir, "fake_filename")
-	md := Metadata{"Fake Header","Fake Version"}
+	md := Metadata{"Fake Header", "Fake Version"}
 
 	db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
 	if err != nil {
@@ -325,8 +333,8 @@ func TestErrDatabaseNotOpen(t *testing.T) {
 
 	boltDB := &BoltDatabase{
 		Metadata: md,
-		DB: db,
-	}	
+		DB:       db,
+	}
 
 	err = boltDB.Close()
 	if err != nil {
@@ -345,8 +353,7 @@ func TestErrDatabaseNotOpen(t *testing.T) {
 	}
 }
 
-
-// TestErrCheckMetadata tests that checkMetadata returns an error when called 
+// TestErrCheckMetadata tests that checkMetadata returns an error when called
 // on a BoltDatabase whose metadata has been changed.
 func TestErrCheckMetadata(t *testing.T) {
 	if testing.Short() {
@@ -359,7 +366,7 @@ func TestErrCheckMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i, in := range testInputs {		
+	for i, in := range testInputs {
 		dbFilename := testFilenames[i%len(testFilenames)]
 		dbFilepath := filepath.Join(testDir, dbFilename)
 
@@ -367,10 +374,10 @@ func TestErrCheckMetadata(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		
+
 		boltDB := &BoltDatabase{
-			Metadata: 	in.md,
-			DB: 		db,
+			Metadata: in.md,
+			DB:       db,
 		}
 
 		err = db.Update(func(tx *bolt.Tx) error {
@@ -383,26 +390,26 @@ func TestErrCheckMetadata(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			
+
 			err = bucket.Put([]byte("Version"), []byte(in.newMd.Version))
 			if err != nil {
 				return err
-				}
+			}
 			return nil
 		})
 
 		if err != nil {
 			t.Errorf("Put method failed for input %v, filename %v with error %v", in, dbFilename, err)
 			continue
-		}	
-	
-		// Should return an error because boltDB's metadata 
-		// now differs from its original metadata. 
-		err = (*boltDB).checkMetadata(in.md) 
-		if err != in.err { 
-			t.Errorf("expected %v, got %v for input %v -> %v", in.err, err, in.md, in.newMd)	
 		}
-	
+
+		// Should return an error because boltDB's metadata
+		// now differs from its original metadata.
+		err = (*boltDB).checkMetadata(in.md)
+		if err != in.err {
+			t.Errorf("expected %v, got %v for input %v -> %v", in.err, err, in.md, in.newMd)
+		}
+
 		err = boltDB.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -415,9 +422,8 @@ func TestErrCheckMetadata(t *testing.T) {
 	}
 }
 
-
 // TestErrIntegratedCheckMetadata checks that checkMetadata returns an error
-// within OpenDatabase when OpenDatabase is called on a BoltDatabase that has 
+// within OpenDatabase when OpenDatabase is called on a BoltDatabase that has
 // already been set up with different metadata.
 func TestErrIntegratedCheckMetadata(t *testing.T) {
 	if testing.Short() {
@@ -431,14 +437,14 @@ func TestErrIntegratedCheckMetadata(t *testing.T) {
 	}
 
 	for i, in := range testInputs {
-		dbFilename := testFilenames[i%len(testFilenames)]	
+		dbFilename := testFilenames[i%len(testFilenames)]
 		dbFilepath := filepath.Join(testDir, dbFilename)
 
 		boltDB, err := OpenDatabase(in.md, dbFilepath)
 		if err != nil {
 			t.Errorf("OpenDatabase failed on input %v, filename %v; error was %v", in, dbFilename, err)
 		}
-		
+
 		err = boltDB.Close()
 		if err != nil {
 			t.Fatal(err)

--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -13,6 +13,59 @@ import (
 	"github.com/NebulousLabs/bolt"
 )
 
+var (
+    testInputs = []struct{
+        md		Metadata
+        newMd	Metadata
+        err     error
+    }{
+		{Metadata{"1sadf23", "12253"}, Metadata{"1sa-df23", "12253"}, ErrBadHeader},
+		{Metadata{"$@#$%^&", "$@#$%^&"}, Metadata{"$@#$%^&", "$@#$%!^&"}, ErrBadVersion},
+		{Metadata{"//", "//"}, Metadata{"////", "//"}, ErrBadHeader},
+		{Metadata{"testHeader" + RandomSuffix(), "0.0.0"}, Metadata{"testHeader" + RandomSuffix(), "0.0.0"}, ErrBadHeader},
+		{Metadata{":]", ":)"}, Metadata{":]", ":("}, ErrBadVersion},
+		{Metadata{"¯|_(ツ)_|¯","_|¯(ツ)¯|_"}, Metadata{"¯|_(ツ)_|¯","_|¯(ツ)_|¯"}, ErrBadVersion},
+		{Metadata{"世界", "怎么办呢"}, Metadata{"世界", "怎么好呢"}, ErrBadVersion},
+		{Metadata{"     ","     "}, Metadata{"\t","     "}, ErrBadHeader},
+        {Metadata{"",""}, Metadata{"asdf",""}, ErrBadHeader},
+        {Metadata{"","_"}, Metadata{"",""}, ErrBadVersion},
+        {Metadata{"%&*","#@$"}, Metadata{"","#@$"}, ErrBadHeader},
+        {Metadata{"a.sdf","0.30.2"}, Metadata{"a.sdf", "0.3.02" }, ErrBadVersion},
+        {Metadata{",,,,,","2^31"}, Metadata{",,,,","2^31"}, ErrBadHeader},
+        {Metadata{"/","/"}, Metadata{"//","/"}, ErrBadHeader},
+        {Metadata{"%*.*s","%d"}, Metadata{"%*.*s","%    d"}, ErrBadVersion},
+        {Metadata{" ",""}, Metadata{"   ",""}, ErrBadHeader},
+        {Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","␢undefined"}, ErrBadVersion},
+        {Metadata{" ","  "}, Metadata{"  ","  "}, ErrBadHeader},
+        {Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"},Metadata{"\xF0\x9F\x98\x8F"," \xF0\x9F\x98\xBE"}, ErrBadVersion},
+        {Metadata{"'",""}, Metadata{"`",""}, ErrBadHeader},
+        {Metadata{"","-"}, Metadata{"","-␡"}, ErrBadVersion},
+		{Metadata{"<foo val=“bar” />","(ﾉಥ益ಥ ┻━┻"}, Metadata{"<foo val=“bar” />","(ﾉ\nಥ益ಥ ┻━┻"}, ErrBadVersion},
+		{Metadata{"\n\n","Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ ̖t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, Metadata{"\n\n","Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, ErrBadVersion},
+    }
+
+
+    testFilenames = []string{
+		" ",
+		"_",
+		"-",
+		"1234sg",
+		"@#$%@#",
+		"test" + RandomSuffix(),
+		":|",
+		"¯|_(ツ)_|¯",
+		"你好好好",
+		"你好好q wgc好",
+		"\xF0\x9F\x99\x8A",
+		"␣",
+		" ",
+		"$HOME",
+		",.;'[]-=",
+		"A:",
+		"%s",
+    }
+)
+
 // TestOpenDatabase tests calling OpenDatabase on the following types of
 // database:
 // - a database that has not yet been created
@@ -27,43 +80,6 @@ func TestOpenDatabase(t *testing.T) {
 		t.SkipNow()
 	}
 
-	testInputs := []struct {
-		dbMetadata Metadata
-		dbFilename string
-	}{
-		{Metadata{"", ""}, " "},
-		{Metadata{"", ""}, "_"},
-		{Metadata{"_", "_"}, "_"},
-		{Metadata{"asdf", "asdf"}, "asdf"},
-		{Metadata{"1sadf23", "12253"}, "123kjhgfd"},
-		{Metadata{"$@#$%^&", "$@#$%^&"}, "$@#$%^&"},
-		{Metadata{"//", "//"}, "_"},
-		{Metadata{"testHeader" + RandomSuffix(), "0.0.0"}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader	" + RandomSuffix(), "7.0.4"}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader?" + RandomSuffix(), "asdf"}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader...." + RandomSuffix(), ""}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader/asdf" + RandomSuffix(), "_"}, "testFilename" + RandomSuffix()},
-		{Metadata{":]", ":)"}, ":|"},
-		{Metadata{"¯|_(ツ)_|¯","_|¯(ツ)¯|_"}, "¯|_(ツ)_|¯"},
-		{Metadata{"世界", "怎么办呢"}, "你好好好"},
-		{Metadata{"		","		"}," "},
-		{Metadata{"你好		好 好", "好a好3好你"}, "你好好q wgc好"},
-		{Metadata{"apparently \xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "\xF0\x9F\x99\x8A"},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE	emoji"}, "\xF0\x9F\x99\x8A"},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "are okay?\xF0\x9F\x99\x8A"},
-		{Metadata{"nil","undefined"}, "A:"},		
-		{Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, "PRN"},		
-		{Metadata{"\n","Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣"}, "CON"},		
-		{Metadata{"𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘","test"}, "␣"},		
-		{Metadata{"⁰⁴⁵₀₁₂","⅛⅜⅝⅞"}, " "},		
-		{Metadata{"הָיְתָהtestالصفحات التّحول",  "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،"},"$HOME"},		
-		{Metadata{"<foo val=“bar” />","(ﾉಥ益ಥ ┻━┻"}, "$HOME"},		
-		{Metadata{"!@#$%^&*()`~","<>?:\"{}|_+/"}, ",.;'[]-="},		
-		{Metadata{"true","false"}, "A:"},		
-		{Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"}, "Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"},		
-		{Metadata{"%*.*s","%d"}, "%s"},		
-	}
-	
 	testBuckets := [][]byte{
 		[]byte("FakeBucket"),
 		[]byte("FakeBucket123"),
@@ -91,115 +107,117 @@ func TestOpenDatabase(t *testing.T) {
 			t.Fatal(err)
 		}
 
-	// Loop through tests for each testInput.
 	for _, in := range testInputs {
-		dbFilePath := filepath.Join(testDir, in.dbFilename)
+		for _, dbFilename := range testFilenames {
+			dbFilepath := filepath.Join(testDir, dbFilename)
 
-		// Create a new database.
-		db, err := OpenDatabase(in.dbMetadata, dbFilePath)
-		if err != nil {
-			t.Fatalf("calling OpenDatabase on a new database failed for input %v; error was %v", in, err)
-		}
-
-		// Close the newly-created, empty database.
-		err = db.Close()
-		if err != nil {
-			t.Fatalf("closing a newly created database failed for input %v; error was %v", in, err)
-		}
-
-		// Call OpenDatabase again, this time on the existing empty database.
-		db, err = OpenDatabase(in.dbMetadata, dbFilePath)
-		if err != nil {
-			t.Fatalf("calling OpenDatabase on an existing empty database failed for input %v; error was %v", in, err)
-		}
-
-		// Create buckets in the database.
-		err = db.Update(func(tx *bolt.Tx) error {
-			for _, testBucket := range testBuckets {
-				_, err := tx.CreateBucketIfNotExists(testBucket)
-				if err != nil {
-					t.Fatalf("db.Update failed on bucket name %v; error was", testBucket, err)
-					return err
-				}
+			// Create a new database.
+			db, err := OpenDatabase(in.md, dbFilepath)
+			if err != nil {
+				t.Fatalf("calling OpenDatabase on a new database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
 			}
+
+			// Close the newly-created, empty database.
+			err = db.Close()
+			if err != nil {
+				t.Fatalf("closing a newly created database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
+			}
+
+			// Call OpenDatabase again, this time on the existing empty database.
+			db, err = OpenDatabase(in.md, dbFilepath)
+			if err != nil {
+				t.Fatalf("calling OpenDatabase on an existing empty database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
+			}
+
+			// Create buckets in the database.
+			err = db.Update(func(tx *bolt.Tx) error {
+				for _, testBucket := range testBuckets {
+					_, err := tx.CreateBucketIfNotExists(testBucket)
+					if err != nil {
+						t.Fatalf("db.Update failed on bucket name %v for metadata %v, filename %v; error was", testBucket, in.md, dbFilename,  err)
+						return err
+					}
+				}
+				return nil
+			})
+			if err != nil {
+			}
+
+			// Make sure CreateBucketIfNotExists method handles invalid (nil)
+			// bucket name.
+			err = db.Update(func(tx *bolt.Tx) error {
+				_, err := tx.CreateBucketIfNotExists(nil)
+				return err				
+			})
+			if err != bolt.ErrBucketNameRequired {
+				t.Fatalf("the CreateBucketIfNotExists method returned wrong error when fed nil byteslice (metadata was %v, filename was %v); expected %v, got %v", in.md, dbFilename, bolt.ErrBucketNameRequired, err)
+			}
+
+			// Fill each bucket with a random number (0-9, inclusive) of key/value
+			// pairs, where each key is a length-10 random byteslice and each value
+			// is a length-1000 random byteslice.
+			err = db.Update(func(tx *bolt.Tx) error {
+				for _, testBucket := range testBuckets {
+					b := tx.Bucket(testBucket)
+					x := rand.Intn(10)
+					for i := 0; i <= x; i++ {
+						k := make([]byte, 10)
+						rand.Read(k)
+						v := make([]byte, 1e3)
+						rand.Read(v)
+						err := b.Put(k, v)
+						if err != nil {
+							return err
+						}
+					}	
+				}
 			return nil
-		})
-		if err != nil {
-		}
+			})		
+			if err != nil {
+				t.Fatal(err)
+			}	
 
-		// Make sure CreateBucketIfNotExists method handles invalid (nil)
-		// bucket name.
-		err = db.Update(func(tx *bolt.Tx) error {
-			_, err := tx.CreateBucketIfNotExists(nil)
-			return err				
-		})
-		if err != bolt.ErrBucketNameRequired {
-			t.Fatalf("the CreateBucketIfNotExists method failed to throw the expected error when fed an invalid (nil) byteslice; expected %v, got %v", bolt.ErrBucketNameRequired, err)
-		}
+			// Close the newly-filled database.
+			err = db.Close()
+			if err != nil {
+				t.Fatalf("closing a newly-filled database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
+			}
 
-		// Fill each bucket with a random number (0-9, inclusive) of key/value
-		// pairs, where each key is a length-10 random byteslice and each value
-		// is a length-1000 random byteslice.
-		err = db.Update(func(tx *bolt.Tx) error {
-			for _, testBucket := range testBuckets {
-				b := tx.Bucket(testBucket)
-				x := rand.Intn(10)
-				for i := 0; i <= x; i++ {
-					k := make([]byte, 10)
-					rand.Read(k)
-					v := make([]byte, 1e3)
-					rand.Read(v)
-					err := b.Put(k, v)
+			// Call OpenDatabase on the database now that it's been filled.
+			db, err = OpenDatabase(in.md, dbFilepath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Empty every bucket in the database.
+			err = db.Update(func(tx *bolt.Tx) error {
+				for _, testBucket := range testBuckets {
+					b := tx.Bucket(testBucket)
+					err := b.ForEach(func(k, v []byte) error {
+						return b.Delete(k)
+					})
 					if err != nil {
 						return err
 					}
-				}	
-			}
-		return nil
-		})		
-		if err != nil {
-			t.Fatal(err)
-		}	
-
-		// Close the newly-filled database.
-		err = db.Close()
-		if err != nil {
-			t.Fatalf("closing a newly-filled database failed for input %v; error was %v", in, err)
-		}
-
-		// Call OpenDatabase on the database now that it's been filled.
-		db, err = OpenDatabase(in.dbMetadata, dbFilePath)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Empty every bucket in the database.
-		err = db.Update(func(tx *bolt.Tx) error {
-			for _, testBucket := range testBuckets {
-				b := tx.Bucket(testBucket)
-				err := b.ForEach(func(k, v []byte) error {
-					return b.Delete(k)
-				})
-				if err != nil {
-					return err
 				}
+				return nil
+			})
+
+			// Close the newly emptied database.
+			err = db.Close()
+			if err != nil {
+				t.Fatalf("closing a newly-emptied database for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
 			}
-			return nil
-		})
 
-		// Close the newly emptied database.
-		err = db.Close()
-		if err != nil {
-			t.Fatalf("closing a newly-emptied database failed for input %v; error was %v", in, err)
-		}
-
-		// Clean up by deleting the testfile.
-		err = os.Remove(dbFilePath)
-		if err != nil {
-			t.Fatalf("removing database file failed for input %v; error was %v", in, err)
+			// Clean up by deleting the testfile.
+			err = os.Remove(dbFilepath)
+			if err != nil {
+				t.Fatalf("removing database file failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
+			}
 		}
 	}
 }
+
 
 // TestErrPermissionOpenDatabase tests calling OpenDatabase on a database file
 // with the wrong filemode (< 0600), which should result in an os.ErrPermission
@@ -249,107 +267,14 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 	}        
 }
 
-// TestErrCheckMetadata tests that checkMetadata returns an error
-// when called on a BoltDatabase whose metadata has been changed.
-func TestErrCheckMetadata(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-
-	testDir := build.TempDir(persistDir, "TestErrCheckMetadata")
-	err := os.MkdirAll(testDir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	dbFilepath := filepath.Join(testDir, "fake_filename")
-
-	testInputs := []struct{
-		old		Metadata
-		new		Metadata
-		err		error
-	}{
-		{Metadata{"",""}, Metadata{"asdf",""}, ErrBadHeader},
-		{Metadata{"",""}, Metadata{"","asdf"}, ErrBadVersion},
-		{Metadata{"_",""}, Metadata{"",""}, ErrBadHeader},
-		{Metadata{"","_"}, Metadata{"",""}, ErrBadVersion},
-		{Metadata{"%&*","#@$"}, Metadata{"","#@$"}, ErrBadHeader},
-		{Metadata{"bleep","bloop"}, Metadata{"bloop","bloop"}, ErrBadHeader},
-		{Metadata{"blip","blop"}, Metadata{"blip","blip"}, ErrBadVersion},
-		{Metadata{"a.sdf","0.30.2"}, Metadata{"a.sdf", "0.3.02" }, ErrBadVersion},
-		{Metadata{".asdf","0.30.2"}, Metadata{"asdf.", "0.3.02" }, ErrBadHeader},
-		{Metadata{".","0.0.0"}, Metadata{"..","0.0.0"}, ErrBadHeader},
-		{Metadata{"haggis","."}, Metadata{"haggis",""}, ErrBadVersion},
-		{Metadata{"¯|_(ツ)_|¯",""}, Metadata{"¯|_(ツ)_|¯","¯|_(ツ)_|¯"}, ErrBadVersion},
-		{Metadata{",,,,,","2^31"}, Metadata{",,,,","2^31"}, ErrBadHeader},
-		{Metadata{"/","/"}, Metadata{"//","/"}, ErrBadHeader},
-        {Metadata{"%*.*s","%d"}, Metadata{"%*.*s","%	d"}, ErrBadVersion},
-		{Metadata{" ",""}, Metadata{"	",""}, ErrBadHeader},
-		{Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"}, Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣ  ॣ ॣ冗"}, ErrBadVersion},
-		{Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","␢undefined"}, ErrBadVersion},
-		{Metadata{" ","  "}, Metadata{"  ","  "}, ErrBadHeader},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"},Metadata{"\xF0\x9F\x98\x8F"," \xF0\x9F\x98\xBE"}, ErrBadVersion},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"},Metadata{"\xF0\x98\x8F","\xF0\x9F\x98\xBE"}, ErrBadHeader},
-		{Metadata{"'",""}, Metadata{"`",""}, ErrBadHeader},
-		{Metadata{"","-"}, Metadata{"","-␡"}, ErrBadVersion},
-	}
-		
-	for _, in := range testInputs {		
-		db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
-		if err != nil {
-			t.Fatal(err)
-		}
-		
-		boltDB := &BoltDatabase{
-			Metadata: 	in.old,
-			DB: 		db,
-		}
-
-		err = db.Update(func(tx *bolt.Tx) error {
-			bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
-			if err != nil {
-				return err
-			}
-
-			err = bucket.Put([]byte("Header"), []byte(in.new.Header))
-			if err != nil {
-				return err
-			}
-			
-			err = bucket.Put([]byte("Version"), []byte(in.new.Version))
-			if err != nil {
-				return err
-				}
-			return nil
-		})
-
-		if err != nil {
-			t.Errorf("Put method failed for input %v with error %v", in, err)
-			continue
-		}	
-
-	
-		// checkMetadata should return an error because boltDB's
-		// metadata now differs from its original metadata. 
-		err = (*boltDB).checkMetadata(in.old) 
-		if err != in.err { 
-			t.Errorf("expected %v, got %v for input %v -> %v", in.err, err, in.old, in.new)	
-		}
-	
-		err = boltDB.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = os.Remove(dbFilepath)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-}
 
 // TestErrTxNotWritable checks that updateMetadata returns an error
 // when called from a read-only transaction.
 func TestErrTxNotWritable(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	testDir := build.TempDir(persistDir, "TestErrTxNotWritable")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
@@ -427,6 +352,10 @@ func TestErrTxNotWritable(t *testing.T) {
 // TestErrDatabaseNotOpen tests that checkMetadata returns an error
 // when called on a BoltDatabase that is closed.
 func TestErrDatabaseNotOpen(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	testDir := build.TempDir(persistDir, "TestErrDatabaseNotOpen")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
@@ -463,59 +392,98 @@ func TestErrDatabaseNotOpen(t *testing.T) {
 	}
 }
 
+// TestErrCheckMetadata tests that checkMetadata returns an error
+// when called on a BoltDatabase whose metadata has been changed.
+func TestErrCheckMetadata(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	testDir := build.TempDir(persistDir, "TestErrCheckMetadata")
+	err := os.MkdirAll(testDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, in := range testInputs {		
+		for _, dbFilename := range testFilenames {
+			dbFilepath := filepath.Join(testDir, dbFilename)
+
+			db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
+			if err != nil {
+				t.Fatal(err)
+			}
+			
+			boltDB := &BoltDatabase{
+				Metadata: 	in.md,
+				DB: 		db,
+			}
+
+			err = db.Update(func(tx *bolt.Tx) error {
+				bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
+				if err != nil {
+					return err
+				}
+
+				err = bucket.Put([]byte("Header"), []byte(in.newMd.Header))
+				if err != nil {
+					return err
+				}
+				
+				err = bucket.Put([]byte("Version"), []byte(in.newMd.Version))
+				if err != nil {
+					return err
+					}
+				return nil
+			})
+
+			if err != nil {
+				t.Errorf("Put method failed for input %v, filename %v with error %v", in, dbFilename, err)
+				continue
+			}	
+		
+			// Should return an error because boltDB's metadata 
+			// now differs from its original metadata. 
+			err = (*boltDB).checkMetadata(in.md) 
+			if err != in.err { 
+				t.Errorf("expected %v, got %v for input %v -> %v", in.err, err, in.md, in.newMd)	
+			}
+		
+			err = boltDB.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = os.Remove(dbFilepath)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+
 // TestErrIntegratedCheckMetadata checks that checkMetadata returns an error
 // within OpenDatabase when OpenDatabase is called on a BoltDatabase that 
 // has already been set up with different metadata.
 func TestErrIntegratedCheckMetadata(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	testDir := build.TempDir(persistDir, "TestErrIntegratedCheckMetadata")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	testInputs := []struct{
-		old		Metadata
-		new		Metadata
-		err		error
-	}{
-		{Metadata{"",""}, Metadata{"asdf",""}, ErrBadHeader},
-		{Metadata{"",""}, Metadata{"","asdf"}, ErrBadVersion},
-		{Metadata{"_",""}, Metadata{"",""}, ErrBadHeader},
-		{Metadata{"","_"}, Metadata{"",""}, ErrBadVersion},
-		{Metadata{"%&*","#@$"}, Metadata{"","#@$"}, ErrBadHeader},
-		{Metadata{"bleep","bloop"}, Metadata{"bloop","bloop"}, ErrBadHeader},
-		{Metadata{"blip","blop"}, Metadata{"blip","blip"}, ErrBadVersion},
-		{Metadata{"a.sdf","0.30.2"}, Metadata{"a.sdf", "0.3.02" }, ErrBadVersion},
-		{Metadata{".asdf","0.30.2"}, Metadata{"asdf.", "0.3.02" }, ErrBadHeader},
-		{Metadata{".","0.0.0"}, Metadata{"..","0.0.0"}, ErrBadHeader},
-		{Metadata{"haggis","."}, Metadata{"haggis",""}, ErrBadVersion},
-		{Metadata{"¯|_(ツ)_|¯",""}, Metadata{"¯|_(ツ)_|¯","¯|_(ツ)_|¯"}, ErrBadVersion},
-		{Metadata{",,,,,","2^31"}, Metadata{",,,,","2^31"}, ErrBadHeader},
-		{Metadata{"/","/"}, Metadata{"//","/"}, ErrBadHeader},
-        {Metadata{"%*.*s","%d"}, Metadata{"%*.*s","%	d"}, ErrBadVersion},
-		{Metadata{" ",""}, Metadata{"	",""}, ErrBadHeader},
-		{Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"}, Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣ  ॣ ॣ冗"}, ErrBadVersion},
-		{Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","␢undefined"}, ErrBadVersion},
-		{Metadata{" ","  "}, Metadata{"  ","  "}, ErrBadHeader},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"},Metadata{"\xF0\x9F\x98\x8F"," \xF0\x9F\x98\xBE"}, ErrBadVersion},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"},Metadata{"\xF0\x98\x8F","\xF0\x9F\x98\xBE"}, ErrBadHeader},
-		{Metadata{"'",""}, Metadata{"`",""}, ErrBadHeader},
-		{Metadata{"","-"}, Metadata{"","-␡"}, ErrBadVersion},
-	}
-
-	testFilenames := []string{
-		"blip",
-		"blop",
-		"bloop",
-	}
-
 	for _, in := range testInputs {
-		for _, filename := range testFilenames {
-			dbFilepath := filepath.Join(testDir, filename)
+		for _, dbFilename := range testFilenames {
+			dbFilepath := filepath.Join(testDir, dbFilename)
 
-			boltDB, err := OpenDatabase(in.old, dbFilepath)
+			boltDB, err := OpenDatabase(in.md, dbFilepath)
 			if err != nil {
-				t.Errorf("OpenDatabase failed on input %v, filepath %v; error was %v", in, dbFilepath, err)
+				t.Errorf("OpenDatabase failed on input %v, filename %v; error was %v", in, dbFilename, err)
 			}
 			
 			err = boltDB.Close()
@@ -523,9 +491,9 @@ func TestErrIntegratedCheckMetadata(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			boltDB, err = OpenDatabase(in.new, dbFilepath)
+			boltDB, err = OpenDatabase(in.newMd, dbFilepath)
 			if err != in.err {
-				t.Error("expected error %v for input %v and filename %v; got %v instead", in, filename, err)
+				t.Error("expected error %v for input %v and filename %v; got %v instead", in, dbFilename, err)
 			}
 
 			err = os.Remove(dbFilepath)

--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -1,18 +1,17 @@
+// Borrowed weird strings from https://github.com/minimaxir/big-list-of-naughty-strings
+
 package persist
 
 import (
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/bolt"
 )
-
-type testInput struct {
-	dbMetadata Metadata
-	dbFilename string
-}
 
 // TestOpenDatabase tests calling OpenDatabase on the following types of
 // database:
@@ -28,12 +27,43 @@ func TestOpenDatabase(t *testing.T) {
 		t.SkipNow()
 	}
 
-	testVersions := []string{"0.0.0", "7.0.4", "asdf"}
-	numTestVersions := len(testVersions)
-
-	const numTestInputs = 25
-	testInputs := make([]testInput, numTestInputs)
-
+	testInputs := []struct {
+		dbMetadata Metadata
+		dbFilename string
+	}{
+		{Metadata{"", ""}, " "},
+		{Metadata{"", ""}, "_"},
+		{Metadata{"_", "_"}, "_"},
+		{Metadata{"asdf", "asdf"}, "asdf"},
+		{Metadata{"1sadf23", "12253"}, "123kjhgfd"},
+		{Metadata{"$@#$%^&", "$@#$%^&"}, "$@#$%^&"},
+		{Metadata{"//", "//"}, "_"},
+		{Metadata{"testHeader" + RandomSuffix(), "0.0.0"}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader	" + RandomSuffix(), "7.0.4"}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader?" + RandomSuffix(), "asdf"}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader...." + RandomSuffix(), ""}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader/asdf" + RandomSuffix(), "_"}, "testFilename" + RandomSuffix()},
+		{Metadata{":]", ":)"}, ":|"},
+		{Metadata{"¯|_(ツ)_|¯","_|¯(ツ)¯|_"}, "¯|_(ツ)_|¯"},
+		{Metadata{"世界", "怎么办呢"}, "你好好好"},
+		{Metadata{"		","		"}," "},
+		{Metadata{"你好		好 好", "好a好3好你"}, "你好好q wgc好"},
+		{Metadata{"apparently \xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "\xF0\x9F\x99\x8A"},
+		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE	emoji"}, "\xF0\x9F\x99\x8A"},
+		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "are okay?\xF0\x9F\x99\x8A"},
+		{Metadata{"nil","undefined"}, "A:"},		
+		{Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, "PRN"},		
+		{Metadata{"\n","Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣"}, "CON"},		
+		{Metadata{"𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘","test"}, "␣"},		
+		{Metadata{"⁰⁴⁵₀₁₂","⅛⅜⅝⅞"}, " "},		
+		{Metadata{"הָיְתָהtestالصفحات التّحول",  "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،"},"$HOME"},		
+		{Metadata{"<foo val=“bar” />","(ﾉಥ益ಥ ┻━┻"}, "$HOME"},		
+		{Metadata{"!@#$%^&*()`~","<>?:\"{}|_+/"}, ",.;'[]-="},		
+		{Metadata{"true","false"}, "A:"},		
+		{Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"}, "Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"},		
+		{Metadata{"%*.*s","%d"}, "%s"},		
+	}
+	
 	testBuckets := [][]byte{
 		[]byte("FakeBucket"),
 		[]byte("FakeBucket123"),
@@ -42,30 +72,31 @@ func TestOpenDatabase(t *testing.T) {
 		[]byte("FakeBucket" + RandomSuffix()),
 		[]byte("_"),
 		[]byte(" asdf"),
+		[]byte("你好好好"),
+		[]byte("¯|_(ツ)_|¯"),
+		[]byte("Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"),
+		[]byte("﷽"),
+		[]byte("(ﾉಥ益ಥ ┻━┻"),
+		[]byte("Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ ̖t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"),
+		[]byte("0xbadidea"),
+		[]byte("nil"),
+		[]byte("你好好好"),
 	}
 
 	// Create a folder for the database file. If a folder by that name exists
 	// already, it will be replaced by an empty folder.
-	testdir := build.TempDir(persistDir, "TestOpenNewDatabase")
-	err := os.MkdirAll(testdir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Generate random testInputs for building database files.
-	for i := range testInputs {
-		dbFilename := "testFilename" + RandomSuffix()
-		dbHeader := "testHeader" + RandomSuffix()
-		dbVersion := testVersions[i%numTestVersions]
-		dbMetadata := Metadata{dbHeader, dbVersion}
-		in := testInput{dbMetadata, dbFilename}
-		testInputs[i] = in
-	}
+	testDir := build.TempDir(persistDir, "TestOpenNewDatabase")
+		err := os.MkdirAll(testDir, 0700)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 	// Loop through tests for each testInput.
 	for _, in := range testInputs {
+		dbFilePath := filepath.Join(testDir, in.dbFilename)
+
 		// Create a new database.
-		db, err := OpenDatabase(in.dbMetadata, in.dbFilename)
+		db, err := OpenDatabase(in.dbMetadata, dbFilePath)
 		if err != nil {
 			t.Fatalf("calling OpenDatabase on a new database failed for input %v; error was %v", in, err)
 		}
@@ -77,7 +108,7 @@ func TestOpenDatabase(t *testing.T) {
 		}
 
 		// Call OpenDatabase again, this time on the existing empty database.
-		db, err = OpenDatabase(in.dbMetadata, in.dbFilename)
+		db, err = OpenDatabase(in.dbMetadata, dbFilePath)
 		if err != nil {
 			t.Fatalf("calling OpenDatabase on an existing empty database failed for input %v; error was %v", in, err)
 		}
@@ -87,13 +118,23 @@ func TestOpenDatabase(t *testing.T) {
 			for _, testBucket := range testBuckets {
 				_, err := tx.CreateBucketIfNotExists(testBucket)
 				if err != nil {
+					t.Fatalf("db.Update failed on bucket name %v; error was", testBucket, err)
 					return err
 				}
 			}
 			return nil
 		})
 		if err != nil {
-			t.Fatal(err)
+		}
+
+		// Make sure CreateBucketIfNotExists method handles invalid (nil)
+		// bucket name.
+		err = db.Update(func(tx *bolt.Tx) error {
+			_, err := tx.CreateBucketIfNotExists(nil)
+			return err				
+		})
+		if err != bolt.ErrBucketNameRequired {
+			t.Fatalf("the CreateBucketIfNotExists method failed to throw the expected error when fed an invalid (nil) byteslice; expected %v, got %v", bolt.ErrBucketNameRequired, err)
 		}
 
 		// Fill each bucket with a random number (0-9, inclusive) of key/value
@@ -112,13 +153,13 @@ func TestOpenDatabase(t *testing.T) {
 					if err != nil {
 						return err
 					}
-				}
+				}	
 			}
-			return nil
-		})
+		return nil
+		})		
 		if err != nil {
 			t.Fatal(err)
-		}
+		}	
 
 		// Close the newly-filled database.
 		err = db.Close()
@@ -127,7 +168,7 @@ func TestOpenDatabase(t *testing.T) {
 		}
 
 		// Call OpenDatabase on the database now that it's been filled.
-		db, err = OpenDatabase(in.dbMetadata, in.dbFilename)
+		db, err = OpenDatabase(in.dbMetadata, dbFilePath)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,10 +194,296 @@ func TestOpenDatabase(t *testing.T) {
 		}
 
 		// Clean up by deleting the testfile.
-		err = os.Remove(in.dbFilename)
+		err = os.Remove(dbFilePath)
 		if err != nil {
-			t.Fatalf("removing database file failing for input %v; error was %v", in, err)
+			t.Fatalf("removing database file failed for input %v; error was %v", in, err)
 		}
 	}
+}
 
+// TestErrPermissionOpenDatabase tests calling OpenDatabase on a database file
+// with the wrong filemode (< 0600), which should result in an os.ErrPermission
+// error.
+func TestErrPermissionOpenDatabase(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	const (
+		dbHeader   = "Fake Header"
+		dbVersion  = "0.0.0"
+		dbFilename = "Fake Filename"
+	)
+
+	// Create a folder for the database file. If a folder by that
+	// name exists already, it will be replaced by an empty folder.
+	testDir := build.TempDir(persistDir, "TestErrPermissionOpenDatabase")
+	err := os.MkdirAll(testDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbFilepath := filepath.Join(testDir, dbFilename)
+	badFileModes := []os.FileMode{0000, 0001, 0002, 0003, 0004, 0005, 0010, 0040, 0060, 0105, 0110, 0126, 0130, 0143, 0150, 0166, 0170, 0200, 0313, 0470, 0504, 0560, 0566, 0577}
+
+	// Make sure OpenDatabase returns a permissions error for each of the modes
+	// in badFileModes.
+	for _, mode := range badFileModes {
+		// Create a file named dbFilename in directory testDir with the wrong
+		// permissions (mode < 0600).
+		_, err := os.OpenFile(dbFilepath, os.O_RDWR|os.O_CREATE, mode) 
+		if err != nil { 
+			t.Fatal(err)
+		}
+
+		// OpenDatabase should return a permissions error because the database
+		// mode is less than 0600.
+		_, err = OpenDatabase(Metadata{dbHeader, dbVersion}, dbFilepath)
+		if !os.IsPermission(err) {
+			t.Errorf("OpenDatabase failed to return expected error when called on a database with the wrong permissions (%o instead of >= 0600);\n wanted:\topen %v: permission denied\n got:\t\t%v", mode, dbFilepath, err)
+		}
+
+		err = os.Remove(dbFilepath)
+		if err != nil {
+			t.Error(err)
+		}
+	}        
+}
+
+// TestErrCheckMetadata tests that checkMetadata returns an error
+// when called on a BoltDatabase whose metadata has been changed.
+func TestErrCheckMetadata(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	testDir := build.TempDir(persistDir, "TestErrCheckMetadata")
+	err := os.MkdirAll(testDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dbFilepath := filepath.Join(testDir, "fake_filename")
+
+	testInputs := []struct{
+		old		Metadata
+		new		Metadata
+		err		error
+	}{
+		{Metadata{"",""}, Metadata{"asdf",""}, ErrBadHeader},
+		{Metadata{"",""}, Metadata{"","asdf"}, ErrBadVersion},
+		{Metadata{"_",""}, Metadata{"",""}, ErrBadHeader},
+		{Metadata{"","_"}, Metadata{"",""}, ErrBadVersion},
+		{Metadata{"%&*","#@$"}, Metadata{"","#@$"}, ErrBadHeader},
+		{Metadata{"bleep","bloop"}, Metadata{"bloop","bloop"}, ErrBadHeader},
+		{Metadata{"blip","blop"}, Metadata{"blip","blip"}, ErrBadVersion},
+		{Metadata{"a.sdf","0.30.2"}, Metadata{"a.sdf", "0.3.02" }, ErrBadVersion},
+		{Metadata{".asdf","0.30.2"}, Metadata{"asdf.", "0.3.02" }, ErrBadHeader},
+		{Metadata{".","0.0.0"}, Metadata{"..","0.0.0"}, ErrBadHeader},
+		{Metadata{"haggis","."}, Metadata{"haggis",""}, ErrBadVersion},
+		{Metadata{"¯|_(ツ)_|¯",""}, Metadata{"¯|_(ツ)_|¯","¯|_(ツ)_|¯"}, ErrBadVersion},
+		{Metadata{",,,,,","2^31"}, Metadata{",,,,","2^31"}, ErrBadHeader},
+		{Metadata{"/","/"}, Metadata{"//","/"}, ErrBadHeader},
+		{Metadata{" ",""}, Metadata{"	",""}, ErrBadHeader},
+		{Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"}, Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣ  ॣ ॣ冗"}, ErrBadVersion},
+	}
+		
+	for _, in := range testInputs {		
+		db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
+		if err != nil {
+			t.Fatal(err)
+		}
+		
+		boltDB := &BoltDatabase{
+			Metadata: 	in.old,
+			DB: 		db,
+		}
+
+		err = db.Update(func(tx *bolt.Tx) error {
+			bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
+			if err != nil {
+				return err
+			}
+
+			err = bucket.Put([]byte("Header"), []byte(in.new.Header))
+			if err != nil {
+				return err
+			}
+			
+			err = bucket.Put([]byte("Version"), []byte(in.new.Version))
+			if err != nil {
+				return err
+				}
+			return nil
+		})
+
+		if err != nil {
+			t.Errorf("Put method failed for input %v with error %v", in, err)
+			continue
+		}	
+
+	
+		// checkMetadata should return an error because boltDB's
+		// metadata now differs from its original metadata. 
+		err = (*boltDB).checkMetadata(in.old) 
+		if err != in.err { 
+			t.Errorf("expected %v, got %v for input %v -> %v", in.err, err, in.old, in.new)	
+		}
+	
+		err = boltDB.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = os.Remove(dbFilepath)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestErrTxNotWritable checks that updateMetadata returns an error
+// when called from a read-only transaction.
+func TestErrTxNotWritable(t *testing.T) {
+	testDir := build.TempDir(persistDir, "TestErrTxNotWritable")
+	err := os.MkdirAll(testDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testInputs := []struct{
+		md			Metadata
+		filename	string
+	}{
+		{Metadata{"", ""}, " "},
+		{Metadata{"", ""}, "_"},
+		{Metadata{"_", "_"}, "_"},
+		{Metadata{"asdf", "asdf"}, "asdf"},
+		{Metadata{"1sadf23", "12253"}, "123kjhgfd"},
+		{Metadata{"$@#$%^&", "$@#$%^&"}, "$@#$%^&"},
+		{Metadata{"//", "//"}, "_"},
+		{Metadata{"testHeader" + RandomSuffix(), "0.0.0"}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader	" + RandomSuffix(), "7.0.4"}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader?" + RandomSuffix(), "asdf"}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader...." + RandomSuffix(), ""}, "testFilename" + RandomSuffix()},
+		{Metadata{"testHeader/asdf" + RandomSuffix(), "_"}, "testFilename" + RandomSuffix()},
+		{Metadata{":]", ":)"}, ":|"},
+		{Metadata{"¯|_(ツ)_|¯","_|¯(ツ)¯|_"}, "¯|_(ツ)_|¯"},
+		{Metadata{"世界", "怎么办呢"}, "你好好好"},
+		{Metadata{"		","		"}," "},
+		{Metadata{"你好		好 好", "好a好3好你"}, "你好好q wgc好"},
+		{Metadata{"apparently \xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "\xF0\x9F\x99\x8A"},
+		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE	emoji"}, "\xF0\x9F\x99\x8A"},
+		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "are okay?\xF0\x9F\x99\x8A"},
+		{Metadata{"nil","undefined"}, "A:"},		
+		{Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, "PRN"},		
+		{Metadata{"\n","Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣"}, "CON"},		
+		{Metadata{"𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘","test"}, "␣"},		
+		{Metadata{"⁰⁴⁵₀₁₂","⅛⅜⅝⅞"}, " "},		
+		{Metadata{"הָיְתָהtestالصفحات التّحول",  "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،"},"$HOME"},		
+		{Metadata{"<foo val=“bar” />","(ﾉಥ益ಥ ┻━┻"}, "$HOME"},		
+		{Metadata{"!@#$%^&*()`~","<>?:\"{}|_+/"}, ",.;'[]-="},		
+		{Metadata{"true","false"}, "A:"},		
+		{Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"}, "Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"},		
+		{Metadata{"%*.*s","%d"}, "%s"},		
+
+	}
+
+	for _, in := range testInputs {
+
+		dbFilepath := filepath.Join(testDir, in.filename)
+
+		db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		boltDB := &BoltDatabase{
+			Metadata: in.md,
+			DB: db,
+		}
+
+		tx, err := db.Begin(false)
+		// Should return an error since tx is a read-only transaction.
+		err = boltDB.updateMetadata(tx)
+		if err != bolt.ErrTxNotWritable {
+			t.Errorf("expected tx not writable, got %v", err)
+		}
+
+		tx.Commit()
+		boltDB.Close()
+		err = os.Remove(dbFilepath)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestErrDatabaseNotOpen tests that checkMetadata returns an error
+// when called on a BoltDatabase that is closed.
+func TestErrDatabaseNotOpen(t *testing.T) {
+	testDir := build.TempDir(persistDir, "TestErrDatabaseNotOpen")
+	err := os.MkdirAll(testDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dbFilepath := filepath.Join(testDir, "fake_filename")
+	md := Metadata{"Fake Header","Fake Version"}
+
+	db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	boltDB := &BoltDatabase{
+		Metadata: md,
+		DB: db,
+	}	
+
+	err = boltDB.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should return an error since boltDB is closed.
+	err = boltDB.checkMetadata(md)
+	if err != bolt.ErrDatabaseNotOpen {
+		t.Errorf("expected database not open, got %v", err)
+	}
+
+	err = os.Remove(dbFilepath)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+
+// TestErrIntegratedCheckMetadata checks that checkMetadata returns an error
+// within OpenDatabase when OpenDatabase is called on a BoltDatabase that 
+// has already been set up with different metadata.
+func TestErrIntegratedCheckMetadata(t *testing.T) {
+	testDir := build.TempDir(persistDir, "TestErrCheckMetadata")
+	err := os.MkdirAll(testDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dbFilepath := filepath.Join(testDir, "fake_filename")
+	old := Metadata{"Old Header", "Old Version"}
+	new := Metadata{"New Header", "New Version"}
+	testErr := ErrBadHeader
+
+	boltDB, err := OpenDatabase(old, dbFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = boltDB.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	boltDB, err = OpenDatabase(new, dbFilepath)
+	if err != testErr {
+		t.Error("expected error %v for input %v -> %v, got %v instead", testErr, old, new, err)
+	}
 }

--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -269,47 +269,9 @@ func TestErrTxNotWritable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testInputs := []struct{
-		md			Metadata
-		filename	string
-	}{
-		{Metadata{"", ""}, " "},
-		{Metadata{"", ""}, "_"},
-		{Metadata{"_", "_"}, "_"},
-		{Metadata{"asdf", "asdf"}, "asdf"},
-		{Metadata{"1sadf23", "12253"}, "123kjhgfd"},
-		{Metadata{"$@#$%^&", "$@#$%^&"}, "$@#$%^&"},
-		{Metadata{"//", "//"}, "_"},
-		{Metadata{"testHeader" + RandomSuffix(), "0.0.0"}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader	" + RandomSuffix(), "7.0.4"}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader?" + RandomSuffix(), "asdf"}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader...." + RandomSuffix(), ""}, "testFilename" + RandomSuffix()},
-		{Metadata{"testHeader/asdf" + RandomSuffix(), "_"}, "testFilename" + RandomSuffix()},
-		{Metadata{":]", ":)"}, ":|"},
-		{Metadata{"¯|_(ツ)_|¯","_|¯(ツ)¯|_"}, "¯|_(ツ)_|¯"},
-		{Metadata{"世界", "怎么办呢"}, "你好好好"},
-		{Metadata{"		","		"}," "},
-		{Metadata{"你好		好 好", "好a好3好你"}, "你好好q wgc好"},
-		{Metadata{"apparently \xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "\xF0\x9F\x99\x8A"},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE	emoji"}, "\xF0\x9F\x99\x8A"},
-		{Metadata{"\xF0\x9F\x98\x8F","\xF0\x9F\x98\xBE"}, "are okay?\xF0\x9F\x99\x8A"},
-		{Metadata{"nil","undefined"}, "A:"},		
-		{Metadata{"⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢","undefined"}, "PRN"},		
-		{Metadata{"\n","Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣"}, "CON"},		
-		{Metadata{"𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘","test"}, "␣"},		
-		{Metadata{"⁰⁴⁵₀₁₂","⅛⅜⅝⅞"}, " "},		
-		{Metadata{"הָיְתָהtestالصفحات التّحول",  "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،"},"$HOME"},		
-		{Metadata{"<foo val=“bar” />","(ﾉಥ益ಥ ┻━┻"}, "$HOME"},		
-		{Metadata{"!@#$%^&*()`~","<>?:\"{}|_+/"}, ",.;'[]-="},		
-		{Metadata{"true","false"}, "A:"},		
-		{Metadata{"Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗","Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"}, "Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"},		
-		{Metadata{"%*.*s","%d"}, "%s"},		
-
-	}
-
-	for _, in := range testInputs {
-
-		dbFilepath := filepath.Join(testDir, in.filename)
+	for i, in := range testInputs {
+		dbFilename := testFilenames[i%len(testFilenames)]
+		dbFilepath := filepath.Join(testDir, dbFilename)
 
 		db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
 		if err != nil {
@@ -325,7 +287,7 @@ func TestErrTxNotWritable(t *testing.T) {
 		// Should return an error since tx is a read-only transaction.
 		err = boltDB.updateMetadata(tx)
 		if err != bolt.ErrTxNotWritable {
-			t.Errorf("expected tx not writable, got %v", err)
+			t.Errorf("updateMetadata returned wrong error for input %v, filename %v; expected tx not writable, got %v", in.md, dbFilename, err)
 		}
 
 		tx.Commit()

--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -43,7 +43,6 @@ var (
 		{Metadata{"<foo val=“bar” />", "(ﾉಥ益ಥ ┻━┻"}, Metadata{"<foo val=“bar” />", "(ﾉ\nಥ益ಥ ┻━┻"}, ErrBadVersion},
 		{Metadata{"\n\n", "Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ ̖t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, Metadata{"\n\n", "Ṱ̺̺o͞ ̷i̲̬n̝̗v̟̜o̶̙kè͚̮ t̝͕h̼͓e͇̣ ̢̼h͚͎i̦̲v̻͍e̺̭-m̢iͅn̖̺d̵̼ ̞̥r̛̗e͙p͠r̼̞e̺̠s̘͇e͉̥ǹ̬͎t͍̬i̪̱n͠g̴͉ ͏͉c̬̟h͡a̫̻o̫̟s̗̦.̨̹"}, ErrBadVersion},
 	}
-
 	testFilenames = []string{
 		" ",
 		"_",
@@ -75,7 +74,6 @@ func TestOpenDatabase(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	testBuckets := [][]byte{
 		[]byte("Fake Bucket123!@#$"),
 		[]byte("你好好好"),
@@ -88,7 +86,6 @@ func TestOpenDatabase(t *testing.T) {
 		[]byte("␣"),
 		[]byte("你好好好"),
 	}
-
 	// Create a folder for the database file. If a folder by that name exists
 	// already, it will be replaced by an empty folder.
 	testDir := build.TempDir(persistDir, "TestOpenNewDatabase")
@@ -96,29 +93,24 @@ func TestOpenDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	for i, in := range testInputs {
 		dbFilename := testFilenames[i%len(testFilenames)]
 		dbFilepath := filepath.Join(testDir, dbFilename)
-
 		// Create a new database.
 		db, err := OpenDatabase(in.md, dbFilepath)
 		if err != nil {
 			t.Fatalf("calling OpenDatabase on a new database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
 		}
-
 		// Close the newly-created, empty database.
 		err = db.Close()
 		if err != nil {
 			t.Fatalf("closing a newly created database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
 		}
-
 		// Call OpenDatabase again, this time on the existing empty database.
 		db, err = OpenDatabase(in.md, dbFilepath)
 		if err != nil {
 			t.Fatalf("calling OpenDatabase on an existing empty database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
 		}
-
 		// Create buckets in the database.
 		err = db.Update(func(tx *bolt.Tx) error {
 			for _, testBucket := range testBuckets {
@@ -130,24 +122,17 @@ func TestOpenDatabase(t *testing.T) {
 			}
 			return nil
 		})
-
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		// Make sure CreateBucketIfNotExists method handles invalid (nil)
 		// bucket name.
 		err = db.Update(func(tx *bolt.Tx) error {
 			_, err := tx.CreateBucketIfNotExists(nil)
 			return err
 		})
-
-		//
 		if err != bolt.ErrBucketNameRequired {
-			t.Errorf("the CreateBucketIfNotExists method returned wrong error when fed nil byteslice (metadata was %v, filename was %v); expected %v, got %v", in.md, dbFilename, bolt.ErrBucketNameRequired, err)
-			continue
 		}
-
 		// Fill each bucket with a random number (0-9, inclusive) of key/value
 		// pairs, where each key is a length-10 random byteslice and each value
 		// is a length-1000 random byteslice.
@@ -169,23 +154,19 @@ func TestOpenDatabase(t *testing.T) {
 			}
 			return nil
 		})
-
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		// Close the newly-filled database.
 		err = db.Close()
 		if err != nil {
 			t.Fatalf("closing a newly-filled database failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
 		}
-
 		// Call OpenDatabase on the database now that it's been filled.
 		db, err = OpenDatabase(in.md, dbFilepath)
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		// Empty every bucket in the database.
 		err = db.Update(func(tx *bolt.Tx) error {
 			for _, testBucket := range testBuckets {
@@ -199,14 +180,11 @@ func TestOpenDatabase(t *testing.T) {
 			}
 			return nil
 		})
-
-		// Close the newly emptied database.
+		// Close and delete the newly emptied database.
 		err = db.Close()
 		if err != nil {
 			t.Fatalf("closing a newly-emptied database for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
 		}
-
-		// Clean up by deleting the testfile.
 		err = os.Remove(dbFilepath)
 		if err != nil {
 			t.Fatalf("removing database file failed for metadata %v, filename %v; error was %v", in.md, dbFilename, err)
@@ -221,15 +199,11 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	const (
 		dbHeader   = "Fake Header"
 		dbVersion  = "0.0.0"
 		dbFilename = "Fake Filename"
 	)
-
-	// Create a folder for the database file. If a folder by that name exists
-	// already, it will be replaced by an empty folder.
 	testDir := build.TempDir(persistDir, "TestErrPermissionOpenDatabase")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
@@ -247,14 +221,12 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		// OpenDatabase should return a permissions error because the database
 		// mode is less than 0600.
 		_, err = OpenDatabase(Metadata{dbHeader, dbVersion}, dbFilepath)
 		if !os.IsPermission(err) {
 			t.Errorf("OpenDatabase failed to return expected error when called on a database with the wrong permissions (%o instead of >= 0600);\n wanted:\topen %v: permission denied\n got:\t\t%v", mode, dbFilepath, err)
 		}
-
 		err = os.Remove(dbFilepath)
 		if err != nil {
 			t.Error(err)
@@ -268,41 +240,35 @@ func TestErrTxNotWritable(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	testDir := build.TempDir(persistDir, "TestErrTxNotWritable")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	for i, in := range testInputs {
 		dbFilename := testFilenames[i%len(testFilenames)]
 		dbFilepath := filepath.Join(testDir, dbFilename)
-
 		db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		boltDB := &BoltDatabase{
 			Metadata: in.md,
 			DB:       db,
 		}
-
+		// Should return an error because updateMetadata is being called from
+		// a read-only transaction.
 		err = db.View(func(tx *bolt.Tx) error {
 			err = boltDB.updateMetadata(tx)
 			return err
 		})
-
 		if err != bolt.ErrTxNotWritable {
 			t.Errorf("updateMetadata returned wrong error for input %v, filename %v; expected tx not writable, got %v", in.md, dbFilename, err)
 		}
-
 		err = boltDB.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		err = os.Remove(dbFilepath)
 		if err != nil {
 			t.Fatal(err)
@@ -316,37 +282,30 @@ func TestErrDatabaseNotOpen(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	testDir := build.TempDir(persistDir, "TestErrDatabaseNotOpen")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	dbFilepath := filepath.Join(testDir, "fake_filename")
 	md := Metadata{"Fake Header", "Fake Version"}
-
 	db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	boltDB := &BoltDatabase{
 		Metadata: md,
 		DB:       db,
 	}
-
 	err = boltDB.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	// Should return an error since boltDB is closed.
 	err = boltDB.checkMetadata(md)
 	if err != bolt.ErrDatabaseNotOpen {
 		t.Errorf("expected database not open, got %v", err)
 	}
-
 	err = os.Remove(dbFilepath)
 	if err != nil {
 		t.Error(err)
@@ -359,62 +318,51 @@ func TestErrCheckMetadata(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	testDir := build.TempDir(persistDir, "TestErrCheckMetadata")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	for i, in := range testInputs {
 		dbFilename := testFilenames[i%len(testFilenames)]
 		dbFilepath := filepath.Join(testDir, dbFilename)
-
 		db, err := bolt.Open(dbFilepath, 0600, &bolt.Options{Timeout: 3 * time.Second})
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		boltDB := &BoltDatabase{
 			Metadata: in.md,
 			DB:       db,
 		}
-
 		err = db.Update(func(tx *bolt.Tx) error {
 			bucket, err := tx.CreateBucketIfNotExists([]byte("Metadata"))
 			if err != nil {
 				return err
 			}
-
 			err = bucket.Put([]byte("Header"), []byte(in.newMd.Header))
 			if err != nil {
 				return err
 			}
-
 			err = bucket.Put([]byte("Version"), []byte(in.newMd.Version))
 			if err != nil {
 				return err
 			}
 			return nil
 		})
-
 		if err != nil {
 			t.Errorf("Put method failed for input %v, filename %v with error %v", in, dbFilename, err)
 			continue
 		}
-
-		// Should return an error because boltDB's metadata
-		// now differs from its original metadata.
+		// Should return an error because boltDB's metadata now differs from
+		// its original metadata.
 		err = (*boltDB).checkMetadata(in.md)
 		if err != in.err {
 			t.Errorf("expected %v, got %v for input %v -> %v", in.err, err, in.md, in.newMd)
 		}
-
 		err = boltDB.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		err = os.Remove(dbFilepath)
 		if err != nil {
 			t.Fatal(err)
@@ -429,32 +377,27 @@ func TestErrIntegratedCheckMetadata(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	testDir := build.TempDir(persistDir, "TestErrIntegratedCheckMetadata")
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	for i, in := range testInputs {
 		dbFilename := testFilenames[i%len(testFilenames)]
 		dbFilepath := filepath.Join(testDir, dbFilename)
-
 		boltDB, err := OpenDatabase(in.md, dbFilepath)
 		if err != nil {
 			t.Errorf("OpenDatabase failed on input %v, filename %v; error was %v", in, dbFilename, err)
 		}
-
 		err = boltDB.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-
+		// Should return an error because boltDB was set up with metadata in.md, not in.newMd
 		boltDB, err = OpenDatabase(in.newMd, dbFilepath)
 		if err != in.err {
 			t.Errorf("expected error %v for input %v and filename %v; got %v instead", in.err, in, dbFilename, err)
 		}
-
 		err = os.Remove(dbFilepath)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Fixes up TestOpenDatabase:
- there is now a broader variety of testInputs and testBuckets
- testInputs are now hardcoded rather than randomly generated
- testInputs can thus now be defined via anonymous struct, so type testInput can be removed
- filepath argument to OpenDatabase is now the full filepath of the database (previously just the file name, dbFilename, was passed in, which meant that the database was created in the wrong directory)

Introduces TestBadFileModeOpenDatabase, which checks that a file with the wrong filemode (less than 0600) will cause OpenDatabase to return a permissions error.