### PR TITLE
Fix nondeterministic timeout in miner tests

### DIFF
--- a/modules/miner/blockmanager_test.go
+++ b/modules/miner/blockmanager_test.go
@@ -14,7 +14,7 @@ import (
 func solveHeader(header types.BlockHeader, target types.Target) types.BlockHeader {
 	// Solve the header.
 	for {
-		// Incrememnt the nonce first to guarantee that a new header is formed
+		// Increment the nonce first to guarantee that a new header is formed
 		// - this helps check for pointer errors.
 		header.Nonce[0]++
 		id := crypto.HashObject(header)
@@ -44,7 +44,7 @@ func TestIntegrationHeaderForWork(t *testing.T) {
 	solvedHeader := solveHeader(header, target)
 	// Sanity check - header and solvedHeader should be different. (within the
 	// testing file, 'header' should always have a nonce of '0' and
-	// solvedHeader should never have a nonce of '0'.
+	// solvedHeader should never have a nonce of '0'.)
 	if header.Nonce == solvedHeader.Nonce {
 		t.Fatal("nonce memory is not independent")
 	}
@@ -63,7 +63,7 @@ func TestIntegrationHeaderForWorkUpdates(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegreationHeaderForWorkUpdates")
+	mt, err := createMinerTester("TestIntegrationHeaderForWorkUpdates")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestIntegrationHeaderForWorkUpdates(t *testing.T) {
 	}
 }
 
-// TestIntegrationManyHeaders checks that requesting a full set of headers a
+// TestIntegrationManyHeaders checks that requesting a full set of headers in a
 // row results in all unique headers, and that all of them can be reassembled
 // into valid blocks.
 func TestIntegrationManyHeaders(t *testing.T) {

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -128,6 +128,9 @@ func TestIntegrationMiner(t *testing.T) {
 // TestIntegrationNilMinerDependencies tests that the miner properly handles
 // nil inputs for its dependencies.
 func TestIntegrationNilMinerDependencies(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	mt, err := createMinerTester("TestIntegrationNilMinerDependencies")
 	if err != nil {
 		t.Fatal(err)
@@ -153,6 +156,9 @@ func TestIntegrationNilMinerDependencies(t *testing.T) {
 // TestIntegrationBlocksMined checks that the BlocksMined function correctly
 // indicates the number of real blocks and stale blocks that have been mined.
 func TestIntegrationBlocksMined(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	mt, err := createMinerTester("TestIntegrationBlocksMined")
 	if err != nil {
 		t.Fatal(err)
@@ -226,7 +232,7 @@ func TestIntegrationBlocksMined(t *testing.T) {
 }
 
 // TestIntegrationAutoRescan triggers a rescan during a call to New and
-// verifies that the rescanning happens correctly. The rerscan is triggered by
+// verifies that the rescanning happens correctly. The rescan is triggered by
 // a call to New, instead of getting called directly.
 func TestIntegrationAutoRescan(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
@DavidVorick's theory for issue #1107 is that the Travis short tests sometimes fail for the miner because Travis is too slow.  If so, this pull request should resolve #1107 by skipping `TestIntegrationNilMinerDependencies` and `TestIntegrationBlocksMined`, the only two miner testing functions with significant I/O that were not already being skipped.