### PR TITLE
Daemon update testing & UX

### DIFF
--- a/api/daemon.go
+++ b/api/daemon.go
@@ -22,6 +22,8 @@ import (
 	"github.com/kardianos/osext"
 )
 
+var errEmptyUpdateResponse = errors.New("API call to https://api.github.com/repos/NebulousLabs/Sia/releases/latest is returning an empty response")
+
 // SiaConstants is a struct listing all of the constants in use.
 type SiaConstants struct {
 	GenesisTimestamp      types.Timestamp   `json:"genesistimestamp"`
@@ -113,6 +115,9 @@ func fetchLatestRelease() (githubRelease, error) {
 	err = json.NewDecoder(resp.Body).Decode(&release)
 	if err != nil {
 		return githubRelease{}, err
+	}
+	if release.TagName == "" && len(release.Assets) == 0 {
+		return githubRelease{}, errEmptyUpdateResponse
 	}
 	return release, nil
 }

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -57,7 +57,7 @@ type UpdateInfo struct {
 	Version   string `json:"version"`
 }
 
-// githubRelease represents of the JSON returned by the GitHub release API
+// githubRelease represents some of the JSON returned by the GitHub release API
 // endpoint. Only the fields relevant to updating are included.
 type githubRelease struct {
 	TagName string `json:"tag_name"`

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -24,6 +24,27 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+// TestUpdate checks that /daemon/update correctly asserts that an update is
+// not available for the daemon (since the test build is always up to date).
+func TestUpdate(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestUpdate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	var update UpdateInfo
+	if err = st.getAPI("/daemon/update", &update); err != nil {
+		t.Fatal(err)
+	}
+	if update.Available && build.Version == update.Version {
+		t.Fatal("daemon should not have an update available")
+	}
+}
+
 /*
 // TODO: enable this test again once proper daemon shutdown is implemented (shutting down modules and listener separately).
 // TestStop tests the /daemon/stop handler.

--- a/api/daemon_test.go
+++ b/api/daemon_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -38,6 +39,11 @@ func TestUpdate(t *testing.T) {
 
 	var update UpdateInfo
 	if err = st.getAPI("/daemon/update", &update); err != nil {
+		// Notify tester that the API call failed, but allow testing to continue.
+		// Otherwise you have to be online to run tests.
+		if strings.HasSuffix(err.Error(), errEmptyUpdateResponse.Error()) {
+			t.Skip(err)
+		}
 		t.Fatal(err)
 	}
 	if update.Available && build.Version == update.Version {

--- a/siac/daemoncmd.go
+++ b/siac/daemoncmd.go
@@ -50,6 +50,7 @@ func updatecmd() {
 	}
 	if !update.Available {
 		fmt.Println("Already up to date.")
+		return
 	}
 
 	err = post("/daemon/update", "")


### PR DESCRIPTION
* Previously, calling `siac update` on an up-to-date daemon yielded
```
Already up to date.
Updated to version 1.0.0! Restart siad now.
```
rather than just 
```
Already up to date.
```

* Implements `TestUpdate` to check that an API call to `/daemon/update` only signals that an update is available if the build version is behind the latest version (which for a test build means that an update should never be available).
