### PR TITLE
don't delete MerkleRoots when renewing

### DIFF
--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -546,6 +546,10 @@ func TestIntegrationRenew(t *testing.T) {
 	} else if contract.FileContract.WindowStart != c.blockHeight+200 {
 		t.Fatal(contract.FileContract.WindowStart)
 	}
+	// check that Merkle roots are intact
+	if len(contract.MerkleRoots) != len(oldContract.MerkleRoots) {
+		t.Fatal(len(contract.MerkleRoots), len(oldContract.MerkleRoots))
+	}
 
 	// download the renewed contract
 	downloader, err := c.Downloader(contract)
@@ -572,6 +576,10 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 	if contract.FileContract.WindowStart != c.blockHeight+100 {
 		t.Fatal(contract.FileContract.WindowStart)
+	}
+	// check that Merkle roots are intact
+	if len(contract.MerkleRoots) != len(oldContract.MerkleRoots) {
+		t.Fatal(len(contract.MerkleRoots), len(oldContract.MerkleRoots))
 	}
 }
 

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -252,6 +252,7 @@ func Renew(contract modules.RenterContract, params ContractParams, txnBuilder tr
 		ID:              fcid,
 		LastRevision:    initRevision,
 		LastRevisionTxn: revisionTxn,
+		MerkleRoots:     contract.MerkleRoots,
 		NetAddress:      host.NetAddress,
 		SecretKey:       ourSK,
 	}, nil


### PR DESCRIPTION
embarrassing. But at least it was an easy fix.

Interestingly, this is one case where using an unkeyed literal would have saved us.