### PR TITLE
Renter resync

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -28,11 +28,12 @@ type Contractor struct {
 	tpool   transactionPool
 	wallet  wallet
 
-	allowance   modules.Allowance
-	blockHeight types.BlockHeight
-	contracts   map[types.FileContractID]modules.RenterContract
-	lastChange  modules.ConsensusChangeID
-	renewHeight types.BlockHeight // height at which to renew contracts
+	allowance       modules.Allowance
+	blockHeight     types.BlockHeight
+	cachedRevisions map[types.FileContractID]types.FileContractRevision
+	contracts       map[types.FileContractID]modules.RenterContract
+	lastChange      modules.ConsensusChangeID
+	renewHeight     types.BlockHeight // height at which to renew contracts
 
 	financialMetrics modules.RenterFinancialMetrics
 
@@ -102,7 +103,8 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 		tpool:   tp,
 		wallet:  w,
 
-		contracts: make(map[types.FileContractID]modules.RenterContract),
+		cachedRevisions: make(map[types.FileContractID]types.FileContractRevision),
+		contracts:       make(map[types.FileContractID]modules.RenterContract),
 	}
 
 	// Load the prior persistence structures.

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules/host"
 	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/modules/renter/hostdb"
+	"github.com/NebulousLabs/Sia/modules/renter/proto"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	modWallet "github.com/NebulousLabs/Sia/modules/wallet"
 	"github.com/NebulousLabs/Sia/types"
