### PR TITLE
remove t.Parallel from networking tests

### DIFF
--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -23,7 +23,6 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	// Create 8 remote peers.
 	remoteCSTs := make([]*consensusSetTester, 8)
@@ -285,7 +284,6 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	// Set minIBDWaitTime to 1s for just this test because no blocks are
 	// transferred between peers so the wait time can be very short.

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -27,7 +27,6 @@ func TestSynchronize(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	cst1, err := createConsensusSetTester("TestSynchronize1")
 	if err != nil {
 		t.Fatal(err)
@@ -108,7 +107,6 @@ func TestBlockHistory(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	cst, err := createConsensusSetTester("TestBlockHistory")
 	if err != nil {
@@ -198,7 +196,6 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	// Setup consensus sets.
 	cst1, err := blankConsensusSetTester("TestSendBlocksBroadcastsOnce1")
@@ -315,7 +312,6 @@ func TestIntegrationRPCSendBlocks(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	type sendBlocksTest struct {
 		commonBlocksToMine types.BlockHeight
@@ -528,7 +524,6 @@ func TestRPCSendBlockSendsOnlyNecessaryBlocks(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	// Create the "remote" peer.
 	cst, err := blankConsensusSetTester("TestRPCSendBlockSendsOnlyNecessaryBlocks - remote")
@@ -673,7 +668,6 @@ func TestSendBlk(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	cst, err := blankConsensusSetTester("TestSendBlk")
 	if err != nil {
 		t.Fatal(err)
@@ -764,7 +758,6 @@ func TestThreadedReceiveBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	cst, err := blankConsensusSetTester("TestThreadedReceiveBlock")
 	if err != nil {
 		t.Fatal(err)
@@ -885,7 +878,6 @@ func TestIntegrationSendBlkRPC(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	cst1, err := blankConsensusSetTester("TestIntegrationSendBlkRPC1")
 	if err != nil {
 		t.Fatal(err)
@@ -989,7 +981,6 @@ func TestRelayHeader(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	cst, err := blankConsensusSetTester("TestRelayHeader")
 	if err != nil {
 		t.Fatal(err)
@@ -1095,7 +1086,6 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	// Setup consensus sets.
 	cst1, err := blankConsensusSetTester("TestIntegrationBroadcastRelayHeader1")
 	if err != nil {
@@ -1156,7 +1146,6 @@ func TestIntegrationRelaySynchronize(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 	cst1, err := blankConsensusSetTester("TestRelaySynchronize1")
 	if err != nil {
 		t.Fatal(err)
@@ -1347,7 +1336,6 @@ func TestThreadedReceiveBlocksStalls(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	cst, err := blankConsensusSetTester("TestThreadedReceiveBlocksStalls")
 	if err != nil {
@@ -1465,7 +1453,6 @@ func TestIntegrationSendBlocksStalls(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	cstLocal, err := blankConsensusSetTester("TestThreadedReceiveBlocksTimesout - local")
 	if err != nil {


### PR DESCRIPTION
The networking tests wait until a network action is complete, but have a
timeout in case the action doesn't complete in time. Running the tests
in parallel makes it much more likely that the tests don't complete in
time because other tests are hogging all of the cpu and disk resources.

For tests which have sensitive timeouts, t.Parallel() has been removed.