### PR TITLE
Add more fields to wallet

### DIFF
--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -9,22 +9,37 @@ import (
 var (
 	bucketHistoricClaimStarts = []byte("bucketHistoricClaimStarts")
 	bucketHistoricOutputs     = []byte("bucketHistoricOutputs")
+
+	dbBuckets = [][]byte{
+		bucketHistoricClaimStarts,
+		bucketHistoricOutputs,
+	}
 )
+
+// dbPut is a helper function for storing a marshalled key/value pair.
+func dbPut(b *bolt.Bucket, key, val interface{}) error {
+	return b.Put(encoding.Marshal(key), encoding.Marshal(val))
+}
+
+// dbGet is a helper function for retrieving a marshalled key/value pair. val
+// must be a pointer.
+func dbGet(b *bolt.Bucket, key, val interface{}) error {
+	return encoding.Unmarshal(b.Get(encoding.Marshal(key)), val)
+}
 
 // dbPutHistoricClaimStart stores the number of siafunds corresponding to the
 // specified SiafundOutputID. The wallet builds a mapping of output -> value
 // so that it can determine the value of siafund outputs that were not created
 // by the wallet.
 func dbPutHistoricClaimStart(tx *bolt.Tx, id types.SiafundOutputID, c types.Currency) error {
-	return tx.Bucket(bucketHistoricClaimStarts).Put(encoding.Marshal(id), encoding.Marshal(c))
+	return dbPut(tx.Bucket(bucketHistoricClaimStarts), id, c)
 }
 
 // dbGetHistoricClaimStart retrieves the number of siafunds corresponding to
 // the specified SiafundOutputID. The wallet uses this mapping to determine
 // the value of siafund outputs that were not created by the wallet.
 func dbGetHistoricClaimStart(tx *bolt.Tx, id types.SiafundOutputID) (c types.Currency, err error) {
-	b := tx.Bucket(bucketHistoricClaimStarts).Get(encoding.Marshal(id))
-	err = encoding.Unmarshal(b, &c)
+	err = dbGet(tx.Bucket(bucketHistoricClaimStarts), id, &c)
 	return
 }
 
@@ -33,14 +48,13 @@ func dbGetHistoricClaimStart(tx *bolt.Tx, id types.SiafundOutputID) (c types.Cur
 // it can determine the value of outputs that were not created
 // by the wallet.
 func dbPutHistoricOutput(tx *bolt.Tx, id types.OutputID, c types.Currency) error {
-	return tx.Bucket(bucketHistoricOutputs).Put(encoding.Marshal(id), encoding.Marshal(c))
+	return dbPut(tx.Bucket(bucketHistoricOutputs), id, c)
 }
 
 // dbGetHistoricOutput retrieves the number of coins corresponding to the
 // specified OutputID. The wallet uses this mapping to determine the value of
 // outputs that were not created by the wallet.
 func dbGetHistoricOutput(tx *bolt.Tx, id types.OutputID) (c types.Currency, err error) {
-	b := tx.Bucket(bucketHistoricOutputs).Get(encoding.Marshal(id))
-	err = encoding.Unmarshal(b, &c)
+	err = dbGet(tx.Bucket(bucketHistoricOutputs), id, &c)
 	return
 }

--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -9,10 +9,16 @@ import (
 var (
 	bucketHistoricClaimStarts = []byte("bucketHistoricClaimStarts")
 	bucketHistoricOutputs     = []byte("bucketHistoricOutputs")
+	bucketSiacoinOutputs      = []byte("bucketSiacoinOutputs")
+	bucketSiafundOutputs      = []byte("bucketSiafundOutputs")
+	bucketSpentOutputs        = []byte("bucketSpentOutputs")
 
 	dbBuckets = [][]byte{
 		bucketHistoricClaimStarts,
 		bucketHistoricOutputs,
+		bucketSiacoinOutputs,
+		bucketSiafundOutputs,
+		bucketSpentOutputs,
 	}
 )
 
@@ -25,6 +31,11 @@ func dbPut(b *bolt.Bucket, key, val interface{}) error {
 // must be a pointer.
 func dbGet(b *bolt.Bucket, key, val interface{}) error {
 	return encoding.Unmarshal(b.Get(encoding.Marshal(key)), val)
+}
+
+// dbDelete is a helper function for deleting a marshalled key/value pair.
+func dbDelete(b *bolt.Bucket, key interface{}) error {
+	return b.Delete(encoding.Marshal(key))
 }
 
 // dbPutHistoricClaimStart stores the number of siafunds corresponding to the
@@ -57,4 +68,61 @@ func dbPutHistoricOutput(tx *bolt.Tx, id types.OutputID, c types.Currency) error
 func dbGetHistoricOutput(tx *bolt.Tx, id types.OutputID) (c types.Currency, err error) {
 	err = dbGet(tx.Bucket(bucketHistoricOutputs), id, &c)
 	return
+}
+
+// dbPutSiacoinOutput stores the output corresponding to the specified
+// SiacoinOutputID.
+func dbPutSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID, output types.SiacoinOutput) error {
+	return dbPut(tx.Bucket(bucketSiacoinOutputs), id, output)
+}
+
+// dbGetSiacoinOutput retrieves the output corresponding to the specified
+// SiacoinOutputID.
+func dbGetSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID) (output types.SiacoinOutput, err error) {
+	err = dbGet(tx.Bucket(bucketSiacoinOutputs), id, &output)
+	return
+}
+
+// dbDeleteSiacoinOutput deletes the output corresponding to the specified
+// SiacoinOutputID.
+func dbDeleteSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID) error {
+	return dbDelete(tx.Bucket(bucketSiacoinOutputs), id)
+}
+
+// dbPutSiafundOutput stores the output corresponding to the specified
+// SiafundOutputID.
+func dbPutSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID, output types.SiafundOutput) error {
+	return dbPut(tx.Bucket(bucketSiafundOutputs), id, output)
+}
+
+// dbGetSiafundOutput retrieves the output corresponding to the specified
+// SiafundOutputID.
+func dbGetSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) (output types.SiafundOutput, err error) {
+	err = dbGet(tx.Bucket(bucketSiafundOutputs), id, &output)
+	return
+}
+
+// dbDeleteSiafundOutput deletes the output corresponding to the specified
+// SiafundOutputID.
+func dbDeleteSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) error {
+	return dbDelete(tx.Bucket(bucketSiafundOutputs), id)
+}
+
+// dbPutSpentOutput registers an output as being spent as of the specified
+// height.
+func dbPutSpentOutput(tx *bolt.Tx, id types.OutputID, height types.BlockHeight) error {
+	return dbPut(tx.Bucket(bucketSpentOutputs), id, height)
+}
+
+// dbGetSpentOutput retrieves the height at which the specified output was
+// spent.
+func dbGetSpentOutput(tx *bolt.Tx, id types.OutputID) (height types.BlockHeight, err error) {
+	err = dbGet(tx.Bucket(bucketSpentOutputs), id, &height)
+	return
+}
+
+// dbDeleteSpentOutput deletes the output corresponding to the specified
+// OutputID.
+func dbDeleteSpentOutput(tx *bolt.Tx, id types.OutputID) error {
+	return dbDelete(tx.Bucket(bucketSpentOutputs), id)
 }

