### PR TITLE
API testing

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -73,6 +73,11 @@ type (
 	ActiveHosts struct {
 		Hosts []modules.HostDBEntry `json:"hosts"`
 	}
+
+	// AllHosts lists all hosts that the renter is aware of.
+	AllHosts struct {
+		Hosts []modules.HostDBEntry `json:"hosts"`
+	}
 )
 
 // renterHandlerGET handles the API call to /renter.
@@ -193,7 +198,7 @@ func (srv *Server) renterFilesHandler(w http.ResponseWriter, req *http.Request, 
 	})
 }
 
-// renterDeleteHander handles the API call to delete a file entry from the
+// renterDeleteHandler handles the API call to delete a file entry from the
 // renter.
 func (srv *Server) renterDeleteHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	err := srv.renter.DeleteFile(strings.TrimPrefix(ps.ByName("siapath"), "/"))
@@ -257,7 +262,7 @@ func (srv *Server) renterUploadHandler(w http.ResponseWriter, req *http.Request,
 	writeSuccess(w)
 }
 
-// renterHostsActiveHandler handes the API call asking for the list of active
+// renterHostsActiveHandler handles the API call asking for the list of active
 // hosts.
 func (srv *Server) renterHostsActiveHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	var numHosts uint64
@@ -285,9 +290,9 @@ func (srv *Server) renterHostsActiveHandler(w http.ResponseWriter, req *http.Req
 	})
 }
 
-// renterHostsAllHandler handes the API call asking for the list of all hosts.
+// renterHostsAllHandler handles the API call asking for the list of all hosts.
 func (srv *Server) renterHostsAllHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	writeJSON(w, ActiveHosts{
+	writeJSON(w, AllHosts{
 		Hosts: srv.renter.AllHosts(),
 	})
 }

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -112,8 +112,9 @@ func TestRenterConflicts(t *testing.T) {
 
 	// Upload using the same nickname.
 	err = st.stdPostAPI("/renter/upload/foo/bar.sia/test", uploadValues)
-	if err == renter.ErrPathOverload {
-		t.Fatalf("expected %v, got %v", renter.ErrPathOverload, err)
+	expectedErr := Error{"Upload failed: " + renter.ErrPathOverload.Error()}
+	if err != expectedErr {
+		t.Fatalf("expected %v, got %v", Error{"Upload failed: " + renter.ErrPathOverload.Error()}, err)
 	}
 
 	// Upload using nickname that conflicts with folder.

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -136,7 +136,7 @@ func TestRenterHostsActiveHandler(t *testing.T) {
 	}
 	defer st.server.Close()
 
-	// Try the call with with numhosts unset, and set to -1, 0, and 1.
+	// Try the call with numhosts unset, and set to -1, 0, and 1.
 	var ah ActiveHosts
 	err = st.getAPI("/hostdb/active", &ah)
 	if err != nil {
@@ -210,5 +210,39 @@ func TestRenterHostsActiveHandler(t *testing.T) {
 	}
 	if len(ah.Hosts) != 1 {
 		t.Fatal(len(ah.Hosts))
+	}
+}
+
+// TestRenterHostsAllHandler checks that announcing a host adds it to the list
+// of all hosts.
+func TestRenterHostsAllHandler(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestRenterHostsAllHandler1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Try the call before any hosts have been declared.
+	// Note that ah is of type ActiveHosts even though it may include inactive
+	// hosts. This is nonintuitive; I'd rather make a new AllHosts type instead.
+	var ah ActiveHosts
+	if err = st.getAPI("/hostdb/all", &ah); err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 0 {
+		t.Fatalf("expected 0 hosts, got %v", len(ah.Hosts))
+	}
+	// Announce the host and try the call again.
+	if err = st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.getAPI("/hostdb/all", &ah); err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatalf("expected 1 host, got %v", len(ah.Hosts))
 	}
 }

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -226,9 +226,7 @@ func TestRenterHostsAllHandler(t *testing.T) {
 	defer st.server.Close()
 
 	// Try the call before any hosts have been declared.
-	// Note that ah is of type ActiveHosts even though it may include inactive
-	// hosts. This is nonintuitive; I'd rather make a new AllHosts type instead.
-	var ah ActiveHosts
+	var ah AllHosts
 	if err = st.getAPI("/hostdb/all", &ah); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* Fixes typos & a faulty error check in `TestRenterConflicts`
* Implements `TestRenterHostsAllHandler` to test `renterHostsAllHandler`, which handles the call to `hostdb/all`.
* Introduces type `AllHosts` to make testing `renterHostsAllHandler` more intuitive (see commit 9710357 for the code without the `AllHosts` type)

Upcoming: test that `renterHostsActiveHandler` and `renterHostsAllHandler` work correctly for a network with multiple hosts.