### PR TITLE
Finalize the hostdb

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -163,8 +163,9 @@ func (srv *Server) initAPI(password string) {
 		router.POST("/renter/rename/*siapath", requirePassword(srv.renterRenameHandler, password))
 		router.POST("/renter/upload/*siapath", requirePassword(srv.renterUploadHandler, password))
 
-		router.GET("/renter/hosts/active", srv.renterHostsActiveHandler)
-		router.GET("/renter/hosts/all", srv.renterHostsAllHandler)
+		// HostDB endpoints.
+		router.GET("/hostdb/active", srv.renterHostsActiveHandler)
+		router.GET("/hostdb/all", srv.renterHostsAllHandler)
 	}
 
 	// TransactionPool API Calls

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -124,7 +124,7 @@ func TestRenterConflicts(t *testing.T) {
 }
 
 // TestRenterHostsActiveHandler checks the behavior of the call to
-// /renter/hosts/active.
+// /hostdb/active.
 func TestRenterHostsActiveHandler(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -137,25 +137,25 @@ func TestRenterHostsActiveHandler(t *testing.T) {
 
 	// Try the call with with numhosts unset, and set to -1, 0, and 1.
 	var ah ActiveHosts
-	err = st.getAPI("/renter/hosts/active", &ah)
+	err = st.getAPI("/hostdb/active", &ah)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(ah.Hosts) != 0 {
 		t.Fatal(len(ah.Hosts))
 	}
-	err = st.getAPI("/renter/hosts/active?numhosts=-1", &ah)
+	err = st.getAPI("/hostdb/active?numhosts=-1", &ah)
 	if err == nil {
 		t.Fatal("expecting an error, got:", err)
 	}
-	err = st.getAPI("/renter/hosts/active?numhosts=0", &ah)
+	err = st.getAPI("/hostdb/active?numhosts=0", &ah)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(ah.Hosts) != 0 {
 		t.Fatal(len(ah.Hosts))
 	}
-	err = st.getAPI("/renter/hosts/active?numhosts=1", &ah)
+	err = st.getAPI("/hostdb/active?numhosts=1", &ah)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,32 +178,32 @@ func TestRenterHostsActiveHandler(t *testing.T) {
 	}
 
 	// Try the call with with numhosts unset, and set to -1, 0, 1, and 2.
-	err = st.getAPI("/renter/hosts/active", &ah)
+	err = st.getAPI("/hostdb/active", &ah)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(ah.Hosts) != 1 {
 		t.Fatal(len(ah.Hosts))
 	}
-	err = st.getAPI("/renter/hosts/active?numhosts=-1", &ah)
+	err = st.getAPI("/hostdb/active?numhosts=-1", &ah)
 	if err == nil {
 		t.Fatal("expecting an error, got:", err)
 	}
-	err = st.getAPI("/renter/hosts/active?numhosts=0", &ah)
+	err = st.getAPI("/hostdb/active?numhosts=0", &ah)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(ah.Hosts) != 0 {
 		t.Fatal(len(ah.Hosts))
 	}
-	err = st.getAPI("/renter/hosts/active?numhosts=1", &ah)
+	err = st.getAPI("/hostdb/active?numhosts=1", &ah)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(ah.Hosts) != 1 {
 		t.Fatal(len(ah.Hosts))
 	}
-	err = st.getAPI("/renter/hosts/active?numhosts=2", &ah)
+	err = st.getAPI("/hostdb/active?numhosts=2", &ah)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -408,13 +408,13 @@ func (st *serverTester) announceHost() error {
 	}
 	// wait for announcement
 	var hosts ActiveHosts
-	err = st.getAPI("/renter/hosts/active", &hosts)
+	err = st.getAPI("/hostdb/active", &hosts)
 	if err != nil {
 		return err
 	}
 	for i := 0; i < 20 && len(hosts.Hosts) == 0; i++ {
 		time.Sleep(100 * time.Millisecond)
-		err = st.getAPI("/renter/hosts/active", &hosts)
+		err = st.getAPI("/hostdb/active", &hosts)
 		if err != nil {
 			return err
 		}

--- a/doc/API.md
+++ b/doc/API.md
@@ -582,8 +582,8 @@ Queries:
 * /renter/download/{siapath} [GET]
 * /renter/rename/{siapath}   [POST]
 * /renter/upload/{siapath}   [POST]
-* /renter/hosts/active       [GET]
-* /renter/hosts/all          [GET]
+* /hostdb/active             [GET]
+* /hostdb/all                [GET]
 
 #### /renter/allowance [GET]
 
@@ -818,7 +818,7 @@ source   string
 
 Response: standard.
 
-#### /renter/hosts/active [GET]
+#### /hostdb/active [GET]
 
 Function: Lists all of the active hosts known to the renter, sorted by
 preference.
@@ -845,9 +845,9 @@ struct {
 	}
 }
 ```
-See /renter/hosts/all for a description of each field.
+See /hostdb/all for a description of each field.
 
-#### /renter/hosts/all [GET]
+#### /hostdb/all [GET]
 
 Function: Lists all of the hosts known to the renter.
 

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -132,7 +132,7 @@ func hostcmd() {
 	// Determine the competitive price string.
 	ah := new(api.ActiveHosts)
 	var competitivePrice string
-	err = getAPI("/renter/hosts/active?numhosts=24", ah)
+	err = getAPI("/hostdb/active?numhosts=24", ah)
 	if err != nil || len(ah.Hosts) == 0 {
 		competitivePrice = "Unavailable"
 	} else {

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -20,7 +20,7 @@ var (
 
 func hostdbcmd() {
 	info := new(api.ActiveHosts)
-	err := getAPI("/renter/hosts/active", info)
+	err := getAPI("/hostdb/active", info)
 	if err != nil {
 		die("Could not fetch host list:", err)
 	}


### PR DESCRIPTION
Move hostdb API endpoints from /renter/hosts to /hostdb

**This PR is incomplete.** The API documentation for the hostdb still needs to be updated to the new style. I'm waiting to update the documentation until I get comments about my concern below.

I was conflicted about whether to call the endpoint `/hostdb` or `/hosts`. `/hostdb` is more in line with naming endpoints after their modules (is it still the plan to make the hostdb its own module in the future?) but is potentially more confusing at first glance. Host DB might be confused as the database hosts use to store renter's files, instead of a database of hosts. `/hosts` make more intuitive sense, especially the full endpoint paths `/hosts/active` and `/hosts/all`) but is more easily mistaken for the `/host` endpoint.

I know this is nit-picky but since the API is being finalized I didn't want to skip over any considerations other people might have.