### PR TITLE
Increment SuccessfulReads in StorageManager.ReadSector

### DIFF
--- a/modules/host/storagemanager/sector.go
+++ b/modules/host/storagemanager/sector.go
@@ -255,12 +255,13 @@ func (sm *StorageManager) ReadSector(sectorRoot crypto.Hash) (sectorBytes []byte
 
 		sectorPath := filepath.Join(sm.persistDir, hex.EncodeToString(su.StorageFolder), string(sectorKey))
 		sectorBytes, err = ioutil.ReadFile(sectorPath)
+		sf := sm.storageFolder(su.StorageFolder)
 		if err != nil {
 			// Mark the read failure in the sector.
-			sf := sm.storageFolder(su.StorageFolder)
 			sf.FailedReads++
 			return err
 		}
+		sf.SuccessfulReads++
 		return nil
 	})
 	return


### PR DESCRIPTION
This was the only case that incremented Failed{Read,Write} without incrementing Success{Read,Write} (or vice versa) in the other case.