### PR TITLE
Finalize gateway API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -115,8 +115,11 @@ func (srv *Server) initAPI(password string) {
 	// Gateway API Calls
 	if srv.gateway != nil {
 		router.GET("/gateway", srv.gatewayHandler)
-		router.POST("/gateway/add/:netaddress", requirePassword(srv.gatewayAddHandler, password))
-		router.POST("/gateway/remove/:netaddress", requirePassword(srv.gatewayRemoveHandler, password))
+		router.POST("/gateway/connect/:netaddress", requirePassword(srv.gatewayConnectHandler, password))
+		router.POST("/gateway/disconnect/:netaddress", requirePassword(srv.gatewayDisconnectHandler, password))
+		// COMPATv0.6.0
+		router.POST("/gateway/add/:netaddress", requirePassword(srv.gatewayConnectHandler, password))
+		router.POST("/gateway/remove/:netaddress", requirePassword(srv.gatewayDisconnectHandler, password))
 	}
 
 	// Host API Calls

--- a/api/api.go
+++ b/api/api.go
@@ -117,9 +117,6 @@ func (srv *Server) initAPI(password string) {
 		router.GET("/gateway", srv.gatewayHandler)
 		router.POST("/gateway/connect/:netaddress", requirePassword(srv.gatewayConnectHandler, password))
 		router.POST("/gateway/disconnect/:netaddress", requirePassword(srv.gatewayDisconnectHandler, password))
-		// COMPATv0.6.0
-		router.POST("/gateway/add/:netaddress", requirePassword(srv.gatewayConnectHandler, password))
-		router.POST("/gateway/remove/:netaddress", requirePassword(srv.gatewayDisconnectHandler, password))
 	}
 
 	// Host API Calls

--- a/api/gateway.go
+++ b/api/gateway.go
@@ -26,8 +26,8 @@ func (srv *Server) gatewayHandler(w http.ResponseWriter, req *http.Request, _ ht
 	writeJSON(w, GatewayInfo{srv.gateway.Address(), peers})
 }
 
-// gatewayAddHandler handles the API call to add a peer to the gateway.
-func (srv *Server) gatewayAddHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+// gatewayConnectHandler handles the API call to add a peer to the gateway.
+func (srv *Server) gatewayConnectHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	addr := modules.NetAddress(ps.ByName("netaddress"))
 	err := srv.gateway.Connect(addr)
 	if err != nil {
@@ -38,8 +38,8 @@ func (srv *Server) gatewayAddHandler(w http.ResponseWriter, req *http.Request, p
 	writeSuccess(w)
 }
 
-// gatewayRemoveHandler handles the API call to remove a peer from the gateway.
-func (srv *Server) gatewayRemoveHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+// gatewayDisconnectHandler handles the API call to remove a peer from the gateway.
+func (srv *Server) gatewayDisconnectHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	addr := modules.NetAddress(ps.ByName("netaddress"))
 	err := srv.gateway.Disconnect(addr)
 	if err != nil {

--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -23,52 +23,52 @@ func TestGatewayStatus(t *testing.T) {
 	}
 }
 
-func TestGatewayPeerAdd(t *testing.T) {
+func TestGatewayPeerConnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestGatewayPeerAdd")
+	st, err := createServerTester("TestGatewayPeerConnect")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerAdd", "gateway"))
+	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerConnect", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.stdPostAPI("/gateway/add/"+string(peer.Address()), nil)
+	st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
 
 	var info GatewayInfo
 	st.getAPI("/gateway", &info)
 	if len(info.Peers) != 1 || info.Peers[0].NetAddress != peer.Address() {
-		t.Fatal("/gateway/add did not add peer", peer.Address())
+		t.Fatal("/gateway/connect did not connect to peer", peer.Address())
 	}
 }
 
-func TestGatewayPeerRemove(t *testing.T) {
+func TestGatewayPeerDisconnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestGatewayPeerRemove")
+	st, err := createServerTester("TestGatewayPeerDisconnect")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerRemove", "gateway"))
+	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerDisconnect", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.stdPostAPI("/gateway/add/"+string(peer.Address()), nil)
+	st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
 
 	var info GatewayInfo
 	st.getAPI("/gateway", &info)
 	if len(info.Peers) != 1 || info.Peers[0].NetAddress != peer.Address() {
-		t.Fatal("/gateway/add did not add peer", peer.Address())
+		t.Fatal("/gateway/connect did not connect to peer", peer.Address())
 	}
 
-	st.stdPostAPI("/gateway/remove/"+string(peer.Address()), nil)
+	st.stdPostAPI("/gateway/disconnect/"+string(peer.Address()), nil)
 	st.getAPI("/gateway", &info)
 	if len(info.Peers) != 0 {
-		t.Fatal("/gateway/remove did not remove peer", peer.Address())
+		t.Fatal("/gateway/disconnect did not disconnect from peer", peer.Address())
 	}
 }

--- a/doc/API.md
+++ b/doc/API.md
@@ -263,11 +263,11 @@ Gateway
 
 Queries:
 
-* /gateway                     [GET]
-* /gateway/add/{netaddress}    [POST]
-* /gateway/remove/{netaddress} [POST]
+* /gateway                         [GET]
+* /gateway/connect/{netaddress}    [POST]
+* /gateway/disconnect/{netaddress} [POST]
 
-#### /gateway
+#### /gateway [GET]
 
 Function: Returns information about the gateway, including the list of peers.
 
@@ -290,22 +290,24 @@ address and the port Sia is listening on.
 'peers' is a list of the network addresses and versions of peers that the
 Gateway is currently connected to.
 
-#### /gateway/add/{netaddress} [POST]
+#### /gateway/connect/{netaddress} [POST]
 
-Function: Adds a peer to the gateway.
+Function: Connects the gateway to a peer. The peer is added to the node list if
+it not already present.
 
 Parameters:
 ```
 netaddress string
 ```
-'netaddress' should be a reachable hostname + port number, typically of the
+'netaddress' should be a reachable ip + port number, typically of the
 form "a.b.c.d:xxxx".
 
 Response: standard
 
-#### /gateway/remove/{netaddress} [POST]
+#### /gateway/disconnect/{netaddress} [POST]
 
-Function: Will remove a peer from the gateway.
+Function: Disconnects the gateway from the peer. The peer remains in the node
+list.
 
 Parameters:
 ```

--- a/doc/API.md
+++ b/doc/API.md
@@ -27,6 +27,17 @@ Example GET curl call:  `curl -A "Sia-Agent" /wallet/transactions?startheight=1&
 
 Example POST curl call: `curl -A "Sia-Agent" --data "amount=123&destination=abcd" /wallet/siacoins
 
+Table of contents:
+- [Daemon](#daemon)
+- [Consensus](#consensus)
+- [Explorer](#explorer)
+- [Gateway](#gateway)
+- [Host](#host)
+- [Miner](#miner)
+- [Renter](#renter)
+- [Transaction Pool](#transaction-pool)
+- [Wallet](#wallet)
+
 Daemon
 ------
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -287,62 +287,66 @@ provided hash.
 Gateway
 -------
 
-Queries:
+| Route | HTTP verb |
+| ----- | --------- |
+| [/gateway](#gateway-get) | GET |
+| [/gateway/connect/{netaddress}](#gatewayconnectnetaddress-post) | POST |
+| [/gateway/disconnect/{netaddress}](#gatewaydisconnectnetaddress-post) | POST |
 
-* /gateway                         [GET]
-* /gateway/connect/{netaddress}    [POST]
-* /gateway/disconnect/{netaddress} [POST]
+For examples and detailed descriptions of request and response parameters,
+refer to [Gateway.md](/doc/api/Gateway.md).
 
 #### /gateway [GET]
 
-Function: Returns information about the gateway, including the list of peers.
+`/gateway [GET]` returns information about the gateway, including the list of
+connected peers.
 
-Parameters: none
-
-Response:
-```
-struct {
-	netaddress string
-	peers      []struct {
-                netaddress string
-                version    string
-                inbound    bool
-        }
+###### JSON Response [(with comments)](/doc/api/Gateway.md#json-response)
+```javascript
+{
+    "netaddress": String,
+    "peers":      []{
+        "netaddress": String,
+        "version":    String,
+        "inbound":    Boolean
+    }
 }
 ```
-'netaddress' is the network address of the Gateway, including its external IP
-address and the port Sia is listening on.
 
-'peers' is a list of the network addresses and versions of peers that the
-Gateway is currently connected to.
+###### [Example](/doc/api/Gateway.md#gateway-info-example)
 
 #### /gateway/connect/{netaddress} [POST]
 
-Function: Connects the gateway to a peer. The peer is added to the node list if
-it not already present.
+`/gateway/connect/{netaddress} [POST]` connects the gateway to a peer. The peer
+is added to the node list if it is not already present. The node list is the
+list of all nodes the gateway knows about, but is not necessarily connected to.
 
-Parameters:
+###### Path Parameters [(with comments)](/doc/api/Gateway.md#path-parameters)
 ```
-netaddress string
+{netaddress}
 ```
-'netaddress' should be a reachable ip + port number, typically of the
-form "a.b.c.d:xxxx".
 
-Response: standard
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
+
+###### [Example](/doc/api/Gateway.md#connect-example)
 
 #### /gateway/disconnect/{netaddress} [POST]
 
-Function: Disconnects the gateway from the peer. The peer remains in the node
-list.
+`/gateway/disconnect/{netaddress} [POST]` disconnects the gateway from a peer.
+The peer remains in the node list.
 
-Parameters:
+###### Path Parameters [(with comments)](/doc/api/Gateway.md#path-parameters-1)
 ```
-netaddress string
+{netaddress}
 ```
-'netaddress' should be a reachable hostname + port number, typically of the
-form "a.b.c.d:xxxx".
 
-Response: standard
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
+
+###### [Example](/doc/api/Gateway.md#disconnect-example)
 
 Host
 ----

--- a/doc/API.md
+++ b/doc/API.md
@@ -287,19 +287,18 @@ provided hash.
 Gateway
 -------
 
-| Route | HTTP verb |
-| ----- | --------- |
-| [/gateway](#gateway-get) | GET |
-| [/gateway/connect/{netaddress}](#gatewayconnectnetaddress-post) | POST |
-| [/gateway/disconnect/{netaddress}](#gatewaydisconnectnetaddress-post) | POST |
+| Route                                                                 | HTTP verb |
+| --------------------------------------------------------------------- | --------- |
+| [/gateway](#gateway-get)                                              | GET       |
+| [/gateway/connect/{netaddress}](#gatewayconnectnetaddress-post)       | POST      |
+| [/gateway/disconnect/{netaddress}](#gatewaydisconnectnetaddress-post) | POST      |
 
 For examples and detailed descriptions of request and response parameters,
 refer to [Gateway.md](/doc/api/Gateway.md).
 
-#### /gateway [GET]
+#### /gateway [GET] [(example)](/doc/api/Gateway.md#gateway-info-example)
 
-`/gateway [GET]` returns information about the gateway, including the list of
-connected peers.
+returns information about the gateway, including the list of connected peers.
 
 ###### JSON Response [(with comments)](/doc/api/Gateway.md#json-response)
 ```javascript
@@ -313,13 +312,11 @@ connected peers.
 }
 ```
 
-###### [Example](/doc/api/Gateway.md#gateway-info-example)
+#### /gateway/connect/{netaddress} [POST] [(example)](/doc/api/Gateway.md#connect-example)
 
-#### /gateway/connect/{netaddress} [POST]
-
-`/gateway/connect/{netaddress} [POST]` connects the gateway to a peer. The peer
-is added to the node list if it is not already present. The node list is the
-list of all nodes the gateway knows about, but is not necessarily connected to.
+connects the gateway to a peer. The peer is added to the node list if it is not
+already present. The node list is the list of all nodes the gateway knows
+about, but is not necessarily connected to.
 
 ###### Path Parameters [(with comments)](/doc/api/Gateway.md#path-parameters)
 ```
@@ -330,12 +327,9 @@ list of all nodes the gateway knows about, but is not necessarily connected to.
 standard success or error response. See
 [#standard-responses](#standard-responses).
 
-###### [Example](/doc/api/Gateway.md#connect-example)
+#### /gateway/disconnect/{netaddress} [POST] [(example)](/doc/api/Gateway.md#disconnect-example)
 
-#### /gateway/disconnect/{netaddress} [POST]
-
-`/gateway/disconnect/{netaddress} [POST]` disconnects the gateway from a peer.
-The peer remains in the node list.
+disconnects the gateway from a peer. The peer remains in the node list.
 
 ###### Path Parameters [(with comments)](/doc/api/Gateway.md#path-parameters-1)
 ```
@@ -345,8 +339,6 @@ The peer remains in the node list.
 ###### Response
 standard success or error response. See
 [#standard-responses](#standard-responses).
-
-###### [Example](/doc/api/Gateway.md#disconnect-example)
 
 Host
 ----

--- a/doc/API.md
+++ b/doc/API.md
@@ -38,7 +38,17 @@ status code 204.
 #### Error
 
 The standard error response indicating the request failed for any reason, is a
-4xx or 5xx HTTP status code with the error message as plain text.
+4xx or 5xx HTTP status code with an error JSON object describing the error.
+```javascript
+{
+    "error": {
+        "message": String
+
+        // The error object may have additional fields depending on the
+        // specific error.
+    }
+}
+```
 
 Table of contents
 -----------------

--- a/doc/API.md
+++ b/doc/API.md
@@ -27,7 +27,22 @@ Example GET curl call:  `curl -A "Sia-Agent" /wallet/transactions?startheight=1&
 
 Example POST curl call: `curl -A "Sia-Agent" --data "amount=123&destination=abcd" /wallet/siacoins
 
-Table of contents:
+Standard responses
+------------------
+
+#### Success
+
+The standard response indicating the request was successfully processed is HTTP
+status code 204.
+
+#### Error
+
+The standard error response indicating the request failed for any reason, is a
+4xx or 5xx HTTP status code with the error message as plain text.
+
+Table of contents
+-----------------
+
 - [Daemon](#daemon)
 - [Consensus](#consensus)
 - [Explorer](#explorer)

--- a/doc/api/Gateway.md
+++ b/doc/api/Gateway.md
@@ -22,25 +22,15 @@ peers on its own.
 Index
 -----
 
-| Route | HTTP verb |
-| ----- | --------- |
-| [/gateway](#gateway-get) | GET |
-| [/gateway/connect/{netaddress}](#gatewayconnectnetaddress-post) | POST |
-| [/gateway/disconnect/{netaddress}](#gatewaydisconnectnetaddress-post) | POST |
+| Route                                                                 | HTTP verb | Examples                                                |
+| --------------------------------------------------------------------- | --------- | ------------------------------------------------------- |
+| [/gateway](#gateway-get)                                              | GET       | [Gateway info](#gateway-info)                           |
+| [/gateway/connect/{netaddress}](#gatewayconnectnetaddress-post)       | POST      | [Connecting to a peer](#connecting-to-a-peer)           |
+| [/gateway/disconnect/{netaddress}](#gatewaydisconnectnetaddress-post) | POST      | [Disconnecting from a peer](#disconnecting-from-a-peer) |
 
-Examples
---------
+#### /gateway [GET] [(example)](#gateway-info-example)
 
-* [gateway info](#gateway-info-example)
-* [connecting to a peer](#connect-example)
-* [disconnecting from a peer](#disconnect-example)
-
--------------------------------------------------------------------------------
-
-#### /gateway [GET]
-
-`/gateway [GET]` returns information about the gateway, including the list of
-connected peers.
+returns information about the gateway, including the list of connected peers.
 
 ###### JSON Response
 ```javascript
@@ -68,13 +58,11 @@ connected peers.
 }
 ```
 
-###### [Example](#gateway-info-example)
+#### /gateway/connect/{netaddress} [POST] [(example)](#connect-example)
 
-#### /gateway/connect/{netaddress} [POST]
-
-`/gateway/connect/{netaddress} [POST]` connects the gateway to a peer. The peer
-is added to the node list if it is not already present. The node list is the
-list of all nodes the gateway knows about, but is not necessarily connected to.
+connects the gateway to a peer. The peer is added to the node list if it is not
+already present. The node list is the list of all nodes the gateway knows
+about, but is not necessarily connected to.
 
 ###### Path Parameters
 ```
@@ -91,13 +79,11 @@ list of all nodes the gateway knows about, but is not necessarily connected to.
 standard success or error response. See
 [API.md#standard-responses](/doc/API.md#standard-responses).
 
-###### [Example](#connect-example)
+#### /gateway/disconnect/{netaddress} [POST] [(example)](#disconnect-example)
 
-#### /gateway/disconnect/{netaddress} [POST]
-
-`/gateway/disconnect/{netaddress} [POST]` disconnects the gateway from a peer.
-The peer remains in the node list. Disconnecting from a peer does not prevent
-the gateway from automatically connecting to the peer in the future.
+disconnects the gateway from a peer. The peer remains in the node list.
+Disconnecting from a peer does not prevent the gateway from automatically
+connecting to the peer in the future.
 
 ###### Path Parameters
 ```
@@ -114,18 +100,22 @@ the gateway from automatically connecting to the peer in the future.
 standard success or error response. See
 [API.md#standard-responses](/doc/API.md#standard-responses).
 
-###### [Example](#disconnect-example)
+Examples
+--------
 
-#### gateway info example
+#### Gateway info
 
-Request:
+###### Request
 ```
 /gateway
 ```
 
-Expected Response Code: 200
+###### Expected Response Code
+```
+200 OK
+```
 
-Example JSON Response:
+###### Example JSON Response
 ```json
 {
     "netaddress":"333.333.333.333:9981",
@@ -144,20 +134,26 @@ Example JSON Response:
 }
 ```
 
-#### connect example
+#### Connecting to a peer
 
-Request:
+###### Request
 ```
 /gateway/connect/123.456.789.0:123
 ```
 
-Expected Response Code: 204
+###### Expected Response Code
+```
+204 No Content
+```
 
-#### disconnect example
+#### Disconnecting from a peer
 
-Request:
+###### Request
 ```
 /gateway/disconnect/123.456.789.0:123
 ```
 
-Expected Response Code: 204
+###### Expected Response Code
+```
+204 No Content
+```

--- a/doc/api/Gateway.md
+++ b/doc/api/Gateway.md
@@ -1,0 +1,163 @@
+Gateway API
+===========
+
+This document contains detailed descriptions of the gateway's API routes. For
+an overview of the gateway's API routes, see
+[API.md#gateway](/doc/API.md#gateway).  For an overview of all API routes, see
+[API.md](/doc/API.md)
+
+There may be functional API calls which are not documented. These are not
+guaranteed to be supported beyond the current release, and should not be used
+in production.
+
+Overview
+--------
+
+The gateway maintains a peer to peer connection to the network and provides a
+method for calling RPCs on connected peers. The gateway's API endpoints expose
+methods for viewing the connected peers, manually connecting to peers, and
+manually disconnecting from peers. The gateway may connect or disconnect from
+peers on its own.
+
+Index
+-----
+
+| Route | HTTP verb |
+| ----- | --------- |
+| [/gateway](#gateway-get) | GET |
+| [/gateway/connect/{netaddress}](#gatewayconnectnetaddress-post) | POST |
+| [/gateway/disconnect/{netaddress}](#gatewaydisconnectnetaddress-post) | POST |
+
+Examples
+--------
+
+* [gateway info](#gateway-info-example)
+* [connecting to a peer](#connect-example)
+* [disconnecting from a peer](#disconnect-example)
+
+-------------------------------------------------------------------------------
+
+#### /gateway [GET]
+
+`/gateway [GET]` returns information about the gateway, including the list of
+connected peers.
+
+###### JSON Response
+```javascript
+{
+    // netaddress is the network address of the gateway as seen by the rest of
+    // the network. The address consists of the external IP address and the
+    // port Sia is listening on. It represents a `modules.NetAddress`.
+    "netaddress": String,
+
+    // peers is an array of peers the gateway is connected to. It represents
+    // an array of `modules.Peer`s.
+    "peers":      []{
+        // netaddress is the address of the peer. It represents a
+        // `modules.NetAddress`.
+        "netaddress": String,
+
+        // version is the version number of the peer.
+        "version":    String,
+
+        // inbound is true when the peer initiated the connection. This field
+        // is exposed as outbound peers are generally trusted more than inbound
+        // peers, as inbound peers are easily manipulated by an adversary.
+        "inbound":    Boolean
+    }
+}
+```
+
+###### [Example](#gateway-info-example)
+
+#### /gateway/connect/{netaddress} [POST]
+
+`/gateway/connect/{netaddress} [POST]` connects the gateway to a peer. The peer
+is added to the node list if it is not already present. The node list is the
+list of all nodes the gateway knows about, but is not necessarily connected to.
+
+###### Path Parameters
+```
+// netaddress is the address of the peer to connect to. It should be a
+// reachable ip address and port number, of the form 'IP:port'. IPV6 addresses
+// must be enclosed in square brackets.
+//
+// Example IPV4 address: 123.456.789.0:123
+// Example IPV6 address: [123::456]:789
+{netaddress}
+```
+
+###### Response
+standard success or error response. See
+[API.md#standard-responses](/doc/API.md#standard-responses).
+
+###### [Example](#connect-example)
+
+#### /gateway/disconnect/{netaddress} [POST]
+
+`/gateway/disconnect/{netaddress} [POST]` disconnects the gateway from a peer.
+The peer remains in the node list. Disconnecting from a peer does not prevent
+the gateway from automatically connecting to the peer in the future.
+
+###### Path Parameters
+```
+// netaddress is the address of the peer to connect to. It should be a
+// reachable ip address and port number, of the form 'IP:port'. IPV6 addresses
+// must be enclosed in square brackets.
+//
+// Example IPV4 address: 123.456.789.0:123
+// Example IPV6 address: [123::456]:789
+{netaddress}
+```
+
+###### Response
+standard success or error response. See
+[API.md#standard-responses](/doc/API.md#standard-responses).
+
+###### [Example](#disconnect-example)
+
+#### gateway info example
+
+Request:
+```
+/gateway
+```
+
+Expected Response Code: 200
+
+Example JSON Response:
+```json
+{
+    "netaddress":"333.333.333.333:9981",
+    "peers":[
+        {
+            "netaddress":"222.222.222.222:9981",
+            "version":"1.0.0",
+            "inbound":false
+        },
+        {
+            "netaddress":"111.111.111.111:9981",
+            "version":"0.6.0",
+            "inbound":true
+        }
+    ]
+}
+```
+
+#### connect example
+
+Request:
+```
+/gateway/connect/123.456.789.0:123
+```
+
+Expected Response Code: 204
+
+#### disconnect example
+
+Request:
+```
+/gateway/disconnect/123.456.789.0:123
+```
+
+Expected Response Code: 204

--- a/siac/README.md
+++ b/siac/README.md
@@ -181,14 +181,16 @@ your saved list.
 if you have multiple downloads happening simultaneously.
 
 #### Gateway tasks
-* `siac gateway add [address:port]` manually adds a peer to your list
-of connected clients
+* `siac gateway` prints info about the gateway, including its address and how
+many peers it's connected to.
 
-* `siac gateway remove [address:port]` manually removes a peer from
-your list of connected peers
+* `siac gateway list` prints a list of all currently connected peers.
 
-* `siac gateway status` prints a list of all the peers you are
-connected to
+* `siac gateway connect [address:port]` manually connects to a peer and adds it
+to the gateway's node list.
+
+* `siac gateway disconnect [address:port]` manually disconnects from a peer, but
+leaves it in the gateway's node list.
 
 #### Miner tasks
 * `siac miner status` returns information about the miner. It is only

--- a/siac/gatewaycmd.go
+++ b/siac/gatewaycmd.go
@@ -14,22 +14,36 @@ var (
 	gatewayCmd = &cobra.Command{
 		Use:   "gateway",
 		Short: "Perform gateway actions",
-		Long:  "Add or remove a peer, view the current peer list, or synchronize to the network.",
+		Long:  "View and manage the gateway's connected peers.",
 		Run:   wrap(gatewaycmd),
 	}
 
-	gatewayAddCmd = &cobra.Command{
-		Use:   "add [address]",
-		Short: "Add a peer",
-		Long:  "Add a new peer to the peer list.",
-		Run:   wrap(gatewayaddcmd),
+	gatewayConnectCmd = &cobra.Command{
+		Use:   "connect [address]",
+		Short: "Connect to a peer",
+		Long:  "Connect to a peer and add it to the node list.",
+		Run:   wrap(gatewayconnectcmd),
 	}
 
-	gatewayRemoveCmd = &cobra.Command{
-		Use:   "remove [address]",
-		Short: "Remove a peer",
-		Long:  "Remove a peer from the peer list.",
-		Run:   wrap(gatewayremovecmd),
+	// COMPATv0.6.0
+	gatewayDeprecatedAddCmd = &cobra.Command{
+		Use:        "add [address]",
+		Deprecated: "use `siac gateway connect` instead.",
+		Run:        wrap(gatewayconnectcmd),
+	}
+
+	gatewayDisconnectCmd = &cobra.Command{
+		Use:   "disconnect [address]",
+		Short: "Disconnect from a peer",
+		Long:  "Disconnect from a peer. Does not remove the peer from the node list.",
+		Run:   wrap(gatewaydisconnectcmd),
+	}
+
+	// COMPATv0.6.0
+	gatewayDeprecatedRemoveCmd = &cobra.Command{
+		Use:        "remove [address]",
+		Deprecated: "use `siac gateway disconnect` instead.",
+		Run:        wrap(gatewaydisconnectcmd),
 	}
 
 	gatewayAddressCmd = &cobra.Command{
@@ -47,9 +61,9 @@ var (
 	}
 )
 
-// gatewayaddcmd is the handler for the command `siac gateway add [address]`.
+// gatewayconnectcmd is the handler for the command `siac gateway add [address]`.
 // Adds a new peer to the peer list.
-func gatewayaddcmd(addr string) {
+func gatewayconnectcmd(addr string) {
 	err := post("/gateway/add/"+addr, "")
 	if err != nil {
 		die("Could not add peer:", err)
@@ -57,9 +71,9 @@ func gatewayaddcmd(addr string) {
 	fmt.Println("Added", addr, "to peer list.")
 }
 
-// gatewayremovecmd is the handler for the command `siac gateway remove [address]`.
+// gatewaydisconnectcmd is the handler for the command `siac gateway remove [address]`.
 // Removes a peer from the peer list.
-func gatewayremovecmd(addr string) {
+func gatewaydisconnectcmd(addr string) {
 	err := post("/gateway/remove/"+addr, "")
 	if err != nil {
 		die("Could not remove peer:", err)

--- a/siac/gatewaycmd.go
+++ b/siac/gatewaycmd.go
@@ -25,25 +25,11 @@ var (
 		Run:   wrap(gatewayconnectcmd),
 	}
 
-	// COMPATv0.6.0
-	gatewayDeprecatedAddCmd = &cobra.Command{
-		Use:        "add [address]",
-		Deprecated: "use `siac gateway connect` instead.",
-		Run:        wrap(gatewayconnectcmd),
-	}
-
 	gatewayDisconnectCmd = &cobra.Command{
 		Use:   "disconnect [address]",
 		Short: "Disconnect from a peer",
 		Long:  "Disconnect from a peer. Does not remove the peer from the node list.",
 		Run:   wrap(gatewaydisconnectcmd),
-	}
-
-	// COMPATv0.6.0
-	gatewayDeprecatedRemoveCmd = &cobra.Command{
-		Use:        "remove [address]",
-		Deprecated: "use `siac gateway disconnect` instead.",
-		Run:        wrap(gatewaydisconnectcmd),
 	}
 
 	gatewayAddressCmd = &cobra.Command{

--- a/siac/main.go
+++ b/siac/main.go
@@ -238,9 +238,13 @@ func main() {
 	renterFilesListCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
 
 	root.AddCommand(gatewayCmd)
-	gatewayCmd.AddCommand(gatewayAddCmd, gatewayRemoveCmd, gatewayAddressCmd, gatewayListCmd)
+	gatewayCmd.AddCommand(gatewayConnectCmd, gatewayDisconnectCmd, gatewayAddressCmd, gatewayListCmd)
 
 	root.AddCommand(consensusCmd)
+
+	// COMPATv0.6.0
+	gatewayCmd.AddCommand(gatewayDeprecatedAddCmd)
+	gatewayCmd.AddCommand(gatewayDeprecatedRemoveCmd)
 
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")

--- a/siac/main.go
+++ b/siac/main.go
@@ -242,10 +242,6 @@ func main() {
 
 	root.AddCommand(consensusCmd)
 
-	// COMPATv0.6.0
-	gatewayCmd.AddCommand(gatewayDeprecatedAddCmd)
-	gatewayCmd.AddCommand(gatewayDeprecatedRemoveCmd)
-
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")
 

--- a/siad/main.go
+++ b/siad/main.go
@@ -147,27 +147,16 @@ func main() {
 	})
 
 	// Set default values, which have the lowest priority.
-	root.Flags().StringVarP(&globalConfig.Siad.RequiredUserAgent, "agent", "A", "Sia-Agent", "required substring for the user agent")
-	root.Flags().StringVarP(&globalConfig.Siad.HostAddr, "host-addr", "H", ":9982", "which port the host listens on")
-	root.Flags().StringVarP(&globalConfig.Siad.ProfileDir, "profile-directory", "P", "profiles", "location of the profiling directory")
-	root.Flags().StringVarP(&globalConfig.Siad.APIaddr, "api-addr", "a", "localhost:9980", "which host:port the API server listens on")
+	root.Flags().StringVarP(&globalConfig.Siad.RequiredUserAgent, "agent", "", "Sia-Agent", "required substring for the user agent")
+	root.Flags().StringVarP(&globalConfig.Siad.HostAddr, "host-addr", "", ":9982", "which port the host listens on")
+	root.Flags().StringVarP(&globalConfig.Siad.ProfileDir, "profile-directory", "", "profiles", "location of the profiling directory")
+	root.Flags().StringVarP(&globalConfig.Siad.APIaddr, "api-addr", "", "localhost:9980", "which host:port the API server listens on")
 	root.Flags().StringVarP(&globalConfig.Siad.SiaDir, "sia-directory", "d", "", "location of the sia directory")
-	root.Flags().BoolVarP(&globalConfig.Siad.NoBootstrap, "no-bootstrap", "n", false, "disable bootstrapping on this run")
-	root.Flags().BoolVarP(&globalConfig.Siad.Profile, "profile", "p", false, "enable profiling")
-	root.Flags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "r", ":9981", "which port the gateway listens on")
+	root.Flags().BoolVarP(&globalConfig.Siad.NoBootstrap, "no-bootstrap", "", false, "disable bootstrapping on this run")
+	root.Flags().BoolVarP(&globalConfig.Siad.Profile, "profile", "", false, "enable profiling")
+	root.Flags().StringVarP(&globalConfig.Siad.RPCaddr, "rpc-addr", "", ":9981", "which port the gateway listens on")
 	root.Flags().StringVarP(&globalConfig.Siad.Modules, "modules", "M", "cghmrtw", "enabled modules, see 'siad modules' for more info")
 	root.Flags().BoolVarP(&globalConfig.Siad.AuthenticateAPI, "authenticate-api", "", false, "enable API password protection")
-
-	// Deprecate shorthand flags that aren't commonly used.
-	// COMPATv0.5.2
-	// TODO: remove shorthands for these flags by supplying a blank shorthand in flag construction above.
-	root.Flags().MarkShorthandDeprecated("agent", "please use --agent instead")
-	root.Flags().MarkShorthandDeprecated("host-addr", "please use --host-addr instead")
-	root.Flags().MarkShorthandDeprecated("profile-directory", "please use --profile-directory instead")
-	root.Flags().MarkShorthandDeprecated("api-addr", "please use --api-addr instead")
-	root.Flags().MarkShorthandDeprecated("no-bootstrap", "please use --no-bootstrap instead")
-	root.Flags().MarkShorthandDeprecated("profile", "please use --profile instead")
-	root.Flags().MarkShorthandDeprecated("rpc-addr", "please use --rpc-addr instead")
 
 	// Parse cmdline flags, overwriting both the default values and the config
 	// file values.


### PR DESCRIPTION
add & remove isn't as clear as connect & disconnect, especially since the peer remains in the node list on disconnect. add & remove could be used in the future to add and remove addresses from the node list.