### PR TITLE
hardfork at block 100,000

### DIFF
--- a/crypto/merkle.go
+++ b/crypto/merkle.go
@@ -124,10 +124,12 @@ func MerkleProof(b []byte, proofIndex uint64) (base []byte, hashSet []Hash) {
 
 	// Get the proof and convert it to a base + hash set.
 	_, proof, _, _ := t.Prove()
-	base = proof[0]
-	hashSet = make([]Hash, len(proof)-1)
-	for i, p := range proof[1:] {
-		copy(hashSet[i][:], p)
+	if len(proof) > 0 {
+		base = proof[0]
+		hashSet = make([]Hash, len(proof)-1)
+		for i, p := range proof[1:] {
+			copy(hashSet[i][:], p)
+		}
 	}
 	return base, hashSet
 }

--- a/crypto/merkle.go
+++ b/crypto/merkle.go
@@ -124,12 +124,15 @@ func MerkleProof(b []byte, proofIndex uint64) (base []byte, hashSet []Hash) {
 
 	// Get the proof and convert it to a base + hash set.
 	_, proof, _, _ := t.Prove()
-	if len(proof) > 0 {
-		base = proof[0]
-		hashSet = make([]Hash, len(proof)-1)
-		for i, p := range proof[1:] {
-			copy(hashSet[i][:], p)
-		}
+	if len(proof) == 0 {
+		// There's no proof, because there's no data. Return blank values.
+		return nil, nil
+	}
+
+	base = proof[0]
+	hashSet = make([]Hash, len(proof)-1)
+	for i, p := range proof[1:] {
+		copy(hashSet[i][:], p)
 	}
 	return base, hashSet
 }

--- a/modules/consensus/accept_reorg_test.go
+++ b/modules/consensus/accept_reorg_test.go
@@ -279,7 +279,6 @@ func TestBuriedBadFork(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	cst, err := createConsensusSetTester("TestBuriedBadFork")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/accept_reorg_test.go
+++ b/modules/consensus/accept_reorg_test.go
@@ -163,6 +163,7 @@ func TestIntegrationSimpleReorg(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	rs := createReorgSets("TestIntegrationSimpleReorg")
 	defer rs.Close()
 
@@ -180,6 +181,7 @@ func TestIntegrationSiacoinReorg(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	rs := createReorgSets("TestIntegrationSiacoinReorg")
 	defer rs.Close()
 
@@ -197,6 +199,7 @@ func TestIntegrationValidStorageProofReorg(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	rs := createReorgSets("TestIntegrationValidStorageProofReorg")
 	defer rs.Close()
 
@@ -215,6 +218,7 @@ func TestIntegrationMissedStorageProofReorg(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	rs := createReorgSets("TestIntegrationMissedStorageProofReorg")
 	defer rs.Close()
 
@@ -233,6 +237,7 @@ func TestIntegrationFileContractRevisionReorg(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	rs := createReorgSets("TestIntegrationFileContractRevisionReorg")
 	defer rs.Close()
 
@@ -251,6 +256,7 @@ func TestIntegrationComplexReorg(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	rs := createReorgSets("TestIntegrationComplexReorg")
 	defer rs.Close()
 
@@ -279,6 +285,7 @@ func TestBuriedBadFork(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestBuriedBadFork")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -489,9 +489,9 @@ func TestUnitValidateHeader(t *testing.T) {
 // TestIntegrationDoSBlockHandling checks that saved bad blocks are correctly
 // ignored.
 func TestIntegrationDoSBlockHandling(t *testing.T) {
-	// TestIntegrationDoSBlockHandling catches a wide array of simple errors,
-	// and therefore is included in the short tests despite being somewhat
-	// computationally expensive.
+	if testing.Short() {
+		t.SkipNow()
+	}
 	cst, err := createConsensusSetTester("TestIntegrationDoSBlockHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -973,6 +973,9 @@ func (g *mockGatewayDoesBroadcast) Broadcast(name string, obj interface{}, peers
 // TestAcceptBlockBroadcasts tests that AcceptBlock broadcasts valid blocks and
 // that managedAcceptBlock does not.
 func TestAcceptBlockBroadcasts(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	cst, err := blankConsensusSetTester("TestAcceptBlockBroadcasts")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -492,6 +492,7 @@ func TestIntegrationDoSBlockHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestIntegrationDoSBlockHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -536,6 +537,7 @@ func TestBlockKnownHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestBlockKnownHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -599,6 +601,7 @@ func TestOrphanHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestOrphanHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -624,6 +627,7 @@ func TestMissedTarget(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestMissedTarget")
 	if err != nil {
 		t.Fatal(err)
@@ -653,6 +657,7 @@ func TestMinerPayoutHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestMinerPayoutHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -680,6 +685,7 @@ func TestEarlyTimestampHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestEarlyTimestampHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -709,6 +715,7 @@ func TestFutureTimestampHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestFutureTimestampHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -753,6 +760,7 @@ func TestExtremeFutureTimestampHandling(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestExtremeFutureTimestampHandling")
 	if err != nil {
 		t.Fatal(err)
@@ -778,6 +786,7 @@ func TestBuriedBadTransaction(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestBuriedBadTransaction")
 	if err != nil {
 		t.Fatal(err)
@@ -828,6 +837,7 @@ func TestInconsistentCheck(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestInconsistentCheck")
 	if err != nil {
 		t.Fatal(err)
@@ -858,6 +868,7 @@ func TestTaxHardfork(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestTaxHardfork")
 	if err != nil {
 		t.Fatal(err)
@@ -976,6 +987,7 @@ func TestAcceptBlockBroadcasts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := blankConsensusSetTester("TestAcceptBlockBroadcasts")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/accept_txntypes_test.go
+++ b/modules/consensus/accept_txntypes_test.go
@@ -89,6 +89,7 @@ func TestIntegrationSimpleBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestIntegrationSimpleBlock")
 	if err != nil {
 		t.Fatal(err)
@@ -146,6 +147,7 @@ func TestIntegrationSpendSiacoinsBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestSpendSiacoinsBlock")
 	if err != nil {
 		t.Fatal(err)
@@ -288,6 +290,7 @@ func TestIntegrationValidStorageProofBlocks(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestIntegrationValidStorageProofBlocks")
 	if err != nil {
 		t.Fatal(err)
@@ -392,6 +395,7 @@ func TestIntegrationMissedStorageProofBlocks(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestIntegrationMissedStorageProofBlocks")
 	if err != nil {
 		t.Fatal(err)
@@ -553,6 +557,7 @@ func TestIntegrationFileContractRevision(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestIntegrationFileContractRevision")
 	if err != nil {
 		t.Fatal(err)
@@ -646,6 +651,7 @@ func (cst *consensusSetTester) TestIntegrationSpendSiafunds(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestIntegtrationSpendSiafunds")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/changelog_test.go
+++ b/modules/consensus/changelog_test.go
@@ -14,6 +14,7 @@ func TestIntegrationChangeLog(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	// Get a blank consensus set tester so that the mocked subscriber can join
 	// immediately after genesis.
 	cst, err := blankConsensusSetTester("TestIntegrationChangeLog")

--- a/modules/consensus/consensusdb_helpers_test.go
+++ b/modules/consensus/consensusdb_helpers_test.go
@@ -62,6 +62,18 @@ func (cs *ConsensusSet) dbGetPath(bh types.BlockHeight) (id types.BlockID, err e
 	return id, err
 }
 
+// dbPushPath is a convenience function allowing pushPath to be called without a
+// bolt.Tx.
+func (cs *ConsensusSet) dbPushPath(bid types.BlockID) {
+	dbErr := cs.db.Update(func(tx *bolt.Tx) error {
+		pushPath(tx, bid)
+		return nil
+	})
+	if dbErr != nil {
+		panic(dbErr)
+	}
+}
+
 // dbGetBlockMap is a convenience function allowing getBlockMap to be called
 // without a bolt.Tx.
 func (cs *ConsensusSet) dbGetBlockMap(id types.BlockID) (pb *processedBlock, err error) {

--- a/modules/consensus/consensusdb_helpers_test.go
+++ b/modules/consensus/consensusdb_helpers_test.go
@@ -143,6 +143,18 @@ func (cs *ConsensusSet) dbAddFileContract(id types.FileContractID, fc types.File
 	}
 }
 
+// dbRemoveFileContract is a convenience function allowing removeFileContract
+// to be called without a bolt.Tx.
+func (cs *ConsensusSet) dbRemoveFileContract(id types.FileContractID) {
+	dbErr := cs.db.Update(func(tx *bolt.Tx) error {
+		removeFileContract(tx, id)
+		return nil
+	})
+	if dbErr != nil {
+		panic(dbErr)
+	}
+}
+
 // dbGetSiafundOutput is a convenience function allowing getSiafundOutput to be
 // called without a bolt.Tx.
 func (cs *ConsensusSet) dbGetSiafundOutput(id types.SiafundOutputID) (sfo types.SiafundOutput, err error) {
@@ -220,4 +232,30 @@ func (cs *ConsensusSet) dbStorageProofSegment(fcid types.FileContractID) (index 
 		panic(dbErr)
 	}
 	return index, err
+}
+
+// dbValidStorageProofs is a convenience function allowing 'validStorageProofs'
+// to be called during testing without a tx.
+func (cs *ConsensusSet) dbValidStorageProofs(t types.Transaction) (err error) {
+	dbErr := cs.db.View(func(tx *bolt.Tx) error {
+		err = validStorageProofs(tx, t)
+		return nil
+	})
+	if dbErr != nil {
+		panic(dbErr)
+	}
+	return err
+}
+
+// dbValidFileContractRevisions is a convenience function allowing
+// 'validFileContractRevisions' to be called during testing without a tx.
+func (cs *ConsensusSet) dbValidFileContractRevisions(t types.Transaction) (err error) {
+	dbErr := cs.db.View(func(tx *bolt.Tx) error {
+		err = validFileContractRevisions(tx, t)
+		return nil
+	})
+	if dbErr != nil {
+		panic(dbErr)
+	}
+	return err
 }

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -176,6 +176,7 @@ func TestNilInputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	testdir := build.TempDir(modules.ConsensusDir, "TestNilInputs")
 	_, err := New(nil, testdir)
 	if err != errNilGateway {
@@ -188,6 +189,7 @@ func TestDatabaseClosing(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	testdir := build.TempDir(modules.ConsensusDir, "TestClosing")
 
 	// Create the gateway.

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -173,6 +173,9 @@ func (cst *consensusSetTester) Close() error {
 
 // TestNilInputs tries to create new consensus set modules using nil inputs.
 func TestNilInputs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	testdir := build.TempDir(modules.ConsensusDir, "TestNilInputs")
 	_, err := New(nil, testdir)
 	if err != errNilGateway {
@@ -182,6 +185,9 @@ func TestNilInputs(t *testing.T) {
 
 // TestClosing tries to close a consenuss set.
 func TestDatabaseClosing(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	testdir := build.TempDir(modules.ConsensusDir, "TestClosing")
 
 	// Create the gateway.

--- a/modules/consensus/diffs_test.go
+++ b/modules/consensus/diffs_test.go
@@ -15,6 +15,7 @@ func TestCommitDelayedSiacoinOutputDiffBadMaturity(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestCommitDelayedSiacoinOutputDiffBadMaturity")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/fork_test.go
+++ b/modules/consensus/fork_test.go
@@ -12,6 +12,7 @@ func TestBacktrackToCurrentPath(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestBacktrackToCurrentPath")
 	if err != nil {
 		t.Fatal(err)
@@ -63,6 +64,7 @@ func TestRevertToNode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestRevertToNode")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/persist_test.go
+++ b/modules/consensus/persist_test.go
@@ -15,6 +15,7 @@ func TestSaveLoad(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestSaveLoad")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/processedblock_test.go
+++ b/modules/consensus/processedblock_test.go
@@ -20,6 +20,7 @@ func TestIntegrationMinimumValidChildTimestamp(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	// Create a custom consnesus set to control the blocks.
 	testdir := build.TempDir(modules.ConsensusDir, "TestIntegrationMinimumValidChildTimestamp")

--- a/modules/consensus/subscribe_test.go
+++ b/modules/consensus/subscribe_test.go
@@ -38,8 +38,9 @@ func (ms *mockSubscriber) copySub() (cms mockSubscriber) {
 // using an unrecognized id.
 func TestUnitInvalidConsensusChangeSubscription(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestUnitInvalidConsensusChangeSubscription")
 	if err != nil {
 		t.Fatal(err)
@@ -58,8 +59,9 @@ func TestUnitInvalidConsensusChangeSubscription(t *testing.T) {
 // subscriber if the Unsubscribe call is made.
 func TestUnitUnsubscribe(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestUnitUnsubscribe")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -23,6 +23,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	// Create 8 remote peers.
 	remoteCSTs := make([]*consensusSetTester, 8)
@@ -284,6 +285,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	// Set minIBDWaitTime to 1s for just this test because no blocks are
 	// transferred between peers so the wait time can be very short.

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -731,6 +731,9 @@ func (mockPeerConnFailingWriter) Write([]byte) (int, error) {
 // TestSendBlk probes the ConsensusSet.rpcSendBlk method and tests that it
 // correctly receives block ids and writes out the corresponding blocks.
 func TestSendBlk(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	cst, err := blankConsensusSetTester("TestSendBlk")
 	if err != nil {
 		t.Fatal(err)
@@ -818,6 +821,9 @@ func TestSendBlk(t *testing.T) {
 // receives a block. Also tests that the block is correctly (not) accepted into
 // the consensus set.
 func TestThreadedReceiveBlock(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	cst, err := blankConsensusSetTester("TestThreadedReceiveBlock")
 	if err != nil {
 		t.Fatal(err)
@@ -1038,6 +1044,9 @@ func (g *mockGatewayCallsRPC) RPC(addr modules.NetAddress, name string, fn modul
 // to valid headers with known parents, or requests the block history to orphan
 // headers.
 func TestRelayHeader(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	cst, err := blankConsensusSetTester("TestRelayHeader")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -108,6 +108,7 @@ func TestBlockHistory(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	cst, err := createConsensusSetTester("TestBlockHistory")
 	if err != nil {
@@ -197,6 +198,7 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	// Setup consensus sets.
 	cst1, err := blankConsensusSetTester("TestSendBlocksBroadcastsOnce1")
@@ -313,6 +315,7 @@ func TestIntegrationRPCSendBlocks(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	type sendBlocksTest struct {
 		commonBlocksToMine types.BlockHeight
@@ -525,6 +528,7 @@ func TestRPCSendBlockSendsOnlyNecessaryBlocks(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	// Create the "remote" peer.
 	cst, err := blankConsensusSetTester("TestRPCSendBlockSendsOnlyNecessaryBlocks - remote")
@@ -669,6 +673,7 @@ func TestSendBlk(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := blankConsensusSetTester("TestSendBlk")
 	if err != nil {
 		t.Fatal(err)
@@ -759,6 +764,7 @@ func TestThreadedReceiveBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := blankConsensusSetTester("TestThreadedReceiveBlock")
 	if err != nil {
 		t.Fatal(err)
@@ -879,6 +885,7 @@ func TestIntegrationSendBlkRPC(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst1, err := blankConsensusSetTester("TestIntegrationSendBlkRPC1")
 	if err != nil {
 		t.Fatal(err)
@@ -982,6 +989,7 @@ func TestRelayHeader(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := blankConsensusSetTester("TestRelayHeader")
 	if err != nil {
 		t.Fatal(err)
@@ -1087,6 +1095,7 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	// Setup consensus sets.
 	cst1, err := blankConsensusSetTester("TestIntegrationBroadcastRelayHeader1")
 	if err != nil {
@@ -1147,6 +1156,7 @@ func TestIntegrationRelaySynchronize(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst1, err := blankConsensusSetTester("TestRelaySynchronize1")
 	if err != nil {
 		t.Fatal(err)
@@ -1337,6 +1347,7 @@ func TestThreadedReceiveBlocksStalls(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	cst, err := blankConsensusSetTester("TestThreadedReceiveBlocksStalls")
 	if err != nil {
@@ -1454,6 +1465,7 @@ func TestIntegrationSendBlocksStalls(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	cstLocal, err := blankConsensusSetTester("TestThreadedReceiveBlocksTimesout - local")
 	if err != nil {

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -27,7 +27,7 @@ func TestSynchronize(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	cst1, err := createConsensusSetTester("TestSynchronize1")
 	if err != nil {
 		t.Fatal(err)
@@ -59,15 +59,14 @@ func TestSynchronize(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	// Mine on cst2 until it is more than 'MaxCatchUpBlocks' ahead of cst2.
+	// Mine on cst2 until it is more than 'MaxCatchUpBlocks' ahead of cst1.
 	// NOTE: we have to disconnect prior to this, otherwise cst2 will relay
 	// blocks to cst1.
 	err = cst1.gateway.Disconnect(cst2.gateway.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
-	// TODO: more than 30 causes a race condition!
-	for cst2.cs.dbBlockHeight() < cst1.cs.dbBlockHeight()+20 {
+	for cst2.cs.dbBlockHeight() < cst1.cs.dbBlockHeight()+50 {
 		b, _ := cst2.miner.FindBlock()
 		err = cst2.cs.AcceptBlock(b)
 		if err != nil {
@@ -85,86 +84,22 @@ func TestSynchronize(t *testing.T) {
 		time.Sleep(250 * time.Millisecond)
 	}
 
-	/*
-		// extend cst2 with a "bad" (old) block, and synchronize. cst1 should
-		// reject the bad block.
-		lockID := cst2.cs.mu.Lock()
-		cst2.cs.db.pushPath(cst2.cs.db.getPath(0))
-		cst2.cs.mu.Unlock(lockID)
-		if cst1.cs.db.pathHeight() == cst2.cs.db.pathHeight() {
-			t.Fatal("cst1 did not reject bad block")
-		}
-	*/
-}
-
-func TestResynchronize(t *testing.T) {
-	t.Skip("takes way too long")
-
-	cst1, err := createConsensusSetTester("TestResynchronize1")
+	// extend cst2 with a "bad" (old) block, and synchronize. cst1 should
+	// reject the bad block.
+	cst2.cs.mu.Lock()
+	id, err := cst2.cs.dbGetPath(0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cst1.Close()
-	cst2, err := createConsensusSetTester("TestResynchronize2")
-	if err != nil {
-		t.Fatal(err)
+	cst2.cs.dbPushPath(id)
+	cst2.cs.mu.Unlock()
+
+	// Sleep for a few seconds to allow the network call between the two time
+	// to occur.
+	time.Sleep(2 * time.Second)
+	if cst1.cs.dbBlockHeight() == cst2.cs.dbBlockHeight() {
+		t.Fatal("cst1 did not reject bad block")
 	}
-	defer cst2.Close()
-
-	// TODO: without this extra block, sync fails. Why?
-	b, _ := cst2.miner.FindBlock()
-	err = cst2.cs.AcceptBlock(b)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// connect and disconnect, so that cst1 and cst2 are synchronized
-	err = cst1.gateway.Connect(cst2.gateway.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = cst1.gateway.Disconnect(cst2.gateway.Address())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if cst1.cs.dbCurrentBlockID() != cst2.cs.dbCurrentBlockID() {
-		t.Fatal("Consensus Sets did not synchronize")
-	}
-
-	// mine a block on cst2, but hide it from cst1 during reconnect
-	/*
-		b, _ = cst2.miner.FindBlock()
-		err = cst2.cs.AcceptBlock(b)
-		if err != nil {
-			t.Fatal(err)
-		}
-		lockID := cst2.cs.mu.Lock()
-		id := cst2.cs.currentBlockID()
-		err = cst2.cs.db.popPath()
-		if err != nil {
-			t.Fatal(err)
-		}
-		cst2.cs.mu.Unlock(lockID)
-
-		err = cst1.gateway.Connect(cst2.gateway.Address())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// add id back to cst2's current path
-		lockID = cst2.cs.mu.Lock()
-		err = cst2.cs.db.pushPath(id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		cst2.cs.mu.Unlock(lockID)
-
-		// cst1 should not have the block
-		if cst1.cs.dbBlockHeight() == cst2.cs.dbBlockHeight() {
-			t.Fatal("Consensus Sets should not have the same height")
-		}
-	*/
 }
 
 // TestBlockHistory tests that blockHistory returns the expected sequence of

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -98,9 +98,75 @@ func storageProofSegment(tx *bolt.Tx, fcid types.FileContractID) (uint64, error)
 	return index, nil
 }
 
+// validStorageProofsPre100e3 runs the code that was running before height
+// 100e3, which contains a hardforking bug, fixed at block 100e3.
+//
+// HARDFORK 100,000
+//
+// Originally, it was impossible to provide a storage proof for data of length
+// zero. A hardfork was added triggering at block 100,000 to enable an
+// optimization where hosts could submit empty storage proofs for files of size
+// 0, saving space on the blockchain in conditions where the renter is content.
+func validStorageProofs100e3(tx *bolt.Tx, t types.Transaction) error {
+	for _, sp := range t.StorageProofs {
+		// Check that the storage proof itself is valid.
+		segmentIndex, err := storageProofSegment(tx, sp.ParentID)
+		if err != nil {
+			return err
+		}
+
+		fc, err := getFileContract(tx, sp.ParentID)
+		if err != nil {
+			return err
+		}
+		leaves := crypto.CalculateLeaves(fc.FileSize)
+		segmentLen := uint64(crypto.SegmentSize)
+		if segmentIndex == leaves-1 {
+			segmentLen = fc.FileSize % crypto.SegmentSize
+		}
+
+		// HARDFORK 21,000
+		//
+		// Originally, the code used the entire segment to verify the
+		// correctness of the storage proof. This made the code incompatible
+		// with data sizes that did not fill an entire segment.
+		//
+		// This was patched with a hardfork in block 21,000. The new code made
+		// it possible to perform successful storage proofs on the final
+		// segment of a file if the final segment was not crypto.SegmentSize
+		// bytes.
+		//
+		// Unfortunately, a new bug was introduced where storage proofs on the
+		// final segment would fail if the final segment was selected and was
+		// crypto.SegmentSize bytes, because the segmentLen would be set to 0
+		// instead of crypto.SegmentSize, due to an error with the modulus
+		// math. This new error has been fixed with the block 100,000 hardfork.
+		if (build.Release == "standard" && blockHeight(tx) < 21e3) || (build.Release == "testing" && blockHeight(tx) < 10) {
+			segmentLen = uint64(crypto.SegmentSize)
+		}
+
+		verified := crypto.VerifySegment(
+			sp.Segment[:segmentLen],
+			sp.HashSet,
+			leaves,
+			segmentIndex,
+			fc.FileMerkleRoot,
+		)
+		if !verified {
+			return errInvalidStorageProof
+		}
+	}
+
+	return nil
+}
+
 // validStorageProofs checks that the storage proofs are valid in the context
 // of the consensus set.
 func validStorageProofs(tx *bolt.Tx, t types.Transaction) error {
+	if (build.Release == "standard" && blockHeight(tx) < 100e3) || (build.Release == "testing" && blockHeight(tx) < 10) {
+		return validStorageProofs100e3(tx, t)
+	}
+
 	for _, sp := range t.StorageProofs {
 		// Check that the storage proof itself is valid.
 		segmentIndex, err := storageProofSegment(tx, sp.ParentID)
@@ -124,33 +190,6 @@ func validStorageProofs(tx *bolt.Tx, t types.Transaction) error {
 			segmentLen = uint64(crypto.SegmentSize)
 		}
 
-		// HARDFORK 21,000
-		//
-		// Originally, the code used the entire segment to verify the
-		// correctness of the storage proof. This made the code incompatible
-		// with data sizes that did not fill an entire segment.
-		//
-		// This was patched with a hardfork in block 21,000. The new code made
-		// it possible to perform successful storage proofs on the final
-		// segment of a file if the final segment was not crypto.SegmentSize
-		// bytes.
-		//
-		// Unfortunately, a new bug was introduced where storage proofs on the
-		// final segment would fail if the final segment was selected and was
-		// crypto.SegmentSize bytes, because the segmentLen would be set to 0
-		// instead of crypto.SegmentSize, due to an error with the modulus
-		// math. This new error has been fixed with the block 100,000 hardfork.
-		if (build.Release == "standard" && blockHeight(tx) < 21e3) || (build.Release == "testing" && blockHeight(tx) < 10) {
-			segmentLen = uint64(crypto.SegmentSize)
-		}
-		// HARDFORK 100,000
-		if (build.Release == "standard" && blockHeight(tx) < 100e3) || (build.Release == "testing" && blockHeight(tx) < 10) {
-			segmentLen = uint64(crypto.SegmentSize)
-			if segmentIndex == leaves-1 {
-				segmentLen = fc.FileSize % crypto.SegmentSize
-			}
-		}
-
 		verified := crypto.VerifySegment(
 			sp.Segment[:segmentLen],
 			sp.HashSet,
@@ -160,19 +199,6 @@ func validStorageProofs(tx *bolt.Tx, t types.Transaction) error {
 		)
 		if !verified && fc.FileSize > 0 {
 			return errInvalidStorageProof
-		}
-
-		// HARDFORK 100,000
-		//
-		// Originally, it was impossible to provide a storage proof for data of
-		// length zero. A hardfork was added triggering at block 100,000 to
-		// enable an optimization where hosts could submit empty storage proofs
-		// for files of size 0, saving space on the blockchain in conditions
-		// where the renter is content.
-		if (build.Release == "standard" && blockHeight(tx) < 100e3) || (build.Release == "testing" && blockHeight(tx) < 10) {
-			if !verified {
-				return errInvalidStorageProof
-			}
 		}
 	}
 

--- a/modules/consensus/validtransaction_test.go
+++ b/modules/consensus/validtransaction_test.go
@@ -417,6 +417,9 @@ func TestStorageProofSegment(t *testing.T) {
 // TestStorageProofSegmentRandomness checks that the storageProofSegment method
 // is producing outputs that pass an imperfect randomness check (gzip).
 func TestStorageProofSegmentRandomness(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	cst, err := createConsensusSetTester("TestStorageProofSegmentRandomness")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/validtransaction_test.go
+++ b/modules/consensus/validtransaction_test.go
@@ -1,8 +1,6 @@
 package consensus
 
 import (
-	"bytes"
-	"compress/gzip"
 	"crypto/rand"
 	"testing"
 
@@ -18,6 +16,7 @@ func TestTryValidTransactionSet(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestTryValidTransactionSet")
 	if err != nil {
 		t.Fatal(err)
@@ -49,6 +48,7 @@ func TestTryInvalidTransactionSet(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestTryInvalidTransactionSet")
 	if err != nil {
 		t.Fatal(err)
@@ -85,6 +85,7 @@ func TestStorageProofBoundaries(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestStorageProofBoundaries")
 	if err != nil {
 		t.Fatal(err)
@@ -213,7 +214,8 @@ func TestEmptyStorageProof(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestStorageProofBoundaries")
+	t.Parallel()
+	cst, err := createConsensusSetTester("TestEmptyStorageProof")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,6 +327,7 @@ func TestValidSiacoins(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestValidSiacoins")
 	if err != nil {
 		t.Fatal(err)
@@ -391,6 +394,7 @@ func TestStorageProofSegment(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestStorageProofSegment")
 	if err != nil {
 		t.Fatal(err)
@@ -414,59 +418,13 @@ func TestStorageProofSegment(t *testing.T) {
 	}
 }
 
-// TestStorageProofSegmentRandomness checks that the storageProofSegment method
-// is producing outputs that pass an imperfect randomness check (gzip).
-func TestStorageProofSegmentRandomness(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	cst, err := createConsensusSetTester("TestStorageProofSegmentRandomness")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cst.Close()
-
-	// Add a file contract to the consensus set that can be used to probe the
-	// storage segment.
-	var outputs []byte
-	for i := 0; i < 20e3; i++ {
-		var fcid types.FileContractID
-		rand.Read(fcid[:])
-		fc := types.FileContract{
-			Payout:      types.NewCurrency64(1),
-			FileSize:    256 * 64,
-			WindowStart: 2,
-		}
-		cst.cs.dbAddFileContract(fcid, fc)
-		if err != nil {
-			t.Fatal(err)
-		}
-		index, err := cst.cs.dbStorageProofSegment(fcid)
-		if err != nil {
-			t.Error(err)
-		}
-		outputs = append(outputs, byte(index))
-	}
-
-	// Perform entropy testing on 'outputs' to verify randomness.
-	var b bytes.Buffer
-	zip := gzip.NewWriter(&b)
-	_, err = zip.Write(outputs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	zip.Close()
-	if b.Len() < len(outputs) {
-		t.Error("supposedly high entropy random segments have been compressed!")
-	}
-}
-
 // TestValidStorageProofs probes the validStorageProofs method of the consensus
 // set.
 func TestValidStorageProofs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestValidStorageProofs")
 	if err != nil {
 		t.Fatal(err)
@@ -591,6 +549,7 @@ func TestPreForkValidStorageProofs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestPreForkValidStorageProofs")
 	if err != nil {
 		t.Fatal(err)
@@ -647,6 +606,7 @@ func TestValidFileContractRevisions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	cst, err := createConsensusSetTester("TestValidFileContractRevisions")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The verify storage proof code is incorrect, missing the case where the
final segment was the correct length. This can be corrected with a
hardfork that has been scheduled for block 100,000.

We may want to consider anything else that might be on the hardfork wishlist since we're doing another hardfork.

All v1.0.0+ versions will have the hardfork code, seems reasonable to me.