### PR TITLE
add RegisterCloser to ThreadGroup

### DIFF
--- a/sync/threadgroup.go
+++ b/sync/threadgroup.go
@@ -78,6 +78,7 @@ func (tg *ThreadGroup) Stop() error {
 	for _, c := range tg.closers {
 		c.Close()
 	}
+	tg.closers = nil
 	tg.mu.Unlock()
 	tg.wg.Wait()
 	return nil

--- a/sync/threadgroup_test.go
+++ b/sync/threadgroup_test.go
@@ -63,7 +63,7 @@ func TestThreadGroupStop(t *testing.T) {
 	if err != ErrStopped {
 		t.Error("expected ErrStopped, got", err)
 	}
-	err = tg.RegisterCloser(nil)
+	err = tg.OnStop(nil)
 	if err != ErrStopped {
 		t.Error("expected ErrStopped, got", err)
 	}
@@ -126,8 +126,9 @@ func TestThreadGroupOnce(t *testing.T) {
 	}
 }
 
-// TestThreadGroupRegisterCloser tests that Stop calls registered io.Closers.
-func TestThreadGroupRegisterCloser(t *testing.T) {
+// TestThreadGroupOnStop tests that Stop calls functions registered with
+// OnStop.
+func TestThreadGroupOnStop(t *testing.T) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +136,7 @@ func TestThreadGroupRegisterCloser(t *testing.T) {
 
 	// create ThreadGroup and register the closer
 	var tg ThreadGroup
-	err = tg.RegisterCloser(l)
+	err = tg.OnStop(func() { l.Close() })
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This makes it clean and easy to close `net.Conn`s and `net.Listener`s during shutdown. No extra goroutines needed.

My only concern is that it's a little opaque. But I think the tradeoff is worth it.