### PR TITLE
Renter 1.0 fixes

### DIFF
--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -368,12 +368,8 @@ func verifyRevision(so *storageObligation, revision types.FileContractRevision, 
 		return errReviseBadRenterMissedOutput
 	}
 	// The new collateral comes out of the host's missed outputs.
-	if revision.NewMissedProofOutputs[1].Value.Add(newCollateral).Cmp(oldFCR.NewMissedProofOutputs[1].Value) > 0 {
+	if revision.NewMissedProofOutputs[1].Value.Add(newCollateral).Cmp(oldFCR.NewMissedProofOutputs[1].Value) < 0 {
 		return errReviseBadCollateralDeduction
-	}
-	// The new collateral and new revenue goes into the host's void outputs.
-	if oldFCR.NewMissedProofOutputs[2].Value.Add(newRevenue).Add(newCollateral).Cmp(revision.NewMissedProofOutputs[2].Value) < 0 {
-		return errReviseBadVoidOutput
 	}
 
 	// The Merkle root is checked last because it is the most expensive check.

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -9,6 +9,9 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// the contractor will cap host's MaxCollateral setting to this value
+var maxUploadCollateral = types.SiacoinPrecision.Mul64(1e3).Div(modules.BlockBytesPerMonthTerabyte) // 1k SC / TB / Month
+
 // An Editor modifies a Contract by communicating with a host. It uses the
 // contract revision protocol to send modification requests to the host.
 // Editors are the means by which the renter uploads data to hosts.
@@ -133,6 +136,10 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 	}
 	if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
 		return nil, errTooExpensive
+	}
+	// cap host.Collateral
+	if host.Collateral.Cmp(maxUploadCollateral) > 0 {
+		host.Collateral = maxUploadCollateral
 	}
 
 	// create editor

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -3,6 +3,7 @@ package contractor
 import (
 	"errors"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/proto"
@@ -137,9 +138,11 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 	if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
 		return nil, errTooExpensive
 	}
-	// cap host.Collateral
-	if host.Collateral.Cmp(maxUploadCollateral) > 0 {
-		host.Collateral = maxUploadCollateral
+	// cap host.Collateral on new hosts
+	if build.VersionCmp(host.Version, "0.6.0") > 0 {
+		if host.Collateral.Cmp(maxUploadCollateral) > 0 {
+			host.Collateral = maxUploadCollateral
+		}
 	}
 
 	// create editor

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -166,6 +166,7 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 
 	return &hostEditor{
 		editor:     e,
+		contract:   contract,
 		contractor: c,
 	}, nil
 }

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -18,6 +18,10 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 	} else if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
 		return modules.RenterContract{}, errTooExpensive
 	}
+	// cap host.MaxCollateral
+	if host.MaxCollateral.Cmp(maxCollateral) > 0 {
+		host.MaxCollateral = maxCollateral
+	}
 
 	// get an address to use for negotiation
 	uc, err := c.wallet.NextAddress()

--- a/modules/renter/pool.go
+++ b/modules/renter/pool.go
@@ -1,6 +1,7 @@
 package renter
 
 import (
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/contractor"
 )
@@ -50,6 +51,7 @@ func (p *hostPool) remove(addr modules.NetAddress) {
 			return
 		}
 	}
+	build.Critical("could not remove host from pool: no record of host", addr)
 }
 
 // uniqueHosts will return up to 'n' unique hosts that are not in 'exclude'.


### PR DESCRIPTION
The renter now caps how much collateral it will spend on a contract.
Old hosts will reject this (for revisions), so the cap is wrapped with a version conditional.

Also fix a bug that caused hostEditors to not report their host's NetAddress. This resulted in upload stalling because the host would not be properly removed from the host pool.