### PR TITLE
Save merkle roots

### DIFF
--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -43,7 +43,7 @@ var (
 	// errReviseBadFileMerkleRoot is returned if the renter sends a file
 	// contract revision with a Merkle root that does not match the changes
 	// presented by the revision request.
-	errReviseBadFileMerkleRoot = errors.New("proposed file contract revision has an incorrect Merkle merkle root")
+	errReviseBadFileMerkleRoot = errors.New("proposed file contract revision has an incorrect Merkle root")
 
 	// errReviseBadHostValidOutput is returned if a proposed file contract
 	// revision does not correctly add value to the host's valid proof outputs.

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -2,6 +2,7 @@ package contractor
 
 import (
 	"errors"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -118,6 +119,10 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		newContracts[newContract.ID] = newContract
 		if len(newContracts) >= int(a.Hosts) {
 			break
+		}
+		if build.Release != "testing" {
+			// sleep for 1 minute to alleviate potential block propagation issues
+			time.Sleep(60 * time.Second)
 		}
 	}
 

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -75,14 +75,14 @@ func (c *Contractor) Downloader(contract modules.RenterContract) (Downloader, er
 	if proto.IsRevisionMismatch(err) {
 		// try again with the cached revision
 		c.mu.RLock()
-		cachedRev, ok := c.cachedRevisions[contract.ID]
+		cached, ok := c.cachedRevisions[contract.ID]
 		c.mu.RUnlock()
 		if !ok {
 			// nothing we can do; return original error
 			return nil, err
 		}
-		c.log.Printf("host has different revision for %v; retrying with cached revision", contract.ID)
-		contract.LastRevision = cachedRev
+		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
+		contract.LastRevision = cached.revision
 		d, err = proto.NewDownloader(host, contract)
 	}
 	if err != nil {

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -150,14 +150,15 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 	if proto.IsRevisionMismatch(err) {
 		// try again with the cached revision
 		c.mu.RLock()
-		cachedRev, ok := c.cachedRevisions[contract.ID]
+		cached, ok := c.cachedRevisions[contract.ID]
 		c.mu.RUnlock()
 		if !ok {
 			// nothing we can do; return original error
 			return nil, err
 		}
-		c.log.Printf("host has different revision for %v; retrying with cached revision", contract.ID)
-		contract.LastRevision = cachedRev
+		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
+		contract.LastRevision = cached.revision
+		contract.MerkleRoots = cached.merkleRoots
 		e, err = proto.NewEditor(host, contract, height)
 	}
 	if err != nil {

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/proto"
 	"github.com/NebulousLabs/Sia/types"
@@ -135,6 +137,10 @@ func (c *Contractor) managedFormContracts(n int, numSectors uint64, endHeight ty
 		contracts = append(contracts, contract)
 		if len(contracts) >= n {
 			break
+		}
+		if build.Release != "testing" {
+			// sleep for 1 minute to alleviate potential block propagation issues
+			time.Sleep(60 * time.Second)
 		}
 	}
 	// If we couldn't form any contracts, return an error. Otherwise, just log

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -2,7 +2,9 @@ package contractor
 
 import (
 	"errors"
+	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/proto"
 	"github.com/NebulousLabs/Sia/types"
@@ -87,6 +89,10 @@ func (c *Contractor) managedRenewContracts() error {
 			c.log.Printf("WARN: failed to renew contract with %v: %v", contract.NetAddress, err)
 		} else {
 			newContracts[contract.ID] = newContract
+		}
+		if build.Release != "testing" {
+			// sleep for 1 minute to alleviate potential block propagation issues
+			time.Sleep(60 * time.Second)
 		}
 	}
 

--- a/modules/renter/proto/negotiate.go
+++ b/modules/renter/proto/negotiate.go
@@ -116,7 +116,7 @@ func verifyRecentRevision(conn net.Conn, contract modules.RenterContract) error 
 
 // negotiateRevision sends a revision and actions to the host for approval,
 // completing one iteration of the revision loop.
-func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey crypto.SecretKey, saveFn revisionSaver) (types.Transaction, error) {
+func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey crypto.SecretKey) (types.Transaction, error) {
 	// create transaction containing the revision
 	signedTxn := types.Transaction{
 		FileContractRevisions: []types.FileContractRevision{rev},
@@ -137,17 +137,6 @@ func negotiateRevision(conn net.Conn, rev types.FileContractRevision, secretKey 
 	// read acceptance
 	if err := modules.ReadNegotiationAcceptance(conn); err != nil {
 		return types.Transaction{}, errors.New("host did not accept revision: " + err.Error())
-	}
-
-	// Before we continue, save the revision. Unexpected termination (e.g.
-	// power failure) during the signature transfer leaves in an ambiguous
-	// state: the host may or may not have received the signature, and thus
-	// may report either revision as being the most recent. To mitigate this,
-	// we save the old revision as a fallback.
-	if saveFn != nil {
-		if err := saveFn(rev); err != nil {
-			return types.Transaction{}, errors.New("failed to save revision: " + err.Error())
-		}
 	}
 
 	// send the new transaction signature

--- a/modules/renter/proto/negotiate_test.go
+++ b/modules/renter/proto/negotiate_test.go
@@ -36,7 +36,7 @@ func TestNegotiateRevisionStopResponse(t *testing.T) {
 	// since the host wrote StopResponse, we should proceed to validating the
 	// transaction. This will return a known error because we are supplying an
 	// empty revision.
-	_, err := negotiateRevision(rConn, types.FileContractRevision{}, crypto.SecretKey{}, nil)
+	_, err := negotiateRevision(rConn, types.FileContractRevision{}, crypto.SecretKey{})
 	if err != types.ErrFileContractWindowStartViolation {
 		t.Fatalf("expected %q, got \"%v\"", types.ErrFileContractWindowStartViolation, err)
 	}
@@ -56,7 +56,7 @@ func TestNegotiateRevisionStopResponse(t *testing.T) {
 		encoding.WriteObject(hConn, types.TransactionSignature{})
 	}()
 	expectedErr := "host did not accept transaction signature: sentinel"
-	_, err = negotiateRevision(rConn, types.FileContractRevision{}, crypto.SecretKey{}, nil)
+	_, err = negotiateRevision(rConn, types.FileContractRevision{}, crypto.SecretKey{})
 	if err == nil || err.Error() != expectedErr {
 		t.Fatalf("expected %q, got \"%v\"", expectedErr, err)
 	}

--- a/modules/renter/proto/proto.go
+++ b/modules/renter/proto/proto.go
@@ -3,6 +3,7 @@ package proto
 import (
 	"fmt"
 
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -39,8 +40,8 @@ type ContractParams struct {
 }
 
 // A revisionSaver is called just before we send our revision signature to the host; this
-// allows the revision to be reloaded later if we desync from the host.
-type revisionSaver func(types.FileContractRevision) error
+// allows the revision and Merkle roots to be reloaded later if we desync from the host.
+type revisionSaver func(types.FileContractRevision, []crypto.Hash) error
 
 // A recentRevisionError occurs if the host reports a different revision
 // number than expected.


### PR DESCRIPTION
One alternative that just occurred to me is defining `cachedRevision` in the proto package. Then `SaveFn` could take a `cachedRevision` as an argument instead of two separate args. Not sure though.