### PR TITLE
fix (again) corruption condition in the hostdb

### DIFF
--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -17,7 +17,7 @@ var (
 // the host database entry. Currently, only the price is considered.
 func calculateHostWeight(entry hostEntry) (weight types.Currency) {
 	// If the price is 0, just return the base weight to avoid divide by zero.
-	price := entry.ContractPrice
+	price := entry.StoragePrice
 	if price.IsZero() {
 		return baseWeight
 	}

--- a/modules/renter/hostdb/hostweight_test.go
+++ b/modules/renter/hostdb/hostweight_test.go
@@ -8,7 +8,7 @@ import (
 
 func calculateWeightFromUInt64Price(price uint64) (weight types.Currency) {
 	var entry hostEntry
-	entry.ContractPrice = types.NewCurrency64(price)
+	entry.StoragePrice = types.NewCurrency64(price)
 	return calculateHostWeight(entry)
 }
 

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -78,6 +78,56 @@ func (hdb *HostDB) decrementReliability(addr modules.NetAddress, penalty types.C
 	}
 }
 
+// managedUpdateEntry updates an entry in the hostdb after a scan has taken
+// place.
+func (hdb *HostDB) managedUpdateEntry(hostEntry *hostEntry, settings modules.HostExternalSettings, err error) {
+	hdb.mu.Lock()
+	defer hdb.mu.Unlock()
+
+	// Regardless of whether the host responded, add it to allHosts.
+	priorHost, exists := hdb.allHosts[hostEntry.NetAddress]
+	if !exists {
+		hdb.allHosts[hostEntry.NetAddress] = hostEntry
+	}
+
+	// If the scan was unsuccessful, decrement the host's reliability.
+	if err != nil {
+		if exists && bytes.Equal(priorHost.PublicKey.Key, hostEntry.PublicKey.Key) {
+			// Only decrement the reliability if the public key in the
+			// hostdb matches the public key in the host announcement -
+			// the failure may just be a failed signature, indicating
+			// the wrong public key.
+			hdb.decrementReliability(hostEntry.NetAddress, UnreachablePenalty)
+		}
+		return
+	}
+
+	// The hostEntry should be updated to reflect the new weight. The
+	// safety properties of the tree require that the weight does not
+	// change while the node is in the tree, so the node must be
+	// removed before the settings and weight are changed.
+	existingNode, exists := hdb.activeHosts[hostEntry.NetAddress]
+	if exists {
+		existingNode.removeNode()
+		delete(hdb.activeHosts, hostEntry.NetAddress)
+	}
+
+	// Update the host settings, reliability, and weight. The old NetAddress
+	// must be preserved.
+	settings.NetAddress = hostEntry.HostExternalSettings.NetAddress
+	hostEntry.HostExternalSettings = settings
+	hostEntry.Reliability = MaxReliability
+	hostEntry.Weight = calculateHostWeight(*hostEntry)
+	hostEntry.Online = true
+
+	// If 'maxActiveHosts' has not been reached, add the host to the
+	// activeHosts tree.
+	if _, exists := hdb.activeHosts[hostEntry.NetAddress]; exists || len(hdb.activeHosts) < maxActiveHosts {
+		hdb.insertNode(hostEntry)
+	}
+	hdb.save()
+}
+
 // threadedProbeHosts tries to fetch the settings of a host. If successful, the
 // host is put in the set of active hosts. If unsuccessful, the host id deleted
 // from the set of active hosts.
@@ -108,55 +158,8 @@ func (hdb *HostDB) threadedProbeHosts() {
 			hdb.log.Debugln("Scanning", hostEntry.NetAddress, hostEntry.PublicKey, "succeeded")
 		}
 
-		// Now that network communication is done, lock the hostdb to modify the
-		// host entry.
-		func() {
-			hdb.mu.Lock()
-			defer hdb.mu.Unlock()
-
-			// Regardless of whether the host responded, add it to allHosts.
-			priorHost, exists := hdb.allHosts[hostEntry.NetAddress]
-			if !exists {
-				hdb.allHosts[hostEntry.NetAddress] = hostEntry
-			}
-
-			// If the scan was unsuccessful, decrement the host's reliability.
-			if err != nil {
-				if exists && bytes.Equal(priorHost.PublicKey.Key, hostEntry.PublicKey.Key) {
-					// Only decrement the reliability if the public key in the
-					// hostdb matches the public key in the host announcement -
-					// the failure may just be a failed signature, indicating
-					// the wrong public key.
-					hdb.decrementReliability(hostEntry.NetAddress, UnreachablePenalty)
-				}
-				return
-			}
-
-			// The hostEntry should be updated to reflect the new weight. The
-			// safety properties of the tree require that the weight does not
-			// change while the node is in the tree, so the node must be
-			// removed before the settings and weight are changed.
-			existingNode, exists := hdb.activeHosts[hostEntry.NetAddress]
-			if exists {
-				existingNode.removeNode()
-				delete(hdb.activeHosts, hostEntry.NetAddress)
-			}
-
-			// Update the host settings, reliability, and weight. The old NetAddress
-			// must be preserved.
-			settings.NetAddress = hostEntry.HostExternalSettings.NetAddress
-			hostEntry.HostExternalSettings = settings
-			hostEntry.Reliability = MaxReliability
-			hostEntry.Weight = calculateHostWeight(*hostEntry)
-			hostEntry.Online = true
-
-			// If 'maxActiveHosts' has not been reached, add the host to the
-			// activeHosts tree.
-			if _, exists := hdb.activeHosts[hostEntry.NetAddress]; exists || len(hdb.activeHosts) < maxActiveHosts {
-				hdb.insertNode(hostEntry)
-			}
-			hdb.save()
-		}()
+		// Update the host tree to have a new entry.
+		hdb.managedUpdateEntry(hostEntry, settings, err)
 	}
 }
 

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -132,6 +132,16 @@ func (hdb *HostDB) threadedProbeHosts() {
 				return
 			}
 
