### PR TITLE
Remove the /transactionpool endpoint in preparation for 1.0

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -169,7 +169,8 @@ func (srv *Server) initAPI(password string) {
 
 	// TransactionPool API Calls
 	if srv.tpool != nil {
-		router.GET("/transactionpool/transactions", srv.transactionpoolTransactionsHandler)
+		// TODO: re-enable this route once the transaction pool API has been finalized
+		//router.GET("/transactionpool/transactions", srv.transactionpoolTransactionsHandler)
 	}
 
 	// Wallet API Calls

--- a/doc/API.md
+++ b/doc/API.md
@@ -60,7 +60,6 @@ Table of contents
 - [Host](#host)
 - [Miner](#miner)
 - [Renter](#renter)
-- [Transaction Pool](#transaction-pool)
 - [Wallet](#wallet)
 
 Daemon
@@ -885,28 +884,6 @@ the host.
 hastings/byte/block.
 
 'unlockhash' is the coin address of the host.
-
-Transaction Pool
-----------------
-
-Queries:
-
-* /transactionpool/transactions [GET]
-
-#### /transactionpool/transactions [GET]
-
-Function: Returns all of the transactions in the transaction pool.
-
-Parameters: none
-
-Response:
-```
-struct {
-	transactions []types.Transaction
-}
-```
-Please see types/transactions.go for a more detailed explanation of
-what a transaction looks like. There are many fields.
 
 
 Wallet


### PR DESCRIPTION
Restore the endpoint once the transaction pool API has been finalized. Refer to issue #1297 for discussing transaction pool API finalization.