### PR TITLE
Fix deadlock in host shutdown

### DIFF
--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -49,14 +49,14 @@ func (h *Host) initNetworking(address string) (err error) {
 		return err
 	}
 	// Automatically close the listener when h.tg.Stop() is called.
+	err = h.tg.Add()
+	if err != nil {
+		return err
+	}
 	go func() {
-		err := h.tg.Add()
-		if err != nil {
-			return
-		}
 		defer h.tg.Done()
 		<-h.tg.StopChan()
-		err = h.listener.Close()
+		err := h.listener.Close()
 		if err != nil {
 			h.log.Println("Closing the listener failed:", err)
 		}

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -98,6 +98,10 @@ func (h *Host) initNetworking(address string) (err error) {
 // threadedHandleConn handles an incoming connection to the host, typically an
 // RPC.
 func (h *Host) threadedHandleConn(conn net.Conn) {
+	// We defer the conn.Close so that the conn is still closed if `Add` returns
+	// an error.
+	defer conn.Close()
+
 	err := h.tg.Add()
 	if err != nil {
 		return
@@ -111,7 +115,6 @@ func (h *Host) threadedHandleConn(conn net.Conn) {
 		h.log.Println("WARN: could not set deadline on connection:", err)
 		return
 	}
-	defer conn.Close()
 
 	// Read a specifier indicating which action is being called.
 	var id types.Specifier

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -191,7 +191,6 @@ func (h *Host) threadedListen() {
 			return
 		}
 
-		// Grab the resource lock before creating a goroutine.
 		go h.threadedHandleConn(conn)
 	}
 }

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -49,18 +49,12 @@ func (h *Host) initNetworking(address string) (err error) {
 		return err
 	}
 	// Automatically close the listener when h.tg.Stop() is called.
-	err = h.tg.Add()
-	if err != nil {
-		return err
-	}
-	go func() {
-		defer h.tg.Done()
-		<-h.tg.StopChan()
+	h.tg.OnStop(func() {
 		err := h.listener.Close()
 		if err != nil {
-			h.log.Println("Closing the listener failed:", err)
+			h.log.Println("WARN: closing the listener failed:", err)
 		}
-	}()
+	})
 
 	// Set the port.
 	_, port, err := net.SplitHostPort(h.listener.Addr().String())

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -18,14 +18,14 @@ var rpcSettingsDeprecated = types.Specifier{'S', 'e', 't', 't', 'i', 'n', 'g', '
 // checks if the host's hostname has changed, and makes an updated host
 // announcement if so.
 func (h *Host) threadedUpdateHostname() {
-	for {
-		err := h.tg.Add()
-		if err != nil {
-			return
-		}
-		h.managedLearnHostname()
-		h.tg.Done()
+	err := h.tg.Add()
+	if err != nil {
+		return
+	}
+	defer h.tg.Done()
 
+	for {
+		h.managedLearnHostname()
 		// Wait 30 minutes to check again. If the hostname is changing
 		// regularly (more than once a week), we want the host to be able to be
 		// seen as having 95% uptime. Every minute that the announcement is


### PR DESCRIPTION
The first commit in this PR fixes the deadlock. The rest of the commits are suggestions. I ask that you evaluate them individually.

The deadlock was possible because it was possible for the listener to start before the host is closed, but for the closer-goroutine to start after the host is closed. This is fixed by calling `Add` outside of the goroutine. The exact same deadlock existed in the gateway in #1178. `Add` should always be called outside of the goroutine when starting a closer-goroutine.