### PR TITLE
Test Parallel Transaction Builders

### DIFF
--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -38,7 +38,7 @@ var (
 
 	// ErrIncompleteTransactions is returned if the wallet has incomplete
 	// transactions being built that are using all of the current outputs, and
-	// therefore the wallet is unable to spend money despite it not techincally
+	// therefore the wallet is unable to spend money despite it not technically
 	// being 'unconfirmed' yet.
 	ErrIncompleteTransactions = errors.New("wallet has coins spent in incomplete transactions - not enough remaining coins")
 

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -36,9 +36,11 @@ var (
 	// complete the desired action.
 	ErrLowBalance = errors.New("insufficient balance")
 
-	// ErrPotentialDoubleSpend is returned when the wallet is uncertain whether
-	// a spend is going to be legal or not.
-	ErrPotentialDoubleSpend = errors.New("wallet has coins spent in unconfirmed transactions - not enough remaining coins to complete transaction")
+	// ErrIncompleteTransactions is returned if the wallet has incomplete
+	// transactions being built that are using all of the current outputs, and
+	// therefore the wallet is unable to spend money despite it not techincally
+	// being 'unconfirmed' yet.
+	ErrIncompleteTransactions = errors.New("wallet has coins spent in incomplete transactions - not enough remaining coins")
 
 	// ErrLockedWallet is returned when an action cannot be performed due to
 	// the wallet being locked.

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -122,7 +122,7 @@ func TestIntegrationSpendHalfHalf(t *testing.T) {
 		t.Error("unexpected error: ", err)
 	}
 	_, err = wt.wallet.SendSiacoins(halfPlus, types.UnlockHash{1})
-	if err != modules.ErrPotentialDoubleSpend {
+	if err != modules.ErrIncompleteTransactions {
 		t.Error("wallet appears to be reusing outputs when building transactions: ", err)
 	}
 }

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -155,7 +155,7 @@ func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
 		}
 	}
 	if potentialFund.Cmp(amount) >= 0 && fund.Cmp(amount) < 0 {
-		return modules.ErrPotentialDoubleSpend
+		return modules.ErrIncompleteTransactions
 	}
 	if fund.Cmp(amount) < 0 {
 		return modules.ErrLowBalance
@@ -266,7 +266,7 @@ func (tb *transactionBuilder) FundSiafunds(amount types.Currency) error {
 		}
 	}
 	if potentialFund.Cmp(amount) >= 0 && fund.Cmp(amount) < 0 {
-		return modules.ErrPotentialDoubleSpend
+		return modules.ErrIncompleteTransactions
 	}
 	if fund.Cmp(amount) < 0 {
 		return modules.ErrLowBalance

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -413,7 +413,7 @@ func TestParallelBuilders(t *testing.T) {
 		go func() {
 			// Create the builder and fund the transaction.
 			builder := wt.wallet.StartTransaction()
-			err = builder.FundSiacoins(funding)
+			err := builder.FundSiacoins(funding)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
I had a suspicion that the wallet would create conflicting transactions and double spends if you used multiple transaction builders at the same time.

This testing pretty thoroughly explores that, and it seems that the wallet does not create conflicting transactions, but is working correctly. Which means the errors in the wild we are seeing are due to some other issue.

This PR only contains a small change to the actual code (first commit), most of it is just testing that didn't fail.