### PR TITLE
Testing renter API functions

### DIFF
--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -4,11 +4,20 @@ import (
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules/renter"
+	"github.com/NebulousLabs/Sia/modules/renter/contractor"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+const (
+	testFunds  = "10000000000000000000000000000"
+	testPeriod = "5"
 )
 
 // createRandFile creates a file on disk and fills it with random bytes.
@@ -219,7 +228,7 @@ func TestRenterHostsAllHandler(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestRenterHostsAllHandler1")
+	st, err := createServerTester("TestRenterHostsAllHandler")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,5 +251,362 @@ func TestRenterHostsAllHandler(t *testing.T) {
 	}
 	if len(ah.Hosts) != 1 {
 		t.Fatalf("expected 1 host, got %v", len(ah.Hosts))
+	}
+}
+
+func TestRenterHandlerContracts(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createServerTester("TestRenterHandlerContracts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Anounce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The renter should not have any contracts yet.
+	var contracts RenterContracts
+	if err = st.getAPI("/renter/contracts", &contracts); err != nil {
+		t.Fatal(err)
+	}
+	if len(contracts.Contracts) != 0 {
+		t.Fatalf("expected renter to have 0 contracts; got %v", len(contracts.Contracts))
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// The renter should now have 1 contract.
+	if err = st.getAPI("/renter/contracts", &contracts); err != nil {
+		t.Fatal(err)
+	}
+	if len(contracts.Contracts) != 1 {
+		t.Fatalf("expected renter to have 1 contract; got %v", len(contracts.Contracts))
+	}
+
+	// Check the renter's contract spending.
+	var get RenterGET
+	if err = st.getAPI("/renter", &get); err != nil {
+		t.Fatal(err)
+	}
+	var expectedContractSpending types.Currency
+	for _, contract := range contracts.Contracts {
+		expectedContractSpending = expectedContractSpending.Add(contract.RenterFunds)
+	}
+	if got := get.FinancialMetrics.ContractSpending; got.Cmp(expectedContractSpending) != 0 {
+		t.Fatalf("expected contract spending to be %v; got %v", expectedContractSpending, got)
+	}
+
+}
+
+func TestRenterHandlerGetAndPost(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createServerTester("TestRenterHandlerGetAndPost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Anounce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that a call to /renter returns the expected values.
+	var get RenterGET
+	if err = st.getAPI("/renter", &get); err != nil {
+		t.Fatal(err)
+	}
+	// Check the renter's funds.
+	expectedFunds, ok := scanAmount(testFunds)
+	if !ok {
+		t.Fatal("scanAmount failed")
+	}
+	if got := get.Settings.Allowance.Funds; got.Cmp(expectedFunds) != 0 {
+		t.Fatalf("expected funds to be %v; got %v", expectedFunds, got)
+	}
+	// Check the renter's period.
+	intPeriod, err := strconv.Atoi(testPeriod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPeriod := types.BlockHeight(intPeriod)
+	if got := get.Settings.Allowance.Period; got != expectedPeriod {
+		t.Fatalf("expected period to be %v; got %v", expectedPeriod, got)
+	}
+	// Check the renter's renew window.
+	expectedRenewWindow := expectedPeriod / 2
+	if got := get.Settings.Allowance.RenewWindow; got != expectedRenewWindow {
+		t.Fatalf("expected renew window to be %v; got %v", expectedRenewWindow, got)
+	}
+
+	// Try an empty funds string.
+	allowanceValues = url.Values{}
+	allowanceValues.Set("funds", "")
+	allowanceValues.Set("period", testPeriod)
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err == nil || err.Error() != "Couldn't parse funds" {
+		t.Errorf("expected error to be 'Couldn't parse funds'; got %v", err)
+	}
+	// Try an invalid funds string. Can't test a negative value since
+	// ErrNegativeCurrency triggers a build.Critical, which calls a panic in
+	// debug mode.
+	allowanceValues.Set("funds", "0")
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err == nil || err.Error() != contractor.ErrInsufficientAllowance.Error() {
+		t.Errorf("expected error to be %v; got %v", contractor.ErrInsufficientAllowance, err)
+	}
+	// Try a empty period string.
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", "")
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err == nil || !strings.HasPrefix(err.Error(), "Couldn't parse period: ") {
+		t.Errorf("expected error to begin with 'Couldn't parse period: '; got %v", err)
+	}
+	// Try an invalid period string.
+	allowanceValues.Set("period", "-1")
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err == nil || err.Error()[:23] != "Couldn't parse period: " {
+		t.Errorf("expected error to begin with 'Couldn't parse period: '; got %v", err)
+	}
+	// Try a period that will lead to a length-zero RenewWindow.
+	allowanceValues.Set("period", "1")
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err == nil || err.Error() != contractor.ErrAllowanceZeroWindow.Error() {
+		t.Errorf("expected error to be %v, got %v", contractor.ErrAllowanceZeroWindow, err)
+	}
+}
+
+func TestRenterLoadNonexistent(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createServerTester("TestRenterLoadNonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Anounce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Try uploading a nonexistent file.
+	fakepath := filepath.Join(st.dir, "dne.dat")
+	uploadValues := url.Values{}
+	uploadValues.Set("source", fakepath)
+	err = st.stdPostAPI("/renter/upload/dne", uploadValues)
+	if err == nil || !strings.HasSuffix(err.Error(), "no such file or directory") {
+		t.Errorf("expected error to end with 'no such file or directory; got %v", err)
+	}
+
+	// Try downloading a nonexistent file.
+	downpath := filepath.Join(st.dir, "dnedown.dat")
+	err = st.stdGetAPI("/renter/download/dne?destination=" + downpath)
+	if err == nil || err.Error() != "Download failed: no file with that path" {
+		t.Errorf("expected error to be 'Download failed: no file with that path'; got %v instead", err)
+	}
+
+	// The renter's downloads queue should be empty.
+	var queue RenterDownloadQueue
+	if err = st.getAPI("/renter/downloads", &queue); err != nil {
+		t.Fatal(err)
+	}
+	if len(queue.Downloads) != 0 {
+		t.Fatalf("expected renter to have 0 downloads in the queue; got %v", len(queue.Downloads))
+	}
+}
+
+func TestRenterHandlerRename(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createServerTester("TestRenterHandlerRename")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Anounce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create two files.
+	path1 := filepath.Join(st.dir, "test1.dat")
+	if err = createRandFile(path1, 512); err != nil {
+		t.Fatal(err)
+	}
+	path2 := filepath.Join(st.dir, "test2.dat")
+	if err = createRandFile(path2, 512); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload to host.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path1)
+	if err = st.stdPostAPI("/renter/upload/test1", uploadValues); err != nil {
+		t.Fatal(err)
+	}
+	uploadValues.Set("source", path2)
+	if err = st.stdPostAPI("/renter/upload/test2", uploadValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Try renaming to a name that's already taken.
+	renameValues := url.Values{}
+	renameValues.Set("newsiapath", "test1")
+	err = st.stdPostAPI("/renter/rename/test2", renameValues)
+	if err == nil || err.Error() != renter.ErrPathOverload.Error() {
+		t.Errorf("expected error to be %v; got %v", renter.ErrPathOverload, err)
+	}
+
+	// Try renaming to an empty string.
+	renameValues.Set("newsiapath", "")
+	err = st.stdPostAPI("/renter/rename/test1", renameValues)
+	if err == nil || err.Error() != renter.ErrEmptyFilename.Error() {
+		t.Fatalf("expected error to be %v; got %v", renter.ErrEmptyFilename, err)
+	}
+
+	// Rename the first file.
+	renameValues.Set("newsiapath", "newtest1")
+	if err = st.stdPostAPI("/renter/rename/test1", renameValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Try renaming a nonexistent file.
+	renameValues.Set("newsiapath", "newdne")
+	err = st.stdPostAPI("/renter/rename/dne", renameValues)
+	if err == nil || err.Error() != renter.ErrUnknownPath.Error() {
+		t.Errorf("expected error to be %v; got %v", renter.ErrUnknownPath, err)
+	}
+}
+
+func TestRenterHandlerDelete(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	st, err := createServerTester("TestRenterHandlerDelete")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Anounce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file.
+	path := filepath.Join(st.dir, "test.dat")
+	if err = createRandFile(path, 1024); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload to host.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	if err = st.stdPostAPI("/renter/upload/test", uploadValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete the file.
+	if err = st.stdPostAPI("/renter/delete/test", url.Values{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The renter's list of files should now be empty.
+	var files RenterFiles
+	if err = st.getAPI("/renter/files", &files); err != nil {
+		t.Fatal(err)
+	}
+	if len(files.Files) != 0 {
+		t.Fatalf("renter's list of files should be empty; got %v instead", files)
+	}
+
+	// Try deleting a nonexistent file.
+	err = st.stdPostAPI("/renter/delete/dne", url.Values{})
+	if err == nil || err.Error() != renter.ErrUnknownPath.Error() {
+		t.Errorf("expected error to be %v, got %v", renter.ErrUnknownPath, err)
 	}
 }

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -254,6 +254,8 @@ func TestRenterHostsAllHandler(t *testing.T) {
 	}
 }
 
+// TestRenterHandlerContracts checks that contract formation between a host and
+// renter behaves as expected, and that contract spending is the right amount.
 func TestRenterHandlerContracts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -316,6 +318,9 @@ func TestRenterHandlerContracts(t *testing.T) {
 
 }
 
+// TestRenterHandlerGetAndPost checks that valid /renter calls successfully set
+// allowance values, while /renter calls with invalid allowance values are
+// correctly handled.
 func TestRenterHandlerGetAndPost(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -411,6 +416,8 @@ func TestRenterHandlerGetAndPost(t *testing.T) {
 	}
 }
 
+// TestRenterLoadNonexistent checks that attempting to upload or download a
+// nonexistent file triggers the appropriate error.
 func TestRenterLoadNonexistent(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -467,6 +474,8 @@ func TestRenterLoadNonexistent(t *testing.T) {
 	}
 }
 
+// TestRenterHandlerRename checks that valid /renter/rename calls are
+// successful, and that invalid  calls fail with the appropriate error.
 func TestRenterHandlerRename(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -547,6 +556,9 @@ func TestRenterHandlerRename(t *testing.T) {
 	}
 }
 
+// TestRenterHandlerDelete checks that deleting a valid file from the renter
+// goes as planned and that attempting to delete a nonexistent file fails with
+// the appropriate error.
 func TestRenterHandlerDelete(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -44,13 +44,30 @@ func TestIntegrationHostAndRent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// create contracts
+	// the renter should not have any contracts yet
+	contracts := RenterContracts{}
+	if err = st.getAPI("/renter/contracts", &contracts); err != nil {
+		t.Fatal(err)
+	}
+	if len(contracts.Contracts) != 0 {
+		t.Fatalf("expected renter to have 0 contracts; got %v", len(contracts.Contracts))
+	}
+
+	// set an allowance for the renter, allowing a contract to be formed
 	allowanceValues := url.Values{}
 	allowanceValues.Set("funds", "10000000000000000000000000000") // 10k SC
 	allowanceValues.Set("period", "5")
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// the renter should now have 1 contract
+	if err = st.getAPI("/renter/contracts", &contracts); err != nil {
+		t.Fatal(err)
+	}
+	if len(contracts.Contracts) != 1 {
+		t.Fatalf("expected renter to have 1 contract; got %v", len(contracts.Contracts))
 	}
 
 	// create a file

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -53,6 +53,15 @@ func TestIntegrationHostAndRent(t *testing.T) {
 		t.Fatalf("expected renter to have 0 contracts; got %v", len(contracts.Contracts))
 	}
 
+	// the renter's downloads queue should be empty
+	queue := RenterDownloadQueue{}
+	if err = st.getAPI("/renter/downloads", &queue); err != nil {
+		t.Fatal(err)
+	}
+	if len(queue.Downloads) != 0 {
+		t.Fatalf("expected renter to have 0 downloads in the queue; got %v", len(queue.Downloads))
+	}
+
 	// set an allowance for the renter, allowing a contract to be formed
 	allowanceValues := url.Values{}
 	allowanceValues.Set("funds", "10000000000000000000000000000") // 10k SC
@@ -133,6 +142,14 @@ func TestIntegrationHostAndRent(t *testing.T) {
 	}
 	if bytes.Compare(orig, download) != 0 {
 		t.Fatal("data mismatch when downloading a file")
+	}
+	// The downloads queue should now contain the second file's download.
+	// Downloads are never removed from the queue within a siad session.
+	if err = st.getAPI("/renter/downloads", &queue); err != nil {
+		t.Fatal(err)
+	}
+	if len(queue.Downloads) != 1 {
+		t.Fatalf("expected renter to have 1 download in the queue; got %v", len(queue.Downloads))
 	}
 
 	// Rename the second file's entry in the renter's list of files.

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -135,6 +135,23 @@ func TestIntegrationHostAndRent(t *testing.T) {
 		t.Fatal("data mismatch when downloading a file")
 	}
 
+	// Rename the second file's entry in the renter's list of files.
+	renameValues := url.Values{}
+	renameValues.Set("newsiapath", "newtest2")
+	if err = st.stdPostAPI("/renter/rename/test2", renameValues); err != nil {
+		t.Fatal(err)
+	}
+	// Make sure the list of files is updated to reflect the name change.
+	files := RenterFiles{}
+	if err = st.getAPI("/renter/files", &files); err != nil {
+		t.Fatal(err)
+	}
+	// The second file entry is at the front of files.Files since new entries
+	// are prepended.
+	if name := files.Files[0].SiaPath; name != "newtest2" {
+		t.Fatalf("test2 should have been renamed to newtest2; named %v instead", name)
+	}
+
 	// Mine blocks until the host recognizes profit. The host will wait for 12
 	// blocks after the storage window has closed to report the profit, a total
 	// of 40 blocks should be mined.

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -10,14 +10,10 @@ import (
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/modules/renter"
-	"github.com/NebulousLabs/Sia/modules/renter/contractor"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -48,24 +44,6 @@ func TestIntegrationHostAndRent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The renter should not have any contracts yet.
-	var contracts RenterContracts
-	if err = st.getAPI("/renter/contracts", &contracts); err != nil {
-		t.Fatal(err)
-	}
-	if len(contracts.Contracts) != 0 {
-		t.Fatalf("expected renter to have 0 contracts; got %v", len(contracts.Contracts))
-	}
-
-	// The renter's downloads queue should be empty.
-	var queue RenterDownloadQueue
-	if err = st.getAPI("/renter/downloads", &queue); err != nil {
-		t.Fatal(err)
-	}
-	if len(queue.Downloads) != 0 {
-		t.Fatalf("expected renter to have 0 downloads in the queue; got %v", len(queue.Downloads))
-	}
-
 	// Set an allowance for the renter, allowing a contract to be formed.
 	allowanceValues := url.Values{}
 	testFunds := "10000000000000000000000000000" // 10k SC
@@ -75,86 +53,6 @@ func TestIntegrationHostAndRent(t *testing.T) {
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// The renter should now have 1 contract.
-	if err = st.getAPI("/renter/contracts", &contracts); err != nil {
-		t.Fatal(err)
-	}
-	if len(contracts.Contracts) != 1 {
-		t.Fatalf("expected renter to have 1 contract; got %v", len(contracts.Contracts))
-	}
-
-	// Check that a call to /renter returns the expected values.
-	var get RenterGET
-	if err = st.getAPI("/renter", &get); err != nil {
-		t.Fatal(err)
-	}
-	// Check the renter's funds.
-	expectedFunds, ok := scanAmount(testFunds)
-	if !ok {
-		t.Fatal("scanAmount failed")
-	}
-	if got := get.Settings.Allowance.Funds; got.Cmp(expectedFunds) != 0 {
-		t.Fatalf("expected funds to be %v; got %v", expectedFunds, got)
-	}
-	// Check the renter's period.
-	intPeriod, err := strconv.Atoi(testPeriod)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedPeriod := types.BlockHeight(intPeriod)
-	if got := get.Settings.Allowance.Period; got != expectedPeriod {
-		t.Fatalf("expected period to be %v; got %v", expectedPeriod, got)
-	}
-	// Check the renter's renew window.
-	expectedRenewWindow := expectedPeriod / 2
-	if got := get.Settings.Allowance.RenewWindow; got != expectedRenewWindow {
-		t.Fatalf("expected renew window to be %v; got %v", expectedRenewWindow, got)
-	}
-	// Check the renter's contract spending.
-	var expectedContractSpending types.Currency
-	for _, contract := range contracts.Contracts {
-		expectedContractSpending = expectedContractSpending.Add(contract.RenterFunds)
-	}
-	if got := get.FinancialMetrics.ContractSpending; got.Cmp(expectedContractSpending) != 0 {
-		t.Fatalf("expected contract spending to be %v; got %v", expectedContractSpending, got)
-	}
-
-	// Check that renterHandlerGET correctly handles invalid inputs.
-	// Try an empty funds string.
-	allowanceValues.Set("funds", "")
-	allowanceValues.Set("period", testPeriod)
-	err = st.stdPostAPI("/renter", allowanceValues)
-	if err == nil || err.Error() != "Couldn't parse funds" {
-		t.Errorf("expected error to be 'Couldn't parse funds'; got %v", err)
-	}
-	// Try an invalid funds string. Can't test a negative value since
-	// ErrNegativeCurrency triggers a build.Critical, which calls a panic in
-	// debug mode.
-	allowanceValues.Set("funds", "0")
-	err = st.stdPostAPI("/renter", allowanceValues)
-	if err == nil || err.Error() != contractor.ErrInsufficientAllowance.Error() {
-		t.Errorf("expected error to be %v; got %v", contractor.ErrInsufficientAllowance, err)
-	}
-	// Try a empty period string.
-	allowanceValues.Set("funds", testFunds)
-	allowanceValues.Set("period", "")
-	err = st.stdPostAPI("/renter", allowanceValues)
-	if err == nil || !strings.HasPrefix(err.Error(), "Couldn't parse period: ") {
-		t.Errorf("expected error to begin with 'Couldn't parse period: '; got %v", err)
-	}
-	// Try an invalid period string.
-	allowanceValues.Set("period", "-1")
-	err = st.stdPostAPI("/renter", allowanceValues)
-	if err == nil || err.Error()[:23] != "Couldn't parse period: " {
-		t.Errorf("expected error to begin with 'Couldn't parse period: '; got %v", err)
-	}
-	// Try a period that will lead to a length-zero RenewWindow.
-	allowanceValues.Set("period", "1")
-	err = st.stdPostAPI("/renter", allowanceValues)
-	if err == nil || err.Error() != contractor.ErrAllowanceZeroWindow.Error() {
-		t.Errorf("expected error to be %v, got %v", contractor.ErrAllowanceZeroWindow, err)
 	}
 
 	// Create a file.
@@ -202,14 +100,6 @@ func TestIntegrationHostAndRent(t *testing.T) {
 	if len(rf.Files) != 2 || rf.Files[0].UploadProgress < 10 || rf.Files[1].UploadProgress < 10 {
 		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0], rf.Files[1])
 	}
-	// Try uploading a nonexistent file.
-	path = filepath.Join(st.dir, "fake.dat")
-	uploadValues = url.Values{}
-	uploadValues.Set("source", path)
-	err = st.stdPostAPI("/renter/upload/fake", uploadValues)
-	if err == nil || !strings.HasSuffix(err.Error(), "no such file or directory") {
-		t.Errorf("expected error to end with 'no such file or directory'; got %v", err)
-	}
 
 	// Try downloading the second file.
 	downpath := filepath.Join(st.dir, "testdown.dat")
@@ -230,38 +120,13 @@ func TestIntegrationHostAndRent(t *testing.T) {
 		t.Fatal("data mismatch when downloading a file")
 	}
 
-	// Try downloading a nonexistent file.
-	err = st.stdGetAPI("/renter/download/fake?destination=" + downpath)
-	if err == nil || err.Error() != "Download failed: no file with that path" {
-		t.Errorf("expected error to be 'Download failed: no file with that path'; got %v instead", err)
-	}
-
-	// The downloads queue should now contain the second file's download.
-	// Downloads are never removed from the queue within a siad session.
+	// The renter's downloads queue should have 1 entry now.
+	var queue RenterDownloadQueue
 	if err = st.getAPI("/renter/downloads", &queue); err != nil {
 		t.Fatal(err)
 	}
 	if len(queue.Downloads) != 1 {
 		t.Fatalf("expected renter to have 1 download in the queue; got %v", len(queue.Downloads))
-	}
-
-	// Rename the second file's entry in the renter's list of files.
-	renameValues := url.Values{}
-	renameValues.Set("newsiapath", "newtest2")
-	if err = st.stdPostAPI("/renter/rename/test2", renameValues); err != nil {
-		t.Fatal(err)
-	}
-	// Try renaming a nonexistent file.
-	renameValues.Set("newsiapath", "newfake")
-	err = st.stdPostAPI("/renter/rename/fake", renameValues)
-	if err == nil || err.Error() != renter.ErrUnknownPath.Error() {
-		t.Errorf("expected %v, got %v", renter.ErrUnknownPath, err)
-	}
-	// Try renaming the first file to a name that's already taken.
-	renameValues.Set("newsiapath", "newtest2")
-	err = st.stdPostAPI("/renter/rename/test", renameValues)
-	if err == nil || err.Error() != renter.ErrPathOverload.Error() {
-		t.Errorf("expected error to be %v, got %v", renter.ErrPathOverload, err)
 	}
 
 	// Mine blocks until the host recognizes profit. The host will wait for 12
@@ -279,25 +144,5 @@ func TestIntegrationHostAndRent(t *testing.T) {
 		t.Log("Bandwidth Revenue:", hg.FinancialMetrics.DownloadBandwidthRevenue)
 		t.Log("Full Financial Metrics:", hg.FinancialMetrics)
 		t.Fatal("Host is not displaying revenue after resolving a storage proof.")
-	}
-
-	// Delete both files.
-	if err = st.stdPostAPI("/renter/delete/test", url.Values{}); err != nil {
-		t.Fatal(err)
-	}
-	if err = st.stdPostAPI("/renter/delete/newtest2", url.Values{}); err != nil {
-		t.Fatal(err)
-	}
-	// The renter's list of files should now be empty.
-	var files RenterFiles
-	if err = st.getAPI("/renter/files", &files); err != nil {
-		t.Fatal(err)
-	}
-	if len(files.Files) != 0 {
-		t.Fatalf("renter's list of files should be empty; got %v instead", files)
-	}
-	// Try deleting a nonexistent file.
-	if err = st.stdPostAPI("/renter/delete/dne", url.Values{}); err.Error() != renter.ErrUnknownPath.Error() {
-		t.Errorf("expected error to be %v, got %v", renter.ErrUnknownPath, err)
 	}
 }

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -12,8 +12,12 @@ import (
 var (
 	errAllowanceNoHosts    = errors.New("hosts must be non-zero")
 	errAllowanceZeroPeriod = errors.New("period must be non-zero")
-	errAllowanceZeroWindow = errors.New("renew window must be non-zero")
 	errAllowanceWindowSize = errors.New("renew window must be less than period")
+
+	// ErrAllowanceZeroWindow is returned when the caller requests a
+	// zero-length renewal window. This will happen if the caller sets the
+	// period to 1 block, since RenewWindow := period / 2.
+	ErrAllowanceZeroWindow = errors.New("renew window must be non-zero")
 )
 
 // contractEndHeight returns the height at which the Contractor's contracts
@@ -58,7 +62,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	} else if a.Period == 0 {
 		return errAllowanceZeroPeriod
 	} else if a.RenewWindow == 0 {
-		return errAllowanceZeroWindow
+		return ErrAllowanceZeroWindow
 	} else if a.RenewWindow >= a.Period {
 		return errAllowanceWindowSize
 	}
@@ -68,7 +72,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	if err != nil {
 		return err
 	} else if numSectors == 0 {
-		return errInsufficientAllowance
+		return ErrInsufficientAllowance
 	}
 
 	c.mu.RLock()

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -195,8 +195,8 @@ func TestIntegrationSetAllowance(t *testing.T) {
 	}
 	a.Period = 20
 	err = c.SetAllowance(a)
-	if err != errAllowanceZeroWindow {
-		t.Errorf("expected %q, got %q", errAllowanceZeroWindow, err)
+	if err != ErrAllowanceZeroWindow {
+		t.Errorf("expected %q, got %q", ErrAllowanceZeroWindow, err)
 	}
 	a.RenewWindow = 20
 	err = c.SetAllowance(a)

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -20,7 +20,9 @@ var (
 	// the contractor will cap host's MaxCollateral setting to this value
 	maxCollateral = types.SiacoinPrecision.Mul64(1e3) // 1k SC
 
-	errInsufficientAllowance = errors.New("allowance is not large enough to perform contract creation")
+	// ErrInsufficientAllowance indicates that the renter's allowance is less
+	// than the amount necessary to store at least one sector
+	ErrInsufficientAllowance = errors.New("allowance is not large enough to perform contract creation")
 	errTooExpensive          = errors.New("host price was too high")
 )
 

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -13,8 +13,9 @@ import (
 )
 
 var (
-	ErrUnknownPath  = errors.New("no file known with that path")
-	ErrPathOverload = errors.New("a file already exists at that location")
+	ErrEmptyFilename = errors.New("filename must be a nonempty string")
+	ErrUnknownPath   = errors.New("no file known with that path")
+	ErrPathOverload  = errors.New("a file already exists at that location")
 )
 
 // A file is a single file that has been uploaded to the network. Files are
@@ -237,6 +238,11 @@ func (r *Renter) FileList() []modules.FileInfo {
 func (r *Renter) RenameFile(currentName, newName string) error {
 	lockID := r.mu.Lock()
 	defer r.mu.Unlock(lockID)
+
+	// Check that newName is nonempty.
+	if newName == "" {
+		return ErrEmptyFilename
+	}
 
 	// Check that currentName exists and newName doesn't.
 	file, exists := r.files[currentName]

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -41,6 +41,9 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	if strings.HasPrefix(up.SiaPath, "/") {
 		return errors.New("nicknames cannot begin with /")
 	}
+	if up.SiaPath == "" {
+		return ErrEmptyFilename
+	}
 
 	// Check for a nickname conflict.
 	lockID := r.mu.RLock()


### PR DESCRIPTION
This PR expands `TestIntegrationHostAndRent` in order to attain complete coverage of renter API calls (excluding calls that rely on sharing, a feature that is currently disabled).

`TestIntegrationHostAndRent` is now unwieldy, but breaking the tests into separate functions wastes several seconds per function because of setup.

Renter testing is still incomplete, of course. We need to be doing tests that include multiple hosts and renters in realistic (out of sync) conditions.  