### PR TITLE
add tracing to failing test

### DIFF
--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -186,11 +186,12 @@ func (h *Host) managedRPCRenewContract(conn net.Conn) error {
 	renewRevenue := renewBasePrice(so, settings, fc)
 	renewRisk := renewBaseCollateral(so, settings, fc)
 	h.mu.RUnlock()
-	hostTxnSignatures, hostRevisionSignature, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, so.SectorRoots, renewCollateral, renewRevenue, renewRisk)
+	hostTxnSignatures, hostRevisionSignature, newSOID, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, so.SectorRoots, renewCollateral, renewRevenue, renewRisk)
 	if err != nil {
 		modules.WriteNegotiationRejection(conn, err) // Error is ignored to preserve type for extendErr
 		return extendErr("failed to finalize contract: ", err)
 	}
+	defer h.managedUnlockStorageObligation(newSOID)
 	err = modules.WriteNegotiationAcceptance(conn)
 	if err != nil {
 		return extendErr("failed to write acceptance: ", ErrorConnection(err.Error()))

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -148,9 +148,9 @@ func (h *Host) threadedHandleConn(conn net.Conn) {
 		var so storageObligation
 		_, so, err = h.managedRPCRecentRevision(conn)
 		if err != nil {
-			defer func() {
-				h.managedUnlockStorageObligation(so.id())
-			}()
+			// The unlock can be called immediately, as no action is taken with
+			// the storage obligation that gets returned.
+			h.managedUnlockStorageObligation(so.id())
 		}
 	case modules.RPCSettings:
 		atomic.AddUint64(&h.atomicSettingsCalls, 1)

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -821,7 +821,6 @@ func (h *Host) threadedHandleActionItem(soid types.FileContractID, wg *sync.Wait
 		if err != nil {
 			return err
 		}
-		soid := so.id()
 		return tx.Bucket(bucketStorageObligations).Put(soid[:], soBytes)
 	})
 	if err != nil {

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -130,6 +130,10 @@ func TestBlankStorageObligation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = ht.host.tg.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Load the storage obligation from the database, see if it updated
 	// correctly.
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
@@ -152,6 +156,10 @@ func TestBlankStorageObligation(t *testing.T) {
 	// host should fail and give up by deleting the storage obligation.
 	for i := types.BlockHeight(0); i <= revisionSubmissionBuffer*2+1; i++ {
 		_, err := ht.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ht.host.tg.Flush()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -653,6 +661,10 @@ func TestAutoRevisionSubmission(t *testing.T) {
 		t.Fatal(err)
 	}
 	ht.host.managedUnlockStorageObligation(so.id())
+	err = ht.host.tg.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Unlike the other tests, this test does not submit the file contract
 	// revision to the transaction pool for the host, the host is expected to
 	// do it automatically.
@@ -660,6 +672,10 @@ func TestAutoRevisionSubmission(t *testing.T) {
 	// Mine until the host submits a storage proof.
 	for i := types.BlockHeight(0); i <= revisionSubmissionBuffer+2+resubmissionTimeout; i++ {
 		_, err := ht.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ht.host.tg.Flush()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -701,6 +717,10 @@ func TestAutoRevisionSubmission(t *testing.T) {
 	// host will delete the file entirely.
 	for i := 0; i <= int(defaultWindowSize); i++ {
 		_, err := ht.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ht.host.tg.Flush()
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
There is a host test that is timing out frequently in appveyor. On my machine the test takes 1.5 seconds, and I can't repro the issue.

This PR currently doesn't fix anything, but it will give me better insight into what's going wrong in the appveyor build.

I suspect that this bug is causing problems in production.