### PR TITLE
Implement Close for the Wallet

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -114,18 +114,6 @@ func (srv *Server) Close() error {
 	srv.wg.Wait()
 
 	// Safely close each module.
-	// TODO: close transaction pool
-
-	// wallet has special closing mechanics
-	if srv.wallet != nil {
-		// TODO: close wallet and lock the wallet in the wallet's Close method.
-		if srv.wallet.Unlocked() {
-			if err := srv.wallet.Lock(); err != nil {
-				errs = append(errs, fmt.Errorf("wallet.Lock failed: %v", err))
-			}
-		}
-	}
-
 	mods := []struct {
 		name string
 		c    io.Closer
@@ -134,6 +122,8 @@ func (srv *Server) Close() error {
 		{"renter", srv.renter},
 		{"explorer", srv.explorer},
 		{"miner", srv.miner},
+		{"wallet", srv.wallet},
+		{"tpool", srv.tpool},
 		{"consensus", srv.cs},
 		{"gateway", srv.gateway},
 	}

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -306,6 +306,9 @@ type (
 		EncryptionManager
 		KeyManager
 
+		// Close permits clean shutdown during testing and serving.
+		Close() error
+
 		// ConfirmedBalance returns the confirmed balance of the wallet, minus
 		// any outgoing transactions. ConfirmedBalance will include unconfirmed
 		// refund transactions.

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -83,7 +83,7 @@ func (w *Wallet) initEncryption(masterKey crypto.TwofishKey) (modules.Seed, erro
 	return seed, nil
 }
 
-// unlock loads all of the encrypted file structures into wallet memory. Even
+// managedUnlock loads all of the encrypted file structures into wallet memory. Even
 // after loading, the structures are kept encrypted, but some data such as
 // addresses are decrypted so that the wallet knows what to track.
 func (w *Wallet) managedUnlock(masterKey crypto.TwofishKey) error {
@@ -200,6 +200,10 @@ func (w *Wallet) Encrypted() bool {
 // reset the wallet, the wallet files must be moved to a different directory or
 // deleted.
 func (w *Wallet) Encrypt(masterKey crypto.TwofishKey) (modules.Seed, error) {
+	if err := w.tg.Add(); err != nil {
+		return modules.Seed{}, err
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.initEncryption(masterKey)

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -53,6 +53,11 @@ func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incoming
 // SendSiacoins creates a transaction sending 'amount' to 'dest'. The transaction
 // is submitted to the transaction pool and is also returned.
 func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error) {
+	if err := w.tg.Add(); err != nil {
+		return nil, err
+	}
+	defer w.tg.Done()
+
 	tpoolFee := types.SiacoinPrecision.Mul64(10) // TODO: better fee algo.
 	output := types.SiacoinOutput{
 		Value:      amount,
@@ -80,6 +85,10 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]t
 // SendSiafunds creates a transaction sending 'amount' to 'dest'. The transaction
 // is submitted to the transaction pool and is also returned.
 func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error) {
+	if err := w.tg.Add(); err != nil {
+		return nil, err
+	}
+	defer w.tg.Done()
 	tpoolFee := types.SiacoinPrecision.Mul64(10) // TODO: better fee algo.
 	output := types.SiafundOutput{
 		Value:      amount,

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -134,6 +134,10 @@ func (w *Wallet) createBackup(backupFilepath string) error {
 
 // CreateBackup creates a backup file at the desired filepath.
 func (w *Wallet) CreateBackup(backupFilepath string) error {
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.createBackup(backupFilepath)
@@ -143,6 +147,11 @@ func (w *Wallet) CreateBackup(backupFilepath string) error {
 // LoadBackup loads a backup file from the provided filepath. The backup file
 // primary seed is loaded as an auxiliary seed.
 func (w *Wallet) LoadBackup(masterKey, backupMasterKey crypto.TwofishKey, backupFilepath string) error {
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
+	defer w.tg.Done()
+
 	lockID := w.mu.Lock()
 	defer w.mu.Unlock(lockID)
 

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -251,6 +251,10 @@ func (w *Wallet) PrimarySeed() (modules.Seed, uint64, error) {
 // NextAddress returns an unlock hash that is ready to receive siacoins or
 // siafunds. The address is generated using the primary address seed.
 func (w *Wallet) NextAddress() (types.UnlockConditions, error) {
+	if err := w.tg.Add(); err != nil {
+		return types.UnlockConditions{}, err
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.nextPrimarySeedAddress()
@@ -261,6 +265,10 @@ func (w *Wallet) NextAddress() (types.UnlockConditions, error) {
 // key. An error will be returned if the seed has already been integrated with
 // the wallet.
 func (w *Wallet) LoadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error {
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	err := w.checkMasterKey(masterKey)

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -22,6 +22,7 @@ func TestPrimarySeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer wt.closeWt()
 
 	// Create a seed and unlock the wallet.
 	seed, err := wt.wallet.Encrypt(crypto.TwofishKey{})
@@ -91,6 +92,7 @@ func TestLoadSeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer wt.closeWt()
 	seed, _, err := wt.wallet.PrimarySeed()
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -82,7 +82,7 @@ func addSignatures(txn *types.Transaction, cf types.CoveredFields, uc types.Unlo
 	return newSigIndices, nil
 }
 
-// FundSiacoins will add a siacoin input of exaclty 'amount' to the
+// FundSiacoins will add a siacoin input of exactly 'amount' to the
 // transaction. A parent transaction may be needed to achieve an input with the
 // correct value. The siacoin input will not be signed until 'Sign' is called
 // on the transaction builder.

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -177,6 +177,10 @@ func (w *Wallet) loadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 
 // LoadSiagKeys loads a set of siag-generated keys into the wallet.
 func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) error {
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	err := w.checkMasterKey(masterKey)
@@ -189,6 +193,10 @@ func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 // Load033xWallet loads a v0.3.3.x wallet as an unseeded key, such that the
 // funds become spendable to the current wallet.
 func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string) error {
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	err := w.checkMasterKey(masterKey)

--- a/modules/wallet/unseeded_test.go
+++ b/modules/wallet/unseeded_test.go
@@ -17,6 +17,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer wt.closeWt()
 
 	// Load the key into the wallet.
 	err = wt.wallet.LoadSiagKeys(wt.walletMasterKey, []string{"../../types/siag0of1of1.siakey"})
@@ -30,6 +31,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer w.Close()
 	err = w.Unlock(wt.walletMasterKey)
 	if err != nil {
 		t.Fatal(err)
@@ -65,6 +67,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer wt.closeWt()
 
 	// Load the key into the wallet.
 	err = wt.wallet.LoadSiagKeys(wt.walletMasterKey, []string{"../../types/siag0of2of3.siakey", "../../types/siag1of2of3.siakey"})
@@ -78,6 +81,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer w.Close()
 	err = w.Unlock(wt.walletMasterKey)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -209,6 +209,13 @@ func (w *Wallet) applyHistory(cc modules.ConsensusChange) {
 // ProcessConsensusChange parses a consensus change to update the set of
 // confirmed outputs known to the wallet.
 func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
+	if err := w.tg.Add(); err != nil {
+		// The wallet should gracefully reject updates from the consensus set
+		// or transaction pool that are sent after the wallet's Close method
+		// has closed the wallet's ThreadGroup.
+		return
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.updateConfirmedSet(cc)
@@ -219,12 +226,18 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 // ReceiveUpdatedUnconfirmedTransactions updates the wallet's unconfirmed
 // transaction set.
 func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction, _ modules.ConsensusChange) {
+	if err := w.tg.Add(); err != nil {
+		// Gracefully reject transactions if the wallet's Close method has
+		// closed the wallet's ThreadGroup already.
+		return
+	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
 	w.unconfirmedProcessedTransactions = nil
 	for _, txn := range txns {
-		// To save on  code complexity, relveancy is determined while building
+		// To save on code complexity, relevancy is determined while building
 		// up the wallet transaction.
 		relevant := false
 		pt := modules.ProcessedTransaction{

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -197,3 +197,31 @@ func TestAllAddresses(t *testing.T) {
 		}
 	}
 }
+
+// TestCloseWallet tries to close the wallet.
+func TestCloseWallet(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	testdir := build.TempDir(modules.WalletDir, "TestCloseWallet")
+	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs, err := consensus.New(g, filepath.Join(testdir, modules.ConsensusDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp, err := transactionpool.New(cs, g, filepath.Join(testdir, modules.TransactionPoolDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wdir := filepath.Join(testdir, modules.WalletDir)
+	w, err := New(cs, tp, wdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -132,8 +132,14 @@ func createBlankWalletTester(name string) (*walletTester, error) {
 
 // closeWt closes all of the modules in the wallet tester.
 func (wt *walletTester) closeWt() {
-	err := wt.gateway.Close()
-	if err != nil {
+	errs := []error{
+		wt.gateway.Close(),
+		wt.cs.Close(),
+		wt.tpool.Close(),
+		wt.miner.Close(),
+		wt.wallet.Close(),
+	}
+	if err := build.JoinErrors(errs, "; "); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
The wallet needs a `Close` method for clean shutdown during testing and serving.