### PR TITLE
Correct JSON case for HostDBEntry

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -98,7 +98,7 @@ type RenterFinancialMetrics struct {
 // aggregates the host's external settings with its public key.
 type HostDBEntry struct {
 	HostExternalSettings
-	PublicKey types.SiaPublicKey
+	PublicKey types.SiaPublicKey `json:"publickey"`
 }
 
 // A RenterContract contains all the metadata necessary to revise or renew a


### PR DESCRIPTION
Are JSONified HostDBEntries ever sent over the network? This would break compatibility if they are.