### PR TITLE
repair an nd-failing test

### DIFF
--- a/modules/consensus/validtransaction_test.go
+++ b/modules/consensus/validtransaction_test.go
@@ -181,9 +181,12 @@ func TestStorageProofBoundaries(t *testing.T) {
 				badTxn := types.Transaction{
 					StorageProofs: []types.StorageProof{badSP},
 				}
+				if sp.Segment == badSP.Segment {
+					continue
+				}
 				err = cst.tpool.AcceptTransactionSet([]types.Transaction{badTxn})
 				if err == nil {
-					t.Fatal("bad storage proof got accepted into the transaction pool")
+					t.Fatal("An empty storage proof got into the transaction pool with non-empty data")
 				}
 			}
 


### PR DESCRIPTION
fixes #1258

There was a bug in the testing code where it tried to create bad storage
proofs. But, it created bad storage proofs by leaving the 'base' blank,
which would not succeed if the base was only 1 byte and the randomly
generate base had an emtpy value (1-in-256 chance for 1 byte).

This PR fixes that.