### PR TITLE
Implement Close methods for tpoolTester and hostTester; close miner in consensusSetTester.Close()

### DIFF
--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -160,12 +160,12 @@ func createConsensusSetTester(name string) (*consensusSetTester, error) {
 // to errcheck when deferring a close, a panic is called in the event of an
 // error.
 func (cst *consensusSetTester) Close() error {
-	err := cst.cs.Close()
-	if err != nil {
-		panic(err)
+	errs := []error{
+		cst.cs.Close(),
+		cst.gateway.Close(),
+		cst.miner.Close(),
 	}
-	err = cst.gateway.Close()
-	if err != nil {
+	if err := build.JoinErrors(errs, "; "); err != nil {
 		panic(err)
 	}
 	return nil

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -104,6 +104,7 @@ func TestHostAnnounceAddress(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Create an announcement finder to scan the blockchain for host
 	// announcements.

--- a/modules/host/host_errors_test.go
+++ b/modules/host/host_errors_test.go
@@ -124,6 +124,7 @@ func TestHostFailedLoadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 	err = ht.host.Close()
 	if err != nil {
 		t.Fatal(err)
@@ -155,6 +156,7 @@ func TestHostFailedListen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 	err = ht.host.Close()
 	if err != nil {
 		t.Fatal(err)

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -199,6 +199,21 @@ func newHostTester(name string) (*hostTester, error) {
 	return ht, nil
 }
 
+// Close safely closes the hostTester. It panics if err != nil because there
+// isn't a good way to errcheck when deferring a close.
+func (ht *hostTester) Close() error {
+	errs := []error{
+		ht.cs.Close(),
+		ht.gateway.Close(),
+		ht.tpool.Close(),
+		ht.miner.Close(),
+	}
+	if err := build.JoinErrors(errs, "; "); err != nil {
+		panic(err)
+	}
+	return nil
+}
+
 // TestHostInitialization checks that the host initializes to sensible default
 // values.
 func TestHostInitialization(t *testing.T) {

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -226,6 +226,7 @@ func TestHostInitialization(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer bht.Close()
 	if bht.host.blockHeight != 0 {
 		t.Error("host initialized to the wrong block height")
 	}
@@ -256,6 +257,7 @@ func TestHostMultiClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	err = ht.host.Close()
 	if err != nil {
@@ -281,6 +283,7 @@ func TestNilValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	hostDir := filepath.Join(ht.persistDir, modules.HostDir)
 	_, err = New(nil, ht.tpool, ht.wallet, "localhost:0", hostDir)
@@ -309,6 +312,7 @@ func TestSetAndGetInternalSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Check the default settings get returned at first call.
 	settings := ht.host.InternalSettings()
@@ -407,6 +411,7 @@ func TestSetAndGetSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Check the default settings get returned at first call.
 	settings := ht.host.Settings()
@@ -484,6 +489,7 @@ func TestPersistentSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Submit updated settings.
 	settings := ht.host.Settings()

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -18,6 +18,7 @@ func TestRPCMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Upload a test file to get some metrics to increment.
 	_, err = ht.uploadFile("TestRPCMetrics - 1", renewDisabled)

--- a/modules/host/persist_compat_1.0.0_test.go
+++ b/modules/host/persist_compat_1.0.0_test.go
@@ -24,6 +24,7 @@ func TestHostPersistCompat100(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Close the host and then swap out the persist file for the one that is
 	// being used for testing.

--- a/modules/host/persist_test.go
+++ b/modules/host/persist_test.go
@@ -18,6 +18,7 @@ func TestEarlySaving(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Store a few of the important fields.
 	var oldSK crypto.SecretKey
@@ -58,6 +59,7 @@ func TestIntegrationValuePersistence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Change one of the features of the host persistence and save.
 	ht.host.fileCounter += 1500

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -93,6 +93,7 @@ func TestBlankStorageObligation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// The number of contracts reported by the host should be zero.
 	fm := ht.host.FinancialMetrics()
@@ -189,6 +190,7 @@ func TestSingleSectorStorageObligationStack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Start by adding a storage obligation to the host. To emulate conditions
 	// of a renter creating the first contract, the storage obligation has no
@@ -353,6 +355,7 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Start by adding a storage obligation to the host. To emulate conditions
 	// of a renter creating the first contract, the storage obligation has no
@@ -589,6 +592,7 @@ func TestAutoRevisionSubmission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Start by adding a storage obligation to the host. To emulate conditions
 	// of a renter creating the first contract, the storage obligation has no

--- a/modules/host/update_test.go
+++ b/modules/host/update_test.go
@@ -21,6 +21,7 @@ func TestStorageProof(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// create a file contract
 	fc := types.FileContract{
@@ -113,6 +114,7 @@ func TestInitRescan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Check that the host's persistent variables have incorporated the first
 	// few blocks.
@@ -147,6 +149,7 @@ func TestIntegrationAutoRescan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ht.Close()
 
 	// Check that the host's persistent variables have incorporated the first
 	// few blocks.

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -45,7 +45,7 @@ type CPUMiner interface {
 	StopCPUMining()
 }
 
-// TestMiner provides direct acesss to block fetching, solving, and
+// TestMiner provides direct access to block fetching, solving, and
 // manipulation. The primary use of this interface is integration testing.
 type TestMiner interface {
 	// AddBlock is an extension of FindBlock - AddBlock will submit the block
@@ -56,6 +56,9 @@ type TestMiner interface {
 	// blocks returned by BlockForWork have a unique Merkle root, meaning that
 	// each can safely start from nonce 0.
 	BlockForWork() (types.Block, types.Target, error)
+
+	// Close is necessary for clean shutdown during testing.
+	Close() error
 
 	// FindBlock will have the miner make 1 attempt to find a solved block that
 	// builds on the current consensus set. It will give up after a few

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"errors"
+	"io"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/types"
@@ -66,6 +67,9 @@ type TransactionPool interface {
 	// AcceptTransactionSet accepts a set of potentially interdependent
 	// transactions.
 	AcceptTransactionSet([]types.Transaction) error
+
+	// Close is necessary for clean shutdown (e.g. during testing).
+	Close() error
 
 	// FeeEstimation returns an estimation for how high the transaction fee
 	// needs to be per byte. The minimum recommended targets getting accepted

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -2,7 +2,6 @@ package modules
 
 import (
 	"errors"
-	"io"
 
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/types"

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -16,6 +16,7 @@ func TestIntegrationAcceptTransactionSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Check that the transaction pool is empty.
 	if len(tpt.tpool.transactionSets) != 0 {
@@ -66,6 +67,7 @@ func TestIntegrationConflictingTransactionSets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
@@ -123,6 +125,7 @@ func TestIntegrationCheckMinerFees(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Fill the transaction pool to the fee limit.
 	for i := 0; i < TransactionPoolSizeForFee/10e3; i++ {
@@ -165,6 +168,7 @@ func TestIntegrationTransactionSuperset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
@@ -223,6 +227,7 @@ func TestIntegrationTransactionSubset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
@@ -269,6 +274,7 @@ func TestIntegrationTransactionChild(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
@@ -314,6 +320,7 @@ func TestIntegrationNilAccept(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	err = tpt.tpool.AcceptTransactionSet(nil)
 	if err == nil {
@@ -337,6 +344,7 @@ func TestAcceptFCAndConflictingRevision(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Create and fund a valid file contract.
 	builder := tpt.wallet.StartTransaction()
@@ -392,6 +400,7 @@ func TestPartialConfirmation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Create and fund a valid file contract.
 	builder := tpt.wallet.StartTransaction()
@@ -468,6 +477,7 @@ func TestPartialConfirmationWeave(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Step 1: create an output to the empty address in a tx.
 	// Step 2: create a second output to the empty address in another tx.

--- a/modules/transactionpool/persist_test.go
+++ b/modules/transactionpool/persist_test.go
@@ -15,13 +15,15 @@ import (
 // TestRescan triggers a rescan in the transaction pool, verifying that the
 // rescan code does not cause deadlocks or crashes.
 func TestRescan(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	tpt, err := createTpoolTester("TestRescan")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if testing.Short() {
-		t.SkipNow()
-	}
+	defer tpt.Close()
 
 	// Create a valid transaction set using the wallet.
 	txns, err := tpt.wallet.SendSiacoins(types.NewCurrency64(100), types.UnlockHash{})

--- a/modules/transactionpool/standard_test.go
+++ b/modules/transactionpool/standard_test.go
@@ -19,6 +19,7 @@ func TestIntegrationLargeTransactions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 
 	// Create a large transaction and try to get it accepted.
 	arbData := make([]byte, modules.TransactionSizeLimit)

--- a/modules/transactionpool/subscribe_test.go
+++ b/modules/transactionpool/subscribe_test.go
@@ -32,8 +32,7 @@ func TestSubscription(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// TODO: add tPoolTester.Close() method
-	//	defer tpt.Close()
+	defer tpt.Close()
 
 	// Check the transaction pool is empty when initialized.
 	if len(tpt.tpool.transactionSets) != 0 {

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -105,7 +105,7 @@ func (tpt *tpoolTester) Close() error {
 	if err := build.JoinErrors(errs, "; "); err != nil {
 		panic(err)
 	}
-	return nil	
+	return nil
 }
 
 // TestIntegrationNewNilInputs tries to trigger a panic with nil inputs.

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -67,7 +67,7 @@ func createTpoolTester(name string) (*tpoolTester, error) {
 		return nil, err
 	}
 
-	// Assebmle all of the objects in to a tpoolTester
+	// Assemble all of the objects into a tpoolTester
 	tpt := &tpoolTester{
 		cs:        cs,
 		gateway:   g,
@@ -89,6 +89,23 @@ func createTpoolTester(name string) (*tpoolTester, error) {
 	}
 
 	return tpt, nil
+}
+
+// Close safely closes the tpoolTester, calling a panic in the event of an
+// error since there isn't a good way to errcheck when deferring a Close.
+func (tpt *tpoolTester) Close() error {
+	errs := []error{
+		tpt.cs.Close(),
+		tpt.gateway.Close(),
+		tpt.tpool.Close(),
+		tpt.miner.Close(),
+		// TODO: implement modules.Wallet.Close()
+		// tpt.wallet.Close()
+	}
+	if err := build.JoinErrors(errs, "; "); err != nil {
+		panic(err)
+	}
+	return nil	
 }
 
 // TestIntegrationNewNilInputs tries to trigger a panic with nil inputs.

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -19,6 +19,7 @@ func TestArbDataOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tpt.Close()
 	txn := types.Transaction{
 		ArbitraryData: [][]byte{
 			append(modules.PrefixNonSia[:], []byte("arb-data")...),


### PR DESCRIPTION
Implements `Close()` methods for `tpoolTester` and `hostTester`.  Adds `io.Closer` to the `TestMiner` interface so that `tpoolTester.Close()` and `hostTester.Close()` can close the miner.

These methods are necessary for clean shutdown during testing.  A later pull request will implement `modules.Wallet.Close()`.

Resolves #1209.  