### PR TITLE
Specify GitHub API version when checking for updates

### DIFF
--- a/api/daemon.go
+++ b/api/daemon.go
@@ -99,7 +99,12 @@ bwIDAQAB
 
 // fetchLatestRelease returns metadata about the most recent GitHub release.
 func fetchLatestRelease() (githubRelease, error) {
-	resp, err := http.Get("https://api.github.com/repos/NebulousLabs/Sia/releases/latest")
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/NebulousLabs/Sia/releases/latest", nil)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	resp, err := new(http.Client).Do(req)
 	if err != nil {
 		return githubRelease{}, err
 	}


### PR DESCRIPTION
>**Important**: The default version of the API may change in the future. If you're building an application and care about the stability of the API, be sure to request a specific version in the `Accept` header as shown in the examples below.

https://developer.github.com/v3/media/#request-specific-version

I haven't tested this change yet.