### PR TITLE
Check for 0 length responses from myexternalip.com

### DIFF
--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/NebulousLabs/go-upnp"
@@ -29,13 +30,15 @@ func myExternalIP() (string, error) {
 		errResp, _ := ioutil.ReadAll(resp.Body)
 		return "", errors.New(string(errResp))
 	}
-	buf := make([]byte, 64)
-	n, err := resp.Body.Read(buf)
-	if err != nil && err != io.EOF {
+	buf, err := ioutil.ReadAll(io.LimitReader(resp.Body, 64))
+	if err != nil {
 		return "", err
 	}
+	if len(buf) == 0 {
+		return "", errors.New("myexternalip.com returned a 0 length IP address")
+	}
 	// trim newline
-	return string(buf[:n-1]), nil
+	return strings.TrimSpace(string(buf)), nil
 }
 
 // threadedLearnHostname discovers the external IP of the Gateway. Once the IP


### PR DESCRIPTION
and improve how the response body is read
and check the HTTP status code in the host.myExternalIP
(the gateway already had this check)

Closes #1322
Thanks @hosiawak!