### PR TITLE
renter no longer needs wallet

### DIFF
--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -189,10 +189,6 @@ func (r *Renter) Download(path, destination string) error {
 		return errors.New("no file with that path")
 	}
 
-	if !r.wallet.Unlocked() {
-		return errors.New("wallet must be unlocked before downloading")
-	}
-
 	// Copy the file's metadata
 	// TODO: this is ugly because we only have the Contracts method for
 	// looking up contracts.

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -217,8 +217,8 @@ func (r *Renter) FileList() []modules.FileInfo {
 	files := make([]modules.FileInfo, 0, len(r.files))
 	for _, f := range r.files {
 		// _, renewing := r.tracking[f.name]
-		// TODO: get renewing working again
-		renewing := false
+		// TODO: bring back per-file renewing
+		renewing := true
 		files = append(files, modules.FileInfo{
 			SiaPath:        f.name,
 			Filesize:       f.size,

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -99,6 +99,10 @@ func New(cs modules.ConsensusSet, wallet modules.Wallet, tpool modules.Transacti
 		return nil, err
 	}
 
+	return newRenter(cs, tpool, hdb, hc, persistDir)
+}
+
+func newRenter(cs modules.ConsensusSet, tpool modules.TransactionPool, hdb hostDB, hc hostContractor, persistDir string) (*Renter, error) {
 	r := &Renter{
 		cs:             cs,
 		hostDB:         hdb,
@@ -110,8 +114,7 @@ func New(cs modules.ConsensusSet, wallet modules.Wallet, tpool modules.Transacti
 		persistDir: persistDir,
 		mu:         sync.New(modules.SafeMutexDelay, 1),
 	}
-	err = r.initPersist()
-	if err != nil {
+	if err := r.initPersist(); err != nil {
 		return nil, err
 	}
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -70,8 +70,7 @@ type trackedFile struct {
 // uploaded to Sia, as well as the locations and health of these files.
 type Renter struct {
 	// modules
-	cs     modules.ConsensusSet
-	wallet modules.Wallet
+	cs modules.ConsensusSet
 
 	// resources
 	hostDB         hostDB
@@ -102,7 +101,6 @@ func New(cs modules.ConsensusSet, wallet modules.Wallet, tpool modules.Transacti
 
 	r := &Renter{
 		cs:             cs,
-		wallet:         wallet,
 		hostDB:         hdb,
 		hostContractor: hc,
 

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -100,7 +100,7 @@ func newRenterTester(name string) (*renterTester, error) {
 
 // newContractorTester creates a renterTester, but with the supplied
 // hostContractor.
-func newContractorTester(name string, hc hostContractor) (*renterTester, error) {
+func newContractorTester(name string, hdb hostDB, hc hostContractor) (*renterTester, error) {
 	// Create the modules.
 	testdir := build.TempDir("renter", name)
 	g, err := gateway.New("localhost:0", filepath.Join(testdir, modules.GatewayDir))
@@ -131,11 +131,10 @@ func newContractorTester(name string, hc hostContractor) (*renterTester, error) 
 	if err != nil {
 		return nil, err
 	}
-	r, err := New(cs, w, tp, filepath.Join(testdir, modules.RenterDir))
+	r, err := newRenter(cs, tp, hdb, hc, filepath.Join(testdir, modules.RenterDir))
 	if err != nil {
 		return nil, err
 	}
-	r.hostContractor = hc
 	m, err := miner.New(cs, tp, w, filepath.Join(testdir, modules.MinerDir))
 	if err != nil {
 		return nil, err

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -218,10 +218,6 @@ func (r *Renter) threadedRepairLoop() {
 	for {
 		time.Sleep(5 * time.Second)
 
-		if !r.wallet.Unlocked() {
-			continue
-		}
-
 		if len(r.hostContractor.Contracts()) == 0 {
 			// nothing to revise
 			continue

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -42,10 +42,6 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 		return errors.New("nicknames cannot begin with /")
 	}
 
-	if !r.wallet.Unlocked() {
-		return errors.New("wallet must be unlocked before uploading")
-	}
-
 	// Check for a nickname conflict.
 	lockID := r.mu.RLock()
 	_, exists := r.files[up.SiaPath]

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -74,7 +74,7 @@ func TestUploadDownload(t *testing.T) {
 	hc := &uploadDownloadContractor{
 		sectors: make(map[crypto.Hash][]byte),
 	}
-	rt, err := newContractorTester("TestUploadDownload", hc)
+	rt, err := newContractorTester("TestUploadDownload", nil, hc)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Since revising contracts does not require wallet access, the renter no longer needs to call any methods of the wallet.