### PR TITLE
better storage obligation safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,15 @@ test:
 test-v:
 	go test -race -v -short -tags='debug testing' -timeout=15s $(pkgs) -run=$(run)
 test-long: clean fmt vet lint
-	go test -v -race -tags='testing debug' -timeout=600s $(pkgs) -run=$(run)
+	go test -v -race -tags='testing debug' -timeout=500s $(pkgs) -run=$(run)
 bench: clean fmt
-	go test -tags='testing' -timeout=600s -run=XXX -bench=. $(pkgs)
+	go test -tags='testing' -timeout=500s -run=XXX -bench=. $(pkgs)
 cover: clean
 	@mkdir -p cover/modules
 	@mkdir -p cover/modules/renter
 	@mkdir -p cover/modules/host
 	@for package in $(pkgs); do                                                                                     \
-		go test -tags='testing debug' -timeout=360s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		go test -tags='testing debug' -timeout=500s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
 		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html                                          \
 		&& rm cover/$$package.out ;                                                                                 \
 	done
@@ -98,7 +98,7 @@ cover-integration: clean
 	@mkdir -p cover/modules/renter
 	@mkdir -p cover/modules/host
 	@for package in $(pkgs); do                                                                                     \
-		go test -run=TestIntegration -tags='testing debug' -timeout=360s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		go test -run=TestIntegration -tags='testing debug' -timeout=500s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
 		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html                                          \
 		&& rm cover/$$package.out ;                                                                                 \
 	done
@@ -107,7 +107,7 @@ cover-unit: clean
 	@mkdir -p cover/modules/renter
 	@mkdir -p cover/modules/host
 	@for package in $(pkgs); do                                                                                     \
