### PR TITLE
restore update functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ dependencies:
 	go get -u github.com/NebulousLabs/muxado
 	go get -u github.com/klauspost/reedsolomon
 	go get -u github.com/julienschmidt/httprouter
+	go get -u github.com/inconshreveable/go-update
+	go get -u github.com/kardianos/osext
 	# Frontend Dependencies
 	go get -u github.com/bgentry/speakeasy
 	go get -u github.com/spf13/cobra

--- a/api/api.go
+++ b/api/api.go
@@ -124,6 +124,8 @@ func (srv *Server) initAPI(password string) {
 	// Daemon API Calls
 	router.GET("/daemon/constants", srv.daemonConstantsHandler)
 	router.GET("/daemon/version", srv.daemonVersionHandler)
+	router.GET("/daemon/update", srv.daemonUpdateHandlerGET)
+	router.POST("/daemon/update", srv.daemonUpdateHandlerPOST)
 	router.GET("/daemon/stop", requirePassword(srv.daemonStopHandler, password))
 
 	// Consensus API Calls

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -149,8 +149,9 @@ func updateToRelease(release githubRelease) error {
 	if err != nil {
 		return err
 	}
-	// release is small enough to store in memory
-	content, err := ioutil.ReadAll(resp.Body)
+	// release should be small enough to store in memory (<10 MiB); use
+	// LimitReader to ensure we don't download more than 32 MiB
+	content, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<25))
 	resp.Body.Close()
 	if err != nil {
 		return err

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -1,14 +1,71 @@
 package api
 
 import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"math/big"
 	"net/http"
+	"path"
+	"path/filepath"
+	"runtime"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/types"
 
+	"github.com/inconshreveable/go-update"
 	"github.com/julienschmidt/httprouter"
+	"github.com/kardianos/osext"
 )
