### PR TITLE
Handle StopResponse correctly in proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ dependencies:
 run = Test
 pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/consensus \
        ./modules/explorer ./modules/gateway ./modules/host ./modules/host/storagemanager \
-	   ./modules/renter/hostdb ./modules/renter/contractor ./modules/miner ./modules/renter \
-	   ./modules/wallet ./modules/transactionpool ./persist ./siac ./siad ./sync ./types
+       ./modules/renter ./modules/renter/contractor ./modules/renter/hostdb ./modules/renter/proto \
+       ./modules/miner ./modules/wallet ./modules/transactionpool ./persist ./siac ./siad ./sync ./types
 
 # fmt calls go fmt on all packages.
 fmt:

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -40,14 +40,6 @@ func (hd *Downloader) Sector(root crypto.Hash) (modules.RenterContract, []byte, 
 	// create the download revision
 	rev := newDownloadRevision(hd.contract.LastRevision, sectorPrice)
 
-	// if a SaveFn was provided, call it before doing any further I/O, because
-	// that's when we're most likely to experience failure
-	if hd.SaveFn != nil {
-		if err := hd.SaveFn(rev); err != nil {
-			return modules.RenterContract{}, nil, errors.New("failed to save unsigned revision: " + err.Error())
-		}
-	}
-
 	// initiate download by confirming host settings
 	if err := startDownload(hd.conn, hd.host); err != nil {
 		return modules.RenterContract{}, nil, err
@@ -64,13 +56,11 @@ func (hd *Downloader) Sector(root crypto.Hash) (modules.RenterContract, []byte, 
 	}
 
 	// send the revision to the host for approval
-	signedTxn, err := negotiateRevision(hd.conn, rev, hd.contract.SecretKey)
+	signedTxn, err := negotiateRevision(hd.conn, rev, hd.contract.SecretKey, hd.SaveFn)
 	if err == modules.ErrStopResponse {
 		// if host gracefully closed, close our connection as well; this will
-		// cause the next operation will fail. We also need to set SaveFn to
-		// nil to prevent saving a revision that the host can't see.
-		he.conn.Close()
-		he.SaveFn = nil
+		// cause the next operation will fail
+		hd.conn.Close()
 	} else if err != nil {
 		return modules.RenterContract{}, nil, err
 	}

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -65,7 +65,13 @@ func (hd *Downloader) Sector(root crypto.Hash) (modules.RenterContract, []byte, 
 
 	// send the revision to the host for approval
 	signedTxn, err := negotiateRevision(hd.conn, rev, hd.contract.SecretKey)
-	if err != nil {
+	if err == modules.ErrStopResponse {
+		// if host gracefully closed, close our connection as well; this will
+		// cause the next operation will fail. We also need to set SaveFn to
+		// nil to prevent saving a revision that the host can't see.
+		he.conn.Close()
+		he.SaveFn = nil
+	} else if err != nil {
 		return modules.RenterContract{}, nil, err
 	}
 

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -59,8 +59,9 @@ func (hd *Downloader) Sector(root crypto.Hash) (modules.RenterContract, []byte, 
 	signedTxn, err := negotiateRevision(hd.conn, rev, hd.contract.SecretKey, hd.SaveFn)
 	if err == modules.ErrStopResponse {
 		// if host gracefully closed, close our connection as well; this will
-		// cause the next operation will fail
-		hd.conn.Close()
+		// cause the next download to fail. However, we must delay closing
+		// until we've finished downloading the sector.
+		defer hd.conn.Close()
 	} else if err != nil {
 		return modules.RenterContract{}, nil, err
 	}

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -82,7 +82,13 @@ func (he *Editor) runRevisionIteration(actions []modules.RevisionAction, rev typ
 
 	// send revision to host and exchange signatures
 	signedTxn, err := negotiateRevision(he.conn, rev, he.contract.SecretKey)
-	if err != nil {
+	if err == modules.ErrStopResponse {
+		// if host gracefully closed, close our connection as well; this will
+		// cause the next operation will fail. We also need to set SaveFn to
+		// nil to prevent saving a revision that the host can't see.
+		he.conn.Close()
+		he.SaveFn = nil
+	} else if err != nil {
 		return err
 	}
 

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -76,7 +76,7 @@ func (he *Editor) runRevisionIteration(actions []modules.RevisionAction, rev typ
 	signedTxn, err := negotiateRevision(he.conn, rev, he.contract.SecretKey, he.SaveFn)
 	if err == modules.ErrStopResponse {
 		// if host gracefully closed, close our connection as well; this will
-		// cause the next operation will fail
+		// cause the next operation to fail
 		he.conn.Close()
 	} else if err != nil {
 		return err

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -62,14 +62,6 @@ func (he *Editor) Close() error {
 // host for approval. If negotiation is successful, it updates the underlying
 // Contract.
 func (he *Editor) runRevisionIteration(actions []modules.RevisionAction, rev types.FileContractRevision, newRoots []crypto.Hash) error {
-	// if a SaveFn was provided, call it before doing any further I/O, because
-	// that's when we're most likely to experience failure
-	if he.SaveFn != nil {
-		if err := he.SaveFn(rev); err != nil {
-			return errors.New("failed to save unsigned revision: " + err.Error())
-		}
-	}
-
 	// initiate revision
 	if err := startRevision(he.conn, he.host); err != nil {
 		return err
@@ -81,13 +73,11 @@ func (he *Editor) runRevisionIteration(actions []modules.RevisionAction, rev typ
 	}
 
 	// send revision to host and exchange signatures
-	signedTxn, err := negotiateRevision(he.conn, rev, he.contract.SecretKey)
+	signedTxn, err := negotiateRevision(he.conn, rev, he.contract.SecretKey, he.SaveFn)
 	if err == modules.ErrStopResponse {
 		// if host gracefully closed, close our connection as well; this will
-		// cause the next operation will fail. We also need to set SaveFn to
-		// nil to prevent saving a revision that the host can't see.
+		// cause the next operation will fail
 		he.conn.Close()
-		he.SaveFn = nil
 	} else if err != nil {
 		return err
 	}

--- a/modules/renter/proto/negotiate.go
+++ b/modules/renter/proto/negotiate.go
@@ -116,7 +116,7 @@ func verifyRecentRevision(conn net.Conn, contract modules.RenterContract) error 
 
 // negotiateRevision sends a revision and actions to the host for approval,
 // completing one iteration of the revision loop.
-func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey crypto.SecretKey) (types.Transaction, error) {
+func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey crypto.SecretKey, saveFn revisionSaver) (types.Transaction, error) {
 	// create transaction containing the revision
 	signedTxn := types.Transaction{
 		FileContractRevisions: []types.FileContractRevision{rev},
@@ -137,6 +137,17 @@ func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey 
 	// read acceptance
 	if err := modules.ReadNegotiationAcceptance(conn); err != nil {
 		return types.Transaction{}, errors.New("host did not accept revision: " + err.Error())
+	}
+
+	// Before we continue, save the revision. Unexpected termination (e.g.
+	// power failure) during the signature transfer leaves in an ambiguous
+	// state: the host may or may not have received the signature, and thus
+	// may report either revision as being the most recent. To mitigate this,
+	// we save the old revision as a fallback.
+	if saveFn != nil {
+		if err := saveFn(rev); err != nil {
+			return types.Transaction{}, errors.New("failed to save revision: " + err.Error())
+		}
 	}
 
 	// send the new transaction signature

--- a/modules/renter/proto/negotiate_test.go
+++ b/modules/renter/proto/negotiate_test.go
@@ -1,0 +1,64 @@
+package proto
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// TestNegotiateRevisionStopResponse tests that when the host sends
+// StopResponse, the renter continues processing the revision instead of
+// immediately terminating.
+func TestNegotiateRevisionStopResponse(t *testing.T) {
+	// simulate a renter-host connection
+	rConn, hConn := net.Pipe()
+
+	// handle the host's half of the pipe
+	go func() {
+		defer hConn.Close()
+		// read revision
+		encoding.ReadObject(hConn, new(types.FileContractRevision), 1<<22)
+		// write acceptance
+		modules.WriteNegotiationAcceptance(hConn)
+		// read txn signature
+		encoding.ReadObject(hConn, new(types.TransactionSignature), 1<<22)
+		// write StopResponse
+		modules.WriteNegotiationStop(hConn)
+		// write txn signature
+		encoding.WriteObject(hConn, types.TransactionSignature{})
+	}()
+
+	// since the host wrote StopResponse, we should proceed to validating the
+	// transaction. This will return a known error because we are supplying an
+	// empty revision.
+	_, err := negotiateRevision(rConn, types.FileContractRevision{}, crypto.SecretKey{}, nil)
+	if err != types.ErrFileContractWindowStartViolation {
+		t.Fatalf("expected %q, got \"%v\"", types.ErrFileContractWindowStartViolation, err)
+	}
+	rConn.Close()
+
+	// same as above, but send an error instead of StopResponse. The error
+	// should be returned by negotiateRevision immediately (if it is not, we
+	// should expect to see a transaction validation error instead).
+	rConn, hConn = net.Pipe()
+	go func() {
+		defer hConn.Close()
+		encoding.ReadObject(hConn, new(types.FileContractRevision), 1<<22)
+		modules.WriteNegotiationAcceptance(hConn)
+		encoding.ReadObject(hConn, new(types.TransactionSignature), 1<<22)
+		// write a sentinel error
+		modules.WriteNegotiationRejection(hConn, errors.New("sentinel"))
+		encoding.WriteObject(hConn, types.TransactionSignature{})
+	}()
+	expectedErr := "host did not accept transaction signature: sentinel"
+	_, err = negotiateRevision(rConn, types.FileContractRevision{}, crypto.SecretKey{}, nil)
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("expected %q, got \"%v\"", expectedErr, err)
+	}
+	rConn.Close()
+}


### PR DESCRIPTION
As reported in #1346, the renter protocol was not properly handling `StopResponse` during revision. The correct behavior is to apply the revision and then gracefully terminate. Instead, the renter treated `StopResponse` as an error and exited early without applying the revision. This caused the renter and host to desync.

Note that in this implementation, the renter will not know that the host has closed the connection until it tries to perform another revision operation. An alternative approach would bubble the `ErrStopResponse` error all the way up to `Upload`, `Delete`, etc., and the caller would have to check for this error specifically and handle it correctly -- namely, they would have to recognize that the other return values were still valid, despite `err != nil`. I opted not to take this approach, because there is little benefit and the renter needs to be safeguarded against random host disconnects anyway.

On that note, this PR should also fix a subtle bug affecting cached revisions. Previously, `SaveFn` was called before doing any network I/O. This meant that if the host had silently disconnected, the renter would cache the revision before finding out. By itself, this shouldn't cause the renter to desync (since it will first try the current revision, not the cached revision), but it may have compounded other issues.