### PR TITLE
Clarify username in API authentication docs

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -56,9 +56,15 @@ Authentication
 
 API authentication can be enabled with the `--authenticate-api` siad flag.
 Authentication is HTTP Basic Authentication as described in
-[RFC 2617](https://tools.ietf.org/html/rfc2617). The flag does not enforce
-authentication on all API endpoints. Only endpoints that expose sensitive
-information or modify state require authentication.
+[RFC 2617](https://tools.ietf.org/html/rfc2617), however, the username is the
+empty string. The flag does not enforce authentication on all API endpoints.
+Only endpoints that expose sensitive information or modify state require
+authentication.
+
+For example, if the API password is "foobar" the request header should include
+```
+Authorization: Basic OmZvb2Jhcg==
+```
 
 Table of contents
 -----------------


### PR DESCRIPTION
The username required for API authentication wasn't documented anywhere, and was confusing users (http://forum.sia.tech/topic/302/what-s-the-authenticate-api-username-rfc-2617).

The username isn't actually checked in the API authentication, but I didn't mention that as it's feasible to imagine an authentication scheme where different users have different permissions for different endpoints.