-		go test -run=TestUnit -tags='testing debug' -timeout=360s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
+		go test -run=TestUnit -tags='testing debug' -timeout=500s -covermode=atomic -coverprofile=cover/$$package.out ./$$package \
 		&& go tool cover -html=cover/$$package.out -o=cover/$$package.html                                          \
 		&& rm cover/$$package.out ;                                                                                 \
 	done

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -71,7 +71,7 @@ func TestIntegrationHostAndRent(t *testing.T) {
 	var rf RenterFiles
 	for i := 0; i < 200 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
 		st.getAPI("/renter/files", &rf)
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 	if len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10 {
 		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
@@ -93,7 +93,7 @@ func TestIntegrationHostAndRent(t *testing.T) {
 	// only one piece will be uploaded (10% at current redundancy)
 	for i := 0; i < 200 && (len(rf.Files) != 2 || rf.Files[0].UploadProgress < 10 || rf.Files[1].UploadProgress < 10); i++ {
 		st.getAPI("/renter/files", &rf)
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 	if len(rf.Files) != 2 || rf.Files[0].UploadProgress < 10 || rf.Files[1].UploadProgress < 10 {
 		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0], rf.Files[1])

--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -67,8 +67,8 @@ func (h *Host) announce(addr modules.NetAddress) error {
 // arbitrary data, signing the transaction, and submitting it to the
 // transaction pool.
 func (h *Host) Announce() error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	lockID := h.mu.Lock()
+	defer h.mu.Unlock(lockID)
 	err := h.tg.Add()
 	if err != nil {
 		return err
@@ -88,8 +88,8 @@ func (h *Host) Announce() error {
 // AnnounceAddress submits a host announcement to the blockchain to announce a
 // specific address. No checks for validity are performed on the address.
 func (h *Host) AnnounceAddress(addr modules.NetAddress) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	lockID := h.mu.Lock()
+	defer h.mu.Unlock(lockID)
 	err := h.tg.Add()
 	if err != nil {
 		return err

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -153,7 +153,7 @@ var (
 			return time.Second * 60
 		}
 		if build.Release == "testing" {
-			return time.Second * 1
+			return time.Second * 2
 		}
 		panic("unrecognized release constant in host - obligationLockTimeout")
 	}()

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -153,7 +153,7 @@ var (
 			return time.Second * 60
 		}
 		if build.Release == "testing" {
-			return time.Second * 2
+			return time.Second * 3
 		}
 		panic("unrecognized release constant in host - obligationLockTimeout")
 	}()

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -3,9 +3,6 @@
 // internet bandwidth into profit for the user.
 package host
 
-// TODO: Review the pointer control on the host, particularly with respect to
-// the storage obligations being flung around in storageobligations.go.
-
 // TODO: what happens if the renter submits the revision early, before the
 // final revision. Will the host mark the contract as complete?
 

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -104,9 +104,7 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 	}
 
 	// Get a lock on the storage obligation.
-	lockID = h.mu.Lock()
-	lockErr := h.tryLockStorageObligation(so.id())
-	h.mu.Unlock(lockID)
+	lockErr := h.managedTryLockStorageObligation(so.id())
 	if lockErr != nil {
 		return nil, types.TransactionSignature{}, lockErr
 	}
@@ -117,7 +115,7 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 	// conflict, wait 30 seconds and try again.
 	err = func() error {
 		// Unlock the storage obligation when finished.
-		defer h.unlockStorageObligation(so.id())
+		defer h.managedUnlockStorageObligation(so.id())
 
 		// Try adding the storage obligation. If there's an error, wait a few
 		// seconds and try again. Eventually time out. It should be noted that

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -91,7 +91,7 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 
 	// Create and add the storage obligation for this file contract.
 	fullTxn, _ := builder.View()
-	so := &storageObligation{
+	so := storageObligation{
 		SectorRoots: initialSectorRoots,
 
 		ContractCost:            h.settings.MinContractPrice,

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -53,11 +53,11 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 	}
 
 	// Verify that the signature for the revision from the renter is correct.
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	blockHeight := h.blockHeight
 	hostSPK := h.publicKey
 	hostSK := h.secretKey
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 	contractTxn := fullTxnSet[len(fullTxnSet)-1]
 	fc := contractTxn.FileContracts[0]
 	noOpRevision := types.FileContractRevision{
@@ -104,9 +104,9 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 	}
 
 	// Get a lock on the storage obligation.
-	h.mu.Lock()
+	lockID = h.mu.Lock()
 	lockErr := h.tryLockStorageObligation(so.id())
-	h.mu.Unlock()
+	h.mu.Unlock(lockID)
 	if lockErr != nil {
 		return nil, types.TransactionSignature{}, lockErr
 	}
@@ -129,9 +129,9 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 		// just when the actual modification is happening.
 		i := 0
 		for {
-			h.mu.Lock()
+			lockID := h.mu.Lock()
 			err = h.addStorageObligation(so)
-			h.mu.Unlock()
+			h.mu.Unlock(lockID)
 			if err == nil {
 				return nil
 			}

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -97,11 +97,11 @@ func (h *Host) managedDownloadIteration(conn net.Conn, so *storageObligation) er
 	}
 
 	// Grab a set of variables that will be useful later in the function.
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	blockHeight := h.blockHeight
 	secretKey := h.secretKey
 	settings := h.settings
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 
 	// Read the download requests, followed by the file contract revision that
 	// pays for them.
@@ -274,9 +274,9 @@ func (h *Host) managedRPCDownload(conn net.Conn) error {
 	// The storage obligation is returned with a lock on it. Defer a call to
 	// unlock the storage obligation.
 	defer func() {
-		h.mu.Lock()
+		lockID := h.mu.Lock()
 		h.unlockStorageObligation(so.id())
-		h.mu.Unlock()
+		h.mu.Unlock(lockID)
 	}()
 
 	// Perform a loop that will allow downloads to happen until the maximum

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -176,7 +176,7 @@ func (h *Host) managedDownloadIteration(conn net.Conn, so *storageObligation) er
 		FileContractRevisions: []types.FileContractRevision{paymentRevision},
 		TransactionSignatures: []types.TransactionSignature{renterSignature, txn.TransactionSignatures[1]},
 	}}
-	err = h.modifyStorageObligation(so, nil, nil, nil)
+	err = h.modifyStorageObligation(*so, nil, nil, nil)
 	if err != nil {
 		return modules.WriteNegotiationRejection(conn, err)
 	}
@@ -271,14 +271,8 @@ func (h *Host) managedRPCDownload(conn net.Conn) error {
 	if err != nil {
 		return err
 	}
-
-	// Lock the storage obligation during the revision.
-	h.mu.Lock()
-	err = h.tryLockStorageObligation(so.id())
-	h.mu.Unlock()
-	if err != nil {
-		return err
-	}
+	// The storage obligation is returned with a lock on it. Defer a call to
+	// unlock the storage obligation.
 	defer func() {
 		h.mu.Lock()
 		h.unlockStorageObligation(so.id())
@@ -288,7 +282,7 @@ func (h *Host) managedRPCDownload(conn net.Conn) error {
 	// Perform a loop that will allow downloads to happen until the maximum
 	// time for a single connection has been reached.
 	for time.Now().Before(startTime.Add(iteratedConnectionTime)) {
-		err := h.managedDownloadIteration(conn, so)
+		err := h.managedDownloadIteration(conn, &so)
 		if err == modules.ErrStopResponse {
 			// The renter has indicated that it has finished downloading the
 			// data, therefore there is no error. Return nil.

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -274,9 +274,7 @@ func (h *Host) managedRPCDownload(conn net.Conn) error {
 	// The storage obligation is returned with a lock on it. Defer a call to
 	// unlock the storage obligation.
 	defer func() {
-		lockID := h.mu.Lock()
-		h.unlockStorageObligation(so.id())
-		h.mu.Unlock(lockID)
+		h.managedUnlockStorageObligation(so.id())
 	}()
 
 	// Perform a loop that will allow downloads to happen until the maximum

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -133,9 +133,9 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	// If the host is not accepting contracts, the connection can be closed.
 	// The renter has been given enough information in the host settings to
 	// understand that the connection is going to be closed.
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	settings := h.settings
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 	if !settings.AcceptingContracts {
 		return nil
 	}
@@ -225,9 +225,9 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	//
 	// During finalization, the siganture for the revision is also checked, and
 	// signatures for the revision transaction are created.
-	h.mu.RLock()
+	lockID = h.mu.RLock()
 	hostCollateral := contractCollateral(h.settings, txnSet[len(txnSet)-1].FileContracts[0])
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 	hostTxnSignatures, hostRevisionSignature, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, nil, hostCollateral, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		// The incoming file contract is not acceptable to the host, indicate
@@ -259,13 +259,13 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 		return errNoFileContract
 	}
 
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	blockHeight := h.blockHeight
 	lockedStorageCollateral := h.financialMetrics.LockedStorageCollateral
 	publicKey := h.publicKey
 	settings := h.settings
 	unlockHash := h.unlockHash
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 	fc := txnSet[len(txnSet)-1].FileContracts[0]
 
 	// A new file contract should have a file size of zero.

--- a/modules/host/negotiaterecentrevision.go
+++ b/modules/host/negotiaterecentrevision.go
@@ -115,18 +115,18 @@ func (h *Host) managedRPCRecentRevision(conn net.Conn) (types.FileContractID, st
 	}
 	// Verify the response. In the process, fetch the related storage
 	// obligation, file contract revision, and transaction signatures.
-	h.mu.Lock()
+	lockID := h.mu.Lock()
 	so, recentRevision, revisionSigs, err := h.verifyChallengeResponse(fcid, challenge, challengeResponse)
-	h.mu.Unlock()
+	h.mu.Unlock(lockID)
 	if err != nil {
 		return types.FileContractID{}, storageObligation{}, modules.WriteNegotiationRejection(conn, err)
 	}
 	// Defer a call to unlock the storage obligation in the event of an error.
 	defer func() {
 		if err != nil {
-			h.mu.Lock()
+			lockID := h.mu.Lock()
 			h.unlockStorageObligation(fcid)
-			h.mu.Unlock()
+			h.mu.Unlock(lockID)
 		}
 	}()
 

--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -84,9 +84,7 @@ func (h *Host) managedRPCRenewContract(conn net.Conn) error {
 	// The storage obligation is received with a lock. Defer a call to unlock
 	// the storage obligation.
 	defer func() {
-		lockID := h.mu.Lock()
-		h.unlockStorageObligation(so.id())
-		h.mu.Unlock(lockID)
+		h.managedUnlockStorageObligation(so.id())
 	}()
 
 	// Perform the host settings exchange with the renter.

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -288,9 +288,7 @@ func (h *Host) managedRPCReviseContract(conn net.Conn) error {
 	// The storage obligation is received with a lock on it. Defer a call to
 	// unlock the storage obligation.
 	defer func() {
-		lockID := h.mu.Lock()
-		h.unlockStorageObligation(so.id())
-		h.mu.Unlock(lockID)
+		h.managedUnlockStorageObligation(so.id())
 	}()
 
 	// Begin the revision loop. The host will process revisions until a

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -226,7 +226,7 @@ func (h *Host) managedRevisionIteration(conn net.Conn, so *storageObligation, fi
 			}
 		}
 		newRevenue := storageRevenue.Add(bandwidthRevenue)
-		return verifyRevision(so, revision, blockHeight, newRevenue, newCollateral)
+		return verifyRevision(*so, revision, blockHeight, newRevenue, newCollateral)
 	}()
 	if err != nil {
 		return modules.WriteNegotiationRejection(conn, err)
@@ -253,7 +253,7 @@ func (h *Host) managedRevisionIteration(conn net.Conn, so *storageObligation, fi
 	so.RiskedCollateral = so.RiskedCollateral.Add(newCollateral)
 	so.PotentialUploadRevenue = so.PotentialUploadRevenue.Add(bandwidthRevenue)
 	so.RevisionTransactionSet = []types.Transaction{txn}
-	err = h.modifyStorageObligation(so, sectorsRemoved, sectorsGained, gainedSectorData)
+	err = h.modifyStorageObligation(*so, sectorsRemoved, sectorsGained, gainedSectorData)
 	if err != nil {
 		return modules.WriteNegotiationRejection(conn, err)
 	}
@@ -285,14 +285,8 @@ func (h *Host) managedRPCReviseContract(conn net.Conn) error {
 	if err != nil {
 		return err
 	}
-
-	// Lock the storage obligation during the revision.
-	h.mu.Lock()
-	err = h.tryLockStorageObligation(so.id())
-	h.mu.Unlock()
-	if err != nil {
-		return err
-	}
+	// The storage obligation is received with a lock on it. Defer a call to
+	// unlock the storage obligation.
 	defer func() {
 		h.mu.Lock()
 		h.unlockStorageObligation(so.id())
@@ -303,7 +297,7 @@ func (h *Host) managedRPCReviseContract(conn net.Conn) error {
 	// timeout is reached, or until the renter sends a StopResponse.
 	for timeoutReached := false; !timeoutReached; {
 		timeoutReached = time.Since(startTime) > iteratedConnectionTime
-		err := h.managedRevisionIteration(conn, so, timeoutReached)
+		err := h.managedRevisionIteration(conn, &so, timeoutReached)
 		if err == modules.ErrStopResponse {
 			return nil
 		} else if err != nil {
@@ -315,7 +309,7 @@ func (h *Host) managedRPCReviseContract(conn net.Conn) error {
 
 // verifyRevision checks that the revision pays the host correctly, and that
 // the revision does not attempt any malicious or unexpected changes.
-func verifyRevision(so *storageObligation, revision types.FileContractRevision, blockHeight types.BlockHeight, newRevenue, newCollateral types.Currency) error {
+func verifyRevision(so storageObligation, revision types.FileContractRevision, blockHeight types.BlockHeight, newRevenue, newCollateral types.Currency) error {
 	// Check that the revision is well-formed.
 	if len(revision.NewValidProofOutputs) != 2 || len(revision.NewMissedProofOutputs) != 3 {
 		return errInsaneFileContractRevisionOutputCounts

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -127,11 +127,11 @@ func (h *Host) managedRevisionIteration(conn net.Conn, so *storageObligation, fi
 	}
 
 	// Read some variables from the host for use later in the function.
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	settings := h.settings
 	secretKey := h.secretKey
 	blockHeight := h.blockHeight
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 
 	// The renter is going to send its intended modifications, followed by the
 	// file contract revision that pays for them.
@@ -288,9 +288,9 @@ func (h *Host) managedRPCReviseContract(conn net.Conn) error {
 	// The storage obligation is received with a lock on it. Defer a call to
 	// unlock the storage obligation.
 	defer func() {
-		h.mu.Lock()
+		lockID := h.mu.Lock()
 		h.unlockStorageObligation(so.id())
-		h.mu.Unlock()
+		h.mu.Unlock(lockID)
 	}()
 
 	// Begin the revision loop. The host will process revisions until a

--- a/modules/host/negotiatesettings.go
+++ b/modules/host/negotiatesettings.go
@@ -64,10 +64,10 @@ func (h *Host) managedRPCSettings(conn net.Conn) error {
 
 	var hes modules.HostExternalSettings
 	var secretKey crypto.SecretKey
-	h.mu.Lock()
+	lockID := h.mu.Lock()
 	h.revisionNumber++
 	secretKey = h.secretKey
 	hes = h.externalSettings()
-	h.mu.Unlock()
+	h.mu.Unlock(lockID)
 	return crypto.WriteSignedObject(conn, hes, secretKey)
 }

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -191,8 +191,8 @@ func (h *Host) threadedListen(closeChan chan struct{}) {
 
 // NetAddress returns the address at which the host can be reached.
 func (h *Host) NetAddress() modules.NetAddress {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	lockID := h.mu.RLock()
+	defer h.mu.RUnlock(lockID)
 
 	if h.settings.NetAddress != "" {
 		return h.settings.NetAddress
@@ -203,8 +203,8 @@ func (h *Host) NetAddress() modules.NetAddress {
 // NetworkMetrics returns information about the types of rpc calls that have
 // been made to the host.
 func (h *Host) NetworkMetrics() modules.HostNetworkMetrics {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	lockID := h.mu.RLock()
+	defer h.mu.RUnlock(lockID)
 	return modules.HostNetworkMetrics{
 		DownloadCalls:     atomic.LoadUint64(&h.atomicDownloadCalls),
 		ErrorCalls:        atomic.LoadUint64(&h.atomicErroredCalls),

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -149,9 +149,7 @@ func (h *Host) threadedHandleConn(conn net.Conn) {
 		_, so, err = h.managedRPCRecentRevision(conn)
 		if err != nil {
 			defer func() {
-				lockID := h.mu.Lock()
-				h.unlockStorageObligation(so.id())
-				h.mu.Unlock(lockID)
+				h.managedUnlockStorageObligation(so.id())
 			}()
 		}
 	case modules.RPCSettings:

--- a/modules/host/persist_compat_1.0.0_test.go
+++ b/modules/host/persist_compat_1.0.0_test.go
@@ -40,7 +40,7 @@ func TestHostPersistCompat100(t *testing.T) {
 
 	// Check that, after loading the compatibility file, all of the values are
 	// still correct. The file that was transplanted had no zero-value fields.
-	ht.host.mu.Lock()
+	lockID := ht.host.mu.Lock()
 	errCalls := atomic.LoadUint64(&h.atomicErroredCalls)
 	if errCalls == 0 {
 		t.Error("error calls incorrectly loaded after compatibility loading")
@@ -66,5 +66,5 @@ func TestHostPersistCompat100(t *testing.T) {
 	if h.unlockHash == (types.UnlockHash{}) {
 		t.Error("unlock hash loaded incorrectly")
 	}
-	ht.host.mu.Unlock()
+	ht.host.mu.Unlock(lockID)
 }

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -333,11 +333,6 @@ func (h *Host) addStorageObligation(so storageObligation) error {
 		// contract ids should happen during the negotiation phase, and not
 		// during the 'addStorageObligation' phase.
 		bso := tx.Bucket(bucketStorageObligations)
-		soBytes := bso.Get(soid[:])
-		if soBytes != nil {
-			h.log.Critical("host already has a save storage obligation for this file contract")
-			return errDuplicateStorageObligation
-		}
 
 		// If the storage obligation already has sectors, it means that the
 		// file contract is being renewed, and that the sector should be

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -587,19 +587,15 @@ func (h *Host) threadedHandleActionItem(soid types.FileContractID, wg *sync.Wait
 	defer wg.Done()
 
 	// Lock the storage obligation in question.
-	lockID := h.mu.Lock()
-	h.lockStorageObligation(soid)
-	h.mu.Unlock(lockID)
+	h.managedLockStorageObligation(soid)
 	defer func() {
-		lockID := h.mu.Lock()
-		h.unlockStorageObligation(soid)
-		h.mu.Unlock(lockID)
+		h.managedUnlockStorageObligation(soid)
 	}()
 
 	// Convert the storage obligation id into a storage obligation.
 	var err error
 	var so storageObligation
-	lockID = h.mu.RLock()
+	lockID := h.mu.RLock()
 	blockHeight := h.blockHeight
 	err = h.db.View(func(tx *bolt.Tx) error {
 		so, err = getStorageObligation(tx, soid)

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -28,7 +28,7 @@ func randSector() (crypto.Hash, []byte, error) {
 
 // newTesterStorageObligation uses the wallet to create and fund a file
 // contract that will form the foundation of a storage obligation.
-func (ht *hostTester) newTesterStorageObligation() (*storageObligation, error) {
+func (ht *hostTester) newTesterStorageObligation() (storageObligation, error) {
 	// Create the file contract that will be used in the obligation.
 	builder := ht.wallet.StartTransaction()
 	// Fund the file contract with a payout. The payout needs to be big enough
@@ -37,7 +37,7 @@ func (ht *hostTester) newTesterStorageObligation() (*storageObligation, error) {
 	payout := types.SiacoinPrecision.Mul64(1e3)
 	err := builder.FundSiacoins(payout)
 	if err != nil {
-		return nil, err
+		return storageObligation{}, err
 	}
 	// Add the file contract that consumes the funds.
 	_ = builder.AddFileContract(types.FileContract{
@@ -70,11 +70,11 @@ func (ht *hostTester) newTesterStorageObligation() (*storageObligation, error) {
 	// Sign the transaction.
 	tSet, err := builder.Sign(true)
 	if err != nil {
-		return nil, err
+		return storageObligation{}, err
 	}
 
 	// Assemble and return the storage obligation.
-	so := &storageObligation{
+	so := storageObligation{
 		OriginTransactionSet: tSet,
 
 		// TODO: There are no tracking values, because no fees were added.
@@ -133,7 +133,7 @@ func TestBlankStorageObligation(t *testing.T) {
 	// Load the storage obligation from the database, see if it updated
 	// correctly.
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -157,7 +157,7 @@ func TestBlankStorageObligation(t *testing.T) {
 		}
 	}
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -256,7 +256,7 @@ func TestSingleSectorStorageObligationStack(t *testing.T) {
 	// Load the storage obligation from the database, see if it updated
 	// correctly.
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -294,7 +294,7 @@ func TestSingleSectorStorageObligationStack(t *testing.T) {
 
 	// Grab the storage proof and inspect the contents.
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func TestSingleSectorStorageObligationStack(t *testing.T) {
 		}
 	}
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -386,7 +386,7 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 	// Load the storage obligation from the database, see if it updated
 	// correctly.
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -499,7 +499,7 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 	// Load the storage obligation from the database, see if it updated
 	// correctly.
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -536,7 +536,7 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 	}
 
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -564,7 +564,7 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 		}
 	}
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -678,7 +678,7 @@ func TestAutoRevisionSubmission(t *testing.T) {
 	}
 
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}
@@ -706,7 +706,7 @@ func TestAutoRevisionSubmission(t *testing.T) {
 		}
 	}
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
-		*so, err = getStorageObligation(tx, so.id())
+		so, err = getStorageObligation(tx, so.id())
 		if err != nil {
 			return err
 		}

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -108,12 +108,12 @@ func TestBlankStorageObligation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.addStorageObligation(so)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Storage obligation should not be marked as having the transaction
 	// confirmed on the blockchain.
 	if so.OriginConfirmed {
@@ -193,12 +193,12 @@ func TestSingleSectorStorageObligationStack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.addStorageObligation(so)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Storage obligation should not be marked as having the transaction
 	// confirmed on the blockchain.
 	if so.OriginConfirmed {
@@ -235,12 +235,12 @@ func TestSingleSectorStorageObligationStack(t *testing.T) {
 			NewUnlockHash:         types.UnlockConditions{}.UnlockHash(),
 		}},
 	}}
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.modifyStorageObligation(so, nil, []crypto.Hash{sectorRoot}, [][]byte{sectorData})
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Submit the revision set to the transaction pool.
 	err = ht.tpool.AcceptTransactionSet(revisionSet)
 	if err != nil {
@@ -366,12 +366,12 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.addStorageObligation(so)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Storage obligation should not be marked as having the transaction
 	// confirmed on the blockchain.
 	if so.OriginConfirmed {
@@ -429,12 +429,12 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 			NewUnlockHash:         types.UnlockConditions{}.UnlockHash(),
 		}},
 	}}
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.modifyStorageObligation(so, nil, []crypto.Hash{sectorRoot}, [][]byte{sectorData})
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Submit the revision set to the transaction pool.
 	err = ht.tpool.AcceptTransactionSet(revisionSet)
 	if err != nil {
@@ -478,12 +478,12 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 			NewUnlockHash:         types.UnlockConditions{}.UnlockHash(),
 		}},
 	}}
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.modifyStorageObligation(so, nil, []crypto.Hash{sectorRoot2}, [][]byte{sectorData2})
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Submit the revision set to the transaction pool.
 	err = ht.tpool.AcceptTransactionSet(revisionSet2)
 	if err != nil {
@@ -604,12 +604,12 @@ func TestAutoRevisionSubmission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.addStorageObligation(so)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Storage obligation should not be marked as having the transaction
 	// confirmed on the blockchain.
 	if so.OriginConfirmed {
@@ -647,12 +647,12 @@ func TestAutoRevisionSubmission(t *testing.T) {
 		}},
 	}}
 	so.RevisionTransactionSet = revisionSet
-	ht.host.lockStorageObligation(so.id())
+	ht.host.managedLockStorageObligation(so.id())
 	err = ht.host.modifyStorageObligation(so, nil, []crypto.Hash{sectorRoot}, [][]byte{sectorData})
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host.unlockStorageObligation(so.id())
+	ht.host.managedUnlockStorageObligation(so.id())
 	// Unlike the other tests, this test does not submit the file contract
 	// revision to the transaction pool for the host, the host is expected to
 	// do it automatically.

--- a/modules/host/storageobligationslock.go
+++ b/modules/host/storageobligationslock.go
@@ -15,47 +15,56 @@ var (
 	errObligationLocked = errors.New("the requested file contract is currently locked")
 )
 
-// lockStorageObligation puts a storage obligation under lock in the host.
-func (h *Host) lockStorageObligation(soid types.FileContractID) {
-	// Check if the storage obligation is locked.
+// managedLockStorageObligation puts a storage obligation under lock in the
+// host.
+func (h *Host) managedLockStorageObligation(soid types.FileContractID) {
+	// Check if a lock has been created for this storage obligation. If not,
+	// create one. The map must be accessed under lock, but the request for the
+	// storage lock must not be made under lock.
+	lockID := h.mu.Lock()
 	tl, exists := h.lockedStorageObligations[soid]
-	if exists {
-		tl.Lock()
-		return
+	if !exists {
+		tl = new(sync.TryMutex)
+		h.lockedStorageObligations[soid] = tl
 	}
+	h.mu.Unlock(lockID)
 
-	// Create a lock for this storage obligation.
-	tl = new(sync.TryMutex)
 	tl.Lock()
-	h.lockedStorageObligations[soid] = tl
 }
 
-// tryLockStorageObligation attempts to put a storage obligation under lock,
-// returning an error if the lock cannot be obtained.
-func (h *Host) tryLockStorageObligation(soid types.FileContractID) error {
-	// Check if the storage obligation is locked.
+// managedTryLockStorageObligation attempts to put a storage obligation under
+// lock, returning an error if the lock cannot be obtained.
+func (h *Host) managedTryLockStorageObligation(soid types.FileContractID) error {
+	// Check if a lock has been created for this storage obligation. If not,
+	// create one. The map must be accessed under lock, but the request for the
+	// storage lock must not be made under lock.
+	lockID := h.mu.Lock()
 	tl, exists := h.lockedStorageObligations[soid]
-	if exists {
-		if tl.TryLockTimed(obligationLockTimeout) {
-			return nil
-		}
-		return errObligationLocked
+	if !exists {
+		tl = new(sync.TryMutex)
+		h.lockedStorageObligations[soid] = tl
 	}
+	h.mu.Unlock(lockID)
 
-	// Create a lock for this storage obligation.
-	tl = new(sync.TryMutex)
-	tl.Lock()
-	h.lockedStorageObligations[soid] = tl
-	return nil
+	if tl.TryLockTimed(obligationLockTimeout) {
+		return nil
+	}
+	return errObligationLocked
 }
 
-// unlockStorageObligation takes a storage obligation out from under lock in
+// managedUnlockStorageObligation takes a storage obligation out from under lock in
 // the host.
-func (h *Host) unlockStorageObligation(soid types.FileContractID) {
+func (h *Host) managedUnlockStorageObligation(soid types.FileContractID) {
+	// Check if a lock has been created for this storage obligation. If not,
+	// create one. The map must be accessed under lock, but the request for the
+	// storage lock must not be made under lock.
+	lockID := h.mu.Lock()
 	tl, exists := h.lockedStorageObligations[soid]
 	if !exists {
 		h.log.Critical(errObligationUnlocked)
 		return
 	}
+	h.mu.Unlock(lockID)
+
 	tl.Unlock()
 }

--- a/modules/host/storageobligationslock_test.go
+++ b/modules/host/storageobligationslock_test.go
@@ -22,72 +22,72 @@ func TestObligationLocks(t *testing.T) {
 
 	// Simple lock and unlock.
 	ob1 := types.FileContractID{1}
-	ht.host.lockStorageObligation(ob1)
-	ht.host.unlockStorageObligation(ob1)
+	ht.host.managedLockStorageObligation(ob1)
+	ht.host.managedUnlockStorageObligation(ob1)
 
 	// Simple lock and unlock, with trylock.
-	err = ht.host.tryLockStorageObligation(ob1)
+	err = ht.host.managedTryLockStorageObligation(ob1)
 	if err != nil {
 		t.Fatal("unable to get lock despite not having a lock in place")
 	}
-	ht.host.unlockStorageObligation(ob1)
+	ht.host.managedUnlockStorageObligation(ob1)
 
 	// Threaded lock and unlock.
 	blockSuccessful := false
-	ht.host.lockStorageObligation(ob1)
+	ht.host.managedLockStorageObligation(ob1)
 	go func() {
 		time.Sleep(obligationLockTimeout * 2)
 		blockSuccessful = true
-		ht.host.unlockStorageObligation(ob1)
+		ht.host.managedUnlockStorageObligation(ob1)
 	}()
-	ht.host.lockStorageObligation(ob1)
+	ht.host.managedLockStorageObligation(ob1)
 	if !blockSuccessful {
 		t.Error("two threads were able to simultaneously grab an obligation lock")
 	}
-	ht.host.unlockStorageObligation(ob1)
+	ht.host.managedUnlockStorageObligation(ob1)
 
 	// Attempted lock and unlock - failed.
-	ht.host.lockStorageObligation(ob1)
+	ht.host.managedLockStorageObligation(ob1)
 	go func() {
 		time.Sleep(obligationLockTimeout * 2)
-		ht.host.unlockStorageObligation(ob1)
+		ht.host.managedUnlockStorageObligation(ob1)
 	}()
-	err = ht.host.tryLockStorageObligation(ob1)
+	err = ht.host.managedTryLockStorageObligation(ob1)
 	if err != errObligationLocked {
 		t.Fatal("storage obligation was able to get a lock, despite already being locked")
 	}
 
 	// Attempted lock and unlock - succeeded.
-	ht.host.lockStorageObligation(ob1)
+	ht.host.managedLockStorageObligation(ob1)
 	go func() {
 		time.Sleep(obligationLockTimeout / 2)
-		ht.host.unlockStorageObligation(ob1)
+		ht.host.managedUnlockStorageObligation(ob1)
 	}()
-	err = ht.host.tryLockStorageObligation(ob1)
+	err = ht.host.managedTryLockStorageObligation(ob1)
 	if err != nil {
 		t.Fatal("storage obligation unable to get lock, depsite having enough time")
 	}
-	ht.host.unlockStorageObligation(ob1)
+	ht.host.managedUnlockStorageObligation(ob1)
 
 	// Multiple locks and unlocks happening together.
 	ob2 := types.FileContractID{2}
 	ob3 := types.FileContractID{3}
-	ht.host.lockStorageObligation(ob1)
-	ht.host.lockStorageObligation(ob2)
-	ht.host.lockStorageObligation(ob3)
-	ht.host.unlockStorageObligation(ob3)
-	ht.host.unlockStorageObligation(ob2)
-	err = ht.host.tryLockStorageObligation(ob2)
+	ht.host.managedLockStorageObligation(ob1)
+	ht.host.managedLockStorageObligation(ob2)
+	ht.host.managedLockStorageObligation(ob3)
+	ht.host.managedUnlockStorageObligation(ob3)
+	ht.host.managedUnlockStorageObligation(ob2)
+	err = ht.host.managedTryLockStorageObligation(ob2)
 	if err != nil {
 		t.Fatal("unable to get lock despite not having a lock in place")
 	}
-	err = ht.host.tryLockStorageObligation(ob3)
+	err = ht.host.managedTryLockStorageObligation(ob3)
 	if err != nil {
 		t.Fatal("unable to get lock despite not having a lock in place")
 	}
-	err = ht.host.tryLockStorageObligation(ob1)
+	err = ht.host.managedTryLockStorageObligation(ob1)
 	if err != errObligationLocked {
 		t.Fatal("storage obligation was able to get a lock, despite already being locked")
 	}
-	ht.host.unlockStorageObligation(ob1)
+	ht.host.managedUnlockStorageObligation(ob1)
 }

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -139,8 +139,8 @@ func (h *Host) ProcessConsensusChange(cc modules.ConsensusChange) {
 
 	// Host needs to unlock before wg.Wait() is called, so that the other
 	// threads may access the host lock.
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	lockID := h.mu.Lock()
+	defer h.mu.Unlock(lockID)
 
 	// Wrap the whole parsing into a single large database tx to keep things
 	// efficient.

--- a/modules/host/update.go
+++ b/modules/host/update.go
@@ -21,7 +21,7 @@ import (
 // in the consensus set or the host.
 func (h *Host) initRescan() error {
 	// Reset all of the variables that have relevance to the consensus set.
-	var allObligations []*storageObligation
+	var allObligations []storageObligation
 	// Reset all of the consensus-relevant variables in the host.
 	h.blockHeight = 0
 
@@ -38,7 +38,7 @@ func (h *Host) initRescan() error {
 			so.OriginConfirmed = false
 			so.RevisionConfirmed = false
 			so.ProofConfirmed = false
-			allObligations = append(allObligations, &so)
+			allObligations = append(allObligations, so)
 			soBytes, err = json.Marshal(so)
 			if err != nil {
 				return err

--- a/modules/host/upnp.go
+++ b/modules/host/upnp.go
@@ -48,9 +48,9 @@ func (h *Host) managedLearnHostname() {
 	if build.Release == "testing" {
 		return
 	}
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	netAddr := h.settings.NetAddress
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 	// If the settings indicate that an address has been manually set, there is
 	// no reason to learn the hostname.
 	if netAddr != "" {
@@ -71,8 +71,8 @@ func (h *Host) managedLearnHostname() {
 		return
 	}
 
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	lockID = h.mu.Lock()
+	defer h.mu.Unlock(lockID)
 	autoAddress := modules.NetAddress(net.JoinHostPort(hostname, h.port))
 	if err := autoAddress.IsValid(); err != nil {
 		h.log.Printf("WARN: discovered hostname %q is invalid: %v", autoAddress, err)
@@ -109,9 +109,9 @@ func (h *Host) managedLearnHostname() {
 func (h *Host) managedForwardPort() error {
 	// If the port is invalid, there is no need to perform any of the other
 	// tasks.
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	port := h.port
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 	portInt, err := strconv.Atoi(port)
 	if err != nil {
 		return err
@@ -137,9 +137,9 @@ func (h *Host) managedForwardPort() error {
 func (h *Host) managedClearPort() error {
 	// If the port is invalid, there is no need to perform any of the other
 	// tasks.
-	h.mu.RLock()
+	lockID := h.mu.RLock()
 	port := h.port
-	h.mu.RUnlock()
+	h.mu.RUnlock(lockID)
 	portInt, err := strconv.Atoi(port)
 	if err != nil {
 		return err


### PR DESCRIPTION
The host now locks storage obligations before ever pulling them from the
database, and keeps the locks until the host is no longer going to be
adding them to the database. This resolves some issues relating to
storage obligation corruption, which can cause errors like 'Consensus
Conflict' and can cause the host to report the wrong revision number, or
to have the wrong sector roots, etc.