@@ -572,4 +573,105 @@ func TestIntegrationRenew(t *testing.T) {
 	if contract.FileContract.WindowStart != c.blockHeight+100 {
 		t.Fatal(contract.FileContract.WindowStart)
 	}
+}
+
+// TestResync tests that the contractor can resync with a host after being
+// interrupted during contract revision.
+func TestResync(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	// create testing trio
+	h, c, _, err := newTestingTrio("TestResync")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get the host's entry from the db
+	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
+	if !ok {
+		t.Fatal("no entry for host in db")
+	}
+
+	// form a contract with the host
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// revise the contract
+	editor, err := c.Editor(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := crypto.RandBytes(int(modules.SectorSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := editor.Upload(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = editor.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// download the data
+	contract = c.contracts[contract.ID]
+	downloader, err := c.Downloader(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retrieved, err := downloader.Sector(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, retrieved) {
+		t.Fatal("downloaded data does not match original")
+	}
+	err = downloader.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract = c.contracts[contract.ID]
+
+	// create a new contractor, mimicking the state of a contractor whose
+	// negotiation had been interrupted
+	c2, err := newTestingContractor(build.TempDir("contractor", "TestResync", "Contractor2"), c.cs.(modules.ConsensusSet), c.tpool.(modules.TransactionPool))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badContract := contract
+	badContract.LastRevision.NewRevisionNumber--
+	badContract.LastRevisionTxn.TransactionSignatures = nil // delete signatures
+	// Editor and Downloader should fail with the bad contract
+	_, err = c2.Editor(badContract)
+	if !proto.IsRevisionMismatch(err) {
+		t.Fatal(err)
+	}
+	_, err = c2.Downloader(badContract)
+	if !proto.IsRevisionMismatch(err) {
+		t.Fatal(err)
+	}
+
+	// add cachedRevision
+	c2.mu.Lock()
+	c2.cachedRevisions[contract.ID] = contract.LastRevision
+	c2.mu.Unlock()
+
+	// Editor and Downloader should now succeed after loading the cachedRevision
+	editor, err = c2.Editor(badContract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	editor.Close()
+
+	downloader, err = c.Downloader(badContract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	downloader.Close()
 }

--- a/modules/renter/contractor/negotiate_test.go
+++ b/modules/renter/contractor/negotiate_test.go
@@ -160,7 +160,7 @@ func TestReviseContract(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	ct, err := newContractorTester("TestNegotiateContract")
+	ct, err := newContractorTester("TestReviseContract")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -9,6 +9,7 @@ import (
 type contractorPersist struct {
 	Allowance        modules.Allowance
 	BlockHeight      types.BlockHeight
+	CachedRevisions  []types.FileContractRevision
 	Contracts        []modules.RenterContract
 	LastChange       modules.ConsensusChangeID
 	RenewHeight      types.BlockHeight
@@ -23,6 +24,9 @@ func (c *Contractor) persistData() contractorPersist {
 		LastChange:       c.lastChange,
 		RenewHeight:      c.renewHeight,
 		FinancialMetrics: c.financialMetrics,
+	}
+	for _, rev := range c.cachedRevisions {
+		data.CachedRevisions = append(data.CachedRevisions, rev)
 	}
 	for _, contract := range c.contracts {
 		data.Contracts = append(data.Contracts, contract)
@@ -39,6 +43,9 @@ func (c *Contractor) load() error {
 	}
 	c.allowance = data.Allowance
 	c.blockHeight = data.BlockHeight
+	for _, rev := range data.CachedRevisions {
+		c.cachedRevisions[rev.ParentID] = rev
+	}
 	for _, contract := range data.Contracts {
 		c.contracts[contract.ID] = contract
 	}
@@ -56,4 +63,15 @@ func (c *Contractor) save() error {
 // saveSync saves the Contractor persistence data to disk and then syncs to disk.
 func (c *Contractor) saveSync() error {
 	return c.persist.saveSync(c.persistData())
+}
+
+// saveRevision returns a function that saves a revision. It is used by the
+// Editor and Downloader types to prevent desynchronizing with their host.
+func (c *Contractor) saveRevision(id types.FileContractID) func(types.FileContractRevision) error {
+	return func(rev types.FileContractRevision) error {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.cachedRevisions[id] = rev
+		return c.saveSync()
+	}
 }

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -110,9 +110,11 @@ func NewDownloader(host modules.HostDBEntry, contract modules.RenterContract) (*
 	extendDeadline(conn, modules.NegotiateRecentRevisionTime)
 	defer extendDeadline(conn, time.Hour)
 	if err := encoding.WriteObject(conn, modules.RPCDownload); err != nil {
+		conn.Close()
 		return nil, errors.New("couldn't initiate RPC: " + err.Error())
 	}
 	if err := verifyRecentRevision(conn, contract); err != nil {
+		conn.Close() // TODO: close gracefully if host has entered revision loop
 		return nil, errors.New("revision exchange failed: " + err.Error())
 	}
 

--- a/modules/renter/proto/negotiate.go
+++ b/modules/renter/proto/negotiate.go
@@ -2,7 +2,6 @@ package proto
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"time"
 
@@ -71,7 +70,7 @@ func verifySettings(conn net.Conn, host modules.HostDBEntry) (modules.HostDBEntr
 }
 
 // verifyRecentRevision confirms that the host and contractor agree upon the current
-// state of the contract being revisde.
+// state of the contract being revised.
 func verifyRecentRevision(conn net.Conn, contract modules.RenterContract) error {
 	// send contract ID
 	if err := encoding.WriteObject(conn, contract.ID); err != nil {
@@ -105,7 +104,7 @@ func verifyRecentRevision(conn net.Conn, contract modules.RenterContract) error 
 	// check that revision number matches; if it does, do a more thorough
 	// check by comparing unlock hashes.
 	if lastRevision.NewRevisionNumber != contract.LastRevision.NewRevisionNumber {
-		return fmt.Errorf("our revision number (%v) does not match the host's (%v)", contract.LastRevision.NewRevisionNumber, lastRevision.NewRevisionNumber)
+		return &recentRevisionError{contract.LastRevision.NewRevisionNumber, lastRevision.NewRevisionNumber}
 	} else if lastRevision.UnlockConditions.UnlockHash() != contract.LastRevision.UnlockConditions.UnlockHash() {
 		return errors.New("unlock conditions do not match")
 	}

--- a/modules/renter/proto/negotiate.go
+++ b/modules/renter/proto/negotiate.go
@@ -101,12 +101,12 @@ func verifyRecentRevision(conn net.Conn, contract modules.RenterContract) error 
 	if err := encoding.ReadObject(conn, &hostSignatures, 2048); err != nil {
 		return errors.New("couldn't read host signatures: " + err.Error())
 	}
-	// check that revision number matches; if it does, do a more thorough
-	// check by comparing unlock hashes.
-	if lastRevision.NewRevisionNumber != contract.LastRevision.NewRevisionNumber {
-		return &recentRevisionError{contract.LastRevision.NewRevisionNumber, lastRevision.NewRevisionNumber}
-	} else if lastRevision.UnlockConditions.UnlockHash() != contract.LastRevision.UnlockConditions.UnlockHash() {
+	// Check that the unlock hashes match; if they do not, something is
+	// seriously wrong. Otherwise, check that the revision numbers match.
+	if lastRevision.UnlockConditions.UnlockHash() != contract.LastRevision.UnlockConditions.UnlockHash() {
 		return errors.New("unlock conditions do not match")
+	} else if lastRevision.NewRevisionNumber != contract.LastRevision.NewRevisionNumber {
+		return &recentRevisionError{contract.LastRevision.NewRevisionNumber, lastRevision.NewRevisionNumber}
 	}
 	// NOTE: we can fake the blockheight here because it doesn't affect
 	// verification; it just needs to be above the fork height and below the

--- a/modules/renter/proto/proto.go
+++ b/modules/renter/proto/proto.go
@@ -1,6 +1,8 @@
 package proto
 
 import (
+	"fmt"
+
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -34,4 +36,25 @@ type ContractParams struct {
 	EndHeight     types.BlockHeight
 	RefundAddress types.UnlockHash
 	// TODO: add optional keypair
+}
+
+// A revisionSaver is called just before we send our revision signature to the host; this
+// allows the revision to be reloaded later if we desync from the host.
+type revisionSaver func(types.FileContractRevision) error
+
+// A recentRevisionError occurs if the host reports a different revision
+// number than expected.
+type recentRevisionError struct {
+	ours, theirs uint64
+}
+
+func (e *recentRevisionError) Error() string {
+	return fmt.Sprintf("our revision number (%v) does not match the host's (%v)", e.ours, e.theirs)
+}
+
+// IsRevisionMismatch returns true if err was caused by the host reporting a
+// different revision number than expected.
+func IsRevisionMismatch(err error) bool {
+	_, ok := err.(*recentRevisionError)
+	return ok
 }


### PR DESCRIPTION
The renter and host can "desynchronize" if a disconnect occurs at a specific part of the revision protocol. Specifically, if the renter disconnects after sending the revision to the host, but before receiving the host's signatures, it will not know for sure whether the host has applied the revision or not.

One solution to this would be for the host to accept references to either the "current" or "previous" revision (according to the host). However, this requires the host to store up to one additional segment per contract.

An alternative (implemented here) is for the renter to save the revision to disk before sending it to the host for approval. If a disconnect then occurs and the renter reconnects, it will first attempt to synchronize with the "old" revision, and then try the "new" revision if that fails. Note that no additional storage requirement is imposed here, because the renter is not the party storing the data.