### PR TITLE
store a status string in the storage obligations 

### DIFF
--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -81,7 +81,7 @@ func (h *Host) initRescan() error {
 		err = composeErrors(err0, err1, err2, err3)
 		if err != nil {
 			h.log.Println("dropping storage obligation during rescan, id", so.id())
-			return composeErrors(err, h.removeStorageObligation(so, obligationRejected))
+			return composeErrors(err, h.removeStorageObligation(so, obligationRejected, "error during rescan: "+err.Error()))
 		}
 	}
 	return nil


### PR DESCRIPTION
When a storage obligation is completed, a status string is added to the
obligation stored on disk. This allows hosts to view their contracts
historically and see why they failed in the event of a failure, which
will help with debugging/troubleshooting

I'm not entirely certain that a string is the best move. An alternate
option has us using error codes. A string is nice because it lets you
see the actual meaning of the error directly in the database. But if we
ever change the errors, the errors could be lost from the codebase.

I think a string is more likely to make sense in the long run, but it
does mean you could be left with a string that you are unable to grep.