+
+// SiaConstants is a struct listing all of the constants in use.
+type SiaConstants struct {
+	GenesisTimestamp      types.Timestamp   `json:"genesistimestamp"`
+	BlockSizeLimit        uint64            `json:"blocksizelimit"`
+	BlockFrequency        types.BlockHeight `json:"blockfrequency"`
+	TargetWindow          types.BlockHeight `json:"targetwindow"`
+	MedianTimestampWindow uint64            `json:"mediantimestampwindow"`
+	FutureThreshold       types.Timestamp   `json:"futurethreshold"`
+	SiafundCount          types.Currency    `json:"siafundcount"`
+	SiafundPortion        *big.Rat          `json:"siafundportion"`
+	MaturityDelay         types.BlockHeight `json:"maturitydelay"`
+
+	InitialCoinbase uint64 `json:"initialcoinbase"`
+	MinimumCoinbase uint64 `json:"minimumcoinbase"`
+
+	RootTarget types.Target `json:"roottarget"`
+	RootDepth  types.Target `json:"rootdepth"`
+
+	MaxAdjustmentUp   *big.Rat `json:"maxadjustmentup"`
+	MaxAdjustmentDown *big.Rat `json:"maxadjustmentdown"`
+
+	SiacoinPrecision types.Currency `json:"siacoinprecision"`
+}
+
+type DaemonVersion struct {
+	Version string `json:"version"`
+}
+
+// UpdateInfo indicates whether an update is available, and to what
+// version.
+type UpdateInfo struct {
+	Available bool
+	Version   string
+}
+
+// githubRelease represents of the JSON returned by the GitHub release API
+// endpoint. Only the fields relevant to updating are included.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name        string `json:"name"`
+		DownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
 
 const (
 	// The developer key is used to sign updates and other important Sia-
@@ -40,32 +97,149 @@ bwIDAQAB
 -----END PUBLIC KEY-----`
 )
 
-// SiaConstants is a struct listing all of the constants in use.
-type SiaConstants struct {
-	GenesisTimestamp      types.Timestamp   `json:"genesistimestamp"`
-	BlockSizeLimit        uint64            `json:"blocksizelimit"`
-	BlockFrequency        types.BlockHeight `json:"blockfrequency"`
-	TargetWindow          types.BlockHeight `json:"targetwindow"`
-	MedianTimestampWindow uint64            `json:"mediantimestampwindow"`
-	FutureThreshold       types.Timestamp   `json:"futurethreshold"`
-	SiafundCount          types.Currency    `json:"siafundcount"`
-	SiafundPortion        *big.Rat          `json:"siafundportion"`
-	MaturityDelay         types.BlockHeight `json:"maturitydelay"`
-
-	InitialCoinbase uint64 `json:"initialcoinbase"`
-	MinimumCoinbase uint64 `json:"minimumcoinbase"`
-
-	RootTarget types.Target `json:"roottarget"`
-	RootDepth  types.Target `json:"rootdepth"`
-
-	MaxAdjustmentUp   *big.Rat `json:"maxadjustmentup"`
-	MaxAdjustmentDown *big.Rat `json:"maxadjustmentdown"`
-
-	SiacoinPrecision types.Currency `json:"siacoinprecision"`
+// fetchLatestRelease returns metadata about the most recent GitHub release.
+func fetchLatestRelease() (githubRelease, error) {
+	resp, err := http.Get("https://api.github.com/repos/NebulousLabs/Sia/releases/latest")
+	if err != nil {
+		return githubRelease{}, err
+	}
+	defer resp.Body.Close()
+	var release githubRelease
+	err = json.NewDecoder(resp.Body).Decode(&release)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	return release, nil
 }
 
-type DaemonVersion struct {
-	Version string `json:"version"`
+// updateToRelease updates siad and siac to the release specified. siac is
+// assumed to be in the same folder as siad.
+func updateToRelease(release githubRelease) error {
+	updateOpts := update.Options{
+		Verifier: update.NewRSAVerifier(),
+	}
+	err := updateOpts.SetPublicKeyPEM([]byte(developerKey))
+	if err != nil {
+		// should never happen
+		return err
+	}
+
+	binaryFolder, err := osext.ExecutableFolder()
+	if err != nil {
+		return err
+	}
+
+	// construct release filename
+	releaseName := fmt.Sprintf("Sia-%s-%s-%s.zip", release.TagName, runtime.GOOS, runtime.GOARCH)
+
+	// find release
+	var downloadURL string
+	for _, asset := range release.Assets {
+		if asset.Name == releaseName {
+			downloadURL = asset.DownloadURL
+			break
+		}
+	}
+	if downloadURL == "" {
+		return errors.New("couldn't find download URL for " + releaseName)
+	}
+
+	// download release archive
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return err
+	}
+	// release is small enough to store in memory
+	content, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	r := bytes.NewReader(content)
+	z, err := zip.NewReader(r, r.Size())
+	if err != nil {
+		return err
+	}
+
+	// process zip, finding siad/siac binaries and signatures
+	for _, binary := range []string{"siad", "siac"} {
+		var binData io.ReadCloser
+		var signature []byte
+		var binaryName string // needed for TargetPath below
+		for _, zf := range z.File {
+			switch base := path.Base(zf.Name); base {
+			case binary, binary + ".exe":
+				binaryName = base
+				binData, err = zf.Open()
+				if err != nil {
+					return err
+				}
+				defer binData.Close()
+			case binary + ".sig", binary + ".exe.sig":
+				sigFile, err := zf.Open()
+				if err != nil {
+					return err
+				}
+				defer sigFile.Close()
+				signature, err = ioutil.ReadAll(sigFile)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if binData == nil {
+			return errors.New("could not find " + binary + " binary")
+		} else if signature == nil {
+			return errors.New("could not find " + binary + " signature")
+		}
+
+		// apply update
+		updateOpts.Signature = signature
+		updateOpts.TargetMode = 0775 // executable
+		updateOpts.TargetPath = filepath.Join(binaryFolder, binaryName)
+		err = update.Apply(binData, updateOpts)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// daemonUpdateHandlerGET handles the API call that checks for an update.
+func (srv *Server) daemonUpdateHandlerGET(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	release, err := fetchLatestRelease()
+	if err != nil {
+		writeError(w, Error{"Failed to fetch latest release: " + err.Error()}, http.StatusInternalServerError)
+		return
+	}
+	latestVersion := release.TagName[1:] // delete leading 'v'
+	writeJSON(w, UpdateInfo{
+		Available: build.VersionCmp(latestVersion, build.Version) > 0,
+		Version:   latestVersion,
+	})
+}
+
+// daemonUpdateHandlerPOST handles the API call that updates siad and siac.
+// There is no safeguard to prevent "updating" to the same release, so callers
+// should always check the latest version via daemonUpdateHandlerGET first.
+// TODO: add support for specifying version to update to.
+func (srv *Server) daemonUpdateHandlerPOST(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	release, err := fetchLatestRelease()
+	if err != nil {
+		writeError(w, Error{"Failed to fetch latest release: " + err.Error()}, http.StatusInternalServerError)
+		return
+	}
+	err = updateToRelease(release)
+	if err != nil {
+		if rerr := update.RollbackError(err); rerr != nil {
+			writeError(w, Error{"Serious error: Failed to rollback from bad update: " + rerr.Error()}, http.StatusInternalServerError)
+		} else {
+			writeError(w, Error{"Failed to apply update: " + err.Error()}, http.StatusInternalServerError)
+		}
+		return
+	}
+	writeSuccess(w)
 }
 
 // debugConstantsHandler prints a json file containing all of the constants.

--- a/siac/main.go
+++ b/siac/main.go
@@ -241,6 +241,9 @@ func main() {
 
 	root.AddCommand(stopCmd)
 
+	root.AddCommand(updateCmd)
+	updateCmd.AddCommand(updateCheckCmd)
+
 	root.AddCommand(hostCmd)
 	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostFolderCmd, hostSectorCmd)
 	hostFolderCmd.AddCommand(hostFolderAddCmd, hostFolderRemoveCmd, hostFolderResizeCmd)


### PR DESCRIPTION
`siad` and `siac` can now be automatically updated (again).

GitHub is used as the update channel. Later, we may add some fallback channels.

Binaries are signed using the `developerKey` provided in `daemon.go`. All future releases must include signatures for the `siad` and `siac` binaries. In addition, I will be signing all my commits from now on, and other core devs should as well. I will also be signing the release tags. Since a tag references all the code at a given commit hash, signing it amounts to signing the entire codebase at that time. This provides verification for users who prefer to build from source.

Only .zip releases are supported. We can restore .tar.gz support later, but I don't view it as a high priority.
Releases must be tagged with a "clean" semver, e.g. `v1.2.3`. Suffixes such as `-beta` will confuse the update code.

`siac` is assumed to be located in the same folder as `siad`. If `siac` is not present, an error will be returned. (This is a limitation of `go-update`, which we can subvert if necessary.)

This PR is missing documentation for the update routes.