### PR TITLE
Use contract and bandwidth prices to calculate host weight

### DIFF
--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -96,8 +96,8 @@ func (hdb *HostDB) AllHosts() (allHosts []modules.HostDBEntry) {
 	return
 }
 
-// AveragePrice returns the average price of a host.
-func (hdb *HostDB) AveragePrice() types.Currency {
+// AverageContractPrice returns the average price of a host.
+func (hdb *HostDB) AverageContractPrice() types.Currency {
 	// maybe a more sophisticated way of doing this
 	var totalPrice types.Currency
 	sampleSize := 18

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -77,13 +77,13 @@ func TestActiveHosts(t *testing.T) {
 	}
 }
 
-// TestAveragePrice tests the AveragePrice method, which also depends on the
+// TestAverageContractPrice tests the AverageContractPrice method, which also depends on the
 // randomHosts method.
-func TestAveragePrice(t *testing.T) {
+func TestAverageContractPrice(t *testing.T) {
 	hdb := bareHostDB()
 
 	// empty
-	if avg := hdb.AveragePrice(); !avg.IsZero() {
+	if avg := hdb.AverageContractPrice(); !avg.IsZero() {
 		t.Error("average of empty hostdb should be zero:", avg)
 	}
 
@@ -94,7 +94,7 @@ func TestAveragePrice(t *testing.T) {
 	h1.Weight = baseWeight
 	h1.AcceptingContracts = true
 	hdb.insertNode(h1)
-	if avg := hdb.AveragePrice(); avg.Cmp(h1.ContractPrice) != 0 {
+	if avg := hdb.AverageContractPrice(); avg.Cmp(h1.ContractPrice) != 0 {
 		t.Error("average of one host should be that host's price:", avg)
 	}
 
@@ -108,7 +108,7 @@ func TestAveragePrice(t *testing.T) {
 	if len(hdb.activeHosts) != 2 {
 		t.Error("host was not added:", hdb.activeHosts)
 	}
-	if avg := hdb.AveragePrice(); avg.Cmp(types.NewCurrency64(200)) != 0 {
+	if avg := hdb.AverageContractPrice(); avg.Cmp(types.NewCurrency64(200)) != 0 {
 		t.Error("average of two hosts should be their sum/2:", avg)
 	}
 }

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Because most weights would otherwise be fractional, we set the base
-	// weight to 10^80 to give ourselves lots of precision when determing the
+	// weight to 10^150 to give ourselves lots of precision when determing the
 	// weight of a host
 	baseWeight = types.NewCurrency(new(big.Int).Exp(big.NewInt(10), big.NewInt(150), nil))
 )
@@ -16,8 +16,14 @@ var (
 // calculateHostWeight returns the weight of a host according to the settings of
 // the host database entry. Currently, only the price is considered.
 func calculateHostWeight(entry hostEntry) (weight types.Currency) {
+	// In the weighted price, the download bandwidth price is multiplied by
+	// numDownloads, which is our guess at the median number of downloads per
+	// file (some files may go untouched, but others may be requested
+	// many times).
+	const numDownloads = uint64(50)
+	price := entry.StoragePrice.Add(entry.ContractPrice).Add(entry.UploadBandwidthPrice).Add(entry.DownloadBandwidthPrice.Mul64(numDownloads))
+
 	// If the price is 0, just return the base weight to avoid divide by zero.
-	price := entry.StoragePrice
 	if price.IsZero() {
 		return baseWeight
 	}

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -20,8 +20,8 @@ type hostDB interface {
 	// order of preference.
 	AllHosts() []modules.HostDBEntry
 
-	// AveragePrice returns the average price of a host.
-	AveragePrice() types.Currency
+	// AverageContractPrice returns the average contract price of a host.
+	AverageContractPrice() types.Currency
 
 	// Close closes the hostdb.
 	Close() error

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -166,11 +166,11 @@ func newContractorTester(name string, hdb hostDB, hc hostContractor) (*renterTes
 // of the hostDB's methods on every mock.
 type stubHostDB struct{}
 
-func (stubHostDB) ActiveHosts() []modules.HostDBEntry { return nil }
-func (stubHostDB) AllHosts() []modules.HostDBEntry    { return nil }
-func (stubHostDB) AveragePrice() types.Currency       { return types.Currency{} }
-func (stubHostDB) Close() error                       { return nil }
-func (stubHostDB) IsOffline(modules.NetAddress) bool  { return true }
+func (stubHostDB) ActiveHosts() []modules.HostDBEntry   { return nil }
+func (stubHostDB) AllHosts() []modules.HostDBEntry      { return nil }
+func (stubHostDB) AverageContractPrice() types.Currency { return types.Currency{} }
+func (stubHostDB) Close() error                         { return nil }
+func (stubHostDB) IsOffline(modules.NetAddress) bool    { return true }
 
 // stubContractor is the minimal implementation of the hostContractor
 // interface.


### PR DESCRIPTION
`calculateHostWeight` now takes into account `hostEntry`'s `DownloadBandwidthPrice`, `UploadBandwidthPrice`, and `ContractPrice` fields; previously only `hostEntry.StoragePrice` was considered.

This PR also renames the `hostDB`'s `AveragePrice` method to `AverageContractPrice` for the sake of clarity (especially since contract and storage price have been [sometimes](https://github.com/NebulousLabs/Sia/pull/1317/commits/3e68f1bf27a0cf2c289ca995bc8b2231916bae28) been mixed up).