### PR TITLE
update calculateHostWeight

### DIFF
--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -16,18 +16,57 @@ var (
 // calculateHostWeight returns the weight of a host according to the settings of
 // the host database entry. Currently, only the price is considered.
 func calculateHostWeight(entry hostEntry) (weight types.Currency) {
-	// In the weighted price, the download bandwidth price is multiplied by
-	// numDownloads, which is our guess at the median number of downloads per
-	// file (some files may go untouched, but others may be requested
-	// many times).
-	const numDownloads = uint64(50)
-	price := entry.StoragePrice.Add(entry.ContractPrice).Add(entry.UploadBandwidthPrice).Add(entry.DownloadBandwidthPrice.Mul64(numDownloads))
+	// Prices tiered as follows:
+	//    - the storage price is presented as 'per block per byte'
+	//    - the contract price is presented as a flat rate
+	//    - the upload bandwidth price is per byte
+	//    - the download bandwidth price is per byte
+	//
+	// The hostdb will naively assume the following for now:
+	//    - each contract covers 6 weeks of storage (default is 12 weeks, but
+	//      renewals occur at midpoint) - 6048 blocks - and 10GB of storage.
+	//    - uploads happen once per 12 weeks (average lifetime of a file is 12 weeks)
+	//    - downloads happen once per 6 weeks (files are on average downloaded twice throughout lifetime)
+	//
+	// In the future, the renter should be able to track average user behavior
+	// and adjust accordingly. This flexibility will be added later.
+	adjustedContractPrice := entry.ContractPrice.Div64(6048).Div64(10e9) // Adjust contract price to match 10GB for 6 weeks.
+	adjustedUploadPrice := entry.UploadBandwidthPrice.Div64(24192)       // Adjust upload price to match a single upload over 24 weeks.
+	adjustedDownloadPrice := entry.DownloadBandwidthPrice.Div64(12096)   // Adjust download price to match one download over 12 weeks.
+	siafundFee := adjustedContractPrice.Add(adjustedUploadPrice).Add(adjustedDownloadPrice).Add(entry.Collateral).MulTax()
+	totalPrice := entry.StoragePrice.Add(adjustedContractPrice).Add(adjustedUploadPrice).Add(adjustedDownloadPrice).Add(siafundFee)
 
-	// If the price is 0, just return the base weight to avoid divide by zero.
-	if price.IsZero() {
-		return baseWeight
+	// Set the weight to the base weight, and then divide it by the price
+	// raised to the fifth power. This means that a host which has half the
+	// total price will be 32x as likely to be selected. A host with a quarter
+	// the total price will be 1024x as likely to be selected, and so on.
+	weight = baseWeight
+	if !totalPrice.IsZero() {
+		// To avoid a divide-by-zero error, this operation is only performed on
+		// non-zero prices.
+		weight = baseWeight.Div(totalPrice).Div(totalPrice).Div(totalPrice).Div(totalPrice).Div(totalPrice)
 	}
 
-	// Divide the base weight by the price to the fifth power.
-	return baseWeight.Div(price).Div(price).Div(price).Div(price).Div(price)
+	// Account for collateral. Collateral has a somewhat complicated
+	// relationship with price, because raising the collateral inherently
+	// raises the price for renters. If the host's score increases linearly to
+	// the amount of collateral they put up, then the host will gain score from
+	// increasing collateral until the siafund fee makes up about 15% of the
+	// total price. After that, the host will actually lose points for having
+	// too much collateral.
+	//
+	// The renter has control over how much collateral the host uses.
+	// Currently, this control is not implemented, so the hosts are penalized
+	// for setting very high collateral values. Once the renter is clamping the
+	// amount being spent on collateral, the hostdb can also clamp the amount
+	// of collateral being taken into account by the host, to optimize the
+	// host's score for the renter's needs.
+	if entry.Collateral.IsZero() {
+		// Instead of zeroing out the weight, just return the weight as though
+		// the collateral is 1 hasting. Competitively speaking, this is
+		// effectively zero.
+		return weight
+	}
+	weight = weight.Mul(entry.Collateral)
+	return weight
 }


### PR DESCRIPTION
calculateHostWeight was very strongly favoring the cost of downloading
the file, and making an unreasonable assumption that the average file
(weighted by size) would be downloaded 50 times.

Additionally, the contract price, upload price, and download price were
not being adjusted to match the fact that the storage price only covers
a single block instead of the contract length.

The updated calculateHostWeight function also takes into account the
collateral, although only minimal emphasis is applied. Price is still by
far the dominating factor.