+			// The hostEntry should be updated to reflect the new weight. The
+			// safety properties of the tree require that the weight does not
+			// change while the node is in the tree, so the node must be
+			// removed before the settings and weight are changed.
+			existingNode, exists := hdb.activeHosts[hostEntry.NetAddress]
+			if exists {
+				existingNode.removeNode()
+				delete(hdb.activeHosts, hostEntry.NetAddress)
+			}
+
 			// Update the host settings, reliability, and weight. The old NetAddress
 			// must be preserved.
 			settings.NetAddress = hostEntry.HostExternalSettings.NetAddress

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -2,7 +2,6 @@ package hostdb
 
 import (
 	"crypto/rand"
-	"errors"
 	"math/big"
 	"strconv"
 	"testing"
@@ -15,73 +14,6 @@ import (
 // addresses are needed in order to satisfy the HostDB's "1 host per IP" rule.
 func fakeAddr(n uint8) modules.NetAddress {
 	return modules.NetAddress("127.0.0." + strconv.Itoa(int(n)) + ":1")
-}
-
-// uniformTreeVerification checks that everything makes sense in the tree given
-// the number of entries that the tree is supposed to have and also given that
-// every entropy has the same weight.
-func uniformTreeVerification(hdb *HostDB, numEntries int) error {
-	// Check that the weight of the hostTree is what is expected.
-	expectedWeight := hdb.hostTree.hostEntry.Weight.Mul64(uint64(numEntries))
-	if hdb.hostTree.weight.Cmp(expectedWeight) != 0 {
-		return errors.New("expected weight is incorrect")
-	}
-
-	// Check that the length of activeHosts and the count of hostTree are
-	// consistent.
-	if len(hdb.activeHosts) != numEntries {
-		return errors.New("unexpected number of active hosts")
-	}
-
-	// Select many random hosts and do naive statistical analysis on the
-	// results.
-	if !testing.Short() {
-		// Pull a bunch of random hosts and count how many times we pull each
-		// host.
-		selectionMap := make(map[modules.NetAddress]int)
-		expected := 100
-		for i := 0; i < expected*numEntries; i++ {
-			entries := hdb.RandomHosts(1, nil)
-			if len(entries) == 0 {
-				return errors.New("no hosts")
-			}
-			selectionMap[entries[0].NetAddress]++
-		}
-
-		// See if each host was selected enough times.
-		errorBound := 64 // Pretty large, but will still detect if something is seriously wrong.
-		for _, count := range selectionMap {
-			if count < expected-errorBound || count > expected+errorBound {
-				return errors.New("error bound was breached")
-			}
-		}
-	}
-
-	// Try removing an re-adding all hosts.
-	var removedEntries []*hostEntry
-	for {
-		if hdb.hostTree.weight.IsZero() {
-			break
-		}
-		randWeight, err := rand.Int(rand.Reader, hdb.hostTree.weight.Big())
-		if err != nil {
-			break
-		}
-		node, err := hdb.hostTree.nodeAtWeight(types.NewCurrency(randWeight))
-		if err != nil {
-			break
-		}
-		node.removeNode()
-		delete(hdb.activeHosts, node.hostEntry.NetAddress)
-
-		// remove the entry from the hostdb so it won't be selected as a
-		// repeat.
-		removedEntries = append(removedEntries, node.hostEntry)
-	}
-	for _, entry := range removedEntries {
-		hdb.insertNode(entry)
-	}
-	return nil
 }
 
 // TestWeightedList inserts and removes nodes in a semi-random manner and


### PR DESCRIPTION
There was a problem in the hostdb previously where the host tree would
corrupt after a scan because the weight would change but the tree would
not restructure to account for the change in the weight.

That bug was supposed to be fixed by re-adding the node to the tree
after the change. But, it was an insufficient move due to the pointer
unsafety of the tree. Adding the node again is prefixed by a call to
remove the existing entry. The existing entry however has a different
weight than when it was inserted, causing corruption upon removal.

This change is not tested, tests to follow in future commits.