### PR TITLE
API standard success & error responses

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -28,6 +28,12 @@ type APIError struct {
 	// be valid or invalid depending on the current state of a module.
 }
 
+// Error implements the error interface for APIError. It returns only the
+// Message field.
+func (err APIError) Error() string {
+	return err.Message
+}
+
 // HttpGET is a utility function for making http get requests to sia with a
 // whitelisted user-agent. A non-2xx response does not return an error.
 func HttpGET(url string) (resp *http.Response, err error) {

--- a/api/api.go
+++ b/api/api.go
@@ -8,10 +8,10 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-// APIError is a type that is encoded as JSON and returned in an API response
-// in the event of an error. Only the Message field is required. More fields
-// may be added to this struct in the future for better error reporting.
-type APIError struct {
+// Error is a type that is encoded as JSON and returned in an API response in
+// the event of an error. Only the Message field is required. More fields may
+// be added to this struct in the future for better error reporting.
+type Error struct {
 	// Message describes the error in English. Typically it is set to
 	// `err.Error()`. This field is required.
 	Message string `json:"message"`
@@ -28,9 +28,9 @@ type APIError struct {
 	// be valid or invalid depending on the current state of a module.
 }
 
-// Error implements the error interface for APIError. It returns only the
+// Error implements the error interface for the Error type. It returns only the
 // Message field.
-func (err APIError) Error() string {
+func (err Error) Error() string {
 	return err.Message
 }
 
@@ -89,7 +89,7 @@ func HttpPOSTAuthenticated(url string, data string, password string) (resp *http
 func requireUserAgent(h http.Handler, ua string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if !strings.Contains(req.UserAgent(), ua) {
-			writeError(w, APIError{"Browser access disabled due to security vulnerability. Use Sia-UI or siac."}, http.StatusBadRequest)
+			writeError(w, Error{"Browser access disabled due to security vulnerability. Use Sia-UI or siac."}, http.StatusBadRequest)
 			return
 		}
 		h.ServeHTTP(w, req)
@@ -108,7 +108,7 @@ func requirePassword(h httprouter.Handle, password string) httprouter.Handle {
 		_, pass, ok := req.BasicAuth()
 		if !ok || pass != password {
 			w.Header().Set("WWW-Authenticate", "Basic realm=\"SiaAPI\"")
-			writeError(w, APIError{"API authentication failed."}, http.StatusUnauthorized)
+			writeError(w, Error{"API authentication failed."}, http.StatusUnauthorized)
 			return
 		}
 		h(w, req, ps)
@@ -231,7 +231,7 @@ func (srv *Server) unrecognizedCallHandler(w http.ResponseWriter, req *http.Requ
 }
 
 // writeError an error to the API caller.
-func writeError(w http.ResponseWriter, err APIError, code int) {
+func writeError(w http.ResponseWriter, err Error, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 	if json.NewEncoder(w).Encode(err) != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -219,8 +219,9 @@ func writeJSON(w http.ResponseWriter, obj interface{}) {
 	}
 }
 
-// writeSuccess writes the success json object ({"Success":true}) to the
-// ResponseWriter
+// writeSuccess writes the HTTP header with status 204 No Content to the
+// ResponseWriter. writeSuccess should only be used to indicate that the
+// requested action succeeded AND there is no data to return.
 func writeSuccess(w http.ResponseWriter) {
-	writeJSON(w, struct{ Success bool }{true})
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"testing"
-	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 )
@@ -25,6 +24,8 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+/*
+// TODO: enable this test again once proper daemon shutdown is implemented (shutting down modules and listener separately).
 // TestStop tests the /daemon/stop handler.
 func TestStop(t *testing.T) {
 	if testing.Short() {
@@ -47,3 +48,4 @@ func TestStop(t *testing.T) {
 		t.Fatal("after /daemon/stop, subsequent calls should fail")
 	}
 }
+*/

--- a/api/explorer.go
+++ b/api/explorer.go
@@ -202,14 +202,14 @@ func (srv *Server) explorerBlocksHandler(w http.ResponseWriter, req *http.Reques
 	var height types.BlockHeight
 	_, err := fmt.Sscan(ps.ByName("height"), &height)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	// Fetch and return the explorer block.
 	block, exists := srv.cs.BlockAtHeight(height)
 	if !exists {
-		writeError(w, "no block found at input height in call to /explorer/block", http.StatusBadRequest)
+		writeError(w, APIError{"no block found at input height in call to /explorer/block"}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, ExplorerBlockGET{
@@ -251,7 +251,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 	// not they have a checksum.
 	hash, err := scanAddress(ps.ByName("hash"))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -320,7 +320,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 	// TODO: lookups on the zero hash are too expensive to allow. Need a
 	// better way to handle this case.
 	if hash == (types.UnlockHash{}) {
-		writeError(w, "can't lookup the empty unlock hash", http.StatusBadRequest)
+		writeError(w, APIError{"can't lookup the empty unlock hash"}, http.StatusBadRequest)
 		return
 	}
 
@@ -344,7 +344,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 	}
 
 	// Hash not found, return an error.
-	writeError(w, "unrecognized hash used as input to /explorer/hash", http.StatusBadRequest)
+	writeError(w, APIError{"unrecognized hash used as input to /explorer/hash"}, http.StatusBadRequest)
 }
 
 // explorerHandler handles API calls to /explorer

--- a/api/explorer.go
+++ b/api/explorer.go
@@ -202,14 +202,14 @@ func (srv *Server) explorerBlocksHandler(w http.ResponseWriter, req *http.Reques
 	var height types.BlockHeight
 	_, err := fmt.Sscan(ps.ByName("height"), &height)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	// Fetch and return the explorer block.
 	block, exists := srv.cs.BlockAtHeight(height)
 	if !exists {
-		writeError(w, APIError{"no block found at input height in call to /explorer/block"}, http.StatusBadRequest)
+		writeError(w, Error{"no block found at input height in call to /explorer/block"}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, ExplorerBlockGET{
@@ -251,7 +251,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 	// not they have a checksum.
 	hash, err := scanAddress(ps.ByName("hash"))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -320,7 +320,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 	// TODO: lookups on the zero hash are too expensive to allow. Need a
 	// better way to handle this case.
 	if hash == (types.UnlockHash{}) {
-		writeError(w, APIError{"can't lookup the empty unlock hash"}, http.StatusBadRequest)
+		writeError(w, Error{"can't lookup the empty unlock hash"}, http.StatusBadRequest)
 		return
 	}
 
@@ -344,7 +344,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 	}
 
 	// Hash not found, return an error.
-	writeError(w, APIError{"unrecognized hash used as input to /explorer/hash"}, http.StatusBadRequest)
+	writeError(w, Error{"unrecognized hash used as input to /explorer/hash"}, http.StatusBadRequest)
 }
 
 // explorerHandler handles API calls to /explorer

--- a/api/gateway.go
+++ b/api/gateway.go
@@ -31,7 +31,7 @@ func (srv *Server) gatewayConnectHandler(w http.ResponseWriter, req *http.Reques
 	addr := modules.NetAddress(ps.ByName("netaddress"))
 	err := srv.gateway.Connect(addr)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -43,7 +43,7 @@ func (srv *Server) gatewayDisconnectHandler(w http.ResponseWriter, req *http.Req
 	addr := modules.NetAddress(ps.ByName("netaddress"))
 	err := srv.gateway.Disconnect(addr)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 

--- a/api/gateway.go
+++ b/api/gateway.go
@@ -31,7 +31,7 @@ func (srv *Server) gatewayConnectHandler(w http.ResponseWriter, req *http.Reques
 	addr := modules.NetAddress(ps.ByName("netaddress"))
 	err := srv.gateway.Connect(addr)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -43,7 +43,7 @@ func (srv *Server) gatewayDisconnectHandler(w http.ResponseWriter, req *http.Req
 	addr := modules.NetAddress(ps.ByName("netaddress"))
 	err := srv.gateway.Disconnect(addr)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 

--- a/api/host.go
+++ b/api/host.go
@@ -92,14 +92,14 @@ func (srv *Server) hostHandlerPOST(w http.ResponseWriter, req *http.Request, _ h
 		if req.FormValue(qs) != "" { // skip empty values
 			_, err := fmt.Sscan(req.FormValue(qs), qsVars[qs])
 			if err != nil {
-				writeError(w, "Malformed "+qs, http.StatusBadRequest)
+				writeError(w, APIError{"Malformed " + qs}, http.StatusBadRequest)
 				return
 			}
 		}
 	}
 	err := srv.host.SetInternalSettings(settings)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -115,7 +115,7 @@ func (srv *Server) hostAnnounceHandler(w http.ResponseWriter, req *http.Request,
 		err = srv.host.Announce()
 	}
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -137,12 +137,12 @@ func (srv *Server) storageFoldersAddHandler(w http.ResponseWriter, req *http.Req
 	var folderSize uint64
 	_, err := fmt.Sscan(req.FormValue("size"), &folderSize)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.host.AddStorageFolder(folderPath, folderSize)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -154,19 +154,19 @@ func (srv *Server) storageFoldersResizeHandler(w http.ResponseWriter, req *http.
 	storageFolders := srv.host.StorageFolders()
 	folderIndex, err := folderIndex(folderPath, storageFolders)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	var newSize uint64
 	_, err = fmt.Sscan(req.FormValue("newsize"), &newSize)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.host.ResizeStorageFolder(folderIndex, newSize)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -179,14 +179,14 @@ func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.
 	storageFolders := srv.host.StorageFolders()
 	folderIndex, err := folderIndex(folderPath, storageFolders)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	force := req.FormValue("force") == "true"
 	err = srv.host.RemoveStorageFolder(folderIndex, force)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -197,12 +197,12 @@ func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.
 func (srv *Server) storageSectorsDeleteHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	sectorRoot, err := scanAddress(ps.ByName("merkleroot"))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.host.DeleteSector(crypto.Hash(sectorRoot))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)

--- a/api/host.go
+++ b/api/host.go
@@ -92,14 +92,14 @@ func (srv *Server) hostHandlerPOST(w http.ResponseWriter, req *http.Request, _ h
 		if req.FormValue(qs) != "" { // skip empty values
 			_, err := fmt.Sscan(req.FormValue(qs), qsVars[qs])
 			if err != nil {
-				writeError(w, APIError{"Malformed " + qs}, http.StatusBadRequest)
+				writeError(w, Error{"Malformed " + qs}, http.StatusBadRequest)
 				return
 			}
 		}
 	}
 	err := srv.host.SetInternalSettings(settings)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -115,7 +115,7 @@ func (srv *Server) hostAnnounceHandler(w http.ResponseWriter, req *http.Request,
 		err = srv.host.Announce()
 	}
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -137,12 +137,12 @@ func (srv *Server) storageFoldersAddHandler(w http.ResponseWriter, req *http.Req
 	var folderSize uint64
 	_, err := fmt.Sscan(req.FormValue("size"), &folderSize)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.host.AddStorageFolder(folderPath, folderSize)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -154,19 +154,19 @@ func (srv *Server) storageFoldersResizeHandler(w http.ResponseWriter, req *http.
 	storageFolders := srv.host.StorageFolders()
 	folderIndex, err := folderIndex(folderPath, storageFolders)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	var newSize uint64
 	_, err = fmt.Sscan(req.FormValue("newsize"), &newSize)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.host.ResizeStorageFolder(folderIndex, newSize)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -179,14 +179,14 @@ func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.
 	storageFolders := srv.host.StorageFolders()
 	folderIndex, err := folderIndex(folderPath, storageFolders)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	force := req.FormValue("force") == "true"
 	err = srv.host.RemoveStorageFolder(folderIndex, force)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -197,12 +197,12 @@ func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.
 func (srv *Server) storageSectorsDeleteHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	sectorRoot, err := scanAddress(ps.ByName("merkleroot"))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.host.DeleteSector(crypto.Hash(sectorRoot))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)

--- a/api/miner.go
+++ b/api/miner.go
@@ -49,7 +49,7 @@ func (srv *Server) minerStopHandler(w http.ResponseWriter, req *http.Request, _ 
 func (srv *Server) minerHeaderHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	bhfw, target, err := srv.miner.HeaderForWork()
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	w.Write(encoding.MarshalAll(target, bhfw))
@@ -61,12 +61,12 @@ func (srv *Server) minerHeaderHandlerPOST(w http.ResponseWriter, req *http.Reque
 	var bh types.BlockHeader
 	err := encoding.NewDecoder(req.Body).Decode(&bh)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.miner.SubmitHeader(bh)
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)

--- a/api/miner.go
+++ b/api/miner.go
@@ -49,7 +49,7 @@ func (srv *Server) minerStopHandler(w http.ResponseWriter, req *http.Request, _ 
 func (srv *Server) minerHeaderHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	bhfw, target, err := srv.miner.HeaderForWork()
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	w.Write(encoding.MarshalAll(target, bhfw))
@@ -61,12 +61,12 @@ func (srv *Server) minerHeaderHandlerPOST(w http.ResponseWriter, req *http.Reque
 	var bh types.BlockHeader
 	err := encoding.NewDecoder(req.Body).Decode(&bh)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	err = srv.miner.SubmitHeader(bh)
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)

--- a/api/renter.go
+++ b/api/renter.go
@@ -79,25 +79,25 @@ func (srv *Server) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _
 	// scan values
 	funds, ok := scanAmount(req.FormValue("funds"))
 	if !ok {
-		writeError(w, "Couldn't parse funds", http.StatusBadRequest)
+		writeError(w, APIError{"Couldn't parse funds"}, http.StatusBadRequest)
 		return
 	}
 	// var hosts uint64
 	// _, err := fmt.Sscan(req.FormValue("hosts"), &hosts)
 	// if err != nil {
-	// 	writeError(w, "Couldn't parse hosts: "+err.Error(), http.StatusBadRequest)
+	// 	writeError(w, APIError{"Couldn't parse hosts: "+err.Error()}, http.StatusBadRequest)
 	// 	return
 	// }
 	var period types.BlockHeight
 	_, err := fmt.Sscan(req.FormValue("period"), &period)
 	if err != nil {
-		writeError(w, "Couldn't parse period: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"Couldn't parse period: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	// var renewWindow types.BlockHeight
 	// _, err = fmt.Sscan(req.FormValue("renewwindow"), &renewWindow)
 	// if err != nil {
-	// 	writeError(w, "Couldn't parse renewwindow: "+err.Error(), http.StatusBadRequest)
+	// 	writeError(w, APIError{"Couldn't parse renewwindow: "+err.Error()}, http.StatusBadRequest)
 	// 	return
 	// }
 
@@ -112,7 +112,7 @@ func (srv *Server) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _
 		},
 	})
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -143,7 +143,7 @@ func (srv *Server) renterDownloadsHandler(w http.ResponseWriter, _ *http.Request
 func (srv *Server) renterLoadHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	files, err := srv.renter.LoadSharedFiles(req.FormValue("source"))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (srv *Server) renterLoadHandler(w http.ResponseWriter, req *http.Request, _
 func (srv *Server) renterLoadAsciiHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	files, err := srv.renter.LoadSharedFilesAscii(req.FormValue("asciisia"))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -167,7 +167,7 @@ func (srv *Server) renterLoadAsciiHandler(w http.ResponseWriter, req *http.Reque
 func (srv *Server) renterRenameHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.RenameFile(strings.TrimPrefix(ps.ByName("siapath"), "/"), req.FormValue("newsiapath"))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -186,7 +186,7 @@ func (srv *Server) renterFilesHandler(w http.ResponseWriter, req *http.Request, 
 func (srv *Server) renterDeleteHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.DeleteFile(strings.TrimPrefix(ps.ByName("siapath"), "/"))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -197,7 +197,7 @@ func (srv *Server) renterDeleteHandler(w http.ResponseWriter, req *http.Request,
 func (srv *Server) renterDownloadHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.Download(strings.TrimPrefix(ps.ByName("siapath"), "/"), req.FormValue("destination"))
 	if err != nil {
-		writeError(w, "Download failed: "+err.Error(), http.StatusInternalServerError)
+		writeError(w, APIError{"Download failed: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (srv *Server) renterDownloadHandler(w http.ResponseWriter, req *http.Reques
 func (srv *Server) renterShareHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.ShareFiles(strings.Split(req.FormValue("siapaths"), ","), req.FormValue("destination"))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -221,7 +221,7 @@ func (srv *Server) renterShareHandler(w http.ResponseWriter, req *http.Request, 
 func (srv *Server) renterShareAsciiHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	ascii, err := srv.renter.ShareFilesAscii(strings.Split(req.FormValue("siapaths"), ","))
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, RenterShareASCII{
@@ -238,7 +238,7 @@ func (srv *Server) renterUploadHandler(w http.ResponseWriter, req *http.Request,
 		ErasureCode: nil,
 	})
 	if err != nil {
-		writeError(w, "Upload failed: "+err.Error(), http.StatusInternalServerError)
+		writeError(w, APIError{"Upload failed: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 
@@ -258,7 +258,7 @@ func (srv *Server) renterHostsActiveHandler(w http.ResponseWriter, req *http.Req
 		// Parse the value for 'numhosts'.
 		_, err := fmt.Sscan(req.FormValue("numhosts"), &numHosts)
 		if err != nil {
-			writeError(w, err.Error(), http.StatusBadRequest)
+			writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 			return
 		}
 

--- a/api/renter.go
+++ b/api/renter.go
@@ -79,25 +79,25 @@ func (srv *Server) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _
 	// scan values
 	funds, ok := scanAmount(req.FormValue("funds"))
 	if !ok {
-		writeError(w, APIError{"Couldn't parse funds"}, http.StatusBadRequest)
+		writeError(w, Error{"Couldn't parse funds"}, http.StatusBadRequest)
 		return
 	}
 	// var hosts uint64
 	// _, err := fmt.Sscan(req.FormValue("hosts"), &hosts)
 	// if err != nil {
-	// 	writeError(w, APIError{"Couldn't parse hosts: "+err.Error()}, http.StatusBadRequest)
+	// 	writeError(w, Error{"Couldn't parse hosts: "+err.Error()}, http.StatusBadRequest)
 	// 	return
 	// }
 	var period types.BlockHeight
 	_, err := fmt.Sscan(req.FormValue("period"), &period)
 	if err != nil {
-		writeError(w, APIError{"Couldn't parse period: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"Couldn't parse period: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	// var renewWindow types.BlockHeight
 	// _, err = fmt.Sscan(req.FormValue("renewwindow"), &renewWindow)
 	// if err != nil {
-	// 	writeError(w, APIError{"Couldn't parse renewwindow: "+err.Error()}, http.StatusBadRequest)
+	// 	writeError(w, Error{"Couldn't parse renewwindow: "+err.Error()}, http.StatusBadRequest)
 	// 	return
 	// }
 
@@ -112,7 +112,7 @@ func (srv *Server) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _
 		},
 	})
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -143,7 +143,7 @@ func (srv *Server) renterDownloadsHandler(w http.ResponseWriter, _ *http.Request
 func (srv *Server) renterLoadHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	files, err := srv.renter.LoadSharedFiles(req.FormValue("source"))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (srv *Server) renterLoadHandler(w http.ResponseWriter, req *http.Request, _
 func (srv *Server) renterLoadAsciiHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	files, err := srv.renter.LoadSharedFilesAscii(req.FormValue("asciisia"))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -167,7 +167,7 @@ func (srv *Server) renterLoadAsciiHandler(w http.ResponseWriter, req *http.Reque
 func (srv *Server) renterRenameHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.RenameFile(strings.TrimPrefix(ps.ByName("siapath"), "/"), req.FormValue("newsiapath"))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -186,7 +186,7 @@ func (srv *Server) renterFilesHandler(w http.ResponseWriter, req *http.Request, 
 func (srv *Server) renterDeleteHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.DeleteFile(strings.TrimPrefix(ps.ByName("siapath"), "/"))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -197,7 +197,7 @@ func (srv *Server) renterDeleteHandler(w http.ResponseWriter, req *http.Request,
 func (srv *Server) renterDownloadHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.Download(strings.TrimPrefix(ps.ByName("siapath"), "/"), req.FormValue("destination"))
 	if err != nil {
-		writeError(w, APIError{"Download failed: " + err.Error()}, http.StatusInternalServerError)
+		writeError(w, Error{"Download failed: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (srv *Server) renterDownloadHandler(w http.ResponseWriter, req *http.Reques
 func (srv *Server) renterShareHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.ShareFiles(strings.Split(req.FormValue("siapaths"), ","), req.FormValue("destination"))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -221,7 +221,7 @@ func (srv *Server) renterShareHandler(w http.ResponseWriter, req *http.Request, 
 func (srv *Server) renterShareAsciiHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	ascii, err := srv.renter.ShareFilesAscii(strings.Split(req.FormValue("siapaths"), ","))
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, RenterShareASCII{
@@ -238,7 +238,7 @@ func (srv *Server) renterUploadHandler(w http.ResponseWriter, req *http.Request,
 		ErasureCode: nil,
 	})
 	if err != nil {
-		writeError(w, APIError{"Upload failed: " + err.Error()}, http.StatusInternalServerError)
+		writeError(w, Error{"Upload failed: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 
@@ -258,7 +258,7 @@ func (srv *Server) renterHostsActiveHandler(w http.ResponseWriter, req *http.Req
 		// Parse the value for 'numhosts'.
 		_, err := fmt.Sscan(req.FormValue("numhosts"), &numHosts)
 		if err != nil {
-			writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+			writeError(w, Error{err.Error()}, http.StatusBadRequest)
 			return
 		}
 

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -338,7 +338,7 @@ func createExplorerServerTester(name string) (*serverTester, error) {
 }
 
 // decodeErrorResponse returns an error if the response's status code is
-// non-2xx. If an error message or APIError is included in the response, it is
+// non-2xx. If an error message or Error is included in the response, it is
 // decoded and returned as the error.
 func decodeErrorResponse(resp *http.Response) error {
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
@@ -346,7 +346,7 @@ func decodeErrorResponse(resp *http.Response) error {
 		if err != nil {
 			return err
 		}
-		var apiErr APIError
+		var apiErr Error
 		err = json.Unmarshal(respErr, &apiErr)
 		if err != nil {
 			return err

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -346,8 +346,12 @@ func decodeErrorResponse(resp *http.Response) error {
 		if err != nil {
 			return err
 		}
-		// TODO: unmarshal respErr to an APIError type if applicable.
-		return errors.New(string(respErr))
+		var apiErr APIError
+		err = json.Unmarshal(respErr, &apiErr)
+		if err != nil {
+			return err
+		}
+		return apiErr
 	}
 	return nil
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -117,7 +117,7 @@ func TestAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decodeErrorResponse(resp) != nil {
+	if non2xx(resp.StatusCode) {
 		t.Fatal("authenticated API call failed with the correct password")
 	}
 	// POST
@@ -125,7 +125,7 @@ func TestAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if decodeErrorResponse(resp) != nil {
+	if non2xx(resp.StatusCode) {
 		t.Fatal("authenticated API call failed with the correct password")
 	}
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -117,7 +117,7 @@ func TestAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusOK {
+	if decodeErrorResponse(resp) != nil {
 		t.Fatal("authenticated API call failed with the correct password")
 	}
 	// POST
@@ -125,7 +125,7 @@ func TestAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusOK {
+	if decodeErrorResponse(resp) != nil {
 		t.Fatal("authenticated API call failed with the correct password")
 	}
 }

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -129,18 +129,18 @@ func (srv *Server) wallet033xHandler(w http.ResponseWriter, req *http.Request, _
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, "error when calling /wallet/033x: "+err.Error(), http.StatusBadRequest)
+			writeError(w, APIError{"error when calling /wallet/033x: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, modules.ErrBadEncryptionKey.Error(), http.StatusBadRequest)
+	writeError(w, APIError{modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }
 
 // walletAddressHandler handles API calls to /wallet/address.
 func (srv *Server) walletAddressHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	unlockConditions, err := srv.wallet.NextAddress()
 	if err != nil {
-		writeError(w, "error after call to /wallet/addresses: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/addresses: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, WalletAddressGET{
@@ -159,7 +159,7 @@ func (srv *Server) walletAddressesHandler(w http.ResponseWriter, req *http.Reque
 func (srv *Server) walletBackupHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	err := srv.wallet.CreateBackup(req.FormValue("destination"))
 	if err != nil {
-		writeError(w, "error after call to /wallet/backup: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/backup: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -173,7 +173,7 @@ func (srv *Server) walletInitHandler(w http.ResponseWriter, req *http.Request, _
 	}
 	seed, err := srv.wallet.Encrypt(encryptionKey)
 	if err != nil {
-		writeError(w, "error when calling /wallet/init: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -183,7 +183,7 @@ func (srv *Server) walletInitHandler(w http.ResponseWriter, req *http.Request, _
 	}
 	seedStr, err := modules.SeedToString(seed, dictID)
 	if err != nil {
-		writeError(w, "error when calling /wallet/init: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, WalletInitPOST{
@@ -197,7 +197,7 @@ func (srv *Server) walletSeedHandler(w http.ResponseWriter, req *http.Request, _
 	dictID := mnemonics.DictionaryID(req.FormValue("dictionary"))
 	seed, err := modules.StringToSeed(req.FormValue("seed"), dictID)
 	if err != nil {
-		writeError(w, "error when calling /wallet/seed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error when calling /wallet/seed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -209,11 +209,11 @@ func (srv *Server) walletSeedHandler(w http.ResponseWriter, req *http.Request, _
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, "error when calling /wallet/seed: "+err.Error(), http.StatusBadRequest)
+			writeError(w, APIError{"error when calling /wallet/seed: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, "error when calling /wallet/seed: "+modules.ErrBadEncryptionKey.Error(), http.StatusBadRequest)
+	writeError(w, APIError{"error when calling /wallet/seed: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }
 
 // walletSiagkeyHandler handles API calls to /wallet/siagkey.
@@ -228,18 +228,18 @@ func (srv *Server) walletSiagkeyHandler(w http.ResponseWriter, req *http.Request
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, "error when calling /wallet/siagkey: "+err.Error(), http.StatusBadRequest)
+			writeError(w, APIError{"error when calling /wallet/siagkey: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, "error when calling /wallet/siagkey: "+modules.ErrBadEncryptionKey.Error(), http.StatusBadRequest)
+	writeError(w, APIError{"error when calling /wallet/siagkey: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }
 
 // walletLockHanlder handles API calls to /wallet/lock.
 func (srv *Server) walletLockHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	err := srv.wallet.Lock()
 	if err != nil {
-		writeError(w, err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -255,26 +255,26 @@ func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, 
 	// Get the primary seed information.
 	primarySeed, progress, err := srv.wallet.PrimarySeed()
 	if err != nil {
-		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	primarySeedStr, err := modules.SeedToString(primarySeed, dictionary)
 	if err != nil {
-		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	// Get the list of seeds known to the wallet.
 	allSeeds, err := srv.wallet.AllSeeds()
 	if err != nil {
-		writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	var allSeedsStrs []string
 	for _, seed := range allSeeds {
 		str, err := modules.SeedToString(seed, dictionary)
 		if err != nil {
-			writeError(w, "error after call to /wallet/seeds: "+err.Error(), http.StatusBadRequest)
+			writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 		allSeedsStrs = append(allSeedsStrs, str)
@@ -290,18 +290,18 @@ func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, 
 func (srv *Server) walletSiacoinsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	amount, ok := scanAmount(req.FormValue("amount"))
 	if !ok {
-		writeError(w, "could not read 'amount' from POST call to /wallet/siacoins", http.StatusBadRequest)
+		writeError(w, APIError{"could not read 'amount' from POST call to /wallet/siacoins"}, http.StatusBadRequest)
 		return
 	}
 	dest, err := scanAddress(req.FormValue("destination"))
 	if err != nil {
-		writeError(w, "error after call to /wallet/siacoins: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	txns, err := srv.wallet.SendSiacoins(amount, dest)
 	if err != nil {
-		writeError(w, "error after call to /wallet/siacoins: "+err.Error(), http.StatusInternalServerError)
+		writeError(w, APIError{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 	var txids []types.TransactionID
@@ -317,18 +317,18 @@ func (srv *Server) walletSiacoinsHandler(w http.ResponseWriter, req *http.Reques
 func (srv *Server) walletSiafundsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	amount, ok := scanAmount(req.FormValue("amount"))
 	if !ok {
-		writeError(w, "could not read 'amount' from POST call to /wallet/siafunds", http.StatusBadRequest)
+		writeError(w, APIError{"could not read 'amount' from POST call to /wallet/siafunds"}, http.StatusBadRequest)
 		return
 	}
 	dest, err := scanAddress(req.FormValue("destination"))
 	if err != nil {
-		writeError(w, "error after call to /wallet/siafunds: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/siafunds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	txns, err := srv.wallet.SendSiafunds(amount, dest)
 	if err != nil {
-		writeError(w, "error after call to /wallet/siafunds: "+err.Error(), http.StatusInternalServerError)
+		writeError(w, APIError{"error after call to /wallet/siafunds: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 	var txids []types.TransactionID
@@ -347,13 +347,13 @@ func (srv *Server) walletTransactionHandler(w http.ResponseWriter, req *http.Req
 	jsonID := "\"" + ps.ByName("id") + "\""
 	err := id.UnmarshalJSON([]byte(jsonID))
 	if err != nil {
-		writeError(w, "error after call to /wallet/history: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/history: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	txn, ok := srv.wallet.Transaction(id)
 	if !ok {
-		writeError(w, "error when calling /wallet/transaction/$(id): transaction not found", http.StatusBadRequest)
+		writeError(w, APIError{"error when calling /wallet/transaction/$(id): transaction not found"}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, WalletTransactionGETid{
@@ -365,23 +365,23 @@ func (srv *Server) walletTransactionHandler(w http.ResponseWriter, req *http.Req
 func (srv *Server) walletTransactionsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	startheightStr, endheightStr := req.FormValue("startheight"), req.FormValue("endheight")
 	if startheightStr == "" || endheightStr == "" {
-		writeError(w, "startheight and endheight must be provided to a /wallet/transactions call.", http.StatusBadRequest)
+		writeError(w, APIError{"startheight and endheight must be provided to a /wallet/transactions call."}, http.StatusBadRequest)
 		return
 	}
 	// Get the start and end blocks.
 	start, err := strconv.Atoi(startheightStr)
 	if err != nil {
-		writeError(w, "parsing integer value for parameter `startheight` failed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"parsing integer value for parameter `startheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	end, err := strconv.Atoi(endheightStr)
 	if err != nil {
-		writeError(w, "parsing integer value for parameter `endheight` failed: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"parsing integer value for parameter `endheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	confirmedTxns, err := srv.wallet.Transactions(types.BlockHeight(start), types.BlockHeight(end))
 	if err != nil {
-		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/transactions: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	unconfirmedTxns := srv.wallet.UnconfirmedTransactions()
@@ -400,7 +400,7 @@ func (srv *Server) walletTransactionsAddrHandler(w http.ResponseWriter, req *htt
 	var addr types.UnlockHash
 	err := addr.UnmarshalJSON([]byte(jsonAddr))
 	if err != nil {
-		writeError(w, "error after call to /wallet/transactions: "+err.Error(), http.StatusBadRequest)
+		writeError(w, APIError{"error after call to /wallet/transactions: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -422,9 +422,9 @@ func (srv *Server) walletUnlockHandler(w http.ResponseWriter, req *http.Request,
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, "error when calling /wallet/unlock: "+err.Error(), http.StatusBadRequest)
+			writeError(w, APIError{"error when calling /wallet/unlock: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, "error when calling /wallet/unlock: "+modules.ErrBadEncryptionKey.Error(), http.StatusBadRequest)
+	writeError(w, APIError{"error when calling /wallet/unlock: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -129,18 +129,18 @@ func (srv *Server) wallet033xHandler(w http.ResponseWriter, req *http.Request, _
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, APIError{"error when calling /wallet/033x: " + err.Error()}, http.StatusBadRequest)
+			writeError(w, Error{"error when calling /wallet/033x: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, APIError{modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
+	writeError(w, Error{modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }
 
 // walletAddressHandler handles API calls to /wallet/address.
 func (srv *Server) walletAddressHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	unlockConditions, err := srv.wallet.NextAddress()
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/addresses: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/addresses: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, WalletAddressGET{
@@ -159,7 +159,7 @@ func (srv *Server) walletAddressesHandler(w http.ResponseWriter, req *http.Reque
 func (srv *Server) walletBackupHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	err := srv.wallet.CreateBackup(req.FormValue("destination"))
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/backup: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/backup: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -173,7 +173,7 @@ func (srv *Server) walletInitHandler(w http.ResponseWriter, req *http.Request, _
 	}
 	seed, err := srv.wallet.Encrypt(encryptionKey)
 	if err != nil {
-		writeError(w, APIError{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -183,7 +183,7 @@ func (srv *Server) walletInitHandler(w http.ResponseWriter, req *http.Request, _
 	}
 	seedStr, err := modules.SeedToString(seed, dictID)
 	if err != nil {
-		writeError(w, APIError{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, WalletInitPOST{
@@ -197,7 +197,7 @@ func (srv *Server) walletSeedHandler(w http.ResponseWriter, req *http.Request, _
 	dictID := mnemonics.DictionaryID(req.FormValue("dictionary"))
 	seed, err := modules.StringToSeed(req.FormValue("seed"), dictID)
 	if err != nil {
-		writeError(w, APIError{"error when calling /wallet/seed: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error when calling /wallet/seed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -209,11 +209,11 @@ func (srv *Server) walletSeedHandler(w http.ResponseWriter, req *http.Request, _
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, APIError{"error when calling /wallet/seed: " + err.Error()}, http.StatusBadRequest)
+			writeError(w, Error{"error when calling /wallet/seed: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, APIError{"error when calling /wallet/seed: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
+	writeError(w, Error{"error when calling /wallet/seed: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }
 
 // walletSiagkeyHandler handles API calls to /wallet/siagkey.
@@ -228,18 +228,18 @@ func (srv *Server) walletSiagkeyHandler(w http.ResponseWriter, req *http.Request
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, APIError{"error when calling /wallet/siagkey: " + err.Error()}, http.StatusBadRequest)
+			writeError(w, Error{"error when calling /wallet/siagkey: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, APIError{"error when calling /wallet/siagkey: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
+	writeError(w, Error{"error when calling /wallet/siagkey: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }
 
 // walletLockHanlder handles API calls to /wallet/lock.
 func (srv *Server) walletLockHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	err := srv.wallet.Lock()
 	if err != nil {
-		writeError(w, APIError{err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
 	}
 	writeSuccess(w)
@@ -255,26 +255,26 @@ func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, 
 	// Get the primary seed information.
 	primarySeed, progress, err := srv.wallet.PrimarySeed()
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	primarySeedStr, err := modules.SeedToString(primarySeed, dictionary)
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	// Get the list of seeds known to the wallet.
 	allSeeds, err := srv.wallet.AllSeeds()
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	var allSeedsStrs []string
 	for _, seed := range allSeeds {
 		str, err := modules.SeedToString(seed, dictionary)
 		if err != nil {
-			writeError(w, APIError{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
+			writeError(w, Error{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 		allSeedsStrs = append(allSeedsStrs, str)
@@ -290,18 +290,18 @@ func (srv *Server) walletSeedsHandler(w http.ResponseWriter, req *http.Request, 
 func (srv *Server) walletSiacoinsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	amount, ok := scanAmount(req.FormValue("amount"))
 	if !ok {
-		writeError(w, APIError{"could not read 'amount' from POST call to /wallet/siacoins"}, http.StatusBadRequest)
+		writeError(w, Error{"could not read 'amount' from POST call to /wallet/siacoins"}, http.StatusBadRequest)
 		return
 	}
 	dest, err := scanAddress(req.FormValue("destination"))
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	txns, err := srv.wallet.SendSiacoins(amount, dest)
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusInternalServerError)
+		writeError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 	var txids []types.TransactionID
@@ -317,18 +317,18 @@ func (srv *Server) walletSiacoinsHandler(w http.ResponseWriter, req *http.Reques
 func (srv *Server) walletSiafundsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	amount, ok := scanAmount(req.FormValue("amount"))
 	if !ok {
-		writeError(w, APIError{"could not read 'amount' from POST call to /wallet/siafunds"}, http.StatusBadRequest)
+		writeError(w, Error{"could not read 'amount' from POST call to /wallet/siafunds"}, http.StatusBadRequest)
 		return
 	}
 	dest, err := scanAddress(req.FormValue("destination"))
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/siafunds: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/siafunds: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	txns, err := srv.wallet.SendSiafunds(amount, dest)
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/siafunds: " + err.Error()}, http.StatusInternalServerError)
+		writeError(w, Error{"error after call to /wallet/siafunds: " + err.Error()}, http.StatusInternalServerError)
 		return
 	}
 	var txids []types.TransactionID
@@ -347,13 +347,13 @@ func (srv *Server) walletTransactionHandler(w http.ResponseWriter, req *http.Req
 	jsonID := "\"" + ps.ByName("id") + "\""
 	err := id.UnmarshalJSON([]byte(jsonID))
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/history: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/history: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
 	txn, ok := srv.wallet.Transaction(id)
 	if !ok {
-		writeError(w, APIError{"error when calling /wallet/transaction/$(id): transaction not found"}, http.StatusBadRequest)
+		writeError(w, Error{"error when calling /wallet/transaction/$(id): transaction not found"}, http.StatusBadRequest)
 		return
 	}
 	writeJSON(w, WalletTransactionGETid{
@@ -365,23 +365,23 @@ func (srv *Server) walletTransactionHandler(w http.ResponseWriter, req *http.Req
 func (srv *Server) walletTransactionsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	startheightStr, endheightStr := req.FormValue("startheight"), req.FormValue("endheight")
 	if startheightStr == "" || endheightStr == "" {
-		writeError(w, APIError{"startheight and endheight must be provided to a /wallet/transactions call."}, http.StatusBadRequest)
+		writeError(w, Error{"startheight and endheight must be provided to a /wallet/transactions call."}, http.StatusBadRequest)
 		return
 	}
 	// Get the start and end blocks.
 	start, err := strconv.Atoi(startheightStr)
 	if err != nil {
-		writeError(w, APIError{"parsing integer value for parameter `startheight` failed: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"parsing integer value for parameter `startheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	end, err := strconv.Atoi(endheightStr)
 	if err != nil {
-		writeError(w, APIError{"parsing integer value for parameter `endheight` failed: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"parsing integer value for parameter `endheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	confirmedTxns, err := srv.wallet.Transactions(types.BlockHeight(start), types.BlockHeight(end))
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/transactions: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/transactions: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 	unconfirmedTxns := srv.wallet.UnconfirmedTransactions()
@@ -400,7 +400,7 @@ func (srv *Server) walletTransactionsAddrHandler(w http.ResponseWriter, req *htt
 	var addr types.UnlockHash
 	err := addr.UnmarshalJSON([]byte(jsonAddr))
 	if err != nil {
-		writeError(w, APIError{"error after call to /wallet/transactions: " + err.Error()}, http.StatusBadRequest)
+		writeError(w, Error{"error after call to /wallet/transactions: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
 
@@ -422,9 +422,9 @@ func (srv *Server) walletUnlockHandler(w http.ResponseWriter, req *http.Request,
 			return
 		}
 		if err != nil && err != modules.ErrBadEncryptionKey {
-			writeError(w, APIError{"error when calling /wallet/unlock: " + err.Error()}, http.StatusBadRequest)
+			writeError(w, Error{"error when calling /wallet/unlock: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 	}
-	writeError(w, APIError{"error when calling /wallet/unlock: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
+	writeError(w, Error{"error when calling /wallet/unlock: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -267,7 +267,7 @@ func TestIntegrationWalletTransactionGETid(t *testing.T) {
 	// A call to /wallet/transactions without startheight and endheight parameters
 	// should return a descriptive error message.
 	err = st.getAPI("/wallet/transactions", &wtg)
-	if err == nil || err.Error() != "startheight and endheight must be provided to a /wallet/transactions call.\n" {
+	if err == nil || err.Error() != "startheight and endheight must be provided to a /wallet/transactions call." {
 		t.Error("expecting /wallet/transactions call with empty parameters to error")
 	}
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -41,12 +41,9 @@ The standard error response indicating the request failed for any reason, is a
 4xx or 5xx HTTP status code with an error JSON object describing the error.
 ```javascript
 {
-    "error": {
-        "message": String
+    "message": String
 
-        // The error object may have additional fields depending on the
-        // specific error.
-    }
+    // There may be additional fields depending on the specific error.
 }
 ```
 

--- a/siac/main.go
+++ b/siac/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"strings"
 
 	"github.com/bgentry/speakeasy"
 	"github.com/spf13/cobra"
@@ -34,8 +33,27 @@ const (
 	exitCodeUsage   = 64 // EX_USAGE in sysexits.h
 )
 
+// decodeErrorResponse returns an error if the response's status code is
+// non-2xx. If the status code is non-2xx and the response body is an encoded
+// APIError and human readable error message is returned.
+func decodeErrorResponse(resp *http.Response) error {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		respErr, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		var apiErr api.APIError
+		err = json.Unmarshal(respErr, apiErr)
+		if err != nil {
+			return err
+		}
+		return apiErr
+	}
+	return nil
+}
+
 // apiGet wraps a GET request with a status code check, such that if the GET does
-// not return 200, the error will be read and returned. The response body is
+// not return 2xx, the error will be read and returned. The response body is
 // not closed.
 func apiGet(call string) (*http.Response, error) {
 	if host, port, _ := net.SplitHostPort(addr); host == "" {
@@ -60,22 +78,28 @@ func apiGet(call string) (*http.Response, error) {
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
-		err = errors.New("API call not recognized: " + call)
-	} else if resp.StatusCode != http.StatusOK {
-		errResp, _ := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		err = errors.New(strings.TrimSpace(string(errResp)))
+		return nil, errors.New("API call not recognized: " + call)
 	}
-	return resp, err
+	if err := decodeErrorResponse(resp); err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+	return resp, nil
 }
 
-// getAPI makes a GET API call and decodes the response.
+// getAPI makes a GET API call and decodes the response. An error is returned
+// if the response status is not 2xx.
 func getAPI(call string, obj interface{}) error {
 	resp, err := apiGet(call)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return errors.New("expecting a response, but API returned status code 204 No Content")
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(obj)
 	if err != nil {
 		return err
@@ -83,7 +107,8 @@ func getAPI(call string, obj interface{}) error {
 	return nil
 }
 
-// get makes an API call and discards the response.
+// get makes an API call and discards the response. An error is returned if the
+// response status is not 2xx.
 func get(call string) error {
 	resp, err := apiGet(call)
 	if err != nil {
@@ -94,7 +119,7 @@ func get(call string) error {
 }
 
 // apiPost wraps a POST request with a status code check, such that if the POST
-// does not return 200, the error will be read and returned. The response body
+// does not return 2xx, the error will be read and returned. The response body
 // is not closed.
 func apiPost(call, vals string) (*http.Response, error) {
 	if host, port, _ := net.SplitHostPort(addr); host == "" {
@@ -120,22 +145,28 @@ func apiPost(call, vals string) (*http.Response, error) {
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
-		err = errors.New("API call not recognized: " + call)
-	} else if resp.StatusCode != http.StatusOK {
-		errResp, _ := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		err = errors.New(strings.TrimSpace(string(errResp)))
+		return nil, errors.New("API call not recognized: " + call)
 	}
-	return resp, err
+	if err := decodeErrorResponse(resp); err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+	return resp, nil
 }
 
-// postResp makes a POST API call and decodes the response.
+// postResp makes a POST API call and decodes the response. An error is
+// returned if the response status is not 2xx.
 func postResp(call, vals string, obj interface{}) error {
 	resp, err := apiPost(call, vals)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return errors.New("expecting a response, but API returned status code 204 No Content")
+	}
+
 	err = json.NewDecoder(resp.Body).Decode(obj)
 	if err != nil {
 		return err
@@ -143,6 +174,8 @@ func postResp(call, vals string, obj interface{}) error {
 	return nil
 }
 
+// post makes an API call and discards the response. An error is returned if
+// the response status is not 2xx.
 func post(call, vals string) error {
 	resp, err := apiPost(call, vals)
 	if err != nil {

--- a/siac/main.go
+++ b/siac/main.go
@@ -35,14 +35,14 @@ const (
 
 // decodeErrorResponse returns an error if the response's status code is
 // non-2xx. If the status code is non-2xx and the response body is an encoded
-// APIError and human readable error message is returned.
+// Error and human readable error message is returned.
 func decodeErrorResponse(resp *http.Response) error {
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		respErr, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
-		var apiErr api.APIError
+		var apiErr api.Error
 		err = json.Unmarshal(respErr, apiErr)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR changes the standard success & error responses as described in #1243.

The APIError type is meant to provide descriptive, useful errors to API clients. Simply returning an error string is often not useful. An error string is the minimum, but other information such as which parameter caused the request to fail should also be included. Only the message field has been implemented in this commit as the other fields are non-trivial to implement. Additional fields can be added to APIError type in the future without breaking compatibility.