### PR TITLE
fix nodeterministically failing test in the host

### DIFF
--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -137,7 +137,7 @@ var (
 			return 250
 		}
 		if build.Release == "testing" {
-			return 10
+			return 100
 		}
 		panic("unrecognized release constant in host - logAllLimit")
 	}()
@@ -153,7 +153,7 @@ var (
 			return 2500
 		}
 		if build.Release == "testing" {
-			return 50
+			return 500
 		}
 		panic("unrecognized release constant in host - logAllLimit")
 	}()


### PR DESCRIPTION
The test was to make sure a probabilistic action was occuring a
reasonable number of times, but was only performing 10 actions to
measure a rare event. To fix the  test, the number of actions was
increased from 10 to 100, smoothing out the fluctuations in the
randomness.