### PR TITLE
Require paths to be absolute when adding a storage folder

### DIFF
--- a/modules/host/storagemanager/storagefolders.go
+++ b/modules/host/storagemanager/storagefolders.go
@@ -111,6 +111,9 @@ var (
 	// errStorageFolderNotFolder is returned if a storage folder gets added
 	// that is not a folder.
 	errStorageFolderNotFolder = errors.New("must use to an existing folder")
+
+	// errRelativePath is returned if a path must be absolute.
+	errRelativePath = errors.New("storage folder paths must be absolute")
 )
 
 // storageFolder tracks a folder that is being used to store sectors. There is
@@ -400,6 +403,10 @@ func (sm *StorageManager) AddStorageFolder(path string, size uint64) error {
 	}
 	if size < minimumStorageFolderSize {
 		return errSmallStorageFolder
+	}
+	// Check that the path is an absolute path.
+	if !filepath.IsAbs(path) {
+		return errRelativePath
 	}
 	// Check that the folder being linked to is not already in use.
 	for _, sf := range sm.storageFolders {

--- a/modules/host/storagemanager/storagefolders.go
+++ b/modules/host/storagemanager/storagefolders.go
@@ -110,7 +110,7 @@ var (
 
 	// errStorageFolderNotFolder is returned if a storage folder gets added
 	// that is not a folder.
-	errStorageFolderNotFolder = errors.New("must use to an existing folder")
+	errStorageFolderNotFolder = errors.New("must use an existing folder")
 
 	// errRelativePath is returned if a path must be absolute.
 	errRelativePath = errors.New("storage folder paths must be absolute")


### PR DESCRIPTION
When writing the API docs for the storage endpoints I realized it might be confusing to add a relative path using the API, as the path would be relative to siad. This is especially confusing if you then restart siad in a different directory.

Another option is to convert the path to an absolute path, so that it's full path is shown in the list of storage folders.