### PR TITLE
ConsensusSubscribe bugfix

### DIFF
--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -110,6 +110,10 @@ type (
 		// SiafundPoolDiffs are the siafund pool diffs that were applied to the
 		// consensus set in the recent change.
 		SiafundPoolDiffs []SiafundPoolDiff
+
+		// Synced indicates whether or not the ConsensusSet is synced with its
+		// peers.
+		Synced bool
 	}
 
 	// A SiacoinOutputDiff indicates the addition or removal of a SiacoinOutput in

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -72,6 +72,8 @@ func (cs *ConsensusSet) computeConsensusChange(tx *bolt.Tx, ce changeEntry) (mod
 			cc.SiafundPoolDiffs = append(cc.SiafundPoolDiffs, sfpd)
 		}
 	}
+
+	cc.Synced = cs.synced
 	return cc, nil
 }
 

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -160,13 +160,14 @@ func (cs *ConsensusSet) initializeSubscribe(subscriber modules.ConsensusSetSubsc
 // sent to the modules starting with the genesis block.
 func (cs *ConsensusSet) ConsensusSetSubscribe(subscriber modules.ConsensusSetSubscriber, start modules.ConsensusChangeID) error {
 	cs.mu.Lock()
+	defer cs.mu.Unlock()
 	cs.subscribers = append(cs.subscribers, subscriber)
-	cs.mu.Demote()
-	defer cs.mu.DemotedUnlock()
 
 	// Get the input module caught up to the currenct consnesus set.
 	err := cs.initializeSubscribe(subscriber, start)
 	if err != nil {
+		// Remove the subscriber from the set of subscribers.
+		cs.subscribers = cs.subscribers[:len(cs.subscribers)-1]
 		return err
 	}
 	// Only add the module as a subscriber if there was no error.

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -42,7 +42,7 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 
 	// only attempt contract formation/renewal if we are synced
 	// (harmless otherwise, since hosts will reject our renewal attempts, but very slow)
-	if c.cs.Synced() {
+	if cc.Synced {
 		// renew any contracts that have entered the renew window
 		err := c.managedRenewContracts()
 		if err != nil {


### PR DESCRIPTION
The commit chain is cleaner and easier to understand than the complete diff.

fixes #1287, as well as a deadlock in the contractor that will cause all of siad to freeze (deadlock exists in RC1 and RC2). 

This bug is pretty significant, this PR should be high priority.