### PR TITLE
Smarter SetAllowance + Auto-renew

### DIFF
--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -241,7 +241,7 @@ func (h *Host) managedVerifyRenewedContract(so *storageObligation, txnSet []type
 	}
 	// The WindowEnd for the new file contract must be further in the future
 	// than the WindowEnd for the existing file contract.
-	if fc.WindowEnd <= so.proofDeadline() {
+	if fc.WindowEnd < so.proofDeadline() {
 		return errRenewDoesNotExtend
 	}
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -108,6 +108,12 @@ type RenterContract struct {
 	SecretKey       crypto.SecretKey           `json:"secretkey"`
 }
 
+// EndHeight returns the height at which the host is no longer obligated to
+// store contract data.
+func (rc *RenterContract) EndHeight() types.BlockHeight {
+	return rc.LastRevision.NewWindowStart
+}
+
 // A Renter uploads, tracks, repairs, and downloads a set of files for the
 // user.
 type Renter interface {

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -114,6 +114,12 @@ func (rc *RenterContract) EndHeight() types.BlockHeight {
 	return rc.LastRevision.NewWindowStart
 }
 
+// RenterFunds returns the funds remaining in the contract's Renter payout as
+// of the most recent revision.
+func (rc *RenterContract) RenterFunds() types.Currency {
+	return rc.LastRevision.NewValidProofOutputs[0].Value
+}
+
 // A Renter uploads, tracks, repairs, and downloads a set of files for the
 // user.
 type Renter interface {

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -101,7 +101,8 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	// should not change either
 	endHeight := c.blockHeight + a.Period
 	if a.Period == c.allowance.Period && len(c.contracts) > 0 {
-		endHeight = c.contractEndHeight()
+		// COMPAT v0.6.0 - old hosts require end height increase by at least 1
+		endHeight = c.contractEndHeight() + 1
 	}
 	c.mu.RUnlock()
 

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -8,6 +8,13 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+var (
+	errAllowanceNoHosts    = errors.New("hosts must be non-zero")
+	errAllowanceZeroPeriod = errors.New("period must be non-zero")
+	errAllowanceZeroWindow = errors.New("renew window must be non-zero")
+	errAllowanceWindowSize = errors.New("renew window must be less than period")
+)
+
 // contractEndHeight returns the height at which the Contractor's contracts
 // end. If there are no contracts, it returns zero.
 func (c *Contractor) contractEndHeight() types.BlockHeight {
@@ -46,13 +53,13 @@ func (c *Contractor) contractEndHeight() types.BlockHeight {
 func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	// sanity checks
 	if a.Hosts == 0 {
-		return errors.New("hosts must be non-zero")
+		return errAllowanceNoHosts
 	} else if a.Period == 0 {
-		return errors.New("period must be non-zero")
+		return errAllowanceZeroPeriod
 	} else if a.RenewWindow == 0 {
-		return errors.New("renew window must be non-zero")
+		return errAllowanceZeroWindow
 	} else if a.RenewWindow >= a.Period {
-		return errors.New("renew window must be less than period")
+		return errAllowanceWindowSize
 	}
 
 	// check that allowance is sufficient to store at least one sector

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -1,0 +1,161 @@
+package contractor
+
+import (
+	"errors"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// SetAllowance sets the amount of money the Contractor is allowed to spend on
+// contracts over a given time period, divided among the number of hosts
+// specified. Note that Contractor can start forming contracts as soon as
+// SetAllowance is called; that is, it may block.
+//
+// In most cases, SetAllowance will renew existing contracts instead of
+// forming new ones. This preserves the data on those hosts. When this occurs,
+// the renewed contracts will atomically replace their previous versions. If
+// SetAllowance is interrupted, renewed contracts may be lost, though the
+// allocated funds will eventually be returned,
+//
+// TODO: can an Editor or Downloader be used across renewals?
+// TODO: will hosts allow renewing the same contract twice?
+//
+// NOTE: At this time, transaction fees are not counted towards the allowance.
+// This means the contractor may spend more than allowance.Funds.
+func (c *Contractor) SetAllowance(a modules.Allowance) error {
+	// sanity checks
+	if a.Hosts == 0 {
+		return errors.New("hosts must be non-zero")
+	} else if a.Period == 0 {
+		return errors.New("period must be non-zero")
+	} else if a.RenewWindow == 0 {
+		return errors.New("renew window must be non-zero")
+	} else if a.RenewWindow >= a.Period {
+		return errors.New("renew window must be less than period")
+	}
+
+	// check that allowance is sufficient to store at least one sector
+	numSectors, err := maxSectors(a, c.hdb)
+	if err != nil {
+		return err
+	} else if numSectors == 0 {
+		return errInsufficientAllowance
+	}
+
+	c.mu.RLock()
+	shouldRenew := a.Period != c.allowance.Period || a.Funds.Cmp(c.allowance.Funds) != 0
+	remaining := int(a.Hosts) - len(c.contracts)
+	c.mu.RUnlock()
+
+	// if no contracts need renewing, run special-case logic instead
+	if !shouldRenew {
+		return c.managedFormAllowanceContracts(remaining, numSectors, a)
+	}
+
+	c.mu.RLock()
+	// gather contracts to renew
+	var renewSet []modules.RenterContract
+	for _, contract := range c.contracts {
+		renewSet = append(renewSet, contract)
+	}
+
+	// calculate new endHeight; if the period has not changed, the endHeight
+	// should not change either
+	endHeight := c.blockHeight + a.Period
+	if a.Period == c.allowance.Period {
+		for _, contract := range c.contracts {
+			endHeight = contract.EndHeight()
+			break
+		}
+	}
+	c.mu.RUnlock()
+
+	// renew existing contracts with new allowance parameters
+	newContracts := make(map[types.FileContractID]modules.RenterContract)
+	for _, contract := range renewSet {
+		newContract, err := c.managedRenew(contract, numSectors, endHeight)
+		if err != nil {
+			c.log.Printf("WARN: failed to renew contract with %v; a new contract will be formed in its place", contract.NetAddress)
+			remaining++
+			continue
+		}
+		newContracts[newContract.ID] = newContract
+		if len(newContracts) >= int(a.Hosts) {
+			break
+		}
+	}
+
+	// if we did not renew enough contracts, form new ones
+	if remaining > 0 {
+		formed, err := c.managedFormContracts(remaining, numSectors, endHeight)
+		if err != nil {
+			return err
+		}
+		for _, contract := range formed {
+			newContracts[contract.ID] = contract
+		}
+	}
+
+	// if we weren't able to form anything, return an error
+	if len(newContracts) == 0 {
+		return errors.New("unable to form or renew any contracts")
+	}
+
+	// Set the allowance and replace the contract set
+	c.mu.Lock()
+	c.allowance = a
+	c.contracts = newContracts
+	// update metrics
+	var spending types.Currency
+	for _, contract := range c.contracts {
+		spending = spending.Add(contract.RenterFunds())
+	}
+	c.financialMetrics.ContractSpending = spending
+	err = c.saveSync()
+	c.mu.Unlock()
+
+	return err
+}
+
+// managedFormAllowanceContracts handles the special case where no contracts
+// need to be renewed when setting the allowance.
+func (c *Contractor) managedFormAllowanceContracts(n int, numSectors uint64, a modules.Allowance) error {
+	if n <= 0 {
+		return nil
+	}
+
+	// if we're forming contracts but not renewing, the new contracts should
+	// have the same endHeight as the existing ones. Otherwise, the endHeight
+	// should be a full period.
+	c.mu.RLock()
+	endHeight := c.blockHeight + a.Period
+	for _, contract := range c.contracts {
+		endHeight = contract.EndHeight()
+		break
+	}
+	c.mu.RUnlock()
+
+	// form the contracts
+	formed, err := c.managedFormContracts(n, numSectors, endHeight)
+	if err != nil {
+		return err
+	}
+
+	// Set the allowance and replace the contract set
+	c.mu.Lock()
+	c.allowance = a
+	for _, contract := range formed {
+		c.contracts[contract.ID] = contract
+	}
+	// update metrics
+	var spending types.Currency
+	for _, contract := range c.contracts {
+		spending = spending.Add(contract.RenterFunds())
+	}
+	c.financialMetrics.ContractSpending = spending
+	err = c.saveSync()
+	c.mu.Unlock()
+
+	return err
+}

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -36,10 +36,6 @@ type Contractor struct {
 
 	financialMetrics modules.RenterFinancialMetrics
 
-	// serialize actions that modify contracts, such as SetAllowance and
-	// ProcessConsensusChange
-	contractLock sync.Mutex
-
 	mu sync.RWMutex
 }
 
@@ -57,95 +53,10 @@ func (c *Contractor) FinancialMetrics() modules.RenterFinancialMetrics {
 	return c.financialMetrics
 }
 
-// SetAllowance sets the amount of money the Contractor is allowed to spend on
-// contracts over a given time period, divided among the number of hosts
-// specified. Note that Contractor can start forming contracts as soon as
-// SetAllowance is called; that is, it may block.
-//
-// NOTE: At this time, transaction fees are not counted towards the allowance.
-// This means the contractor may spend more than allowance.Funds.
-func (c *Contractor) SetAllowance(a modules.Allowance) error {
-	// sanity checks
-	if a.Hosts == 0 {
-		return errors.New("hosts must be non-zero")
-	} else if a.Period == 0 {
-		return errors.New("period must be non-zero")
-	} else if a.RenewWindow == 0 {
-		return errors.New("renew window must be non-zero")
-	} else if a.RenewWindow >= a.Period {
-		return errors.New("renew window must be less than period")
-	}
-
-	// check that allowance is sufficient to store at least one sector
-	numSectors, err := maxSectors(a, c.hdb)
-	if err != nil {
-		return err
-	} else if numSectors == 0 {
-		return errInsufficientAllowance
-	}
-
-	// prevent ProcessConsensusChange from renewing contracts until we have
-	// finished
-	c.contractLock.Lock()
-	defer c.contractLock.Unlock()
-
-	c.mu.Lock()
-	endHeight := c.blockHeight + a.Period
-
-	// check if allowance has different period or funds; if so, we should
-	// renew existing contracts with the new allowance.
-	// TODO: compare numSectors instead of allowance.Funds?
-	var renewSet []modules.RenterContract
-	if a.Period != c.allowance.Period || a.Funds.Cmp(c.allowance.Funds) != 0 {
-		for _, contract := range c.contracts {
-			renewSet = append(renewSet, contract)
-		}
-		// TODO: dangerous -- figure out a safer approach later
-		c.contracts = map[types.FileContractID]modules.RenterContract{}
-	}
-	c.mu.Unlock()
-
-	// renew existing contracts with new allowance parameters
-	var nRenewed int
-	for _, contract := range renewSet {
-		_, err := c.managedRenew(contract, numSectors, endHeight)
-		if err != nil {
-			c.log.Printf("WARN: failed to renew contract with %v; a new contract will be formed in its place", contract.NetAddress)
-		} else if nRenewed++; nRenewed >= int(a.Hosts) {
-			break
-		}
-	}
-
-	// determine number of new contracts to form
-	var remaining int
-	if len(renewSet) != 0 {
-		remaining = int(a.Hosts) - nRenewed
-	} else {
-		c.mu.RLock()
-		remaining = int(a.Hosts) - len(c.contracts)
-		c.mu.RUnlock()
-	}
-
-	if remaining > 0 {
-		err := c.managedFormContracts(remaining, numSectors, endHeight)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Set the allowance.
-	c.mu.Lock()
-	c.allowance = a
-	err = c.saveSync()
-	c.mu.Unlock()
-
-	return err
-}
-
 // Contracts returns the contracts formed by the contractor.
 func (c *Contractor) Contracts() (cs []modules.RenterContract) {
-	c.contractLock.Lock()
-	defer c.contractLock.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	for _, c := range c.contracts {
 		cs = append(cs, c)
 	}

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -21,6 +21,7 @@ var (
 // contracts.
 type Contractor struct {
 	// dependencies
+	cs      consensusSet
 	hdb     hostDB
 	log     *persist.Logger
 	persist persister
@@ -152,6 +153,7 @@ func New(cs consensusSet, wallet walletShim, tpool transactionPool, hdb hostDB, 
 func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p persister, l *persist.Logger) (*Contractor, error) {
 	// Create the Contractor object.
 	c := &Contractor{
+		cs:      cs,
 		hdb:     hdb,
 		log:     l,
 		persist: p,

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -33,10 +33,7 @@ type Contractor struct {
 	lastChange  modules.ConsensusChangeID
 	renewHeight types.BlockHeight // height at which to renew contracts
 
-	// metrics
-	downloadSpending types.Currency
-	storageSpending  types.Currency
-	uploadSpending   types.Currency
+	financialMetrics modules.RenterFinancialMetrics
 
 	mu sync.RWMutex
 }
@@ -52,17 +49,7 @@ func (c *Contractor) Allowance() modules.Allowance {
 func (c *Contractor) FinancialMetrics() modules.RenterFinancialMetrics {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	// calculate contract spending
-	var contractSpending types.Currency
-	for _, contract := range c.contracts {
-		contractSpending = contractSpending.Add(contract.FileContract.Payout)
-	}
-	return modules.RenterFinancialMetrics{
-		ContractSpending: contractSpending,
-		DownloadSpending: c.downloadSpending,
-		StorageSpending:  c.storageSpending,
-		UploadSpending:   c.uploadSpending,
-	}
+	return c.financialMetrics
 }
 
 // SetAllowance sets the amount of money the Contractor is allowed to spend on

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -146,23 +146,23 @@ func TestIntegrationSetAllowance(t *testing.T) {
 	// bad args
 	var a modules.Allowance
 	err = c.SetAllowance(a)
-	if err == nil {
-		t.Error("expected error, got nil")
+	if err != errAllowanceNoHosts {
+		t.Errorf("expected %q, got %q", errAllowanceNoHosts, err)
 	}
 	a.Hosts = 1
 	err = c.SetAllowance(a)
-	if err == nil {
-		t.Error("expected error, got nil")
+	if err != errAllowanceZeroPeriod {
+		t.Errorf("expected %q, got %q", errAllowanceZeroPeriod, err)
 	}
 	a.Period = 20
 	err = c.SetAllowance(a)
-	if err == nil {
-		t.Error("expected error, got nil")
+	if err != errAllowanceZeroWindow {
+		t.Errorf("expected %q, got %q", errAllowanceZeroWindow, err)
 	}
 	a.RenewWindow = 20
 	err = c.SetAllowance(a)
-	if err == nil {
-		t.Error("expected error, got nil")
+	if err != errAllowanceWindowSize {
+		t.Errorf("expected %q, got %q", errAllowanceWindowSize, err)
 	}
 
 	// reasonable values; should succeed

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -138,7 +138,7 @@ func TestIntegrationSetAllowance(t *testing.T) {
 		t.SkipNow()
 	}
 	// create testing trio
-	h, c, m, err := newTestingTrio("TestIntegrationAutoRenew")
+	h, c, m, err := newTestingTrio("TestIntegrationSetAllowance")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -20,6 +20,7 @@ type newStub struct{}
 func (newStub) ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error {
 	return nil
 }
+func (newStub) Synced() bool { return true }
 
 // wallet stubs
 func (newStub) NextAddress() (uc types.UnlockConditions, err error) { return }

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -13,6 +13,7 @@ import (
 type (
 	consensusSet interface {
 		ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error
+		Synced() bool
 	}
 	// in order to restrict the modules.TransactionBuilder interface, we must
 	// provide a shim to bridge the gap between modules.Wallet and

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -59,7 +59,7 @@ func (c *Contractor) Downloader(contract modules.RenterContract) (Downloader, er
 	c.mu.RLock()
 	height := c.blockHeight
 	c.mu.RUnlock()
-	if height > contract.FileContract.WindowStart {
+	if height > contract.EndHeight() {
 		return nil, errors.New("contract has already ended")
 	}
 	host, ok := c.hdb.Host(contract.NetAddress)

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -41,7 +41,7 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 	delta := hd.downloader.DownloadSpending.Sub(oldSpending)
 
 	hd.contractor.mu.Lock()
-	hd.contractor.downloadSpending = hd.contractor.downloadSpending.Add(delta)
+	hd.contractor.financialMetrics.DownloadSpending = hd.contractor.financialMetrics.DownloadSpending.Add(delta)
 	hd.contractor.contracts[contract.ID] = contract
 	hd.contractor.saveSync()
 	hd.contractor.mu.Unlock()

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -55,7 +55,7 @@ func (he *hostEditor) ContractID() types.FileContractID { return he.contract.ID 
 
 // EndHeight returns the height at which the host is no longer obligated to
 // store the file.
-func (he *hostEditor) EndHeight() types.BlockHeight { return he.contract.FileContract.WindowStart }
+func (he *hostEditor) EndHeight() types.BlockHeight { return he.contract.EndHeight() }
 
 // Close cleanly terminates the revision loop with the host and closes the
 // connection.
@@ -124,7 +124,7 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 	c.mu.RLock()
 	height := c.blockHeight
 	c.mu.RUnlock()
-	if height > contract.FileContract.WindowStart {
+	if height > contract.EndHeight() {
 		return nil, errors.New("contract has already ended")
 	}
 	host, ok := c.hdb.Host(contract.NetAddress)

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -73,8 +73,8 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	storageDelta := he.editor.StorageSpending.Sub(oldStorageSpending)
 
 	he.contractor.mu.Lock()
-	he.contractor.uploadSpending = he.contractor.uploadSpending.Add(uploadDelta)
-	he.contractor.storageSpending = he.contractor.storageSpending.Add(storageDelta)
+	he.contractor.financialMetrics.UploadSpending = he.contractor.financialMetrics.UploadSpending.Add(uploadDelta)
+	he.contractor.financialMetrics.StorageSpending = he.contractor.financialMetrics.StorageSpending.Add(storageDelta)
 	he.contractor.contracts[contract.ID] = contract
 	he.contractor.saveSync()
 	he.contractor.mu.Unlock()
@@ -109,7 +109,7 @@ func (he *hostEditor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newDat
 	uploadDelta := he.editor.UploadSpending.Sub(oldUploadSpending)
 
 	he.contractor.mu.Lock()
-	he.contractor.uploadSpending = he.contractor.uploadSpending.Add(uploadDelta)
+	he.contractor.financialMetrics.UploadSpending = he.contractor.financialMetrics.UploadSpending.Add(uploadDelta)
 	he.contractor.contracts[contract.ID] = contract
 	he.contractor.saveSync()
 	he.contractor.mu.Unlock()

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -20,16 +20,38 @@ var (
 	errTooExpensive          = errors.New("host price was too high")
 )
 
-// averageHostPrice returns the average price of hosts.
-func averageHostPrice(hosts []modules.HostDBEntry) types.Currency {
-	if len(hosts) == 0 {
-		return types.ZeroCurrency
+// maxSectors is the estimated maximum number of sectors that the allowance
+// can support.
+func maxSectors(a modules.Allowance, hdb hostDB) (uint64, error) {
+	if a.Hosts == 0 || a.Period == 0 {
+		return 0, errors.New("invalid allowance")
 	}
+
+	// Sample at least 10 hosts.
+	nRandomHosts := int(a.Hosts)
+	if nRandomHosts < 10 {
+		nRandomHosts = 10
+	}
+	hosts := hdb.RandomHosts(nRandomHosts, nil)
+	if len(hosts) < int(a.Hosts) {
+		return 0, errors.New("not enough hosts")
+	}
+
+	// Calculate cost of storing 1 sector per host for the allowance period.
 	var sum types.Currency
 	for _, h := range hosts {
 		sum = sum.Add(h.StoragePrice)
 	}
-	return sum.Div64(uint64(len(hosts)))
+	averagePrice := sum.Div64(uint64(len(hosts)))
+	costPerSector := averagePrice.Mul64(a.Hosts).Mul64(modules.SectorSize).Mul64(uint64(a.Period))
+
+	// Divide total funds by cost per sector.
+	numSectors, err := a.Funds.Div(costPerSector).Uint64()
+	if err != nil {
+		// if there was an overflow, something is definitely wrong
+		return 0, errors.New("allowance can fund suspiciously large number of sectors")
+	}
+	return numSectors, nil
 }
 
 // managedNewContract negotiates an initial file contract with the specified
@@ -80,7 +102,7 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, filesize uint6
 
 // managedFormContracts forms contracts with n hosts using the allowance
 // parameters.
-func (c *Contractor) managedFormContracts(n int, funds types.Currency, endHeight types.BlockHeight) error {
+func (c *Contractor) managedFormContracts(n int, a modules.Allowance) error {
 	// Sample at least 10 hosts.
 	nRandomHosts := 2 * n
 	if nRandomHosts < 10 {
@@ -101,19 +123,13 @@ func (c *Contractor) managedFormContracts(n int, funds types.Currency, endHeight
 	// Check that allowance is sufficient to store at least one sector per
 	// host for the specified duration.
 	c.mu.RLock()
-	duration := endHeight - c.blockHeight
+	endHeight := c.blockHeight + a.Period
+	numSectors, err := maxSectors(a, c.hdb)
 	c.mu.RUnlock()
-	costPerSector := averageHostPrice(hosts).Mul64(uint64(n)).Mul64(modules.SectorSize).Mul64(uint64(duration))
-	if funds.Cmp(costPerSector) < 0 {
-		return errInsufficientAllowance
-	}
-
-	// Calculate the filesize of the contracts by using the average host price
-	// and rounding down to the nearest sector.
-	numSectors, err := funds.Div(costPerSector).Uint64()
 	if err != nil {
-		// if there was an overflow, something is definitely wrong
-		return errors.New("allowance resulted in unexpectedly large contract size")
+		return err
+	} else if numSectors == 0 {
+		return errInsufficientAllowance
 	}
 	filesize := numSectors * modules.SectorSize
 

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -53,7 +53,7 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, filesize uint6
 		txnBuilder.Drop()
 		return modules.RenterContract{}, err
 	}
-	contractValue := contract.LastRevision.NewValidProofOutputs[0].Value
+	contractValue := contract.RenterFunds()
 
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -53,13 +53,14 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, filesize uint6
 		txnBuilder.Drop()
 		return modules.RenterContract{}, err
 	}
+	contractValue := contract.LastRevision.NewValidProofOutputs[0].Value
 
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
+	c.financialMetrics.ContractSpending = c.financialMetrics.ContractSpending.Add(contractValue)
 	c.saveSync()
 	c.mu.Unlock()
 
-	contractValue := contract.LastRevision.NewValidProofOutputs[0].Value
 	c.log.Printf("Formed contract with %v for %v SC", host.NetAddress, contractValue.Div(types.SiacoinPrecision))
 
 	return contract, nil

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -122,10 +122,7 @@ func (c *Contractor) managedFormContracts(n int, a modules.Allowance) error {
 
 	// Check that allowance is sufficient to store at least one sector per
 	// host for the specified duration.
-	c.mu.RLock()
-	endHeight := c.blockHeight + a.Period
 	numSectors, err := maxSectors(a, c.hdb)
-	c.mu.RUnlock()
 	if err != nil {
 		return err
 	} else if numSectors == 0 {
@@ -133,6 +130,9 @@ func (c *Contractor) managedFormContracts(n int, a modules.Allowance) error {
 	}
 
 	// Form contracts with each host.
+	c.mu.RLock()
+	endHeight := c.blockHeight + a.Period
+	c.mu.RUnlock()
 	var numContracts int
 	var errs []string
 	for _, h := range hosts {

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -188,7 +188,7 @@ func TestIntegrationFormContract(t *testing.T) {
 	}
 
 	// form a contract with the host
-	contract, err := c.managedNewContract(hostEntry, 64000, c.blockHeight+100)
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func TestIntegrationReviseContract(t *testing.T) {
 	}
 
 	// form a contract with the host
-	contract, err := c.managedNewContract(hostEntry, 64000, c.blockHeight+100)
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestIntegrationUploadDownload(t *testing.T) {
 	}
 
 	// form a contract with the host
-	contract, err := c.managedNewContract(hostEntry, modules.SectorSize*10, c.blockHeight+100)
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestIntegrationDelete(t *testing.T) {
 	}
 
 	// form a contract with the host
-	contract, err := c.managedNewContract(hostEntry, modules.SectorSize*10, c.blockHeight+100)
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func TestIntegrationInsertDelete(t *testing.T) {
 	}
 
 	// form a contract with the host
-	contract, err := c.managedNewContract(hostEntry, modules.SectorSize*10, c.blockHeight+100)
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,7 +434,7 @@ func TestIntegrationModify(t *testing.T) {
 	}
 
 	// form a contract with the host
-	contract, err := c.managedNewContract(hostEntry, modules.SectorSize*10, c.blockHeight+100)
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +497,7 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 
 	// form a contract with the host
-	contract, err := c.managedNewContract(hostEntry, modules.SectorSize*10, c.blockHeight+100)
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -61,7 +61,31 @@ func newTestingHost(testdir string, cs modules.ConsensusSet, tp modules.Transact
 	if err != nil {
 		return nil, err
 	}
-	return host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	h, err := host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	if err != nil {
+		return nil, err
+	}
+
+	// configure host to accept contracts
+	settings := h.InternalSettings()
+	settings.AcceptingContracts = true
+	err = h.SetInternalSettings(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	// add storage to host
+	storageFolder := filepath.Join(testdir, "storage")
+	err = os.MkdirAll(storageFolder, 0700)
+	if err != nil {
+		return nil, err
+	}
+	err = h.AddStorageFolder(storageFolder, 1e6)
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
 }
 
 // newTestingContractor is a helper function that creates a ready-to-use
@@ -125,25 +149,6 @@ func newTestingTrio(name string) (modules.Host, *Contractor, modules.TestMiner, 
 		return nil, nil, nil, err
 	}
 	c, err := newTestingContractor(filepath.Join(testdir, "Contractor"), cs, tp)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// Configure host to accept contracts
-	settings := h.InternalSettings()
-	settings.AcceptingContracts = true
-	err = h.SetInternalSettings(settings)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// add storage to host
-	storageFolder := filepath.Join(build.SiaTestingDir, "contractor", "TestIntegrationReviseContract", "storage")
-	err = os.MkdirAll(storageFolder, 0700)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	err = h.AddStorageFolder(storageFolder, 1e6)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -522,14 +522,13 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 
 	// renew the contract
-	contract = c.contracts[contract.ID]
-	newID, err := c.managedRenew(contract, modules.SectorSize*10, c.blockHeight+200)
+	oldContract := c.contracts[contract.ID]
+	contract, err = c.managedRenew(oldContract, modules.SectorSize*10, c.blockHeight+200)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check renewed contract
-	contract = c.contracts[newID]
 	if contract.FileContract.FileMerkleRoot != root {
 		t.Fatal(contract.FileContract.FileMerkleRoot)
 	} else if contract.FileContract.FileSize != modules.SectorSize {

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -7,15 +7,12 @@ import (
 
 // contractorPersist defines what Contractor data persists across sessions.
 type contractorPersist struct {
-	Allowance   modules.Allowance
-	BlockHeight types.BlockHeight
-	Contracts   []modules.RenterContract
-	LastChange  modules.ConsensusChangeID
-	RenewHeight types.BlockHeight
-	// metrics
-	DownloadSpending types.Currency
-	StorageSpending  types.Currency
-	UploadSpending   types.Currency
+	Allowance        modules.Allowance
+	BlockHeight      types.BlockHeight
+	Contracts        []modules.RenterContract
+	LastChange       modules.ConsensusChangeID
+	RenewHeight      types.BlockHeight
+	FinancialMetrics modules.RenterFinancialMetrics
 }
 
 // persistData returns the data in the Contractor that will be saved to disk.
@@ -25,9 +22,7 @@ func (c *Contractor) persistData() contractorPersist {
 		BlockHeight:      c.blockHeight,
 		LastChange:       c.lastChange,
 		RenewHeight:      c.renewHeight,
-		DownloadSpending: c.downloadSpending,
-		StorageSpending:  c.storageSpending,
-		UploadSpending:   c.uploadSpending,
+		FinancialMetrics: c.financialMetrics,
 	}
 	for _, contract := range c.contracts {
 		data.Contracts = append(data.Contracts, contract)
@@ -49,9 +44,7 @@ func (c *Contractor) load() error {
 	}
 	c.lastChange = data.LastChange
 	c.renewHeight = data.RenewHeight
-	c.downloadSpending = data.DownloadSpending
-	c.storageSpending = data.StorageSpending
-	c.uploadSpending = data.UploadSpending
+	c.financialMetrics = data.FinancialMetrics
 	return nil
 }
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -11,7 +11,6 @@ import (
 // managedRenew negotiates a new contract for data already stored with a host.
 // It returns the ID of the new contract. This is a blocking call that
 // performs network I/O.
-// TODO: take an allowance and renew with those parameters
 func (c *Contractor) managedRenew(contract modules.RenterContract, filesize uint64, newEndHeight types.BlockHeight) (types.FileContractID, error) {
 	c.mu.RLock()
 	height := c.blockHeight
@@ -52,9 +51,10 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, filesize uint
 		return types.FileContractID{}, err
 	}
 
-	// update host contract
+	// replace old contract with renewed contract
 	c.mu.Lock()
 	c.contracts[newContract.ID] = newContract
+	delete(c.contracts, contract.ID)
 	err = c.saveSync()
 	c.mu.Unlock()
 	if err != nil {

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -73,13 +73,11 @@ func (c *Contractor) managedRenewContracts() {
 
 	numSectors, err := maxSectors(c.allowance, c.hdb)
 	c.mu.RUnlock()
-	if err != nil {
-		c.log.Println("WARN: could not calculate number of sectors allowance can support:", err)
-		return
-	}
-
 	if len(renewSet) == 0 {
 		// nothing to do
+		return
+	} else if err != nil {
+		c.log.Println("WARN: could not calculate number of sectors allowance can support:", err)
 		return
 	} else if numSectors == 0 {
 		c.log.Printf("WARN: want to renew %v contracts, but allowance is too small", len(renewSet))

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -79,9 +79,20 @@ func (c *Contractor) managedRenewContracts() {
 	for _, contract := range renewSet {
 		newContract, err := c.managedRenew(contract, numSectors, endHeight)
 		if err != nil {
-			c.log.Println("WARN: failed to renew contract", contract.ID)
+			c.log.Printf("WARN: failed to renew contract with %v; a new contract will be formed in its place", contract.NetAddress)
 		} else {
 			newContracts[contract.ID] = newContract
+		}
+	}
+
+	// if we did not renew enough contracts, form new ones
+	if remaining := len(newContracts) - len(renewSet); remaining > 0 {
+		formed, err := c.managedFormContracts(remaining, numSectors, endHeight)
+		if err != nil {
+			c.log.Println("WARN: failed to form new contracts during auto-renew:", err)
+		}
+		for _, contract := range formed {
+			newContracts[contract.ID] = contract
 		}
 	}
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -11,13 +11,7 @@ import (
 // managedRenew negotiates a new contract for data already stored with a host.
 // It returns the ID of the new contract. This is a blocking call that
 // performs network I/O.
-func (c *Contractor) managedRenew(contract modules.RenterContract, filesize uint64, newEndHeight types.BlockHeight) (types.FileContractID, error) {
-	c.mu.RLock()
-	height := c.blockHeight
-	c.mu.RUnlock()
-	if newEndHeight < height {
-		return types.FileContractID{}, errors.New("cannot renew below current height")
-	}
+func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors uint64, newEndHeight types.BlockHeight) (types.FileContractID, error) {
 	host, ok := c.hdb.Host(contract.NetAddress)
 	if !ok {
 		return types.FileContractID{}, errors.New("no record of that host")
@@ -35,7 +29,7 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, filesize uint
 	c.mu.RLock()
 	params := proto.ContractParams{
 		Host:          host,
-		Filesize:      filesize,
+		Filesize:      numSectors * modules.SectorSize,
 		StartHeight:   c.blockHeight,
 		EndHeight:     newEndHeight,
 		RefundAddress: uc.UnlockHash(),
@@ -64,48 +58,38 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, filesize uint
 	return newContract.ID, nil
 }
 
-// threadedRenewContracts renews the Contractor's contracts according to the
-// specified allowance and at the specified height.
-func (c *Contractor) threadedRenewContracts(allowance modules.Allowance, newHeight types.BlockHeight) {
-	// calculate filesize using new allowance
-	contracts := c.Contracts()
-	var sum types.Currency
-	var numHosts uint64
-	for _, contract := range contracts {
-		if h, ok := c.hdb.Host(contract.NetAddress); ok {
-			sum = sum.Add(h.StoragePrice)
-			numHosts++
+// managedRenewContracts renews any contracts that are up for renewal, using
+// the current allowance.
+func (c *Contractor) managedRenewContracts() {
+	c.mu.RLock()
+	// Renew contracts when they enter the renew window.
+	var renewSet []modules.RenterContract
+	for _, contract := range c.contracts {
+		if c.blockHeight+c.allowance.RenewWindow >= contract.EndHeight() {
+			renewSet = append(renewSet, contract)
 		}
 	}
-	if numHosts == 0 || numHosts < allowance.Hosts {
-		// ??? get more
+	endHeight := c.blockHeight + c.allowance.Period
+
+	numSectors, err := maxSectors(c.allowance, c.hdb)
+	c.mu.RUnlock()
+	if err != nil {
+		c.log.Println("WARN: could not calculate number of sectors allowance can support:", err)
 		return
 	}
-	avgPrice := sum.Div64(numHosts)
 
-	costPerSector := avgPrice.Mul64(allowance.Hosts).Mul64(modules.SectorSize).Mul64(uint64(allowance.Period))
-
-	if allowance.Funds.Cmp(costPerSector) < 0 {
-		// errors.New("insufficient funds")
+	if len(renewSet) == 0 {
+		// nothing to do
+		return
+	} else if numSectors == 0 {
+		c.log.Printf("WARN: want to renew %v contracts, but allowance is too small", len(renewSet))
+		return
 	}
 
-	// Calculate the filesize of the contracts by using the average host price
-	// and rounding down to the nearest sector.
-	numSectors, err := allowance.Funds.Div(costPerSector).Uint64()
-	if err != nil {
-		// errors.New("allowance resulted in unexpectedly large contract size")
-	}
-	filesize := numSectors * modules.SectorSize
-
-	for _, contract := range contracts {
-		if contract.FileContract.WindowStart < newHeight {
-			_, err := c.managedRenew(contract, filesize, newHeight)
-			if err != nil {
-				c.log.Println("WARN: failed to renew contract", contract.ID, ":", err)
-			}
+	for _, contract := range renewSet {
+		_, err := c.managedRenew(contract, numSectors, endHeight)
+		if err != nil {
+			c.log.Println("WARN: failed to renew contract", contract.ID)
 		}
 	}
-
-	// TODO: reset renewHeight if too many rewewals failed.
-	// TODO: form more contracts if numRenewed < allowance.Hosts
 }

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -101,5 +101,9 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	}
 	c.mu.Unlock()
 
-	c.managedRenewContracts()
+	// only attempt renewal if we are synced
+	// (harmless otherwise, since hosts will reject our renewal attempts, but very slow)
+	if c.cs.Synced() {
+		c.managedRenewContracts()
+	}
 }

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -26,7 +26,7 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	var expired []types.FileContractID
 	for id, contract := range c.contracts {
 		// TODO: offset this by some sort of confirmation height?
-		if c.blockHeight > contract.LastRevision.NewWindowStart {
+		if c.blockHeight > contract.EndHeight() {
 			expired = append(expired, id)
 		}
 	}

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -5,12 +5,71 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// managedRenewContracts renews any contracts that are up for renewal, using
+// the current allowance.
+func (c *Contractor) managedRenewContracts() {
+	c.mu.RLock()
+	// Renew contracts when they enter the renew window. All contracts are
+	// renewed to the same height, using available remaining funds.
+	var renewSet []modules.RenterContract
+	var currentSpent types.Currency
+	for _, contract := range c.contracts {
+		if c.blockHeight+c.allowance.RenewWindow >= contract.EndHeight() {
+			renewSet = append(renewSet, contract)
+		} else {
+			// only count the contracts that aren't up for renewal
+			currentSpent = currentSpent.Add(contract.FileContract.ValidProofOutputs[0].Value)
+		}
+	}
+	endHeight := c.blockHeight + c.allowance.Period
+	allowance := c.allowance
+	c.mu.RUnlock()
+
+	if len(renewSet) == 0 || allowance.Hosts == 0 {
+		// nothing to do
+		return
+	}
+
+	if len(renewSet) > 0 && allowance.Funds.Cmp(currentSpent) < 0 {
+		c.log.Printf("WARN: want to renew %v contracts, but allowance is too small", len(renewSet))
+		return
+	}
+
+	// calculate how many sectors we can support when renewing
+	var hosts []modules.HostDBEntry
+	for _, contract := range renewSet {
+		h, ok := c.hdb.Host(contract.NetAddress)
+		if !ok {
+			c.log.Printf("WARN: want to renew contract with %v, but that host is no longer in the host DB", contract.NetAddress)
+			continue
+		}
+		hosts = append(hosts, h)
+	}
+	if len(hosts) == 0 {
+		return
+	}
+	funds := allowance.Funds.Sub(currentSpent)
+	costPerSector := averageHostPrice(hosts).Mul64(uint64(len(hosts))).Mul64(modules.SectorSize).Mul64(uint64(allowance.Period))
+	numSectors, err := funds.Div(costPerSector).Uint64()
+	if err != nil {
+		// if there was an overflow, something is definitely wrong
+		c.log.Println("WARN: allowance resulted in unexpectedly large contract size")
+		return
+	}
+	filesize := numSectors * modules.SectorSize
+
+	for _, contract := range renewSet {
+		_, err := c.managedRenew(contract, filesize, endHeight)
+		if err != nil {
+			c.log.Println("WARN: failed to renew contract", contract.ID)
+		}
+	}
+}
+
 // ProcessConsensusChange will be called by the consensus set every time there
 // is a change in the blockchain. Updates will always be called in order.
 func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	for _, block := range cc.RevertedBlocks {
 		if block.ID() != types.GenesisID {
 			c.blockHeight--
@@ -35,18 +94,12 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 		c.log.Debugln("INFO: deleted expired contract", id)
 	}
 
-	// renew contracts
-	// TODO: re-enable this functionality
-	// if c.blockHeight+c.allowance.RenewWindow >= c.renewHeight {
-	// 	c.renewHeight += c.allowance.Period
-	// 	go c.threadedRenewContracts(c.allowance, c.renewHeight)
-	// 	// reset the spentPeriod metric
-	// 	c.spentPeriod = types.ZeroCurrency
-	// }
-
 	c.lastChange = cc.ID
 	err := c.save()
 	if err != nil {
 		c.log.Println(err)
 	}
+	c.mu.Unlock()
+
+	c.managedRenewContracts()
 }

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -9,55 +9,31 @@ import (
 // the current allowance.
 func (c *Contractor) managedRenewContracts() {
 	c.mu.RLock()
-	// Renew contracts when they enter the renew window. All contracts are
-	// renewed to the same height, using available remaining funds.
+	// Renew contracts when they enter the renew window.
 	var renewSet []modules.RenterContract
-	var currentSpent types.Currency
 	for _, contract := range c.contracts {
 		if c.blockHeight+c.allowance.RenewWindow >= contract.EndHeight() {
 			renewSet = append(renewSet, contract)
-		} else {
-			// only count the contracts that aren't up for renewal
-			currentSpent = currentSpent.Add(contract.FileContract.ValidProofOutputs[0].Value)
 		}
 	}
 	endHeight := c.blockHeight + c.allowance.Period
-	allowance := c.allowance
-	c.mu.RUnlock()
 
-	if len(renewSet) == 0 || allowance.Hosts == 0 {
-		// nothing to do
+	numSectors, err := maxSectors(c.allowance, c.hdb)
+	c.mu.RUnlock()
+	if err != nil {
+		c.log.Println("WARN: could not calculate number of sectors allowance can support:", err)
 		return
 	}
 
-	if len(renewSet) > 0 && allowance.Funds.Cmp(currentSpent) < 0 {
+	if len(renewSet) == 0 {
+		// nothing to do
+		return
+	} else if numSectors == 0 {
 		c.log.Printf("WARN: want to renew %v contracts, but allowance is too small", len(renewSet))
 		return
 	}
 
-	// calculate how many sectors we can support when renewing
-	var hosts []modules.HostDBEntry
-	for _, contract := range renewSet {
-		h, ok := c.hdb.Host(contract.NetAddress)
-		if !ok {
-			c.log.Printf("WARN: want to renew contract with %v, but that host is no longer in the host DB", contract.NetAddress)
-			continue
-		}
-		hosts = append(hosts, h)
-	}
-	if len(hosts) == 0 {
-		return
-	}
-	funds := allowance.Funds.Sub(currentSpent)
-	costPerSector := averageHostPrice(hosts).Mul64(uint64(len(hosts))).Mul64(modules.SectorSize).Mul64(uint64(allowance.Period))
-	numSectors, err := funds.Div(costPerSector).Uint64()
-	if err != nil {
-		// if there was an overflow, something is definitely wrong
-		c.log.Println("WARN: allowance resulted in unexpectedly large contract size")
-		return
-	}
 	filesize := numSectors * modules.SectorSize
-
 	for _, contract := range renewSet {
 		_, err := c.managedRenew(contract, filesize, endHeight)
 		if err != nil {

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -43,9 +43,6 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// only attempt renewal if we are synced
 	// (harmless otherwise, since hosts will reject our renewal attempts, but very slow)
 	if c.cs.Synced() {
-		// prevent allowance from being set until we have finished renewing
-		c.contractLock.Lock()
 		c.managedRenewContracts()
-		c.contractLock.Unlock()
 	}
 }

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -43,6 +43,9 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// only attempt renewal if we are synced
 	// (harmless otherwise, since hosts will reject our renewal attempts, but very slow)
 	if c.cs.Synced() {
+		// prevent allowance from being set until we have finished renewing
+		c.contractLock.Lock()
 		c.managedRenewContracts()
+		c.contractLock.Unlock()
 	}
 }

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -1,0 +1,120 @@
+package contractor
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// TestProcessConsensusUpdate tests that contracts are removed at the expected
+// block height.
+func TestProcessConsensusUpdate(t *testing.T) {
+	// create contractor with a contract ending at height 20
+	var rc modules.RenterContract
+	rc.LastRevision.NewWindowStart = 20
+	rc.FileContract.ValidProofOutputs = []types.SiacoinOutput{{}}
+	c := &Contractor{
+		contracts: map[types.FileContractID]modules.RenterContract{
+			rc.ID: rc,
+		},
+		persist: new(memPersist),
+		log:     persist.NewLogger(ioutil.Discard),
+	}
+
+	// process 20 blocks; contract should remain
+	cc := modules.ConsensusChange{
+		// just need to increment blockheight by 1
+		AppliedBlocks: []types.Block{{}},
+	}
+	for i := 0; i < 20; i++ {
+		c.ProcessConsensusChange(cc)
+	}
+	if len(c.contracts) != 1 {
+		t.Error("expected 1 contract, got", len(c.contracts))
+	}
+
+	// process one more block; contract should be removed
+	c.ProcessConsensusChange(cc)
+	if len(c.contracts) != 0 {
+		t.Error("expected 0 contracts, got", len(c.contracts))
+	}
+}
+
+// TestIntegrationAutoRenew tests that contracts are automatically renwed at
+// the expected block height.
+func TestIntegrationAutoRenew(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	// create testing trio
+	h, c, m, err := newTestingTrio("TestIntegrationAutoRenew")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get the host's entry from the db
+	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
+	if !ok {
+		t.Fatal("no entry for host in db")
+	}
+
+	// form a contract with the host
+	contract, err := c.managedNewContract(hostEntry, modules.SectorSize*10, c.blockHeight+50)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// revise the contract
+	editor, err := c.Editor(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := crypto.RandBytes(int(modules.SectorSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// insert the sector
+	root, err := editor.Upload(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = editor.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// set allowance (manually) so that Contractor will auto-renew
+	c.mu.Lock()
+	c.allowance = modules.Allowance{
+		Funds:       types.SiacoinPrecision.Mul64(100), // 100 SC
+		Hosts:       1,
+		Period:      50,
+		RenewWindow: 10,
+	}
+	c.mu.Unlock()
+
+	// mine until we enter the renew window
+	renewHeight := contract.EndHeight() - c.allowance.RenewWindow
+	for c.blockHeight < renewHeight {
+		_, err := m.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// check renewed contract
+	contract = c.Contracts()[0]
+	if contract.FileContract.FileMerkleRoot != root {
+		t.Fatal(contract.FileContract.FileMerkleRoot)
+	} else if contract.FileContract.FileSize != modules.SectorSize {
+		t.Fatal(contract.FileContract.FileSize)
+	} else if contract.FileContract.RevisionNumber != 0 {
+		t.Fatal(contract.FileContract.RevisionNumber)
+	} else if contract.FileContract.WindowStart != c.blockHeight+c.allowance.Period {
+		t.Fatal(contract.FileContract.WindowStart)
+	}
+}

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -14,11 +14,13 @@ import (
 // block height.
 func TestProcessConsensusUpdate(t *testing.T) {
 	// create contractor with a contract ending at height 20
+	var stub newStub
 	var rc modules.RenterContract
 	rc.LastRevision.NewWindowStart = 20
 	rc.FileContract.ValidProofOutputs = []types.SiacoinOutput{{}}
 	c := &Contractor{
-		cs: new(newStub),
+		cs:  stub,
+		hdb: stub,
 		contracts: map[types.FileContractID]modules.RenterContract{
 			rc.ID: rc,
 		},

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -18,6 +18,7 @@ func TestProcessConsensusUpdate(t *testing.T) {
 	rc.LastRevision.NewWindowStart = 20
 	rc.FileContract.ValidProofOutputs = []types.SiacoinOutput{{}}
 	c := &Contractor{
+		cs: new(newStub),
 		contracts: map[types.FileContractID]modules.RenterContract{
 			rc.ID: rc,
 		},

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -31,7 +31,7 @@ func (hd *Downloader) Sector(root crypto.Hash) (modules.RenterContract, []byte, 
 
 	// calculate price
 	sectorPrice := hd.host.DownloadBandwidthPrice.Mul64(modules.SectorSize)
-	if hd.contract.LastRevision.NewValidProofOutputs[0].Value.Cmp(sectorPrice) < 0 {
+	if hd.contract.RenterFunds().Cmp(sectorPrice) < 0 {
 		return modules.RenterContract{}, nil, errors.New("contract has insufficient funds to support download")
 	}
 
@@ -97,7 +97,7 @@ func NewDownloader(host modules.HostDBEntry, contract modules.RenterContract) (*
 		return nil, errors.New("invalid contract")
 	}
 	sectorPrice := host.DownloadBandwidthPrice.Mul64(modules.SectorSize)
-	if contract.LastRevision.NewValidProofOutputs[0].Value.Cmp(sectorPrice) < 0 {
+	if contract.RenterFunds().Cmp(sectorPrice) < 0 {
 		return nil, errors.New("contract has insufficient funds to support download")
 	}
 

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -96,11 +96,9 @@ func NewDownloader(host modules.HostDBEntry, contract modules.RenterContract) (*
 	if len(contract.LastRevision.NewValidProofOutputs) != 2 {
 		return nil, errors.New("invalid contract")
 	}
-	if !host.DownloadBandwidthPrice.IsZero() {
-		bytes, errOverflow := contract.LastRevision.NewValidProofOutputs[0].Value.Div(host.DownloadBandwidthPrice).Uint64()
-		if errOverflow == nil && bytes < modules.SectorSize {
-			return nil, errors.New("contract has insufficient funds to support download")
-		}
+	sectorPrice := host.DownloadBandwidthPrice.Mul64(modules.SectorSize)
+	if contract.LastRevision.NewValidProofOutputs[0].Value.Cmp(sectorPrice) < 0 {
+		return nil, errors.New("contract has insufficient funds to support download")
 	}
 
 	// initiate download loop

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -95,7 +95,7 @@ func (he *Editor) Upload(data []byte) (modules.RenterContract, crypto.Hash, erro
 	sectorStoragePrice := he.host.StoragePrice.Mul(blockBytes)
 	sectorBandwidthPrice := he.host.UploadBandwidthPrice.Mul64(modules.SectorSize)
 	sectorPrice := sectorStoragePrice.Add(sectorBandwidthPrice)
-	if he.contract.LastRevision.NewValidProofOutputs[0].Value.Cmp(sectorPrice) < 0 {
+	if he.contract.RenterFunds().Cmp(sectorPrice) < 0 {
 		return modules.RenterContract{}, crypto.Hash{}, errors.New("contract has insufficient funds to support upload")
 	}
 	sectorCollateral := he.host.Collateral.Mul(blockBytes)
@@ -171,7 +171,7 @@ func (he *Editor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newData []
 
 	// calculate price
 	sectorBandwidthPrice := he.host.UploadBandwidthPrice.Mul64(uint64(len(newData)))
-	if he.contract.LastRevision.NewValidProofOutputs[0].Value.Cmp(sectorBandwidthPrice) < 0 {
+	if he.contract.RenterFunds().Cmp(sectorBandwidthPrice) < 0 {
 		return modules.RenterContract{}, errors.New("contract has insufficient funds to support modification")
 	}
 

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -218,12 +218,6 @@ func NewEditor(host modules.HostDBEntry, contract modules.RenterContract, curren
 	if len(contract.LastRevision.NewValidProofOutputs) != 2 {
 		return nil, errors.New("invalid contract")
 	}
-	if !host.StoragePrice.IsZero() {
-		bytes, errOverflow := contract.LastRevision.NewValidProofOutputs[0].Value.Div(host.StoragePrice).Uint64()
-		if errOverflow == nil && bytes < modules.SectorSize {
-			return nil, errors.New("contract has insufficient capacity")
-		}
-	}
 
 	// initiate revision loop
 	conn, err := net.DialTimeout("tcp", string(contract.NetAddress), 15*time.Second)

--- a/modules/renter/proto/formcontract.go
+++ b/modules/renter/proto/formcontract.go
@@ -51,6 +51,11 @@ func FormContract(params ContractParams, txnBuilder transactionBuilder, tpool tr
 	payout := storageAllocation.Add(hostPayout).Mul64(10406).Div64(10000) // renter pays for siafund fee
 	renterCost := payout.Sub(hostCollateral)
 
+	// check for negative currency
+	if types.PostTax(startHeight, payout).Cmp(hostPayout) < 0 {
+		return modules.RenterContract{}, errors.New("payout smaller than host payout")
+	}
+
 	// create file contract
 	fc := types.FileContract{
 		FileSize:       0,

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -18,6 +18,10 @@ func Renew(contract modules.RenterContract, params ContractParams, txnBuilder tr
 	host, filesize, startHeight, endHeight, refundAddress := params.Host, params.Filesize, params.StartHeight, params.EndHeight, params.RefundAddress
 	ourSK := contract.SecretKey
 
+	if endHeight+host.WindowSize < contract.LastRevision.NewWindowEnd {
+		return modules.RenterContract{}, errors.New("contract cannot be renewed to a lower height")
+	}
+
 	// calculate cost to renter and cost to host
 	storageAllocation := host.StoragePrice.Mul64(filesize).Mul64(uint64(endHeight - startHeight))
 	hostCollateral := host.Collateral.Mul64(filesize).Mul64(uint64(endHeight - startHeight))

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -36,6 +36,13 @@ func Renew(contract modules.RenterContract, params ContractParams, txnBuilder tr
 	payout := storageAllocation.Add(hostCollateral.Add(host.ContractPrice)).Mul64(10406).Div64(10000) // renter covers siafund fee
 	renterCost := payout.Sub(hostCollateral)
 
+	// check for negative currency
+	if types.PostTax(startHeight, payout).Cmp(hostPayout) < 0 {
+		return modules.RenterContract{}, errors.New("payout smaller than host payout")
+	} else if hostCollateral.Cmp(baseCollateral) < 0 {
+		return modules.RenterContract{}, errors.New("new collateral smaller than old collateral")
+	}
+
 	// create file contract
 	fc := types.FileContract{
 		FileSize:       contract.LastRevision.NewFileSize,


### PR DESCRIPTION
`SetAllowance` will now only form contracts as needed, to make up the difference between the current number of contracts and the desired number.
This new scheme may result in "heterogenous" contracts, i.e. a set of contracts ending at different heights.

Contracts are renewed as soon as the blockheight enters their "renew window." The amount of funds allocated per contract is calculated such that each renewed contract can support the same number of sectors.

To prevent slow rescans, contracts are only checked for renewal when `cs.Synced() == true`.