### PR TITLE
separate ThreadGroup locking by function

### DIFF
--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1125,7 +1125,7 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Give time for on connect RPCs to finish.
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Test that broadcasting an invalid block header over RelayHeader on cst1.cs
 	// does not result in cst2.cs.gateway receiving a broadcast.
@@ -1133,7 +1133,7 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	select {
 	case <-mg.broadcastCalled:
 		t.Fatal("RelayHeader broadcasted an invalid block header")
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 	}
 
 	// Test that broadcasting a valid block header over RelayHeader on cst1.cs
@@ -1152,7 +1152,7 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 		// Broadcast is called twice, once to broadcast blocks to peers <= v0.5.1
 		// and once to broadcast block headers to peers > v0.5.1.
 		<-mg.broadcastCalled
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		t.Fatal("RelayHeader didn't broadcast a valid block header")
 	}
 }

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -19,10 +19,10 @@ var (
 
 func init() {
 	if build.Release == "dev" {
-		SafeMutexDelay = 40 * time.Second
-	} else if build.Release == "standard" {
 		SafeMutexDelay = 60 * time.Second
+	} else if build.Release == "standard" {
+		SafeMutexDelay = 90 * time.Second
 	} else if build.Release == "testing" {
-		SafeMutexDelay = 20 * time.Second
+		SafeMutexDelay = 30 * time.Second
 	}
 }


### PR DESCRIPTION
The threadgroup has two separate things that it is protecting when it
locks the mutex. One group of things is to block the execution of other
threads, in the case of 'Add', 'Flush', and 'Stop'. The other group of
things is to protect the ThreadGroup state variables, namely 'onStopFns'
and 'afterStopFns'.

Previously, you would get a deadlock with the following:

tg.Add()
go func {
	tg.Stop()
}
time.Sleep(1 * time.Second)
tg.OnStop()
tg.Done()

The deadlock happens because tg.Stop() is blocking the OnStop call while
it waits for the tg.Add to return, but the tg.Add will not return until
tg.OnStop can get the lock.

I don't see any reason for this behavior to be forbidden. You want to be
able to do something like:

tg.Add()
tg.RegisterRPC()
tg.OnStop(func() {
	tg.UnregisterRPC()
})
tg.Done()

and currently that's not safe code if you are assuming that Stop() could
be called at any time.