### PR TITLE
add `api.Client` API communication methods

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -57,20 +57,15 @@ func (c *Client) Get(resource string, obj interface{}) error {
 		return apiErr
 	}
 
-	if res.StatusCode == http.StatusNoContent {
-		return Error{"expecting a response, but API returned status code 204 No Content"}
-	}
-
-	err = json.NewDecoder(res.Body).Decode(obj)
-	if err != nil {
-		return err
+	if res.StatusCode != http.StatusNoContent {
+		return json.NewDecoder(res.Body).Decode(obj)
 	}
 	return nil
 }
 
 // POST makes a POST request to the resource at `resource`, using `data` as the
-// request body.
-func (c *Client) Post(resource string, data string) error {
+// request body.  The response, if provided, will be decoded into `obj`.
+func (c *Client) Post(resource string, data string, obj interface{}) error {
 	url := "http://" + c.address + resource
 	req, err := http.NewRequest("POST", url, strings.NewReader(data))
 	if err != nil {
@@ -100,5 +95,8 @@ func (c *Client) Post(resource string, data string) error {
 		return apiErr
 	}
 
+	if res.StatusCode != http.StatusNoContent {
+		return json.NewDecoder(res.Body).Decode(&obj)
+	}
 	return nil
 }

--- a/api/client.go
+++ b/api/client.go
@@ -57,7 +57,7 @@ func (c *Client) Get(resource string, obj interface{}) error {
 		return apiErr
 	}
 
-	if res.StatusCode != http.StatusNoContent {
+	if res.StatusCode != http.StatusNoContent && obj != nil {
 		return json.NewDecoder(res.Body).Decode(obj)
 	}
 	return nil
@@ -95,7 +95,7 @@ func (c *Client) Post(resource string, data string, obj interface{}) error {
 		return apiErr
 	}
 
-	if res.StatusCode != http.StatusNoContent {
+	if res.StatusCode != http.StatusNoContent && obj != nil {
 		return json.NewDecoder(res.Body).Decode(&obj)
 	}
 	return nil

--- a/api/client.go
+++ b/api/client.go
@@ -31,6 +31,9 @@ func (c *Client) Get(resource string, obj interface{}) error {
 		return err
 	}
 	req.Header.Set("User-Agent", "Sia-Agent")
+	if c.password != "" {
+		req.SetBasicAuth("", c.password)
+	}
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err

--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -40,7 +42,12 @@ func (c *Client) Get(resource string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() {
+		// res.Body should always be fully read even when discarding its content,
+		// such that the underlying connection can be reused.
+		io.Copy(ioutil.Discard, res.Body)
+		res.Body.Close()
+	}()
 
 	if res.StatusCode == http.StatusNotFound {
 		return errors.New("API call not recognized: " + resource)
@@ -63,7 +70,7 @@ func (c *Client) Get(resource string, obj interface{}) error {
 	return nil
 }
 
-// POST makes a POST request to the resource at `resource`, using `data` as the
+// Post makes a POST request to the resource at `resource`, using `data` as the
 // request body.  The response, if provided, will be decoded into `obj`.
 func (c *Client) Post(resource string, data string, obj interface{}) error {
 	url := "http://" + c.address + resource
@@ -80,7 +87,12 @@ func (c *Client) Post(resource string, data string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() {
+		// res.Body should always be fully read even when discarding its content,
+		// such that the underlying connection can be reused.
+		io.Copy(ioutil.Discard, res.Body)
+		res.Body.Close()
+	}()
 
 	if res.StatusCode == http.StatusNotFound {
 		return errors.New("API call not recognized: " + resource)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -23,3 +23,30 @@ func TestApiClient(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestAuthenticatedApiClient tests that the API client connects to an
+// authenticated server tester and can call and decode routes correctly, using
+// the correct password.
+func TestAuthenticatedApiClient(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	testpass := "testPassword"
+	st, err := createAuthenticatedServerTester("TestAuthenticatedApiClient", testpass)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	c := NewClient("localhost:9980", "")
+	var gatewayInfo GatewayGET
+	err = c.Get("/gateway", &gatewayInfo)
+	if err == nil {
+		t.Fatal("api.Client did not return an error when requesting an authenticated resource without a password")
+	}
+	c = NewClient("localhost:9980", testpass)
+	err = c.Get("/gateway", &gatewayInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -6,7 +6,7 @@ import (
 
 // TestApiClient tests that the API client connects to the server tester and
 // can call and decode routes correctly.
-func TestApiClient(t *testing.T) {
+func TestIntegrationApiClient(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -27,7 +27,7 @@ func TestApiClient(t *testing.T) {
 // TestAuthenticatedApiClient tests that the API client connects to an
 // authenticated server tester and can call and decode routes correctly, using
 // the correct password.
-func TestAuthenticatedApiClient(t *testing.T) {
+func TestIntegrationAuthenticatedApiClient(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -16,7 +16,7 @@ func TestApiClient(t *testing.T) {
 	}
 	defer st.server.Close()
 
-	c := NewClient("localhost:9980", "")
+	c := NewClient(st.server.listener.Addr().String(), "")
 	var gatewayInfo GatewayGET
 	err = c.Get("/gateway", &gatewayInfo)
 	if err != nil {
@@ -38,14 +38,14 @@ func TestAuthenticatedApiClient(t *testing.T) {
 	}
 	defer st.server.Close()
 
-	c := NewClient("localhost:9980", "")
-	var gatewayInfo GatewayGET
-	err = c.Get("/gateway", &gatewayInfo)
+	c := NewClient(st.server.listener.Addr().String(), "")
+	var walletAddress WalletAddressGET
+	err = c.Get("/wallet/address", &walletAddress)
 	if err == nil {
 		t.Fatal("api.Client did not return an error when requesting an authenticated resource without a password")
 	}
-	c = NewClient("localhost:9980", testpass)
-	err = c.Get("/gateway", &gatewayInfo)
+	c = NewClient(st.server.listener.Addr().String(), testpass)
+	err = c.Get("/wallet/address", &walletAddress)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"testing"
+)
+
+// TestApiClient tests that the API client connects to the server tester and
+// can call and decode routes correctly.
+func TestApiClient(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestApiClient")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	c := NewClient("localhost:9980", "")
+	var gatewayInfo GatewayGET
+	err = c.Get("/gateway", &gatewayInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds `api.Client`, an interface for communicating with a Sia API.  It handles creating the request with the proper user agent and url, basic authentication, and decoding.  Here's an example usage:

```
c := api.NewClient("localhost:9980", "")
var gatewayInfo api.GatewayGET
err := c.Get("/gateway", &gatewayInfo)
if err != nil {
   // handle this error
}
fmt.Println(gatewayInfo)
```

this should provide a more elegant and easy-to-grok interface for Golang devs to use when they use the Sia API.  