### PR TITLE
test host API calls

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -11,6 +11,10 @@ import (
 )
 
 var (
+	// errNoPath is returned when a call fails to provide a nonempty string
+	// for the path parameter.
+	errNoPath = Error{"path parameter is required"}
+
 	// errStorageFolderNotFound is returned if a call is made looking for a
 	// storage folder which does not appear to exist within the storage
 	// manager.
@@ -149,7 +153,7 @@ func (srv *Server) storageFoldersAddHandler(w http.ResponseWriter, req *http.Req
 func (srv *Server) storageFoldersResizeHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	folderPath := req.FormValue("path")
 	if folderPath == "" {
-		writeError(w, Error{"path parameter is required"}, http.StatusBadRequest)
+		writeError(w, errNoPath, http.StatusBadRequest)
 		return
 	}
 
@@ -179,7 +183,7 @@ func (srv *Server) storageFoldersResizeHandler(w http.ResponseWriter, req *http.
 func (srv *Server) storageFoldersRemoveHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	folderPath := req.FormValue("path")
 	if folderPath == "" {
-		writeError(w, Error{"path parameter is required"}, http.StatusBadRequest)
+		writeError(w, errNoPath, http.StatusBadRequest)
 		return
 	}
 

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -1,5 +1,284 @@
 package api
 
+import (
+	"io"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/modules/host/storagemanager"
+)
+
+var (
+	// Various folder sizes for testing host storage folder resizing.
+	// Must be provided as strings to the API call.
+	minFolderSizeString    = strconv.FormatUint(storagemanager.MinimumStorageFolderSize(), 10)
+	maxFolderSizeString    = strconv.FormatUint(storagemanager.MaximumStorageFolderSize(), 10)
+	tooSmallFolderString   = strconv.FormatUint(storagemanager.MinimumStorageFolderSize()-1, 10)
+	tooLargeFolderString   = strconv.FormatUint(storagemanager.MaximumStorageFolderSize()+1, 10)
+	mediumSizeFolderString = strconv.FormatUint(3*storagemanager.MinimumStorageFolderSize(), 10)
+
+	// Test cases for resizing a host's storage folder.
+	// Running all the invalid cases before the valid ones simplifies some
+	// logic in the tests that use resizeTests.
+	resizeTests = []struct {
+		sizeString string
+		size       uint64
+		err        error
+	}{
+		// invalid sizes
+		{"", 0, io.EOF},
+		{"0", 0, storagemanager.ErrSmallStorageFolder},
+		{tooSmallFolderString, storagemanager.MinimumStorageFolderSize() - 1, storagemanager.ErrSmallStorageFolder},
+		{tooLargeFolderString, storagemanager.MaximumStorageFolderSize() + 1, storagemanager.ErrLargeStorageFolder},
+
+		// valid sizes
+		{minFolderSizeString, storagemanager.MinimumStorageFolderSize(), nil},
+		{maxFolderSizeString, storagemanager.MaximumStorageFolderSize(), nil},
+		{mediumSizeFolderString, 3 * storagemanager.MinimumStorageFolderSize(), nil},
+	}
+)
+
+// TestResizeEmptyStorageFolder tests that invalid and valid calls to resize
+// an empty storage folder are properly handled.
+func TestResizeEmptyStorageFolder(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestResizeEmptyStorageFolder")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Announce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find out how large the host's initial storage folder is.
+	var sg StorageGET
+	if err := st.getAPI("/host/storage", &sg); err != nil {
+		t.Fatal(err)
+	}
+	defaultSize := sg.Folders[0].Capacity
+	// Convert defaultSize (uint64) to a string for the API call.
+	defaultSizeString := strconv.FormatUint(defaultSize, 10)
+
+	resizeValues := url.Values{}
+	resizeValues.Set("path", st.dir)
+	resizeValues.Set("newsize", defaultSizeString)
+
+	// Attempting to resize to the same size should return an error.
+	err = st.stdPostAPI("/host/storage/folders/resize", resizeValues)
+	if err == nil || err.Error() != storagemanager.ErrNoResize.Error() {
+		t.Fatalf("expected error %v, got %v", storagemanager.ErrNoResize, err)
+	}
+
+	// Try resizing to a bunch of sizes (invalid ones first, valid ones second).
+	// This ordering simplifies logic within the for loop.
+	for _, test := range resizeTests {
+		// Attempt to resize the host's storage folder.
+		resizeValues.Set("newsize", test.sizeString)
+		err = st.stdPostAPI("/host/storage/folders/resize", resizeValues)
+		if (err == nil && test.err != nil) || (err != nil && err.Error() != test.err.Error()) {
+			t.Fatalf("expected error to be %v, got %v", test.err, err)
+		}
+
+		// Find out if the resize call worked as expected.
+		if err := st.getAPI("/host/storage", &sg); err != nil {
+			t.Fatal(err)
+		}
+		// If the test size is valid, check that the folder has been resized
+		// properly.
+		if test.err == nil {
+			// Check that the folder's total capacity has been updated.
+			if got := sg.Folders[0].Capacity; got != test.size {
+				t.Fatalf("expected folder to be resized to %v; got %v instead", test.size, got)
+			}
+			// Check that the folder's remaining capacity has been updated.
+			if got := sg.Folders[0].CapacityRemaining; got != test.size {
+				t.Fatalf("folder should be empty, but capacity remaining (%v) != total capacity (%v)", got, test.size)
+			}
+		} else {
+			// If the test size is invalid, the folder should not have been
+			// resized. The invalid test cases are all run before the valid ones,
+			// so the folder size should still be defaultSize.
+			if got := sg.Folders[0].Capacity; got != defaultSize {
+				t.Fatalf("folder was resized to an invalid size (%v) in a test case that should have failed: %v", got, test)
+			}
+		}
+	}
+}
+
+// TestResizeNonemptyStorageFolder tests that invalid and valid calls to resize
+// a storage folder with one sector filled are properly handled.
+// Ideally, we would also test a very full storage folder (including the case
+// where the host tries to resize to a size smaller than the amount of data
+// in the folder), but that would be a very expensive test.
+func TestResizeNonemptyStorageFolder(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestResizeNonemptyStorageFolder")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Announce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file.
+	path := filepath.Join(st.dir, "test.dat")
+	fileBytes := 1024
+	if err := createRandFile(path, fileBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload to host.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	if err := st.stdPostAPI("/renter/upload/test", uploadValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only one piece will be uploaded (10% at current redundancy)
+	var rf RenterFiles
+	for i := 0; i < 200 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
+		st.getAPI("/renter/files", &rf)
+		time.Sleep(50 * time.Millisecond)
+	}
+	if len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10 {
+		t.Error(rf.Files[0].UploadProgress)
+		t.Fatal("uploading has failed")
+	}
+
+	// Find out how large the host's initial storage folder is.
+	var sg StorageGET
+	if err := st.getAPI("/host/storage", &sg); err != nil {
+		t.Fatal(err)
+	}
+	defaultSize := sg.Folders[0].Capacity
+	// Convert defaultSize (uint64) to a string for the API call.
+	defaultSizeString := strconv.FormatUint(defaultSize, 10)
+
+	resizeValues := url.Values{}
+	resizeValues.Set("path", st.dir)
+	resizeValues.Set("newsize", defaultSizeString)
+
+	// Attempting to resize to the same size should return an error.
+	err = st.stdPostAPI("/host/storage/folders/resize", resizeValues)
+	if err == nil || err.Error() != storagemanager.ErrNoResize.Error() {
+		t.Fatalf("expected error %v, got %v", storagemanager.ErrNoResize, err)
+	}
+
+	// Try resizing to a bunch of sizes (invalid ones first, valid ones second).
+	// This ordering simplifies logic within the for loop.
+	for _, test := range resizeTests {
+		// Attempt to resize the host's storage folder.
+		resizeValues.Set("newsize", test.sizeString)
+		err = st.stdPostAPI("/host/storage/folders/resize", resizeValues)
+		if (err == nil && test.err != nil) || (err != nil && err.Error() != test.err.Error()) {
+			t.Fatalf("expected error to be %v, got %v", test.err, err)
+		}
+
+		// Find out if the resize call worked as expected.
+		if err := st.getAPI("/host/storage", &sg); err != nil {
+			t.Fatal(err)
+		}
+		// If the test size is valid, check that the folder has been resized
+		// properly.
+		if test.err == nil {
+			// Check that the folder's total capacity has been updated.
+			if sg.Folders[0].Capacity != test.size {
+				t.Fatalf("expected folder to be resized to %v; got %v instead", test.size, sg.Folders[0].Capacity)
+			}
+			// Since one sector has been uploaded, the available capacity
+			// should be one sector size smaller than the total capacity.
+			if used := test.size - sg.Folders[0].CapacityRemaining; used != modules.SectorSize {
+				t.Fatalf("used capacity (%v) != the size of 1 sector (%v)", used, modules.SectorSize)
+			}
+		} else {
+			// If the test size is invalid, the folder should not have been
+			// resized. The invalid test cases are all run before the valid
+			// ones, so the folder size should still be defaultSize.
+			if got := sg.Folders[0].Capacity; got != defaultSize {
+				t.Fatalf("folder was resized to an invalid size (%v) in a test case that should have failed: %v", got, test)
+			}
+		}
+	}
+}
+
+// TestResizeNonexistentFolder checks that an API call to resize a nonexistent
+// folder triggers the appropriate error.
+func TestResizeNonexistentFolder(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestResizeNonexistentFolder")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// No folder has been created yet at st.dir, so using it as the path for
+	// the resize call should trigger an error.
+	resizeValues := url.Values{}
+	resizeValues.Set("path", st.dir)
+	resizeValues.Set("newsize", mediumSizeFolderString)
+	err = st.stdPostAPI("/host/storage/folders/resize", resizeValues)
+	if err == nil || err.Error() != errStorageFolderNotFound.Error() {
+		t.Fatalf("expected error to be %v, got %v", errStorageFolderNotFound, err)
+	}
+}
+
+// TestResizeFolderNoPath checks that an API call to resize a storage folder fails
+// if no path was provided.
+func TestResizeFolderNoPath(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestResizeFolderNoPath")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// The call to resize should fail if no path has been provided.
+	resizeValues := url.Values{}
+	resizeValues.Set("newsize", mediumSizeFolderString)
+	err = st.stdPostAPI("/host/storage/folders/resize", resizeValues)
+	if err == nil || err.Error() != "path parameter is required" {
+		t.Fatalf("expected error to be path parameter is required; got %v", err)
+	}
+}
+
 /*
 // TestIntegrationRenewing tests that the renter and host manage contract
 // renewals properly.

--- a/modules/host/storagemanager/consts.go
+++ b/modules/host/storagemanager/consts.go
@@ -57,8 +57,8 @@ var (
 			// or 3 virtual sectors when manipulating data, so 250 is generous
 			// as long as the renter is properly encrypting data. 250 is
 			// unlikely to cause the host problems, even if an attacker is
-			// creating hundreds of thousands of phsyical sectors (an expensive
-			// action!) each with 250 vitrual sectors.
+			// creating hundreds of thousands of physical sectors (an expensive
+			// action!) each with 250 virtual sectors.
 			return 250
 		}
 		if build.Release == "testing" {
@@ -73,7 +73,7 @@ var (
 	// little storage capacity are not very useful to the network, and can
 	// actually frustrate price planning. 32 GB has been chosen as a minimum
 	// for the early days of the network, to allow people to experiment in the
-	// beta, but in the future I think something like 256GB would be much more
+	// beta, but in the future I think something like 256 GB would be much more
 	// appropriate.
 	minimumStorageFolderSize = func() uint64 {
 		if build.Release == "dev" {
@@ -115,3 +115,15 @@ var (
 	// times a sector is in use is encoded as a big endian uint64.
 	bucketSectorUsage = []byte("BucketSectorUsage")
 )
+
+// MaximumStorageFolderSize provides the maximumStorageFolderSize value to
+// other modules for testing purposes.
+func MaximumStorageFolderSize() uint64 {
+	return maximumStorageFolderSize
+}
+
+// MinimumStorageFolderSize provides the minimumStorageFolderSize value to
+// other modules for testing purposes.
+func MinimumStorageFolderSize() uint64 {
+	return minimumStorageFolderSize
+}

--- a/modules/host/storagemanager/storagefolders_smoke_errors_test.go
+++ b/modules/host/storagemanager/storagefolders_smoke_errors_test.go
@@ -196,7 +196,7 @@ func TestStorageFolderTolerance(t *testing.T) {
 	// folder is not going to be able to be deleted successfully.
 	ffs.brokenSubstrings = []string{filepath.Join(smt.persistDir, modules.StorageManagerDir, smt.sm.storageFolders[0].uidString())}
 	err = smt.sm.RemoveStorageFolder(0, false)
-	if err != errIncompleteOffload {
+	if err != ErrIncompleteOffload {
 		t.Fatal(err)
 	}
 	// Check that the storage folder was not removed.
@@ -228,7 +228,7 @@ func TestStorageFolderTolerance(t *testing.T) {
 	// error in the destination folder.
 	ffs.brokenSubstrings = []string{filepath.Join(smt.persistDir, modules.StorageManagerDir, smt.sm.storageFolders[1].uidString())}
 	err = smt.sm.RemoveStorageFolder(0, false)
-	if err != errIncompleteOffload {
+	if err != ErrIncompleteOffload {
 		t.Fatal(err)
 	}
 	// Do a probabilistic reset of the storage manager, to verify that the
@@ -444,7 +444,7 @@ func TestStorageFolderTolerance(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = smt.sm.ResizeStorageFolder(0, minimumStorageFolderSize)
-	if err != errIncompleteOffload {
+	if err != ErrIncompleteOffload {
 		t.Fatal(err)
 	}
 	// Do a probabilistic reset of the storage manager, to verify that the

--- a/modules/host/storagemanager/storagefolders_smoke_test.go
+++ b/modules/host/storagemanager/storagefolders_smoke_test.go
@@ -95,13 +95,13 @@ func TestStorageFolderUsage(t *testing.T) {
 	// Try using a file size that is too small. Because a filesize check is
 	// quicker than a disk check, the filesize check should come first.
 	err = smt.sm.AddStorageFolder(storageFolderOne, minimumStorageFolderSize-1)
-	if err != errSmallStorageFolder {
-		t.Fatal("expecting errSmallStorageFolder:", err)
+	if err != ErrSmallStorageFolder {
+		t.Fatal("expecting ErrSmallStorageFolder:", err)
 	}
 	// Try a file size that is too large.
 	err = smt.sm.AddStorageFolder(storageFolderOne, maximumStorageFolderSize+1)
-	if err != errLargeStorageFolder {
-		t.Fatal("expecting errLargeStorageFolder:", err)
+	if err != ErrLargeStorageFolder {
+		t.Fatal("expecting ErrLargeStorageFolder:", err)
 	}
 	// Try linking to a storage folder that does not exist.
 	err = smt.sm.AddStorageFolder(storageFolderOne, minimumStorageFolderSize)
@@ -285,11 +285,11 @@ func TestStorageFolderUsage(t *testing.T) {
 		t.Error(err)
 	}
 	err = smt.sm.ResizeStorageFolder(0, minimumStorageFolderSize-1)
-	if err != errSmallStorageFolder {
+	if err != ErrSmallStorageFolder {
 		t.Error(err)
 	}
 	err = smt.sm.ResizeStorageFolder(0, maximumStorageFolderSize+1)
-	if err != errLargeStorageFolder {
+	if err != ErrLargeStorageFolder {
 		t.Error(err)
 	}
 	err = smt.sm.ResizeStorageFolder(0, minimumStorageFolderSize*10)
@@ -297,7 +297,7 @@ func TestStorageFolderUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = smt.sm.ResizeStorageFolder(0, minimumStorageFolderSize*10)
-	if err != errNoResize {
+	if err != ErrNoResize {
 		t.Fatal(err)
 	}
 	// Do a probabilistic reset of the manager, to verify that the persistence
@@ -352,7 +352,7 @@ func TestStorageFolderUsage(t *testing.T) {
 	}
 	oldSize := smt.sm.storageFolders[0].Size
 	err = smt.sm.ResizeStorageFolder(0, minimumStorageFolderSize)
-	if err != errIncompleteOffload {
+	if err != ErrIncompleteOffload {
 		t.Fatal(err)
 	}
 	size := smt.sm.storageFolders[0].Size
@@ -591,13 +591,13 @@ func TestStorageFolderUsage(t *testing.T) {
 	}
 	// Try some illegal sector removal operations before trying a legal one.
 	err = smt.sm.RemoveSector(sectorRoot, sectorExpiry+50e6)
-	if err != errSectorNotFound {
+	if err != ErrSectorNotFound {
 		t.Fatal("wrong error when removing illegal sector:", err)
 	}
 	alteredRoot := sectorRoot
 	alteredRoot[0]++
 	err = smt.sm.RemoveSector(alteredRoot, 81)
-	if err != errSectorNotFound {
+	if err != ErrSectorNotFound {
 		t.Fatal("wrong error when removing illegal sector:", err)
 	}
 	// Now try the legal sector removal.
@@ -675,7 +675,7 @@ func TestStorageFolderUsage(t *testing.T) {
 
 			// Try to remove the sector using a wildcard expiry height.
 			err = smt.sm.RemoveSector(root, expiryHeights[0]+548e6)
-			if err != errSectorNotFound {
+			if err != ErrSectorNotFound {
 				t.Fatal(err)
 			}
 

--- a/modules/host/storagemanager/storagefolders_test.go
+++ b/modules/host/storagemanager/storagefolders_test.go
@@ -357,7 +357,7 @@ func TestRepeatStorageFolderPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = smt.sm.AddStorageFolder(smt.persistDir, minimumStorageFolderSize)
-	if err != errRepeatFolder {
-		t.Fatal("expected errRepeatFolder, got", err)
+	if err != ErrRepeatFolder {
+		t.Fatal("expected ErrRepeatFolder, got", err)
 	}
 }

--- a/modules/storagemanager.go
+++ b/modules/storagemanager.go
@@ -15,8 +15,8 @@ type (
 	// StorageFolderMetadata contains metadata about a storage folder that is
 	// tracked by the storage folder manager.
 	StorageFolderMetadata struct {
-		Capacity          uint64 `json:"capacity"`
-		CapacityRemaining uint64 `json:"capacityremaining"`
+		Capacity          uint64 `json:"capacity"`          // bytes
+		CapacityRemaining uint64 `json:"capacityremaining"` // bytes
 		Path              string `json:"path"`
 
 		// Below are statistics about the filesystem. FailedReads and


### PR DESCRIPTION
This PR tests that API calls to add, resize and remove host storage folders are handled properly, including various flavors of invalid calls.

Several errors from the `storagemanager` module are now exported, and I added a couple of exported functions so that the tests could access `storagemanager`'s `minimumStorageFolderSize`and `maximumStorageFolderSize` constants.

I also fixed some typos.

TODO:  
* a couple more tests to cover all error handling by the add/resize storage folder API calls
* test the API call to delete a specific storage sector