### PR TITLE
properly return the latest block facts from /explorer

### DIFF
--- a/api/explorer.go
+++ b/api/explorer.go
@@ -353,8 +353,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 
 // explorerHandler handles API calls to /explorer
 func (srv *Server) explorerHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	height := srv.cs.Height()
-	facts, exists := srv.explorer.BlockFacts(height)
+	facts, exists := srv.explorer.LatestBlockFacts()
 	if !exists && build.DEBUG {
 		panic("stats for the most recent block do not exist")
 	}

--- a/api/explorer.go
+++ b/api/explorer.go
@@ -353,10 +353,7 @@ func (srv *Server) explorerHashHandler(w http.ResponseWriter, req *http.Request,
 
 // explorerHandler handles API calls to /explorer
 func (srv *Server) explorerHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	facts, exists := srv.explorer.LatestBlockFacts()
-	if !exists && build.DEBUG {
-		panic("stats for the most recent block do not exist")
-	}
+	facts := srv.explorer.LatestBlockFacts()
 	writeJSON(w, ExplorerGET{
 		BlockFacts: facts,
 	})

--- a/modules/explorer.go
+++ b/modules/explorer.go
@@ -58,7 +58,7 @@ type (
 
 		// LatestBlockFacts returns the block facts of the last block
 		// in the explorer's database.
-		LatestBlockFacts() (BlockFacts, bool)
+		LatestBlockFacts() BlockFacts
 
 		// Transaction returns the block that contains the input transaction
 		// id. The transaction itself is either the block (indicating the miner

--- a/modules/explorer.go
+++ b/modules/explorer.go
@@ -56,6 +56,10 @@ type (
 		// appeared at a given block.
 		BlockFacts(types.BlockHeight) (BlockFacts, bool)
 
+		// LatestBlockFacts returns the block facts of the last block
+		// in the explorer's database.
+		LatestBlockFacts() (BlockFacts, bool)
+
 		// Transaction returns the block that contains the input transaction
 		// id. The transaction itself is either the block (indicating the miner
 		// payouts are somehow involved), or it is a transaction inside of the

--- a/modules/explorer/database.go
+++ b/modules/explorer/database.go
@@ -90,6 +90,18 @@ func dbGetTransactionIDSet(bucket []byte, key interface{}, ids *[]types.Transact
 	}
 }
 
+// dbGetBlockFacts returns a 'func(*bolt.Tx) error' that decodes
+// the block facts for `height` into blockfacts
+func (e *Explorer) dbGetBlockFacts(height types.BlockHeight, bf *blockFacts) func(*bolt.Tx) error {
+	return func(tx *bolt.Tx) error {
+		block, exists := e.cs.BlockAtHeight(height)
+		if !exists {
+			return errors.New("requested block facts for a block that does not exist")
+		}
+		return dbGetAndDecode(bucketBlockFacts, block.ID(), bf)(tx)
+	}
+}
+
 // dbSetInternal sets the specified key of bucketInternal to the encoded value.
 func dbSetInternal(key []byte, val interface{}) func(*bolt.Tx) error {
 	return func(tx *bolt.Tx) error {

--- a/modules/explorer/info.go
+++ b/modules/explorer/info.go
@@ -38,6 +38,26 @@ func (e *Explorer) BlockFacts(height types.BlockHeight) (modules.BlockFacts, boo
 	return bf.BlockFacts, true
 }
 
+// LatestBlockFacts returns a set of statistics about the blockchain as they appeared
+// at the latest block height in the explorer's consensus set.
+func (e *Explorer) LatestBlockFacts() (modules.BlockFacts, bool) {
+	var height types.BlockHeight
+	err := e.db.View(dbGetInternal(internalBlockHeight, &height))
+	if err != nil {
+		return modules.BlockFacts{}, false
+	}
+	block, exists := e.cs.BlockAtHeight(height)
+	if !exists {
+		return modules.BlockFacts{}, false
+	}
+	var bf blockFacts
+	err = e.db.View(dbGetAndDecode(bucketBlockFacts, block.ID(), &bf))
+	if err != nil {
+		return modules.BlockFacts{}, false
+	}
+	return bf.BlockFacts, true
+}
+
 // Transaction takes a transaction ID and finds the block containing the
 // transaction. Because of the miner payouts, the transaction ID might be a
 // block ID. To find the transaction, iterate through the block.

--- a/modules/explorer/info.go
+++ b/modules/explorer/info.go
@@ -2,10 +2,12 @@ package explorer
 
 import (
 	"errors"
+	
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
 	"github.com/NebulousLabs/bolt"
 )
 

--- a/modules/explorer/info_test.go
+++ b/modules/explorer/info_test.go
@@ -14,10 +14,7 @@ func TestImmediateBlockFacts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	facts, exists := et.explorer.BlockFacts(et.cs.Height())
-	if !exists {
-		t.Fatal("could not find block facts for current height")
-	}
+	facts := et.explorer.LatestBlockFacts()
 	var explorerHeight types.BlockHeight
 	err = et.explorer.db.View(dbGetInternal(internalBlockHeight, &explorerHeight))
 	if err != nil {


### PR DESCRIPTION
This PR adds `LatestBlockFacts()`, which uses the explorer's internal block height to get the latest `BlockFacts`.  Previously, the consensus set's block height was used, which sometimes caused empty block facts to be returned because the explorer's block facts are not always up to date with the latest consensus set.

