### PR TITLE
redundancy: return -1 instead of math.NaN

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -2,7 +2,6 @@ package renter
 
 import (
 	"errors"
-	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -114,7 +113,7 @@ func (f *file) uploadProgress() float64 {
 // unique within a file contract. -1 is returned if the file has size 0.
 func (f *file) redundancy() float64 {
 	if f.size == 0 {
-		return math.NaN()
+		return -1
 	}
 	piecesPerChunk := make([]int, f.numChunks())
 	// If the file has non-0 size then the number of chunks should also be
@@ -122,7 +121,7 @@ func (f *file) redundancy() float64 {
 	// before this check.
 	if len(piecesPerChunk) == 0 {
 		build.Critical("cannot get redundancy of a file with 0 chunks")
-		return math.NaN()
+		return -1
 	}
 	for _, fc := range f.contracts {
 		for _, p := range fc.Pieces {

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -367,11 +366,11 @@ func renterfileslistcmd() {
 			availableStr := yesNo(file.Available)
 			renewingStr := yesNo(file.Renewing)
 			redundancyStr := fmt.Sprintf("%.2f", file.Redundancy)
-			if math.IsNaN(file.Redundancy) {
+			if file.Redundancy == -1 {
 				redundancyStr = "-"
 			}
 			uploadProgressStr := fmt.Sprintf("%.2f%%", file.UploadProgress)
-			if math.IsNaN(file.UploadProgress) {
+			if file.UploadProgress == -1 {
 				uploadProgressStr = "-"
 			}
 			fmt.Fprintf(w, "\t%s\t%8s\t%10s\t%s", availableStr, uploadProgressStr, redundancyStr, renewingStr)


### PR DESCRIPTION
NaN cannot be marshalled, resulting in encoding errors.

Thanks to Slack user "snakes" for reporting this bug!