### PR TITLE
Fix ConsensusSetTester names to match their test names

### DIFF
--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -753,7 +753,7 @@ func TestExtremeFutureTimestampHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestFutureTimestampHandling")
+	cst, err := createConsensusSetTester("TestExtremeFutureTimestampHandling")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -646,7 +646,7 @@ func TestApplySiafundInputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	cst, err := createConsensusSetTester("TestApplySiafundInputs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/fork_test.go
+++ b/modules/consensus/fork_test.go
@@ -63,7 +63,7 @@ func TestRevertToNode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestBacktrackToCurrentPath")
+	cst, err := createConsensusSetTester("TestRevertToNode")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -119,7 +119,7 @@ func TestApplyMaturedSiacoinOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyMissedStorageProof")
+	cst, err := createConsensusSetTester("TestApplyMaturedSiacoinOutputs")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/processedblock_test.go
+++ b/modules/consensus/processedblock_test.go
@@ -330,7 +330,7 @@ func TestSetChildTarget(t *testing.T) {
 
 // TestNewChild probes the newChild method of the block node type.
 func TestNewChild(t *testing.T) {
-	cst, err := createConsensusSetTester("TestSetChildTarget")
+	cst, err := createConsensusSetTester("TestNewChild")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/subscribe_test.go
+++ b/modules/consensus/subscribe_test.go
@@ -60,7 +60,7 @@ func TestUnitUnsubscribe(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	cst, err := createConsensusSetTester("TestUnitInvalidConsensusChangeSubscription")
+	cst, err := createConsensusSetTester("TestUnitUnsubscribe")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/validtransaction_test.go
+++ b/modules/consensus/validtransaction_test.go
@@ -12,7 +12,7 @@ func TestTryValidTransactionSet(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestValidTransaction")
+	cst, err := createConsensusSetTester("TestTryValidTransactionSet")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestTryInvalidTransactionSet(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestValidTransaction")
+	cst, err := createConsensusSetTester("TestTryInvalidTransactionSet")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestStorageProofSegment(t *testing.T) {
 // is producing outputs that pass an imperfect randomness check (gzip).
 func TestStorageProofSegmentRandomness(t *testing.T) {
 	t.Skip("randomness check takes a long time")
-	cst, err := createConsensusSetTester("TestStorageProofSegment")
+	cst, err := createConsensusSetTester("TestStorageProofSegmentRandomness")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Presumably from copy-pasting skeleton tester code. It was fun to use regex to find these.