### PR TITLE
wrap /renter/contracts type

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -37,11 +37,11 @@ type (
 
 	// RenterContract represents a contract formed by the renter.
 	RenterContract struct {
-		FileContract types.FileContract         `json:"filecontract"`
-		ID           types.FileContractID       `json:"id"`
-		LastRevision types.FileContractRevision `json:"lastrevision"`
-		NetAddress   modules.NetAddress         `json:"netaddress"`
-		Size         uint64                     `json:"size"`
+		EndHeight   types.BlockHeight    `json:"endheight"`
+		ID          types.FileContractID `json:"id"`
+		NetAddress  modules.NetAddress   `json:"netaddress"`
+		RenterFunds types.Currency       `json:"renterfunds"`
+		Size        uint64               `json:"size"`
 	}
 
 	// RenterContracts contains the renter's contracts.
@@ -132,11 +132,11 @@ func (srv *Server) renterContractsHandler(w http.ResponseWriter, _ *http.Request
 	contracts := []RenterContract{}
 	for _, c := range srv.renter.Contracts() {
 		contracts = append(contracts, RenterContract{
-			FileContract: c.FileContract,
-			ID:           c.ID,
-			LastRevision: c.LastRevision,
-			NetAddress:   c.NetAddress,
-			Size:         modules.SectorSize * uint64(len(c.MerkleRoots)),
+			EndHeight:   c.EndHeight(),
+			ID:          c.ID,
+			NetAddress:  c.NetAddress,
+			RenterFunds: c.RenterFunds(),
+			Size:        modules.SectorSize * uint64(len(c.MerkleRoots)),
 		})
 	}
 	writeJSON(w, RenterContracts{

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -281,7 +281,7 @@ type byHeight []api.RenterContract
 func (s byHeight) Len() int      { return len(s) }
 func (s byHeight) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s byHeight) Less(i, j int) bool {
-	hi, hj := s[i].LastRevision.NewWindowStart, s[j].LastRevision.NewWindowStart
+	hi, hj := s[i].EndHeight, s[j].EndHeight
 	if hi == hj {
 		return s[i].NetAddress < s[j].NetAddress
 	}
@@ -307,9 +307,9 @@ func rentercontractscmd() {
 	for _, c := range rc.Contracts {
 		fmt.Fprintf(w, "%v\t%8s\t%v\t%v\t%v\n",
 			c.NetAddress,
-			currencyUnits(c.LastRevision.NewValidProofOutputs[0].Value),
+			currencyUnits(c.RenterFunds),
 			filesizeUnits(int64(c.Size)),
-			c.LastRevision.NewWindowStart,
+			c.EndHeight,
 			c.ID)
 	}
 	w.Flush()

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -276,7 +276,7 @@ func rentersetallowancecmd(amount, period string) {
 
 // byHeight sorts contracts by their expiration, high to low. If two contracts
 // expire at the same height, they are sorted by their host's address.
-type byHeight []modules.RenterContract
+type byHeight []api.RenterContract
 
 func (s byHeight) Len() int      { return len(s) }
 func (s byHeight) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
@@ -305,9 +305,12 @@ func rentercontractscmd() {
 	w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "Host\tValue\tData\tEnd Height\tID")
 	for _, c := range rc.Contracts {
-		value := currencyUnits(c.LastRevision.NewValidProofOutputs[0].Value)
-		data := filesizeUnits(int64(modules.SectorSize) * int64(len(c.MerkleRoots)))
-		fmt.Fprintf(w, "%v\t%8s\t%v\t%v\t%v\n", c.NetAddress, value, data, c.LastRevision.NewWindowStart, c.ID)
+		fmt.Fprintf(w, "%v\t%8s\t%v\t%v\t%v\n",
+			c.NetAddress,
+			currencyUnits(c.LastRevision.NewValidProofOutputs[0].Value),
+			filesizeUnits(int64(c.Size)),
+			c.LastRevision.NewWindowStart,
+			c.ID)
 	}
 	w.Flush()
 }


### PR DESCRIPTION
This prevents the API from marshalling all of the contract Merkle roots, which can be a non-trivial amount of data (and is rarely useful).