### PR TITLE
Share dialback port on Connect in the gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ test:
 test-v:
 	go test -race -v -short -tags='debug testing' -timeout=15s $(pkgs) -run=$(run)
 test-long: clean fmt vet lint
-	go test -v -race -tags='testing debug' -timeout=300s $(pkgs) -run=$(run)
+	go test -v -race -tags='testing debug' -timeout=600s $(pkgs) -run=$(run)
 bench: clean fmt
-	go test -tags='testing' -timeout=300s -run=XXX -bench=. $(pkgs)
+	go test -tags='testing' -timeout=600s -run=XXX -bench=. $(pkgs)
 cover: clean
 	@mkdir -p cover/modules
 	@mkdir -p cover/modules/renter

--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -25,46 +25,55 @@ func TestGatewayStatus(t *testing.T) {
 	}
 }
 
-// TestGatewayPeerAdd checks that /gateway/add is adding a peer to the
+// TestGatewayPeerConnect checks that /gateway/connect is adding a peer to the
 // gateway's peerlist.
-func TestGatewayPeerAdd(t *testing.T) {
+func TestGatewayPeerConnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestGatewayPeerConnect")
+	st, err := createServerTester("TestGatewayPeerConnect1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerConnect", "gateway"))
+	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerConnect2", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
+	err = st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var info GatewayInfo
-	st.getAPI("/gateway", &info)
+	err = st.getAPI("/gateway", &info)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(info.Peers) != 1 || info.Peers[0].NetAddress != peer.Address() {
 		t.Fatal("/gateway/connect did not connect to peer", peer.Address())
 	}
 }
 
