### PR TITLE
Clean shutdown of miner

### DIFF
--- a/api/miner_test.go
+++ b/api/miner_test.go
@@ -73,7 +73,7 @@ func TestIntegrationMinerStartStop(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !mg.CPUMining {
-		t.Error("cpu is not reporting through the api that it is mining.")
+		t.Error("cpu is not reporting through the api that it is mining")
 	}
 
 	// Stop the cpu miner and wait for the stop call to go through.
@@ -83,7 +83,7 @@ func TestIntegrationMinerStartStop(t *testing.T) {
 	}
 	time.Sleep(100 * time.Millisecond)
 	if st.server.miner.CPUMining() {
-		t.Error("cpu miner is reporting that it is not on")
+		t.Error("cpu miner is reporting that it is on after being stopped")
 	}
 
 	// Check the numbers through the status api call.
@@ -92,7 +92,7 @@ func TestIntegrationMinerStartStop(t *testing.T) {
 		t.Fatal(err)
 	}
 	if mg.CPUMining {
-		t.Error("cpu is not reporting through the api that it is mining.")
+		t.Error("cpu is not reporting through the api that it is mining")
 	}
 }
 

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -69,6 +69,11 @@ func (m *Miner) newSourceBlock() {
 // it is typically safe to assume that headers will be remembered for
 // min(10 minutes, 10e3 requests).
 func (m *Miner) HeaderForWork() (types.BlockHeader, types.Target, error) {
+	if err := m.tg.Add(); err != nil {
+		return types.BlockHeader{}, types.Target{}, err
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -158,6 +163,11 @@ func (m *Miner) managedSubmitBlock(b types.Block) error {
 
 // SubmitHeader accepts a block header.
 func (m *Miner) SubmitHeader(bh types.BlockHeader) error {
+	if err := m.tg.Add(); err != nil {
+		return err
+	}
+	defer m.tg.Done()
+
 	// Because a call to managedSubmitBlock is required at the end of this
 	// function, the first part needs to be wrapped in an anonymous function
 	// for lock safety.

--- a/modules/miner/cpuminer.go
+++ b/modules/miner/cpuminer.go
@@ -2,11 +2,18 @@ package miner
 
 import (
 	"time"
+
+	"github.com/NebulousLabs/Sia/build"
 )
 
 // threadedMine starts a gothread that does CPU mining. threadedMine is the
 // only function that should be setting the mining flag to true.
 func (m *Miner) threadedMine() {
+	if err := m.tg.Add(); err != nil {
+		return
+	}
+	defer m.tg.Done()
+
 	// There should not be another thread mining, and mining should be enabled.
 	m.mu.Lock()
 	if m.mining || !m.miningOn {
@@ -54,6 +61,11 @@ func (m *Miner) threadedMine() {
 
 // CPUHashrate returns an estimated cpu hashrate.
 func (m *Miner) CPUHashrate() int {
+	if err := m.tg.Add(); err != nil {
+		build.Critical(err)
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return int(m.hashRate)
@@ -61,6 +73,11 @@ func (m *Miner) CPUHashrate() int {
 
 // CPUMining indicates whether the cpu miner is running.
 func (m *Miner) CPUMining() bool {
+	if err := m.tg.Add(); err != nil {
+		build.Critical(err)
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.miningOn
@@ -69,6 +86,11 @@ func (m *Miner) CPUMining() bool {
 // StartCPUMining will start a single threaded cpu miner. If the miner is
 // already running, nothing will happen.
 func (m *Miner) StartCPUMining() {
+	if err := m.tg.Add(); err != nil {
+		build.Critical(err)
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.miningOn = true
@@ -78,6 +100,11 @@ func (m *Miner) StartCPUMining() {
 // StopCPUMining will stop the cpu miner. If the cpu miner is already stopped,
 // nothing will happen.
 func (m *Miner) StopCPUMining() {
+	if err := m.tg.Add(); err != nil {
+		build.Critical(err)
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.hashRate = 0

--- a/modules/miner/cpuminer.go
+++ b/modules/miner/cpuminer.go
@@ -27,8 +27,15 @@ func (m *Miner) threadedMine() {
 	// occurring.
 	cycleStart := time.Now()
 	for {
-		// Kill the thread if mining has been turned off.
 		m.mu.Lock()
+		// Kill the thread if the miner's threadgroup is stopped.
+		if m.tg.IsStopped() {
+			m.miningOn = false
+			m.mining = false
+			m.mu.Unlock()
+			return
+		}
+		// Kill the thread if mining has been turned off.
 		if !m.miningOn {
 			m.mining = false
 			m.mu.Unlock()

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -206,6 +206,7 @@ func (m *Miner) Close() error {
 	defer m.mu.Unlock()
 
 	m.cs.Unsubscribe(m)
+	m.tpool.Unsubscribe(m)
 
 	var errs []error
 	if err := m.saveSync(); err != nil {

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -235,6 +235,11 @@ func (m *Miner) checkAddress() error {
 // BlocksMined returns the number of good blocks and stale blocks that have
 // been mined by the miner.
 func (m *Miner) BlocksMined() (goodBlocks, staleBlocks int) {
+	if err := m.tg.Add(); err != nil {
+		build.Critical(err)
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -224,7 +224,7 @@ func TestIntegrationBlocksMined(t *testing.T) {
 	}
 	goodBlocks, staleBlocks = rebootMiner.BlocksMined()
 	if goodBlocks != 1 {
-		t.Error("expexting 1 good block")
+		t.Error("expecting 1 good block")
 	}
 	if staleBlocks != 1 {
 		t.Error("expecting 1 stale block, got", staleBlocks)

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -8,6 +8,11 @@ import (
 
 // ProcessConsensusDigest will update the miner's most recent block.
 func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
+	if err := m.tg.Add(); err != nil {
+		return
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -71,6 +76,11 @@ func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 // ReceiveUpdatedUnconfirmedTransactions will replace the current unconfirmed
 // set of transactions with the input transactions.
 func (m *Miner) ReceiveUpdatedUnconfirmedTransactions(unconfirmedTransactions []types.Transaction, _ modules.ConsensusChange) {
+	if err := m.tg.Add(); err != nil {
+		return
+	}
+	defer m.tg.Done()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -95,6 +95,10 @@ type TransactionPool interface {
 	// Subscribers will receive all consensus set changes as well as
 	// transaction pool changes, and should not subscribe to both.
 	TransactionPoolSubscribe(TransactionPoolSubscriber)
+
+	// Unsubscribe removes a subscriber from the transaction pool.
+	// This is necessary for clean shutdown of the miner.
+	Unsubscribe(TransactionPoolSubscriber)
 }
 
 // ConsensusConflict implements the error interface, and indicates that a

--- a/modules/transactionpool/subscribe.go
+++ b/modules/transactionpool/subscribe.go
@@ -42,3 +42,20 @@ func (tp *TransactionPool) TransactionPoolSubscribe(subscriber modules.Transacti
 	}
 	subscriber.ReceiveUpdatedUnconfirmedTransactions(txns, cc)
 }
+
+// Unsubscribe removes a subscriber from the transaction pool. If the
+// subscriber is not in tp.subscribers, Unsubscribe does nothing. If the
+// subscriber occurs more than once in tp.subscribers, only the earliest
+// occurrence is removed (unsubscription fails).
+func (tp *TransactionPool) Unsubscribe(subscriber modules.TransactionPoolSubscriber) {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
+	// Search for and remove subscriber from list of subscribers.
+	for i := range tp.subscribers {
+		if tp.subscribers[i] == subscriber {
+			tp.subscribers = append(tp.subscribers[0:i], tp.subscribers[i+1:]...)
+			break
+		}
+	}
+}

--- a/modules/transactionpool/subscribe_test.go
+++ b/modules/transactionpool/subscribe_test.go
@@ -13,7 +13,7 @@ type mockSubscriber struct {
 }
 
 // ReceiveUpdatedUnconfirmedTransactions receives transactinos from the
-// transaction pool and stores them in the order they were received. 
+// transaction pool and stores them in the order they were received.
 // This method allows *mockSubscriber to satisfy the
 // modules.TransactionPoolSubscriber interface.
 func (ms *mockSubscriber) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction, _ modules.ConsensusChange) {
@@ -28,7 +28,7 @@ func TestSubscription(t *testing.T) {
 		t.Skip()
 	}
 
-	tpt, err  := createTpoolTester("TestUnsubscribe")
+	tpt, err := createTpoolTester("TestUnsubscribe")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,11 +63,10 @@ func TestSubscription(t *testing.T) {
 	if len(ms.txns) != numTxns {
 		t.Errorf("mock subscriber should've received %v transactions; received %v instead", numTxns, len(ms.txns))
 	}
-	
+
 	numSubscribers := len(tpt.tpool.subscribers)
 	tpt.tpool.Unsubscribe(&ms)
 	if len(tpt.tpool.subscribers) != numSubscribers-1 {
 		t.Error("transaction pool failed to unsubscribe mock subscriber")
 	}
 }
-

--- a/modules/transactionpool/subscribe_test.go
+++ b/modules/transactionpool/subscribe_test.go
@@ -1,0 +1,73 @@
+package transactionpool
+
+import (
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+	"testing"
+)
+
+// mockSubscriber receives transactions from the transaction pool it is
+// subscribed to, retaining them in the order they were received.
+type mockSubscriber struct {
+	txns []types.Transaction
+}
+
+// ReceiveUpdatedUnconfirmedTransactions receives transactinos from the
+// transaction pool and stores them in the order they were received. 
+// This method allows *mockSubscriber to satisfy the
+// modules.TransactionPoolSubscriber interface.
+func (ms *mockSubscriber) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction, _ modules.ConsensusChange) {
+	ms.txns = append(ms.txns, txns...)
+}
+
+// TestSubscription checks that calling Unsubscribe on a mockSubscriber
+// shortens the list of subscribers to the transaction pool by 1 (doesn't
+// actually check that the mockSubscriber was the one unsubscribed).
+func TestSubscription(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	tpt, err  := createTpoolTester("TestUnsubscribe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// TODO: add tPoolTester.Close() method
+	//	defer tpt.Close()
+
+	// Check the transaction pool is empty when initialized.
+	if len(tpt.tpool.transactionSets) != 0 {
+		t.Fatal("transaction pool is not empty")
+	}
+
+	// Create a mock subscriber and subscribe it to the transaction pool.
+	ms := mockSubscriber{}
+	tpt.tpool.TransactionPoolSubscribe(&ms)
+	if len(ms.txns) != 0 {
+		t.Fatalf("mock subscriber has received %v transactions; shouldn't have received any yet", len(ms.txns))
+	}
+
+	// Create a valid transaction set and check that the mock subscriber's
+	// transaction list is updated.
+	_, err = tpt.wallet.SendSiacoins(types.NewCurrency64(100), types.UnlockHash{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tpt.tpool.transactionSets) != 1 {
+		t.Error("sending coins didn't increase the transaction sets by 1")
+	}
+	numTxns := 0
+	for _, txnSet := range tpt.tpool.transactionSets {
+		numTxns += len(txnSet)
+	}
+	if len(ms.txns) != numTxns {
+		t.Errorf("mock subscriber should've received %v transactions; received %v instead", numTxns, len(ms.txns))
+	}
+	
+	numSubscribers := len(tpt.tpool.subscribers)
+	tpt.tpool.Unsubscribe(&ms)
+	if len(tpt.tpool.subscribers) != numSubscribers-1 {
+		t.Error("transaction pool failed to unsubscribe mock subscriber")
+	}
+}
+


### PR DESCRIPTION
Adds `tg *siasync.ThreadGroup` field to the Miner type; m.tg.Stop() is called at the start of m.Close(), automatically unsubscribing the miner from its consensus set and transaction pool and blocking until the m.threadedMine() goroutine is done.

To unsubscribe the miner from the transaction pool, I've added an exported Unsubscribe method to TransactionPool (akin to the ConsensusSet Unsubscribe method).