### PR TITLE
implement muxado v2 transition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ dependencies:
 	go get -u github.com/NebulousLabs/entropy-mnemonics
 	go get -u github.com/NebulousLabs/go-upnp
 	go get -u github.com/NebulousLabs/muxado
+	go get -u github.com/inconshreveable/muxado
 	go get -u github.com/klauspost/reedsolomon
 	go get -u github.com/julienschmidt/httprouter
 	# Frontend Dependencies

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/muxado"
 )
 
 const (
@@ -77,7 +76,7 @@ func (s invalidVersionError) Error() string {
 
 type peer struct {
 	modules.Peer
-	sess muxado.Session
+	sess streamSession
 }
 
 func (p *peer) open() (modules.PeerConn, error) {
@@ -212,7 +211,7 @@ func (g *Gateway) managedAcceptConnOldPeer(conn net.Conn, remoteVersion string) 
 			Inbound:    true,
 			Version:    remoteVersion,
 		},
-		sess: muxado.Server(conn),
+		sess: newMuxadoV1Server(conn),
 	})
 
 	return nil
@@ -252,7 +251,7 @@ func (g *Gateway) managedAcceptConnNewPeer(conn net.Conn, remoteVersion string) 
 			Inbound:    true,
 			Version:    remoteVersion,
 		},
-		sess: muxado.Server(conn),
+		sess: newMuxadoV2Server(conn),
 	})
 
 	return nil
@@ -403,7 +402,7 @@ func (g *Gateway) managedConnectOldPeer(conn net.Conn, remoteVersion string, rem
 			Inbound:    false,
 			Version:    remoteVersion,
 		},
-		sess: muxado.Client(conn),
+		sess: newMuxadoV1Client(conn),
 	})
 	return nil
 }
@@ -439,7 +438,7 @@ func (g *Gateway) managedConnectNewPeer(conn net.Conn, remoteVersion string, rem
 			Inbound:    false,
 			Version:    remoteVersion,
 		},
-		sess: muxado.Client(conn),
+		sess: newMuxadoV2Client(conn),
 	})
 	return nil
 }

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -7,20 +7,17 @@ import (
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/muxado"
 )
 
 // dummyConn implements the net.Conn interface, but does not carry any actual
-// data. It is passed to muxado, because passing nil results in segfaults.
+// data.
 type dummyConn struct {
 	net.Conn
 }
 