-// TestGatewayPeerRemove checks that gateway/remove removes the correct peer
-// from the gateway's peerlist.
-func TestGatewayPeerRemove(t *testing.T) {
+// TestGatewayPeerDisconnect checks that /gateway/disconnect removes the
+// correct peer from the gateway's peerlist.
+func TestGatewayPeerDisconnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestGatewayPeerDisconnect")
+	st, err := createServerTester("TestGatewayPeerDisconnect1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerDisconnect", "gateway"))
+	peer, err := gateway.New("localhost:0", build.TempDir("api", "TestGatewayPeerDisconnect2", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
+	err = st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var info GatewayInfo
 	st.getAPI("/gateway", &info)
@@ -72,8 +81,14 @@ func TestGatewayPeerRemove(t *testing.T) {
 		t.Fatal("/gateway/connect did not connect to peer", peer.Address())
 	}
 
-	st.stdPostAPI("/gateway/disconnect/"+string(peer.Address()), nil)
-	st.getAPI("/gateway", &info)
+	err = st.stdPostAPI("/gateway/disconnect/"+string(peer.Address()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.getAPI("/gateway", &info)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(info.Peers) != 0 {
 		t.Fatal("/gateway/disconnect did not disconnect from peer", peer.Address())
 	}

--- a/build/version.go
+++ b/build/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version is the current version of siad.
-const Version = "0.6.0"
+const Version = "1.0.0"
 
 // IsVersion returns whether str is a valid version number.
 func IsVersion(str string) bool {

--- a/build/version.go
+++ b/build/version.go
@@ -5,8 +5,17 @@ import (
 	"strings"
 )
 
-// Version is the current version of siad.
-const Version = "1.0.0"
+const (
+	// Version is the current version of siad.
+	Version = "1.0.0"
+
+	// MaxEncodedVersionLength is the maximum length of a version string encoded
+	// with the encode package. 100 is much larger than any version number we send
+	// now, but it allows us to send additional information in the version string
+	// later if we choose. For example appending the version string with the HEAD
+	// commit hash.
+	MaxEncodedVersionLength = 100
+)
 
 // IsVersion returns whether str is a valid version number.
 func IsVersion(str string) bool {

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -349,7 +349,7 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 		// received from the peer is discarded and will be downloaded again if
 		// the parent is found.
 		go func() {
-			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
+			err := cs.gateway.RPC(conn.RPCAddr(), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
 				cs.log.Debugln("WARN: failed to get parents of orphan block:", err)
 			}
@@ -380,7 +380,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	if err == errOrphan {
 		// If the header is an orphan, try to find the parents.
 		go func() {
-			err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlocks", cs.threadedReceiveBlocks)
+			err := cs.gateway.RPC(conn.RPCAddr(), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
 				cs.log.Debugln("WARN: failed to get parents of orphan header:", err)
 			}
@@ -392,7 +392,7 @@ func (cs *ConsensusSet) rpcRelayHeader(conn modules.PeerConn) error {
 	// If the header is valid and extends the heaviest chain, fetch, accept it,
 	// and broadcast it.
 	go func() {
-		err := cs.gateway.RPC(modules.NetAddress(conn.RemoteAddr().String()), "SendBlk", cs.threadedReceiveBlock(h.ID()))
+		err := cs.gateway.RPC(conn.RPCAddr(), "SendBlk", cs.threadedReceiveBlock(h.ID()))
 		if err != nil {
 			cs.log.Debugln("WARN: failed to get header's corresponding block:", err)
 		}

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -47,7 +47,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 		}
 	}
 	// Give the OnConnectRPCs time to finish.
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Test IBD when all peers have only the genesis block.
 	doneChan := make(chan struct{})
@@ -72,7 +72,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 		}
 		for _, cst := range remoteCSTs {
 			err = cst.cs.managedAcceptBlock(b)
-			if err != nil {
+			if err != nil && err != modules.ErrBlockKnown {
 				t.Fatal(err)
 			}
 		}
@@ -98,7 +98,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 		}
 		for _, cst := range remoteCSTs {
 			err = cst.cs.managedAcceptBlock(b)
-			if err != nil {
+			if err != nil && err != modules.ErrBlockKnown {
 				t.Fatal(err)
 			}
 		}
@@ -134,7 +134,8 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 		}
 		for _, cst := range remoteCSTs {
 			err = cst.cs.managedAcceptBlock(b)
-			if err != nil {
+			if err != nil && err != modules.ErrBlockKnown {
+				t.Log(i)
 				t.Fatal(err)
 			}
 		}
@@ -170,7 +171,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 		}
 		for _, cst := range remoteCSTs {
 			err = cst.cs.managedAcceptBlock(b)
-			if err != nil {
+			if err != nil && err != modules.ErrBlockKnown {
 				t.Fatal(err)
 			}
 		}

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -172,6 +172,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 		for _, cst := range remoteCSTs {
 			err = cst.cs.managedAcceptBlock(b)
 			if err != nil && err != modules.ErrBlockKnown {
+				t.Log(i)
 				t.Fatal(err)
 			}
 		}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -54,9 +54,9 @@ func TestSynchronize(t *testing.T) {
 	}
 
 	// blockchains should now match
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 50; i++ {
 		if cst1.cs.dbCurrentBlockID() != cst2.cs.dbCurrentBlockID() {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(250 * time.Millisecond)
 		}
 	}
 	if cst1.cs.dbCurrentBlockID() != cst2.cs.dbCurrentBlockID() {
@@ -70,7 +70,7 @@ func TestSynchronize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for cst2.cs.dbBlockHeight() < cst1.cs.dbBlockHeight()+50 {
+	for cst2.cs.dbBlockHeight() < cst1.cs.dbBlockHeight()+3+MaxCatchUpBlocks {
 		b, _ := cst2.miner.FindBlock()
 		err = cst2.cs.AcceptBlock(b)
 		if err != nil {
@@ -84,7 +84,7 @@ func TestSynchronize(t *testing.T) {
 	}
 
 	// block heights should now match
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 50; i++ {
 		if cst1.cs.dbBlockHeight() != cst2.cs.dbBlockHeight() {
 			time.Sleep(250 * time.Millisecond)
 		}
@@ -105,7 +105,7 @@ func TestSynchronize(t *testing.T) {
 
 	// Sleep for a few seconds to allow the network call between the two time
 	// to occur.
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	if cst1.cs.dbBlockHeight() == cst2.cs.dbBlockHeight() {
 		t.Fatal("cst1 did not reject bad block")
 	}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -54,8 +54,13 @@ func TestSynchronize(t *testing.T) {
 	}
 
 	// blockchains should now match
-	for cst1.cs.dbCurrentBlockID() != cst2.cs.dbCurrentBlockID() {
-		time.Sleep(10 * time.Millisecond)
+	for i := 0; i < 20; i++ {
+		if cst1.cs.dbCurrentBlockID() != cst2.cs.dbCurrentBlockID() {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	if cst1.cs.dbCurrentBlockID() != cst2.cs.dbCurrentBlockID() {
+		t.Fatal("Synchronize failed")
 	}
 
 	// Mine on cst2 until it is more than 'MaxCatchUpBlocks' ahead of cst1.
@@ -79,8 +84,13 @@ func TestSynchronize(t *testing.T) {
 	}
 
 	// block heights should now match
-	for cst1.cs.dbBlockHeight() != cst2.cs.dbBlockHeight() {
-		time.Sleep(250 * time.Millisecond)
+	for i := 0; i < 20; i++ {
+		if cst1.cs.dbBlockHeight() != cst2.cs.dbBlockHeight() {
+			time.Sleep(250 * time.Millisecond)
+		}
+	}
+	if cst1.cs.dbBlockHeight() != cst2.cs.dbBlockHeight() {
+		t.Fatal("synchronize failed")
 	}
 
 	// extend cst2 with a "bad" (old) block, and synchronize. cst1 should

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -637,11 +637,14 @@ func TestRPCSendBlockSendsOnlyNecessaryBlocks(t *testing.T) {
 
 // mock PeerConns for testing peer conns that fail reading or writing.
 type (
+	mockPeerConn struct {
+		net.Conn
+	}
 	mockPeerConnFailingReader struct {
-		modules.PeerConn
+		mockPeerConn
 	}
 	mockPeerConnFailingWriter struct {
-		modules.PeerConn
+		mockPeerConn
 	}
 )
 
@@ -649,6 +652,11 @@ var (
 	errFailingReader = errors.New("failing reader")
 	errFailingWriter = errors.New("failing writer")
 )
+
+// RPCAddr implements this method of the modules.PeerConn interface.
+func (pc mockPeerConn) RPCAddr() modules.NetAddress {
+	return "mockPeerConn dialback addr"
+}
 
 // Read is a mock implementation of modules.PeerConn.Read that always returns
 // an error.
@@ -675,6 +683,7 @@ func TestSendBlk(t *testing.T) {
 	defer cst.Close()
 
 	p1, p2 := net.Pipe()
+	mockP1 := mockPeerConn{p1}
 	fnErr := make(chan error)
 
 	tests := []struct {
@@ -687,14 +696,14 @@ func TestSendBlk(t *testing.T) {
 		// TODO: Test with a failing database.
 		// Test with a failing reader.
 		{
-			conn:    mockPeerConnFailingReader{PeerConn: p1},
+			conn:    mockPeerConnFailingReader{mockP1},
 			fn:      func() { fnErr <- nil },
 			errWant: errFailingReader,
 			msg:     "expected rpcSendBlk to error with a failing reader conn",
 		},
 		// Test with a block id not found in the blockmap.
 		{
-			conn: p1,
+			conn: mockP1,
 			fn: func() {
 				// Write a block id to the conn.
 				fnErr <- encoding.WriteObject(p2, types.BlockID{})
@@ -704,7 +713,7 @@ func TestSendBlk(t *testing.T) {
 		},
 		// Test with a failing writer.
 		{
-			conn: mockPeerConnFailingWriter{PeerConn: p1},
+			conn: mockPeerConnFailingWriter{mockP1},
 			fn: func() {
 				// Write a valid block id to the conn.
 				fnErr <- encoding.WriteObject(p2, types.GenesisID)
@@ -714,7 +723,7 @@ func TestSendBlk(t *testing.T) {
 		},
 		// Test with a valid conn and valid block.
 		{
-			conn: p1,
+			conn: mockP1,
 			fn: func() {
 				// Write a valid block id to the conn.
 				if err := encoding.WriteObject(p2, types.GenesisID); err != nil {
@@ -765,6 +774,7 @@ func TestThreadedReceiveBlock(t *testing.T) {
 	defer cst.Close()
 
 	p1, p2 := net.Pipe()
+	mockP1 := mockPeerConn{p1}
 	fnErr := make(chan error)
 
 	tests := []struct {
@@ -776,14 +786,14 @@ func TestThreadedReceiveBlock(t *testing.T) {
 	}{
 		// Test with failing writer.
 		{
-			conn:    mockPeerConnFailingWriter{PeerConn: p1},
+			conn:    mockPeerConnFailingWriter{mockP1},
 			fn:      func() { fnErr <- nil },
 			errWant: errFailingWriter,
 			msg:     "the function returned from threadedReceiveBlock should fail with a PeerConn with a failing writer",
 		},
 		// Test with failing reader.
 		{
-			conn: mockPeerConnFailingReader{PeerConn: p1},
+			conn: mockPeerConnFailingReader{mockP1},
 			fn: func() {
 				// Read the id written to conn.
 				var id types.BlockID
@@ -803,7 +813,7 @@ func TestThreadedReceiveBlock(t *testing.T) {
 		// Test with a valid conn, but an invalid block.
 		{
 			id:   types.BlockID{1},
-			conn: p1,
+			conn: mockP1,
 			fn: func() {
 				// Read the id written to conn.
 				var id types.BlockID
@@ -830,7 +840,7 @@ func TestThreadedReceiveBlock(t *testing.T) {
 		// Test with a valid conn and a valid block.
 		{
 			id:   types.BlockID{2},
-			conn: p1,
+			conn: mockP1,
 			fn: func() {
 				// Read the id written to conn.
 				var id types.BlockID
@@ -890,10 +900,6 @@ func TestIntegrationSendBlkRPC(t *testing.T) {
 	defer cst2.Close()
 
 	err = cst1.cs.gateway.Connect(cst2.cs.gateway.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = cst2.cs.gateway.Connect(cst1.cs.gateway.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -994,6 +1000,7 @@ func TestRelayHeader(t *testing.T) {
 	cst.cs.gateway = mg
 
 	p1, p2 := net.Pipe()
+	mockP2 := mockPeerConn{p2}
 
 	// Valid block that rpcRelayHeader should accept.
 	validBlock, err := cst.miner.FindBlock()
@@ -1053,7 +1060,7 @@ func TestRelayHeader(t *testing.T) {
 		go func() {
 			errChan <- encoding.WriteObject(p1, tt.header)
 		}()
-		err = cst.cs.rpcRelayHeader(p2)
+		err = cst.cs.rpcRelayHeader(mockP2)
 		if err != tt.errWant {
 			t.Errorf("%s: expected '%v', got '%v'", tt.errMSG, tt.errWant, err)
 		}
@@ -1107,6 +1114,8 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Give time for on connect RPCs to finish.
+	time.Sleep(200 * time.Millisecond)
 
 	// Test that broadcasting an invalid block header over RelayHeader on cst1.cs
 	// does not result in cst2.cs.gateway receiving a broadcast.
@@ -1286,30 +1295,31 @@ func TestIntegrationRelaySynchronize(t *testing.T) {
 	}
 }
 
-// mockConnMockReadWrite is a mock implementation of net.Conn that returns
-// fails reading or writing if readErr or writeErr is non-nil, respectively.
-type mockConnMockReadWrite struct {
-	net.Conn
+// mockPeerConnMockReadWrite is a mock implementation of modules.PeerConn that
+// returns fails reading or writing if readErr or writeErr is non-nil,
+// respectively.
+type mockPeerConnMockReadWrite struct {
+	modules.PeerConn
 	readErr  error
 	writeErr error
 }
 
 // Read is a mock implementation of conn.Read that fails with the mock error if
 // readErr != nil.
-func (conn mockConnMockReadWrite) Read(b []byte) (n int, err error) {
+func (conn mockPeerConnMockReadWrite) Read(b []byte) (n int, err error) {
 	if conn.readErr != nil {
 		return 0, conn.readErr
 	}
-	return conn.Conn.Read(b)
+	return conn.PeerConn.Read(b)
 }
 
 // Write is a mock implementation of conn.Write that fails with the mock error
 // if writeErr != nil.
-func (conn mockConnMockReadWrite) Write(b []byte) (n int, err error) {
+func (conn mockPeerConnMockReadWrite) Write(b []byte) (n int, err error) {
 	if conn.writeErr != nil {
 		return 0, conn.writeErr
 	}
-	return conn.Conn.Write(b)
+	return conn.PeerConn.Write(b)
 }
 
 // mockNetError is a mock net.Error.
@@ -1344,40 +1354,42 @@ func TestThreadedReceiveBlocksStalls(t *testing.T) {
 	defer cst.Close()
 
 	p1, p2 := net.Pipe()
-	writeTimeoutConn := mockConnMockReadWrite{
-		Conn: p2,
+	mockP2 := mockPeerConn{p2}
+
+	writeTimeoutConn := mockPeerConnMockReadWrite{
+		PeerConn: mockP2,
 		writeErr: mockNetError{
 			error:   errors.New("Write timeout"),
 			timeout: true,
 		},
 	}
-	readTimeoutConn := mockConnMockReadWrite{
-		Conn: p2,
+	readTimeoutConn := mockPeerConnMockReadWrite{
+		PeerConn: mockP2,
 		readErr: mockNetError{
 			error:   errors.New("Read timeout"),
 			timeout: true,
 		},
 	}
 
-	readNetErrConn := mockConnMockReadWrite{
-		Conn: p2,
+	readNetErrConn := mockPeerConnMockReadWrite{
+		PeerConn: mockP2,
 		readErr: mockNetError{
 			error: errors.New("mock read net.Error"),
 		},
 	}
-	writeNetErrConn := mockConnMockReadWrite{
-		Conn: p2,
+	writeNetErrConn := mockPeerConnMockReadWrite{
+		PeerConn: mockP2,
 		writeErr: mockNetError{
 			error: errors.New("mock write net.Error"),
 		},
 	}
 
-	readErrConn := mockConnMockReadWrite{
-		Conn:    p2,
-		readErr: errors.New("mock read err"),
+	readErrConn := mockPeerConnMockReadWrite{
+		PeerConn: mockP2,
+		readErr:  errors.New("mock read err"),
 	}
-	writeErrConn := mockConnMockReadWrite{
-		Conn:     p2,
+	writeErrConn := mockPeerConnMockReadWrite{
+		PeerConn: mockP2,
 		writeErr: errors.New("mock write err"),
 	}
 

--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -41,9 +41,13 @@ type (
 	}
 
 	// A PeerConn is the connection type used when communicating with peers during
-	// an RPC. For now it is identical to a net.Conn.
+	// an RPC. It is identical to a net.Conn with the additional RPCAddr method.
+	// This method acts as an identifier for peers and is the address that the
+	// peer can be dialed on. It is also the address that should be used when
+	// calling an RPC on the peer.
 	PeerConn interface {
 		net.Conn
+		RPCAddr() NetAddress
 	}
 
 	// RPCFunc is the type signature of functions that handle RPCs. It is used for

--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -2,9 +2,18 @@ package gateway
 
 import (
 	"net"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // peerConn is a simple type that implements the modules.PeerConn interface.
 type peerConn struct {
 	net.Conn
+	dialbackAddr modules.NetAddress
+}
+
+// RPCAddr implements the RPCAddr method of the modules.PeerConn interface. It
+// is the address that identifies a peer.
+func (pc peerConn) RPCAddr() modules.NetAddress {
+	return pc.dialbackAddr
 }

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -109,7 +109,6 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 
 	// Register RPCs.
 	g.RegisterRPC("ShareNodes", g.shareNodes)
-	g.RegisterRPC("RelayNode", g.relayNode)
 	g.RegisterConnectCall("ShareNodes", g.requestNodes)
 
 	// Load the old node list. If it doesn't exist, no problem, but if it does,

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -152,7 +152,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	g.log.Println("INFO: gateway created, started logging")
 
 	// Forward the RPC port, if possible.
-	go g.threadedForwardPort()
+	go g.threadedForwardPort(g.port)
 	// Learn our external IP.
 	go g.threadedLearnHostname()
 

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -121,7 +121,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	if build.Release == "standard" {
 		for _, addr := range modules.BootstrapPeers {
 			err := g.addNode(addr)
-			if err != nil {
+			if err != nil && err != errNodeExists {
 				g.log.Printf("WARN: failed to add the bootstrap node '%v': %v", addr, err)
 			}
 		}

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -58,6 +58,9 @@ func TestAddress(t *testing.T) {
 	}
 	host := modules.NetAddress(g.listener.Addr().String()).Host()
 	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatal("address is not an IP address")
+	}
 	if ip.IsUnspecified() {
 		t.Fatal("expected a non-unspecified address")
 	}

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -12,18 +12,22 @@ import (
 
 const (
 	maxSharedNodes = 10
-	maxAddrLength  = 100
+	maxAddrLength  = 100 // TODO: max NetAddress length is 254 for the hostname (including the trailing dot, 253 without) + 1 for the : + 5 for the port.
 	minPeers       = 3
+)
+
+var (
+	errNodeExists = errors.New("node already added")
 )
 
 // addNode adds an address to the set of nodes on the network.
 func (g *Gateway) addNode(addr modules.NetAddress) error {
 	if _, exists := g.nodes[addr]; exists {
-		return errors.New("node already added")
-	} else if net.ParseIP(addr.Host()) == nil {
-		return errors.New("address is not routable: " + string(addr))
+		return errNodeExists
 	} else if addr.IsValid() != nil {
 		return errors.New("address is not valid: " + string(addr))
+	} else if net.ParseIP(addr.Host()) == nil {
+		return errors.New("address must be an IP address: " + string(addr))
 	}
 	g.nodes[addr] = struct{}{}
 	return nil

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -84,7 +84,7 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	for _, node := range nodes {
 		err := g.addNode(node)
 		if err != nil && err != errNodeExists && err != errOurAddress {
-			g.log.Printf("WARN: peer '%v' sent the invalid addr '%v'", conn.RemoteAddr(), node)
+			g.log.Printf("WARN: peer '%v' sent the invalid addr '%v'", conn.RPCAddr(), node)
 		}
 	}
 	g.save()

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	maxSharedNodes = 10
-	maxAddrLength  = 100 // TODO: max NetAddress length is 254 for the hostname (including the trailing dot, 253 without) + 1 for the : + 5 for the port.
 	minPeers       = 3
 )
 
@@ -77,7 +76,7 @@ func (g *Gateway) shareNodes(conn modules.PeerConn) error {
 // requestNodes is the calling end of the ShareNodes RPC.
 func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	var nodes []modules.NetAddress
-	if err := encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength); err != nil {
 		return err
 	}
 	g.mu.Lock()

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -40,7 +40,6 @@ func (g *Gateway) removeNode(addr modules.NetAddress) error {
 		return errors.New("no record of that node")
 	}
 	delete(g.nodes, addr)
-	g.log.Println("INFO: removed node", addr)
 	return nil
 }
 
@@ -140,6 +139,7 @@ func (g *Gateway) threadedNodeManager() {
 			g.removeNode(node)
 			g.save()
 			g.mu.Unlock()
+			g.log.Debugf("INFO: removing node %q because dialing it failed: %v", node, err)
 			continue
 		}
 		// if connection succeeds, supply an unacceptable version to ensure

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -208,20 +208,19 @@ func TestShareNodes(t *testing.T) {
 	}
 }
 
-func TestRelayNodes(t *testing.T) {
+// TestNodesAreSharedOnConnect tests that nodes that a gateway has never seen
+// before are added to the node list when connecting to another gateway that
+// has seen said nodes.
+func TestNodesAreSharedOnConnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	g1 := newTestingGateway("TestRelayNodes1", t)
+	g1 := newTestingGateway("TestNodesAreSharedOnConnect1", t)
 	defer g1.Close()
-	g2 := newTestingGateway("TestRelayNodes2", t)
+	g2 := newTestingGateway("TestNodesAreSharedOnConnect2", t)
 	defer g2.Close()
-	g3 := newTestingGateway("TestRelayNodes3", t)
+	g3 := newTestingGateway("TestNodesAreSharedOnConnect3", t)
 	defer g3.Close()
-
-	// normally the Gateway will only register this RPC if has discovered its
-	// IP through external means.
-	g3.RegisterConnectCall("RelayNode", g3.sendAddress)
 
 	// connect g2 to g1
 	err := g2.Connect(g1.Address())
@@ -235,11 +234,11 @@ func TestRelayNodes(t *testing.T) {
 		t.Fatal("couldn't connect:", err)
 	}
 
-	// g2 should have received g3's address from g1
+	// g3 should have received g2's address from g1
 	time.Sleep(200 * time.Millisecond)
-	g2.mu.Lock()
-	defer g2.mu.Unlock()
-	if _, ok := g2.nodes[g3.Address()]; !ok {
-		t.Fatal("node was not relayed:", g2.nodes)
+	g3.mu.Lock()
+	defer g3.mu.Unlock()
+	if _, ok := g3.nodes[g2.Address()]; !ok {
+		t.Fatal("node was not relayed:", g3.nodes)
 	}
 }

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -23,7 +23,7 @@ func TestAddNode(t *testing.T) {
 	if err := g.addNode(dummyNode); err != nil {
 		t.Fatal("addNode failed:", err)
 	}
-	if err := g.addNode(dummyNode); err == nil {
+	if err := g.addNode(dummyNode); err != errNodeExists {
 		t.Error("addNode added duplicate node")
 	}
 	if err := g.addNode("foo"); err == nil {
@@ -34,6 +34,9 @@ func TestAddNode(t *testing.T) {
 	}
 	if err := g.addNode("[::]:9981"); err == nil {
 		t.Error("addNode added unspecified address")
+	}
+	if err := g.addNode(g.myAddr); err != errOurAddress {
+		t.Error("addNode added our own address")
 	}
 }
 

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -179,7 +179,7 @@ func TestShareNodes(t *testing.T) {
 	// SharePeers should now return no peers
 	var nodes []modules.NetAddress
 	err = g1.RPC(g2.Address(), "ShareNodes", func(conn modules.PeerConn) error {
-		return encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength)
+		return encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength)
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +198,7 @@ func TestShareNodes(t *testing.T) {
 		}
 	}
 	err = g1.RPC(g2.Address(), "ShareNodes", func(conn modules.PeerConn) error {
-		return encoding.ReadObject(conn, &nodes, maxSharedNodes*maxAddrLength)
+		return encoding.ReadObject(conn, &nodes, maxSharedNodes*modules.MaxEncodedNetAddressLength)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -178,7 +178,6 @@ func (g *Gateway) threadedAcceptConn(conn net.Conn) {
 	remoteVersion, err := acceptConnVersionHandshake(conn, build.Version)
 	if err != nil {
 		g.log.Debugf("INFO: %v wanted to connect but version handshake failed: %v", addr, err)
-		// TODO: should this be muxado.Server(conn).Close()?
 		conn.Close()
 		return
 	}
@@ -256,7 +255,7 @@ func connectVersionHandshake(conn net.Conn, version string) (remoteVersion strin
 
 // acceptConnVersionHandshake performs the version handshake and should be
 // called on the side accepting a connection request. The remote version is
-// only returned in err == nil.
+// only returned if err == nil.
 func acceptConnVersionHandshake(conn net.Conn, version string) (remoteVersion string, err error) {
 	// Read remote version.
 	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
@@ -304,7 +303,6 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 	}
 	remoteVersion, err := connectVersionHandshake(conn, build.Version)
 	if err != nil {
-		// TODO: should this be muxado.Client(conn).Close()?
 		conn.Close()
 		return err
 	}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -85,7 +85,7 @@ func (p *peer) open() (modules.PeerConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &peerConn{conn}, nil
+	return &peerConn{conn, p.NetAddress}, nil
 }
 
 func (p *peer) accept() (modules.PeerConn, error) {
@@ -93,7 +93,7 @@ func (p *peer) accept() (modules.PeerConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &peerConn{conn}, nil
+	return &peerConn{conn, p.NetAddress}, nil
 }
 
 // addPeer adds a peer to the Gateway's peer list and spawns a listener thread

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -173,7 +173,7 @@ func (g *Gateway) threadedAcceptConn(conn net.Conn) {
 	defer g.threads.Done()
 
 	addr := modules.NetAddress(conn.RemoteAddr().String())
-	g.log.Printf("INFO: %v wants to connect", addr)
+	g.log.Debugf("INFO: %v wants to connect", addr)
 
 	remoteVersion, err := acceptConnVersionHandshake(conn, build.Version)
 	if err != nil {
@@ -218,7 +218,7 @@ func (g *Gateway) threadedAcceptConn(conn net.Conn) {
 	})
 	g.mu.Unlock()
 
-	g.log.Printf("INFO: accepted connection from new peer %v (v%v)", addr, remoteVersion)
+	g.log.Debugf("INFO: accepted connection from new peer %v (v%v)", addr, remoteVersion)
 }
 
 // acceptableVersion returns an error if the version is unacceptable.
@@ -309,7 +309,7 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 		return err
 	}
 
-	g.log.Println("INFO: connected to new peer", addr)
+	g.log.Debugln("INFO: connected to new peer", addr)
 
 	g.mu.Lock()
 	g.addPeer(&peer{
@@ -339,7 +339,10 @@ func (g *Gateway) Connect(addr modules.NetAddress) error {
 			}
 			defer g.threads.Done()
 
-			g.RPC(addr, name, fn)
+			err := g.RPC(addr, name, fn)
+			if err != nil {
+				g.log.Debugf("INFO: RPC %q on peer %q failed: %v", name, addr, err)
+			}
 		}(name, fn)
 	}
 	g.mu.RUnlock()

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -347,7 +347,7 @@ func connectVersionHandshake(conn net.Conn, version string) (remoteVersion strin
 		return "", fmt.Errorf("failed to write version: %v", err)
 	}
 	// Read remote version.
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		return "", fmt.Errorf("failed to read remote version: %v", err)
 	}
 	// Check that their version is acceptable.
@@ -365,7 +365,7 @@ func connectVersionHandshake(conn net.Conn, version string) (remoteVersion strin
 // only returned if err == nil.
 func acceptConnVersionHandshake(conn net.Conn, version string) (remoteVersion string, err error) {
 	// Read remote version.
-	if err := encoding.ReadObject(conn, &remoteVersion, maxAddrLength); err != nil {
+	if err := encoding.ReadObject(conn, &remoteVersion, build.MaxEncodedVersionLength); err != nil {
 		return "", fmt.Errorf("failed to read remote version: %v", err)
 	}
 	// Check that their version is acceptable.

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -241,6 +241,10 @@ func (g *Gateway) managedAcceptConnNewPeer(conn net.Conn, remoteVersion string) 
 	if err != nil && err != errNodeExists {
 		return fmt.Errorf("error adding node %q: %v", remoteAddr, err)
 	}
+	err = g.save()
+	if err != nil {
+		return fmt.Errorf("error saving node list: %v", err)
+	}
 
 	g.acceptPeer(&peer{
 		Peer: modules.Peer{
@@ -388,6 +392,10 @@ func (g *Gateway) managedConnectOldPeer(conn net.Conn, remoteVersion string, rem
 	if err != nil && err != errNodeExists {
 		return err
 	}
+	err = g.save()
+	if err != nil {
+		return fmt.Errorf("error saving node list: %v", err)
+	}
 
 	g.addPeer(&peer{
 		Peer: modules.Peer{
@@ -416,6 +424,10 @@ func (g *Gateway) managedConnectNewPeer(conn net.Conn, remoteVersion string, rem
 	err = g.addNode(remoteAddr)
 	if err != nil && err != errNodeExists {
 		return err
+	}
+	err = g.save()
+	if err != nil {
+		return fmt.Errorf("error saving node list: %v", err)
 	}
 
 	g.addPeer(&peer{

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -411,9 +411,12 @@ func (g *Gateway) managedConnectOldPeer(conn net.Conn, remoteVersion string, rem
 // managedConnectNewPeer connects to peers >= v1.0.0. The peer is added as a
 // node and a peer. The peer is only added if a nil error is returned.
 func (g *Gateway) managedConnectNewPeer(conn net.Conn, remoteVersion string, remoteAddr modules.NetAddress) error {
+	g.mu.RLock()
+	port := g.port
+	g.mu.RUnlock()
 	// Send our dialable address to the peer so they can dial us back should we
 	// disconnect.
-	err := connectPortHandshake(conn, g.port)
+	err := connectPortHandshake(conn, port)
 	if err != nil {
 		return err
 	}

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -306,7 +306,11 @@ func TestUnitAcceptableVersion(t *testing.T) {
 // addresses.
 func TestConnectRejectsInvalidAddrs(t *testing.T) {
 	g := newTestingGateway("TestConnectRejectsInvalidAddrs", t)
+	defer g.Close()
+
 	g2 := newTestingGateway("TestConnectRejectsInvalidAddrs2", t)
+	defer g2.Close()
+
 	_, g2Port, err := net.SplitHostPort(string(g2.Address()))
 	if err != nil {
 		t.Fatal(err)

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -169,12 +169,10 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 	fn, ok := g.handlers[id]
 	g.mu.RUnlock()
 	if !ok {
-		g.log.Printf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RemoteAddr(), id)
+		g.log.Debugf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RemoteAddr(), id)
 		return
 	}
-	if build.DEBUG {
-		g.log.Printf("INFO: incoming conn %v requested RPC \"%v\"", conn.RemoteAddr(), id)
-	}
+	g.log.Debugf("INFO: incoming conn %v requested RPC \"%v\"", conn.RemoteAddr(), id)
 
 	// call fn
 	err := fn(conn)
@@ -183,7 +181,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 		err = nil
 	}
 	if err != nil {
-		g.log.Printf("WARN: incoming RPC \"%v\" from conn %v failed: %v", id, conn.RemoteAddr(), err)
+		g.log.Debugf("WARN: incoming RPC \"%v\" from conn %v failed: %v", id, conn.RemoteAddr(), err)
 	}
 }
 
@@ -197,7 +195,7 @@ func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) 
 	}
 	defer g.threads.Done()
 
-	g.log.Printf("INFO: broadcasting RPC \"%v\" to %v peers", name, len(peers))
+	g.log.Printf("INFO: broadcasting RPC %q to %v peers", name, len(peers))
 
 	// only encode obj once, instead of using WriteObject
 	enc := encoding.Marshal(obj)

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -169,10 +169,10 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 	fn, ok := g.handlers[id]
 	g.mu.RUnlock()
 	if !ok {
-		g.log.Debugf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RemoteAddr(), id)
+		g.log.Debugf("WARN: incoming conn %v requested unknown RPC \"%v\"", conn.RPCAddr(), id)
 		return
 	}
-	g.log.Debugf("INFO: incoming conn %v requested RPC \"%v\"", conn.RemoteAddr(), id)
+	g.log.Debugf("INFO: incoming conn %v requested RPC \"%v\"", conn.RPCAddr(), id)
 
 	// call fn
 	err := fn(conn)
@@ -181,7 +181,7 @@ func (g *Gateway) threadedHandleConn(conn modules.PeerConn) {
 		err = nil
 	}
 	if err != nil {
-		g.log.Debugf("WARN: incoming RPC \"%v\" from conn %v failed: %v", id, conn.RemoteAddr(), err)
+		g.log.Debugf("WARN: incoming RPC \"%v\" from conn %v failed: %v", id, conn.RPCAddr(), err)
 	}
 }
 

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -492,7 +492,7 @@ func TestCallingRPCFromRPC(t *testing.T) {
 
 	errChan := make(chan error)
 	g1.RegisterRPC("FOO", func(conn modules.PeerConn) error {
-		err := g1.RPC(modules.NetAddress(conn.RemoteAddr().String()), "BAR", func(conn modules.PeerConn) error { return nil })
+		err := g1.RPC(conn.RPCAddr(), "BAR", func(conn modules.PeerConn) error { return nil })
 		errChan <- err
 		return err
 	})

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -508,14 +508,16 @@ func TestCallingRPCFromRPC(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Call the "FOO" RPC on g1. We don't know g1's address as g2 sees it, so we
-	// get it from the first address in g2's peer list.
-	var addr modules.NetAddress
-	for _, p := range g2.Peers() {
-		addr = p.NetAddress
-		break
+	// Wait for g2 to accept the connection
+	for {
+		if len(g2.Peers()) > 0 {
+			break
+		}
 	}
-	err = g2.RPC(addr, "FOO", func(conn modules.PeerConn) error { return nil })
+
+	err = g2.RPC(g1.Address(), "FOO", func(conn modules.PeerConn) error {
+		return nil
+	})
 
 	select {
 	case err = <-errChan:

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -77,9 +77,6 @@ func (g *Gateway) threadedLearnHostname() {
 	g.mu.Unlock()
 
 	g.log.Println("INFO: our address is", g.myAddr)
-
-	// now that we know our address, we can start advertising it
-	g.RegisterConnectCall("RelayNode", g.sendAddress)
 }
 
 // threadedForwardPort adds a port mapping to the router.

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -38,10 +38,15 @@ func myExternalIP() (string, error) {
 	return string(buf[:n-1]), nil
 }
 
-// learnHostname discovers the external IP of the Gateway. Once the IP has
-// been discovered, it registers the ShareNodes RPC to be called on new
+// threadedLearnHostname discovers the external IP of the Gateway. Once the IP
+// has been discovered, it registers the ShareNodes RPC to be called on new
 // connections, advertising the IP to other nodes.
-func (g *Gateway) learnHostname(port string) {
+func (g *Gateway) threadedLearnHostname() {
+	if err := g.threads.Add(); err != nil {
+		return
+	}
+	defer g.threads.Done()
+
 	if build.Release == "testing" {
 		return
 	}
@@ -61,7 +66,7 @@ func (g *Gateway) learnHostname(port string) {
 		return
 	}
 
-	addr := modules.NetAddress(net.JoinHostPort(host, port))
+	addr := modules.NetAddress(net.JoinHostPort(host, g.port))
 	if err := addr.IsValid(); err != nil {
 		g.log.Printf("WARN: discovered hostname %q is invalid: %v", addr, err)
 		return
@@ -77,26 +82,31 @@ func (g *Gateway) learnHostname(port string) {
 	g.RegisterConnectCall("RelayNode", g.sendAddress)
 }
 
-// forwardPort adds a port mapping to the router.
-func (g *Gateway) forwardPort(port string) {
+// threadedForwardPort adds a port mapping to the router.
+func (g *Gateway) threadedForwardPort() {
+	if err := g.threads.Add(); err != nil {
+		return
+	}
+	defer g.threads.Done()
+
 	if build.Release == "testing" {
 		return
 	}
 
 	d, err := upnp.Discover()
 	if err != nil {
-		g.log.Printf("WARN: could not automatically forward port %s: no UPnP-enabled devices found", port)
+		g.log.Printf("WARN: could not automatically forward port %s: no UPnP-enabled devices found", g.port)
 		return
 	}
 
-	portInt, _ := strconv.Atoi(port)
+	portInt, _ := strconv.Atoi(g.port)
 	err = d.Forward(uint16(portInt), "Sia RPC")
 	if err != nil {
-		g.log.Printf("WARN: could not automatically forward port %s: %v", port, err)
+		g.log.Printf("WARN: could not automatically forward port %s: %v", g.port, err)
 		return
 	}
 
-	g.log.Println("INFO: successfully forwarded port", port)
+	g.log.Println("INFO: successfully forwarded port", g.port)
 }
 
 // clearPort removes a port mapping from the router.

--- a/modules/netaddress.go
+++ b/modules/netaddress.go
@@ -9,6 +9,12 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
+// MaxEncodedNetAddressLength is the maximum length of a NetAddress encoded
+// with the encode package. 266 was chosen because the maximum length for the
+// hostname is 254 + 1 for the separating colon + 5 for the port + 8 byte
+// string length prefix.
+const MaxEncodedNetAddressLength = 266
+
 // A NetAddress contains the information needed to contact a peer.
 type NetAddress string
 


### PR DESCRIPTION
The gateway now shares a port that you can dial it back on when it connects to you. Consequently, inbound peers are now identified by this dialback port instead of `conn.RemoteAddr()`. Therefore `conn.RemoteAddr()` should no longer be used to call an RPC from within an RPC.