### PR TITLE
Improve 'ActiveHosts' behavior

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -242,8 +242,28 @@ func (srv *Server) renterUploadHandler(w http.ResponseWriter, req *http.Request,
 // renterHostsActiveHandler handes the API call asking for the list of active
 // hosts.
 func (srv *Server) renterHostsActiveHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	var numHosts uint64
+	hosts := srv.renter.ActiveHosts()
+
+	if req.FormValue("numhosts") == "" {
+		// Default value for 'numhosts' is all of them.
+		numHosts = uint64(len(hosts))
+	} else {
+		// Parse the value for 'numhosts'.
+		_, err := fmt.Sscan(req.FormValue("numhosts"), &numHosts)
+		if err != nil {
+			writeError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Catch any boundary errors.
+		if numHosts > uint64(len(hosts)) {
+			numHosts = uint64(len(hosts))
+		}
+	}
+
 	writeJSON(w, ActiveHosts{
-		Hosts: srv.renter.ActiveHosts(),
+		Hosts: hosts[:numHosts],
 	})
 }
 

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -119,3 +119,92 @@ func TestRenterConflicts(t *testing.T) {
 		t.Fatal("expecting conflict error, got nil")
 	}
 }
+
+// TestRenterHostsActiveHandler checks the behavior of the call to
+// /renter/hosts/active.
+func TestRenterHostsActiveHandler(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestRenterHostsActiveHandler")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Try the call with with numhosts unset, and set to -1, 0, and 1.
+	var ah ActiveHosts
+	err = st.getAPI("/renter/hosts/active", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 0 {
+		t.Fatal(len(ah.Hosts))
+	}
+	err = st.getAPI("/renter/hosts/active?numhosts=-1", &ah)
+	if err == nil {
+		t.Fatal("expecting an error, got:", err)
+	}
+	err = st.getAPI("/renter/hosts/active?numhosts=0", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 0 {
+		t.Fatal(len(ah.Hosts))
+	}
+	err = st.getAPI("/renter/hosts/active?numhosts=1", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 0 {
+		t.Fatal(len(ah.Hosts))
+	}
+
+	// announce the host and start accepting contracts
+	err = st.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.acceptContracts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.setHostStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try the call with with numhosts unset, and set to -1, 0, 1, and 2.
+	err = st.getAPI("/renter/hosts/active", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatal(len(ah.Hosts))
+	}
+	err = st.getAPI("/renter/hosts/active?numhosts=-1", &ah)
+	if err == nil {
+		t.Fatal("expecting an error, got:", err)
+	}
+	err = st.getAPI("/renter/hosts/active?numhosts=0", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 0 {
+		t.Fatal(len(ah.Hosts))
+	}
+	err = st.getAPI("/renter/hosts/active?numhosts=1", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatal(len(ah.Hosts))
+	}
+	err = st.getAPI("/renter/hosts/active?numhosts=2", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatal(len(ah.Hosts))
+	}
+}

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -96,7 +96,7 @@ func TestIntegrationHostAndRent(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	if len(rf.Files) != 2 || rf.Files[0].UploadProgress < 10 || rf.Files[1].UploadProgress < 10 {
-		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
+		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0], rf.Files[1])
 	}
 
 	// Try downloading the second file.

--- a/doc/API.md
+++ b/doc/API.md
@@ -819,9 +819,15 @@ Response: standard.
 
 #### /renter/hosts/active [GET]
 
-Function: Lists all of the active hosts known to the renter.
+Function: Lists all of the active hosts known to the renter, sorted by
+preference.
 
-Parameters: none
+Parameters:
+```
+numhosts uint64 // Optional
+```
+'numhosts' is the maximum number of hosts that should be returned by the active
+hosts call.
 
 Response:
 ```

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -126,8 +126,8 @@ type Renter interface {
 	// Allowance returns the current allowance.
 	Allowance() Allowance
 
-	// ActiveHosts returns the list of hosts that are actively being selected
-	// from.
+	// ActiveHosts provides the list of hosts that the renter is selecting,
+	// sorted by preference.
 	ActiveHosts() []HostDBEntry
 
 	// AllHosts returns the full list of hosts known to the renter.
@@ -162,7 +162,7 @@ type Renter interface {
 	// renter.
 	LoadSharedFilesAscii(asciiSia string) ([]string, error)
 
-	// Rename changes the path of a file.
+	// RenameFile changes the path of a file.
 	RenameFile(path, newPath string) error
 
 	// SetAllowance sets the amount of money the Renter is allowed to spend on

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -73,15 +73,15 @@ func (hdb *HostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, bool) {
 }
 
 // ActiveHosts returns the hosts that can be randomly selected out of the
-// hostdb.
+// hostdb, sorted by preference.
 func (hdb *HostDB) ActiveHosts() (activeHosts []modules.HostDBEntry) {
 	hdb.mu.RLock()
-	defer hdb.mu.RUnlock()
+	numHosts := len(hdb.activeHosts)
+	hdb.mu.RUnlock()
 
-	for _, node := range hdb.activeHosts {
-		activeHosts = append(activeHosts, node.hostEntry.HostDBEntry)
-	}
-	return
+	// Get the hosts using RandomHosts so that they are in sorted order.
+	sortedHosts := hdb.RandomHosts(numHosts, nil)
+	return sortedHosts
 }
 
 // AllHosts returns all of the hosts known to the hostdb, including the

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -53,9 +53,8 @@ func TestActiveHosts(t *testing.T) {
 	// with one host
 	h1 := new(hostEntry)
 	h1.NetAddress = "foo"
-	hdb.activeHosts = map[modules.NetAddress]*hostNode{
-		h1.NetAddress: {hostEntry: h1},
-	}
+	h1.Weight = types.NewCurrency64(1)
+	hdb.insertNode(h1)
 	if hosts := hdb.ActiveHosts(); len(hosts) != 1 {
 		t.Errorf("wrong number of hosts: expected %v, got %v", 1, len(hosts))
 	} else if hosts[0].NetAddress != h1.NetAddress {
@@ -65,10 +64,8 @@ func TestActiveHosts(t *testing.T) {
 	// with multiple hosts
 	h2 := new(hostEntry)
 	h2.NetAddress = "bar"
-	hdb.activeHosts = map[modules.NetAddress]*hostNode{
-		h1.NetAddress: {hostEntry: h1},
-		h2.NetAddress: {hostEntry: h2},
-	}
+	h2.Weight = types.NewCurrency64(1)
+	hdb.insertNode(h2)
 	if hosts := hdb.ActiveHosts(); len(hosts) != 2 {
 		t.Errorf("wrong number of hosts: expected %v, got %v", 2, len(hosts))
 	} else if hosts[0].NetAddress != h1.NetAddress && hosts[1].NetAddress != h1.NetAddress {

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -16,7 +16,8 @@ type hostDB interface {
 	// from.
 	ActiveHosts() []modules.HostDBEntry
 
-	// AllHosts returns the full list of hosts known to the hostdb.
+	// AllHosts returns the full list of hosts known to the hostdb, sorted in
+	// order of preference.
 	AllHosts() []modules.HostDBEntry
 
 	// AveragePrice returns the average price of a host.


### PR DESCRIPTION
First, I changed it so that 'ActiveHosts' sorts the hosts by preference. As we add more preferences like geography and reliability, the UI doesn't need to worry about price estimation as much.

Second, I extended the `/renter/hosts/active` call to support limiting the number of hosts returned to 'numhosts'. This field is optional, and has testing.

I think, in another PR, we should add a field that just gives a price estimate, instead of having the UI do the price estimate. The renter knows a lot better what it's behavior is going to be.