--- a/modules/wallet/database_test.go
+++ b/modules/wallet/database_test.go
@@ -27,11 +27,7 @@ func TestDBOpen(t *testing.T) {
 		t.Fatal(err)
 	}
 	w.db.View(func(tx *bolt.Tx) error {
-		buckets := [][]byte{
-			bucketHistoricOutputs,
-			bucketHistoricClaimStarts,
-		}
-		for _, b := range buckets {
+		for _, b := range dbBuckets {
 			if tx.Bucket(b) == nil {
 				t.Error("bucket", string(b), "does not exist")
 			}

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -119,11 +119,7 @@ func (w *Wallet) openDB(filename string) (err error) {
 	}
 	// initialize the database
 	err = w.db.Update(func(tx *bolt.Tx) error {
-		buckets := [][]byte{
-			bucketHistoricOutputs,
-			bucketHistoricClaimStarts,
-		}
-		for _, b := range buckets {
+		for _, b := range dbBuckets {
 			_, err := tx.CreateBucketIfNotExists(b)
 			if err != nil {
 				return fmt.Errorf("could not create bucket %v: %v", string(b), err)

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -141,7 +141,8 @@ func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
 			// Check that this output has not recently been spent by the wallet.
 			spendHeight, err := dbGetSpentOutput(tx, types.OutputID(scoid))
 			if err != nil {
-				return err
+				// mimic map behavior: no entry means zero value
+				spendHeight = 0
 			}
 			// Prevent an underflow error.
 			allowedHeight := tb.wallet.consensusSetHeight - RespendTimeout
@@ -267,7 +268,8 @@ func (tb *transactionBuilder) FundSiafunds(amount types.Currency) error {
 			// Check that this output has not recently been spent by the wallet.
 			spendHeight, err := dbGetSpentOutput(tx, types.OutputID(sfoid))
 			if err != nil {
-				return err
+				// mimic map behavior: no entry means zero value
+				spendHeight = 0
 			}
 			// Prevent an underflow error.
 			allowedHeight := tb.wallet.consensusSetHeight - RespendTimeout

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -305,11 +305,6 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check that there is only one output in the wallet.
-	if len(wt.wallet.siacoinOutputs) != 1 {
-		t.Fatal("wallet is supposed to have only one output", wt.wallet.siacoinOutputs)
-	}
-
 	// Get a baseline balance for the wallet.
 	startingSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
 	startingOutgoing, startingIncoming := wt.wallet.UnconfirmedBalance()

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -10,8 +10,8 @@ import (
 	"github.com/NebulousLabs/bolt"
 )
 
-// isWalletAddress is a helper function that an UnlockHash is derived from
-// one of the wallet's spendable keys.
+// isWalletAddress is a helper function that checks if an UnlockHash is
+// derived from one of the wallet's spendable keys.
 func (w *Wallet) isWalletAddress(uh types.UnlockHash) bool {
 	_, exists := w.keys[uh]
 	return exists

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -68,12 +68,8 @@ type Wallet struct {
 	// from the seeds, when checking new outputs or spending outputs, the seeds
 	// are not referenced at all. The seeds are only stored so that the user
 	// may access them.
-	//
-	// siacoinOutptus, siafundOutputs, and spentOutputs are kept so that they
-	// can be scanned when trying to fund transactions.
-	seeds        []modules.Seed
-	keys         map[types.UnlockHash]spendableKey
-	spentOutputs map[types.OutputID]types.BlockHeight
+	seeds []modules.Seed
+	keys  map[types.UnlockHash]spendableKey
 
 	// The following fields are kept to track transaction history.
 	// processedTransactions are stored in chronological order, and have a map for
@@ -121,9 +117,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		cs:    cs,
 		tpool: tpool,
 
-		keys:         make(map[types.UnlockHash]spendableKey),
-		spentOutputs: make(map[types.OutputID]types.BlockHeight),
-
+		keys: make(map[types.UnlockHash]spendableKey),
 		processedTransactionMap: make(map[types.TransactionID]*modules.ProcessedTransaction),
 
 		persistDir: persistDir,

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -71,10 +71,9 @@ type Wallet struct {
 	//
 	// siacoinOutptus, siafundOutputs, and spentOutputs are kept so that they
 	// can be scanned when trying to fund transactions.
-	seeds          []modules.Seed
-	keys           map[types.UnlockHash]spendableKey
-	siacoinOutputs map[types.SiacoinOutputID]types.SiacoinOutput
-	spentOutputs   map[types.OutputID]types.BlockHeight
+	seeds        []modules.Seed
+	keys         map[types.UnlockHash]spendableKey
+	spentOutputs map[types.OutputID]types.BlockHeight
 
 	// The following fields are kept to track transaction history.
 	// processedTransactions are stored in chronological order, and have a map for
@@ -122,9 +121,8 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		cs:    cs,
 		tpool: tpool,
 
-		keys:           make(map[types.UnlockHash]spendableKey),
-		siacoinOutputs: make(map[types.SiacoinOutputID]types.SiacoinOutput),
-		spentOutputs:   make(map[types.OutputID]types.BlockHeight),
+		keys:         make(map[types.UnlockHash]spendableKey),
+		spentOutputs: make(map[types.OutputID]types.BlockHeight),
 
 		processedTransactionMap: make(map[types.TransactionID]*modules.ProcessedTransaction),
 

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -74,7 +74,6 @@ type Wallet struct {
 	seeds          []modules.Seed
 	keys           map[types.UnlockHash]spendableKey
 	siacoinOutputs map[types.SiacoinOutputID]types.SiacoinOutput
-	siafundOutputs map[types.SiafundOutputID]types.SiafundOutput
 	spentOutputs   map[types.OutputID]types.BlockHeight
 
 	// The following fields are kept to track transaction history.
@@ -125,7 +124,6 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 
 		keys:           make(map[types.UnlockHash]spendableKey),
 		siacoinOutputs: make(map[types.SiacoinOutputID]types.SiacoinOutput),
-		siafundOutputs: make(map[types.SiafundOutputID]types.SiafundOutput),
 		spentOutputs:   make(map[types.OutputID]types.BlockHeight),
 
 		processedTransactionMap: make(map[types.TransactionID]*modules.ProcessedTransaction),


### PR DESCRIPTION
Add siafundOutputs, siacoinOutputs, and spentOutputs to the database.

Also improve unlock speed by determining transaction relevancy first.

