### PR TITLE
only build master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ sudo: false
 branches:
   only:
     - master
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ install:
 script: make test && make test-long && make cover && make bench
 
 sudo: false
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
this allows us to build both PR commits and master branch merges, without double-building each PR push. This is nice because we can relax the "all PR branches must be up-to-date before merging restriction" -- the post-merge code will be tested as well, in a separate build.