-// muxado uses these methods when sending its GoAway signal
-func (dc *dummyConn) Write(p []byte) (int, error) { return len(p), nil }
-
-func (dc *dummyConn) Close() error { return nil }
-
+func (dc *dummyConn) Read(p []byte) (int, error)       { return len(p), nil }
+func (dc *dummyConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (dc *dummyConn) Close() error                     { return nil }
 func (dc *dummyConn) SetWriteDeadline(time.Time) error { return nil }
 
 func TestAddPeer(t *testing.T) {
@@ -36,7 +33,7 @@ func TestAddPeer(t *testing.T) {
 		Peer: modules.Peer{
 			NetAddress: "foo.com:123",
 		},
-		sess: muxado.Client(new(dummyConn)),
+		sess: newMuxadoV2Client(new(dummyConn)),
 	})
 	if len(g.peers) != 1 {
 		t.Fatal("gateway did not add peer")
@@ -62,7 +59,7 @@ func TestRandomInboundPeer(t *testing.T) {
 			NetAddress: "foo.com:123",
 			Inbound:    true,
 		},
-		sess: muxado.Client(new(dummyConn)),
+		sess: newMuxadoV2Client(new(dummyConn)),
 	})
 	if len(g.peers) != 1 {
 		t.Fatal("gateway did not add peer")
@@ -104,8 +101,8 @@ func TestListen(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// a simple 'conn.Close' would not obey the muxado disconnect protocol
-	muxado.Client(conn).Close()
+	// a simple 'conn.Close' would not obey the muxer's disconnect protocol
+	newMuxadoV2Client(conn).Close()
 
 	// compliant connect with invalid port
 	conn, err = net.Dial("tcp", string(g.Address()))
@@ -134,8 +131,8 @@ func TestListen(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// a simple 'conn.Close' would not obey the muxado disconnect protocol
-	muxado.Client(conn).Close()
+	// a simple 'conn.Close' would not obey the muxer's disconnect protocol
+	newMuxadoV2Client(conn).Close()
 
 	// compliant connect
 	conn, err = net.Dial("tcp", string(g.Address()))
@@ -163,7 +160,7 @@ func TestListen(t *testing.T) {
 		g.mu.RUnlock()
 	}
 
-	muxado.Client(conn).Close()
+	newMuxadoV2Client(conn).Close()
 
 	// g should remove the peer
 	for ok {
@@ -664,7 +661,7 @@ func TestDisconnect(t *testing.T) {
 		Peer: modules.Peer{
 			NetAddress: "foo.com:123",
 		},
-		sess: muxado.Client(conn),
+		sess: newMuxadoV2Client(conn),
 	})
 	g.mu.Unlock()
 	if err := g.Disconnect("foo.com:123"); err != nil {

--- a/modules/gateway/stream.go
+++ b/modules/gateway/stream.go
@@ -1,0 +1,42 @@
+package gateway
+
+import (
+	"net"
+
+	muxadov1 "github.com/NebulousLabs/muxado"    // used pre-1.0
+	muxadov2 "github.com/inconshreveable/muxado" // used post-1.0
+)
+
+// A streamSession is a multiplexed transport that can accept or initiate
+// streams.
+type streamSession interface {
+	Accept() (net.Conn, error)
+	Open() (net.Conn, error)
+	Close() error
+}
+
+// muxado's Session methods do not return a net.Conn, but rather a
+// muxado.Stream, necessitating an adaptor.
+type muxadoAdaptor struct {
+	sess muxadov1.Session
+}
+
+func (m muxadoAdaptor) Accept() (net.Conn, error) { return m.sess.Accept() }
+func (m muxadoAdaptor) Open() (net.Conn, error)   { return m.sess.Open() }
+func (m muxadoAdaptor) Close() error              { return m.sess.Close() }
+
+func newMuxadoV1Server(conn net.Conn) muxadoAdaptor {
+	return muxadoAdaptor{muxadov1.Server(conn)}
+}
+
+func newMuxadoV1Client(conn net.Conn) muxadoAdaptor {
+	return muxadoAdaptor{muxadov1.Client(conn)}
+}
+
+func newMuxadoV2Server(conn net.Conn) muxadov2.Session {
+	return muxadov2.Server(conn, nil)
+}
+
+func newMuxadoV2Client(conn net.Conn) muxadov2.Session {
+	return muxadov2.Client(conn, nil)
+}

--- a/modules/gateway/stream.go
+++ b/modules/gateway/stream.go
@@ -34,9 +34,9 @@ func newMuxadoV1Client(conn net.Conn) muxadoAdaptor {
 }
 
 func newMuxadoV2Server(conn net.Conn) muxadov2.Session {
-	return muxadov2.Server(conn, nil)
+	return muxadov2.Server(conn, &muxadov2.Config{})
 }
 
 func newMuxadoV2Client(conn net.Conn) muxadov2.Session {
-	return muxadov2.Client(conn, nil)
+	return muxadov2.Client(conn, &muxadov2.Config{})
 }


### PR DESCRIPTION
yamux was the original choice, but produced "duplicate stream id" errors during `TestCallingRPCFromRPC`. I haven't yet identified the root cause of this, but it seems to be a "cross-network race condition" that can occur if the client and server initiate a stream at the same time.

This diff turned out to be pleasantly tiny thanks to Jordan's recent reorganization that cleanly split the old version code from the new.
