### PR TITLE
Consensus threadgroup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 os:
   - linux
-  - osx
 
 go:
   - 1.6

--- a/api/ecosystem_test.go
+++ b/api/ecosystem_test.go
@@ -34,7 +34,7 @@ func synchronizationCheck(sts []*serverTester) (types.BlockID, error) {
 	for i := range sts {
 		// Spin until the current block matches the leader block.
 		success := false
-		for j := 0; j < 50; j++ {
+		for j := 0; j < 100; j++ {
 			err = sts[i].getAPI("/consensus", &cg)
 			if err != nil {
 				return types.BlockID{}, err
@@ -43,7 +43,7 @@ func synchronizationCheck(sts []*serverTester) (types.BlockID, error) {
 				success = true
 				break
 			}
-			time.Sleep(time.Millisecond * 50)
+			time.Sleep(time.Millisecond * 100)
 		}
 		if !success {
 			return types.BlockID{}, errors.New("synchronization check failed - nodes do not seem to be synchronized")
@@ -63,7 +63,6 @@ func TestHostPoorConnectivity(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	// Create the various nodes that will be forming the simulated ecosystem of
 	// this test.
@@ -174,7 +173,7 @@ func TestHostPoorConnectivity(t *testing.T) {
 		// instead of creating orphans.
 		var cg ConsensusGET
 		success := false
-		for j := 0; j < 50; j++ {
+		for j := 0; j < 100; j++ {
 			err = allTesters[i].getAPI("/consensus", &cg)
 			if err != nil {
 				t.Fatal(err)
@@ -183,7 +182,7 @@ func TestHostPoorConnectivity(t *testing.T) {
 				success = true
 				break
 			}
-			time.Sleep(time.Millisecond * 50)
+			time.Sleep(time.Millisecond * 100)
 		}
 		if !success {
 			t.Fatal("nodes do not seem to be synchronizing")
@@ -205,7 +204,7 @@ func TestHostPoorConnectivity(t *testing.T) {
 	// Wait until the leader has the most recent block.
 	var cg ConsensusGET
 	success := false
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 100; i++ {
 		err = allTesters[0].getAPI("/consensus", &cg)
 		if err != nil {
 			t.Fatal(err)
@@ -214,7 +213,7 @@ func TestHostPoorConnectivity(t *testing.T) {
 			success = true
 			break
 		}
-		time.Sleep(time.Millisecond * 50)
+		time.Sleep(time.Millisecond * 100)
 	}
 	if !success {
 		t.Fatal("nodes do not seem to be synchronizing")

--- a/api/ecosystem_test.go
+++ b/api/ecosystem_test.go
@@ -15,7 +15,7 @@ import (
 // synchronizationCheck takes a bunch of server testers as input and checks
 // that they all have the same current block as the first server tester. The
 // first server tester needs to have the most recent block in order for the
-// test to work.
+// check to work.
 func synchronizationCheck(sts []*serverTester) (types.BlockID, error) {
 	// Prefer returning an error in the event of a zero-length server tester -
 	// an error should be returned if the developer accidentally uses a nil
@@ -60,7 +60,6 @@ func synchronizationCheck(sts []*serverTester) (types.BlockID, error) {
 // host must get a file contract to the blockchain despite not getting any of
 // the dependencies into the transaction pool from the flood network.
 func TestHostPoorConnectivity(t *testing.T) {
-	t.Skip("Necessary consensus functions unavailable")
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -188,6 +187,10 @@ func TestHostPoorConnectivity(t *testing.T) {
 		}
 		if !success {
 			t.Fatal("nodes do not seem to be synchronizing")
+		}
+		err := allTesters[i].cs.Flush()
+		if err != nil {
+			t.Fatal(err)
 		}
 
 		// Mine a block for this node. The next iteration will wait for

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -194,6 +194,10 @@ type (
 		// blockchain.
 		CurrentBlock() types.Block
 
+		// Flush will cause the consensus set to finish all in-progress
+		// routines.
+		Flush() error
+
 		// Height returns the current height of consensus.
 		Height() types.BlockHeight
 

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -143,7 +143,7 @@ func New(gateway modules.Gateway, persistDir string) (*ConsensusSet, error) {
 		// Register RPCs
 		gateway.RegisterRPC("SendBlocks", cs.rpcSendBlocks)
 		gateway.RegisterRPC("RelayBlock", cs.rpcRelayBlock) // COMPATv0.5.1
-		gateway.RegisterRPC("RelayHeader", cs.rpcRelayHeader)
+		gateway.RegisterRPC("RelayHeader", cs.threadedRPCRelayHeader)
 		gateway.RegisterRPC("SendBlk", cs.rpcSendBlk)
 		gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)
 		cs.tg.OnStop(func() {

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -228,6 +228,12 @@ func (cs *ConsensusSet) CurrentBlock() (block types.Block) {
 	return block
 }
 
+// Flush will block until the consensus set has finished all in-progress
+// routines.
+func (cs *ConsensusSet) Flush() error {
+	return cs.tg.Flush()
+}
+
 // Height returns the height of the consensus set.
 func (cs *ConsensusSet) Height() (height types.BlockHeight) {
 	_ = cs.db.View(func(tx *bolt.Tx) error {

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -343,7 +343,7 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 	}
 
 	// Submit the block to the consensus set and broadcast it.
-	err = cs.AcceptBlock(b)
+	err = cs.managedAcceptBlock(b)
 	if err == errOrphan {
 		// If the block is an orphan, try to find the parents. The block
 		// received from the peer is discarded and will be downloaded again if
@@ -358,6 +358,7 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 	if err != nil {
 		return err
 	}
+	cs.managedBroadcastBlock(b)
 	return nil
 }
 
@@ -445,9 +446,10 @@ func (cs *ConsensusSet) threadedReceiveBlock(id types.BlockID) modules.RPCFunc {
 		if err := encoding.ReadObject(conn, &block, types.BlockSizeLimit); err != nil {
 			return err
 		}
-		if err := cs.AcceptBlock(block); err != nil {
+		if err := cs.managedAcceptBlock(block); err != nil {
 			return err
 		}
+		cs.managedBroadcastBlock(block)
 		return nil
 	}
 	return managedFN

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -393,11 +393,13 @@ func (cs *ConsensusSet) threadedRPCRelayHeader(conn modules.PeerConn) error {
 	cs.mu.RUnlock()
 	if err == errOrphan {
 		// If the header is an orphan, try to find the parents.
+		wg.Add(1)
 		go func() {
 			err := cs.gateway.RPC(conn.RPCAddr(), "SendBlocks", cs.threadedReceiveBlocks)
 			if err != nil {
 				cs.log.Debugln("WARN: failed to get parents of orphan header:", err)
 			}
+			wg.Done()
 		}()
 		return nil
 	} else if err != nil {

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1070,7 +1070,7 @@ func TestRelayHeader(t *testing.T) {
 		go func() {
 			errChan <- encoding.WriteObject(p1, tt.header)
 		}()
-		err = cst.cs.rpcRelayHeader(mockP2)
+		err = cst.cs.threadedRPCRelayHeader(mockP2)
 		if err != tt.errWant {
 			t.Errorf("%s: expected '%v', got '%v'", tt.errMSG, tt.errWant, err)
 		}

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -232,9 +232,10 @@ func TestConnect(t *testing.T) {
 		t.Fatal(err)
 	}
 	// g should have the node
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	g.mu.RLock()
 	if _, ok := g.nodes[dummyNode]; !ok {
+		g.mu.RUnlock() // Needed to prevent a deadlock if this error condition is reached.
 		t.Fatal("bootstrapper should have received dummyNode:", g.nodes)
 	}
 	g.mu.RUnlock()


### PR DESCRIPTION
This PR adds a ThreadGroup to the consensus set. Note that it does not fully implement clean shutdown. It does however provide enough syncing that the ecosystem test can start working.

This thread may experience NDFs. I think most of them are fixed by my threadgroup-safety PR. The rest will be fixed by a ThreadGroup related PR that's in-progress for the gateway.

@mnsl, and anyone else, I ask that you not touch the ecosystem test. I'm still working on it, just wanted to have the proof-of-concept out. It's fine to copy it into a different test and then extend that, if you've got some tests you want to implement.