### PR TITLE
Restore shared pointer between allHosts and activeHosts

### DIFF
--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -45,7 +45,7 @@ func (hdb *HostDB) load() error {
 		hdb.allHosts[data.AllHosts[i].NetAddress] = &data.AllHosts[i]
 	}
 	for i := range data.ActiveHosts {
-		hdb.insertNode(&data.ActiveHosts[i])
+		hdb.insertNode(hdb.allHosts[data.ActiveHosts[i].NetAddress])
 	}
 	hdb.lastChange = data.LastChange
 	return nil


### PR DESCRIPTION
In the hostdb, there's an implicit assumption that the hostEntry in the
allHosts map is the same hostEntry in the activeHosts map. The
persistence was not being loaded to reflect this correctly.

This PR restores that. Better safety in the hostdb would solve all of
these edge cases, this will be addressed at some point.

fix #1281