### PR TITLE
encapsulate Allowance in RenterSettings

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -145,9 +145,8 @@ func (srv *Server) initAPI(password string) {
 
 	// Renter API Calls
 	if srv.renter != nil {
-		router.GET("/renter", srv.renterHandler)
-		router.GET("/renter/allowance", srv.renterAllowanceHandlerGET)
-		router.POST("/renter/allowance", requirePassword(srv.renterAllowanceHandlerPOST, password))
+		router.GET("/renter", srv.renterHandlerGET)
+		router.POST("/renter", requirePassword(srv.renterHandlerPOST, password))
 		router.GET("/renter/contracts", srv.renterContractsHandler)
 		router.GET("/renter/downloads", srv.renterDownloadsHandler)
 		router.GET("/renter/files", srv.renterFilesHandler)

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -48,7 +48,7 @@ func TestIntegrationHostAndRent(t *testing.T) {
 	allowanceValues := url.Values{}
 	allowanceValues.Set("funds", "10000000000000000000000000000") // 10k SC
 	allowanceValues.Set("period", "5")
-	err = st.stdPostAPI("/renter/allowance", allowanceValues)
+	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -74,6 +74,11 @@ type Allowance struct {
 	RenewWindow types.BlockHeight `json:"renewwindow"`
 }
 
+// RenterSettings control the behavior of the Renter.
+type RenterSettings struct {
+	Allowance Allowance `json:"allowance"`
+}
+
 // RenterFinancialMetrics contains metrics about how much the Renter has
 // spent on storage, uploads, and downloads.
 type RenterFinancialMetrics struct {
@@ -123,9 +128,6 @@ func (rc *RenterContract) RenterFunds() types.Currency {
 // A Renter uploads, tracks, repairs, and downloads a set of files for the
 // user.
 type Renter interface {
-	// Allowance returns the current allowance.
-	Allowance() Allowance
-
 	// ActiveHosts provides the list of hosts that the renter is selecting,
 	// sorted by preference.
 	ActiveHosts() []HostDBEntry
@@ -165,11 +167,11 @@ type Renter interface {
 	// RenameFile changes the path of a file.
 	RenameFile(path, newPath string) error
 
-	// SetAllowance sets the amount of money the Renter is allowed to spend on
-	// contracts over a given time period, divided among the number of hosts
-	// specified. Note that Renter can start forming contracts as soon as
-	// SetAllowance is called; that is, it may block.
-	SetAllowance(Allowance) error
+	// Settings returns the Renter's current settings.
+	Settings() RenterSettings
+
+	// SetSettings sets the Renter's settings.
+	SetSettings(RenterSettings) error
 
 	// ShareFiles creates a '.sia' file that can be shared with others.
 	ShareFiles(paths []string, shareDest string) error

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -132,11 +132,17 @@ func (r *Renter) ActiveHosts() []modules.HostDBEntry { return r.hostDB.ActiveHos
 func (r *Renter) AllHosts() []modules.HostDBEntry    { return r.hostDB.AllHosts() }
 
 // contractor passthroughs
-func (r *Renter) Allowance() modules.Allowance           { return r.hostContractor.Allowance() }
-func (r *Renter) Contracts() []modules.RenterContract    { return r.hostContractor.Contracts() }
-func (r *Renter) SetAllowance(a modules.Allowance) error { return r.hostContractor.SetAllowance(a) }
+func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
 func (r *Renter) FinancialMetrics() modules.RenterFinancialMetrics {
 	return r.hostContractor.FinancialMetrics()
+}
+func (r *Renter) Settings() modules.RenterSettings {
+	return modules.RenterSettings{
+		Allowance: r.hostContractor.Allowance(),
+	}
+}
+func (r *Renter) SetSettings(s modules.RenterSettings) error {
+	return r.hostContractor.SetAllowance(s.Allowance)
 }
 
 // enforce that Renter satisfies the modules.Renter interface

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -243,11 +243,12 @@ func renterdownloadscmd() {
 
 // renterallowancecmd displays the current allowance.
 func renterallowancecmd() {
-	var allowance modules.Allowance
-	err := getAPI("/renter/allowance", &allowance)
+	var rg api.RenterGET
+	err := getAPI("/renter", &rg)
 	if err != nil {
 		die("Could not get allowance:", err)
 	}
+	allowance := rg.Settings.Allowance
 
 	// convert to SC
 	fmt.Printf(`Allowance:
@@ -266,7 +267,7 @@ func rentersetallowancecmd(amount, period string) {
 	if err != nil {
 		die("Could not parse period")
 	}
-	err = post("/renter/allowance", fmt.Sprintf("funds=%s&period=%s", hastings, blocks))
+	err = post("/renter", fmt.Sprintf("funds=%s&period=%s", hastings, blocks))
 	if err != nil {
 		die("Could not set allowance:", err)
 	}


### PR DESCRIPTION
The renter is now structured similarly to the host; the `/renter/allowance` endpoints have been merged with `/renter`, and the backend has been updated accordingly.

There is one discrepancy that warrants consideration: Whereas the host has an `announce` endpoint that "activates" the settings, the renter has no such corresponding call. This means that the renter will attempt to start forming contracts even if you only set `funds` or `period` (i.e., not both). Clearly this doesn't make much sense, so the current behavior of `/renter` is to only allow calls that specify both parameters. Similarly, siac still uses `renter allowance` instead of `renter config`, because the former forces you to provide both parameters.
Bottom line: we may want to consider adding an endpoint that instructs the renter to put the settings into effect.

Later I would like to tweak the renter internals such that `SetSettings` merely informs the contractor of the new allowance, instead of commanding it to form/renew contracts. One downside of this is that contract formation errors won't be immediately returned by the `SetSettings` call; they will need to be bubbled up in some other fashion. However, this is already the case for automatically scheduled renewals, so clearly we need a better approach anyway.