### PR TITLE
set responses to close

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -42,7 +42,7 @@ func HttpGET(url string) (resp *http.Response, err error) {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "Sia-Agent")
-	return new(http.Client).Do(req)
+	return http.DefaultClient.Do(req)
 }
 
 // HttpGETAuthenticated is a utility function for making authenticated http get
@@ -55,7 +55,7 @@ func HttpGETAuthenticated(url string, password string) (resp *http.Response, err
 	}
 	req.Header.Set("User-Agent", "Sia-Agent")
 	req.SetBasicAuth("", password)
-	return new(http.Client).Do(req)
+	return http.DefaultClient.Do(req)
 }
 
 // HttpPOST is a utility function for making post requests to sia with a
@@ -67,7 +67,7 @@ func HttpPOST(url string, data string) (resp *http.Response, err error) {
 	}
 	req.Header.Set("User-Agent", "Sia-Agent")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	return new(http.Client).Do(req)
+	return http.DefaultClient.Do(req)
 }
 
 // HttpPOSTAuthenticated is a utility function for making authenticated http
@@ -81,7 +81,7 @@ func HttpPOSTAuthenticated(url string, data string, password string) (resp *http
 	req.Header.Set("User-Agent", "Sia-Agent")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth("", password)
-	return new(http.Client).Do(req)
+	return http.DefaultClient.Do(req)
 }
 
 // requireUserAgent is middleware that requires all requests to set a

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -104,7 +104,7 @@ func fetchLatestRelease() (githubRelease, error) {
 		return githubRelease{}, err
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	resp, err := new(http.Client).Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return githubRelease{}, err
 	}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -535,7 +535,7 @@ func (st *serverTester) stdGetAPIUA(call string, userAgent string) error {
 		return err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	resp, err := new(http.Client).Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
HTTP connections are persistent by default, unless you specify in the
header that the server is supposed to close the connection once the call
has finished.

This was causing 'too many files open' errors in our Travis build
system.