### PR TITLE
API Absolute Paths

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -3,8 +3,8 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"path/filepath"
+	"strings"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -161,8 +161,8 @@ func (srv *Server) renterDownloadsHandler(w http.ResponseWriter, _ *http.Request
 func (srv *Server) renterLoadHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	source := req.FormValue("source")
 	if !filepath.IsAbs(source) {
-	    writeError(w, Error{"source must be an absolute path"}, http.StatusBadRequest)
-	    return
+		writeError(w, Error{"source must be an absolute path"}, http.StatusBadRequest)
+		return
 	}
 
 	files, err := srv.renter.LoadSharedFiles(source)
@@ -222,8 +222,8 @@ func (srv *Server) renterDownloadHandler(w http.ResponseWriter, req *http.Reques
 	destination := req.FormValue("destination")
 	// Check that the destination path is absolute.
 	if !filepath.IsAbs(destination) {
-	    writeError(w, Error{"destination must be an absolute path"}, http.StatusBadRequest)
-	    return
+		writeError(w, Error{"destination must be an absolute path"}, http.StatusBadRequest)
+		return
 	}
 
 	err := srv.renter.Download(strings.TrimPrefix(ps.ByName("siapath"), "/"), destination)
@@ -241,8 +241,8 @@ func (srv *Server) renterShareHandler(w http.ResponseWriter, req *http.Request, 
 	destination := req.FormValue("destination")
 	// Check that the destination path is absolute.
 	if !filepath.IsAbs(destination) {
-	    writeError(w, Error{"destination must be an absolute path"}, http.StatusBadRequest)
-	    return
+		writeError(w, Error{"destination must be an absolute path"}, http.StatusBadRequest)
+		return
 	}
 
 	err := srv.renter.ShareFiles(strings.Split(req.FormValue("siapaths"), ","), destination)
@@ -271,8 +271,8 @@ func (srv *Server) renterShareAsciiHandler(w http.ResponseWriter, req *http.Requ
 func (srv *Server) renterUploadHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	source := req.FormValue("source")
 	if !filepath.IsAbs(source) {
-	    writeError(w, Error{"source must be an absolute path"}, http.StatusBadRequest)
-	    return
+		writeError(w, Error{"source must be an absolute path"}, http.StatusBadRequest)
+		return
 	}
 
 	err := srv.renter.Upload(modules.FileUploadParams{

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
-	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
@@ -124,8 +124,8 @@ func (srv *Server) wallet033xHandler(w http.ResponseWriter, req *http.Request, _
 	source := req.FormValue("source")
 	// Check that source is an absolute paths.
 	if !filepath.IsAbs(source) {
-	    writeError(w, Error{"error when calling /wallet/033x: source must be an absolute path"}, http.StatusBadRequest)
-	    return
+		writeError(w, Error{"error when calling /wallet/033x: source must be an absolute path"}, http.StatusBadRequest)
+		return
 	}
 	potentialKeys := encryptionKeys(req.FormValue("encryptionpassword"))
 	for _, key := range potentialKeys {
@@ -166,8 +166,8 @@ func (srv *Server) walletBackupHandler(w http.ResponseWriter, req *http.Request,
 	destination := req.FormValue("destination")
 	// Check that the destination is absolute.
 	if !filepath.IsAbs(destination) {
-	    writeError(w, Error{"error when calling /wallet/backup: destination must be an absolute path"}, http.StatusBadRequest)
-	    return
+		writeError(w, Error{"error when calling /wallet/backup: destination must be an absolute path"}, http.StatusBadRequest)
+		return
 	}
 	err := srv.wallet.CreateBackup(destination)
 	if err != nil {
@@ -238,11 +238,11 @@ func (srv *Server) walletSiagkeyHandler(w http.ResponseWriter, req *http.Request
 	potentialKeys := encryptionKeys(req.FormValue("encryptionpassword"))
 
 	for _, keypath := range keyfiles {
-	    // Check that all key paths are absolute paths.
-	    if !filepath.IsAbs(keypath) {
+		// Check that all key paths are absolute paths.
+		if !filepath.IsAbs(keypath) {
 			writeError(w, Error{"error when calling /wallet/siagkey: keyfiles contains a non-absolute path"}, http.StatusBadRequest)
-	        return
-	    }
+			return
+		}
 	}
 
 	for _, key := range potentialKeys {

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
@@ -121,6 +122,11 @@ func (srv *Server) walletHandler(w http.ResponseWriter, req *http.Request, _ htt
 // wallet033xHandler handles API calls to /wallet/033x.
 func (srv *Server) wallet033xHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	source := req.FormValue("source")
+	// Check that source is an absolute paths.
+	if !filepath.IsAbs(source) {
+	    writeError(w, Error{"error when calling /wallet/033x: source must be an absolute path"}, http.StatusBadRequest)
+	    return
+	}
 	potentialKeys := encryptionKeys(req.FormValue("encryptionpassword"))
 	for _, key := range potentialKeys {
 		err := srv.wallet.Load033xWallet(key, source)
@@ -157,7 +163,13 @@ func (srv *Server) walletAddressesHandler(w http.ResponseWriter, req *http.Reque
 
 // walletBackupHandler handles API calls to /wallet/backup.
 func (srv *Server) walletBackupHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	err := srv.wallet.CreateBackup(req.FormValue("destination"))
+	destination := req.FormValue("destination")
+	// Check that all key paths are absolute paths.
+	if !filepath.IsAbs(destination) {
+	    writeError(w, Error{"error when calling /wallet/backup: destination must be an absolute path"}, http.StatusBadRequest)
+	    return
+	}
+	err := srv.wallet.CreateBackup(destination)
 	if err != nil {
 		writeError(w, Error{"error after call to /wallet/backup: " + err.Error()}, http.StatusBadRequest)
 		return
@@ -224,6 +236,15 @@ func (srv *Server) walletSiagkeyHandler(w http.ResponseWriter, req *http.Request
 	// Fetch the list of keyfiles from the post body.
 	keyfiles := strings.Split(req.FormValue("keyfiles"), ",")
 	potentialKeys := encryptionKeys(req.FormValue("encryptionpassword"))
+
+	for _, key := range potentialKeys {
+	    // Check that all key paths are absolute paths.
+	    if !filepath.IsAbs(key) {
+			writeError(w, Error{"error when calling /wallet/siagkey: keyfiles contains a non-absolute path"}, http.StatusBadRequest)
+	        return
+	    }
+	}
+
 	for _, key := range potentialKeys {
 		err := srv.wallet.LoadSiagKeys(key, keyfiles)
 		if err == nil {

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -164,7 +164,7 @@ func (srv *Server) walletAddressesHandler(w http.ResponseWriter, req *http.Reque
 // walletBackupHandler handles API calls to /wallet/backup.
 func (srv *Server) walletBackupHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	destination := req.FormValue("destination")
-	// Check that all key paths are absolute paths.
+	// Check that the destination is absolute.
 	if !filepath.IsAbs(destination) {
 	    writeError(w, Error{"error when calling /wallet/backup: destination must be an absolute path"}, http.StatusBadRequest)
 	    return

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -237,9 +237,9 @@ func (srv *Server) walletSiagkeyHandler(w http.ResponseWriter, req *http.Request
 	keyfiles := strings.Split(req.FormValue("keyfiles"), ",")
 	potentialKeys := encryptionKeys(req.FormValue("encryptionpassword"))
 
-	for _, key := range potentialKeys {
+	for _, keypath := range keyfiles {
 	    // Check that all key paths are absolute paths.
-	    if !filepath.IsAbs(key) {
+	    if !filepath.IsAbs(keypath) {
 			writeError(w, Error{"error when calling /wallet/siagkey: keyfiles contains a non-absolute path"}, http.StatusBadRequest)
 	        return
 	    }

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -369,7 +369,7 @@ func TestWalletRelativePathError033x(t *testing.T) {
 	}
 	// This is not the actual wallet password. The createServerTester doesn't
 	// return the string password. So for the sucess test we check if we make
-    // it past the absolute value check and instead error because of the key.
+	// it past the absolute value check and instead error because of the key.
 	seed, err := modules.SeedToString(rawSeed, "english")
 	if err != nil {
 		t.Fatal(err)
@@ -437,7 +437,7 @@ func TestWalletRelativePathErrorSiag(t *testing.T) {
 	}
 	// This is not the actual wallet password. The createServerTester does not
 	// return the string password. So for the sucess tests we check if we make
-    // it past the absolute value check and instead error because of the key.
+	// it past the absolute value check and instead error because of the key.
 	seed, err := modules.SeedToString(rawSeed, "english")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Validates that file paths sent to the renter and wallet apis are absolute paths. Throws an error otherwise.

The host module has implemented this behavior since pr #1325. I am not sure if we should move this check to the api to or the wallet/host checks into the modules so in the mean time I have left the host api as is.

Fixes #1385.