### PR TITLE
Update Miner API docs

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -629,84 +629,71 @@ any particular order, and the order may change in subsequent calls.
 Miner
 -----
 
-Queries:
+| Route                              | HTTP verb |
+| ---------------------------------- | --------- |
+| [/miner](#miner-get)               | GET       |
+| [/miner/start](#minerstart-get)    | GET       |
+| [/miner/stop](#minerstop-get)      | GET       |
+| [/miner/header](#minerheader-get)  | GET       |
+| [/miner/header](#minerheader-post) | POST      |
 
-* /miner        [GET]
-* /miner/start  [GET]
-* /miner/stop   [GET]
-* /miner/header [GET]
-* /miner/header [POST]
+For examples and detailed descriptions of request and response parameters,
+refer to [Miner.md](/doc/api/Miner.md).
 
 #### /miner [GET]
 
-Function: Return the status of the miner.
+returns the status of the miner.
 
-Parameters: none
-
-Response:
-```
-struct {
-	blocksmined      int
-	cpuhashrate      int
-	cpumining        bool
-	staleblocksmined int
+###### JSON Response [(with comments)](/doc/api/Miner.md#json-response)
+```javascript
+{
+  "blocksmined":      9001,
+  "cpuhashrate":      1337,
+  "cpumining":        false,
+  "staleblocksmined": 0,
 }
 ```
-'cpumining' indicates whether the cpu miner is active or not.
-
-'cpuhashrate' indicates how fast the cpu is hashing, in hashes per second.
-
-'blocksmined' indicates how many blocks have been mined, this value is remembered after restarting.
-
-'staleblocksmined' indicates how many stale blocks have been mined, this value is remembered after restarting.
 
 #### /miner/start [GET]
 
-Function: Starts a single threaded cpu miner. Does nothing if the cpu miner is
-already running.
+starts a single threaded cpu miner. Does nothing if the cpu miner is already
+running.
 
-Parameters: none
-
-Response: standard
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
 
 #### /miner/stop [GET]
 
-Function: Stops the cpu miner. Does nothing if the cpu miner is not running.
+stops the cpu miner. Does nothing if the cpu miner is not running.
 
-Parameters: none
-
-Response: standard
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
 
 #### /miner/header [GET]
 
-Function: Provide a block header that is ready to be grinded on for work.
+provides a block header that is ready to be grinded on for work.
 
-Parameters: none
+###### Byte Response
 
-Response:
-```
-[]byte
-```
-The response is a byte array containing a target followed by a block header
-followed by a block. The target is the first 32 bytes. The block header is the
-following 80 bytes, and the nonce is bytes 32-39 (inclusive) of the header
-(bytes 64-71 of the whole array).
-
-Layout:
-
-0-31: target
-
-32-111: header
+For efficiency the header for work is returned as a raw byte encoding of the
+header, rather than encoded to JSON. Refer to
+[Miner.md#byte-response](/doc/api/Miner.md#byte-response) for a detailed
+description of the byte encoding.
 
 #### /miner/header [POST]
 
-Function: Submit a header that has passed the POW.
+submits a header that has passed the POW.
 
-Parameters:
-```
-input []byte
-```
-The input byte array should be 80 bytes that form the solved block header. *Unlike most API calls, it should be written directly to the request body, not as a query parameter.*
+###### Request Body Bytes
+
+For efficiency headers are submitted as raw byte encodings of the header in the
+body of the request, rather than as a query string parameter or path parameter.
+The request body should contain only the 80 bytes of the encoded header. The
+encoding is the same encoding used in `/miner/header [GET]` endpoint. Refer to
+[Miner.md#byte-response](/doc/api/Miner.md#byte-response) for a detailed
+description of the byte encoding.
 
 Renter
 ------

--- a/doc/api/Miner.md
+++ b/doc/api/Miner.md
@@ -84,10 +84,12 @@ possible nonces result in a header with a hash less than the target, call
 root. The above process can then be repeated for the new block header.
 
 The other fields can generally be ignored. The parent block ID field is the
-hash of the parent block's header. The timestamp is the time at which the block
-was mined. The merkle root is the merkle root of a merkle tree consisting of
-the timestamp, the miner outputs (one leaf per payout), and the transactions
-(one leaf per transaction).
+hash of the parent block's header. Modifying this field will result in an
+orphan block. The timestamp is the time at which the block was mined and is set
+by the Sia Daemon. Modifying this field can result in invalid block. The merkle
+root is the merkle root of a merkle tree consisting of the timestamp, the miner
+outputs (one leaf per payout), and the transactions (one leaf per transaction).
+Modifying this field will result in an invalid block.
 
 | Field           | Byte range within response | Byte range within header |
 | --------------- | -------------------------- | ------------------------ |
@@ -106,17 +108,6 @@ tttttttttttttttttttttttttttttttt (target)
                                                                 nnnnnnnn (nonce)
                                                                         ssssssss (timestamp)
                                                                                 mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm (merkle root)
-```
-
-```
-                                                                                                                                                                                                         1                   1
-                     1                   2                   3                   4                   5                   6                   7                   8                   9                   0                   1
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-| Target                                                        | Header                                                                                                                                                        |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                                                               | Parent block ID                                                 | Nonce         | Timestamp     | Merkle root                                                 |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
 #### /miner/header [POST]

--- a/doc/api/Miner.md
+++ b/doc/api/Miner.md
@@ -1,0 +1,108 @@
+Miner API
+=========
+
+This document contains detailed descriptions of the miner's API routes. For an
+overview of the miner's API routes, see [API.md#miner](/doc/API.md#miner).  For
+an overview of all API routes, see [API.md](/doc/API.md)
+
+There may be functional API calls which are not documented. These are not
+guaranteed to be supported beyond the current release, and should not be used
+in production.
+
+Overview
+--------
+
+The miner provides endpoints for getting headers for work and submitting solved
+headers to the network. The miner also provides endpoints for controlling a
+basic CPU mining implementation.
+
+Index
+-----
+
+| Route                              | HTTP verb |
+| ---------------------------------- | --------- |
+| [/miner](#miner-get)               | GET       |
+| [/miner/start](#minerstart-get)    | GET       |
+| [/miner/stop](#minerstop-get)      | GET       |
+| [/miner/header](#minerheader-get)  | GET       |
+| [/miner/header](#minerheader-post) | POST      |
+
+#### /miner [GET]
+
+returns the status of the miner.
+
+###### JSON Response
+```javascript
+{
+  // Number of mined blocks. This value is remembered after restarting.
+  "blocksmined": 9001,
+
+  // How fast the cpu is hashing, in hashes per second.
+  "cpuhashrate": 1337,
+
+  // true if the cpu miner is active.
+  "cpumining": false,
+
+  // Number of mined blocks that are stale, indicating that they are not
+  // included in the current longest chain, likely because some other block at
+  // the same height had its chain extended first.
+  "staleblocksmined": 0,
+}
+```
+
+#### /miner/start [GET]
+
+starts a single threaded cpu miner. Does nothing if the cpu miner is already
+running.
+
+###### Response
+standard success or error response. See
+[API.md#standard-responses](/doc/API.md#standard-responses).
+
+#### /miner/stop [GET]
+
+stops the cpu miner. Does nothing if the cpu miner is not running.
+
+###### Response
+standard success or error response. See
+[API.md#standard-responses](/doc/API.md#standard-responses).
+
+#### /miner/header [GET]
+
+provides a block header that is ready to be grinded on for work.
+
+###### Byte Response
+
+For efficiency the header for work is returned as a raw byte encoding of the
+header, rather than encoded to JSON.
+
+The response bytes contain a target followed by a block header
+followed by a block. The target is the first 32 bytes. The block header is the
+following 80 bytes, and the nonce is bytes 32-39 (inclusive) of the header
+(bytes 64-71 of the whole array).
+
+Layout:
+
+0-31: target
+
+32-111: header
+
+```
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (returned bytes)
+tttttttttttttttttttttttttttttttt (target)
+                                hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh (header)
+                                                                nnnnnnnn (nonce)
+```
+
+#### /miner/header [POST]
+
+submits a header that has passed the POW.
+
+###### Request Body Bytes
+
+For efficiency headers are submitted as raw byte encodings of the header in the
+body of the request, rather than as a query string parameter or path parameter.
+The request body should contain only the 80 bytes of the encoded header. The
+encoding is the same encoding used in `/miner/header [GET]` endpoint. Refer to
+[#byte-response](#byte-response) for a detailed description of the byte
+encoding.

--- a/types/block.go
+++ b/types/block.go
@@ -111,8 +111,8 @@ func (b Block) ID() BlockID {
 }
 
 // MerkleRoot calculates the Merkle root of a Block. The leaves of the Merkle
-// tree are composed of the Timestamp, the miner outputs (one leaf per
-// payout), and the transactions (one leaf per transaction).
+// tree are composed of the miner outputs (one leaf per payout), and the
+// transactions (one leaf per transaction).
 func (b Block) MerkleRoot() crypto.Hash {
 	tree := crypto.NewTree()
 	for _, payout := range b.MinerPayouts {


### PR DESCRIPTION
Only significant non-styling difference is the addition of the visual depiction of the header encoding in /doc/api/Miner.md#byte-response