### PR TITLE
Add ProcessedTransactions to wallet db

### DIFF
--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -93,6 +93,19 @@ func dbDeleteProcessedTransaction(tx *bolt.Tx, id types.TransactionID) error {
 	return dbDelete(tx.Bucket(bucketProcessedTransactions), id)
 }
 
+// dbForEachProcessedTransaction iterates over the ProcessedTransactions
+// bucket, calling fn on each entry.
+func dbForEachProcessedTransaction(tx *bolt.Tx, fn func(modules.ProcessedTransaction)) error {
+	return tx.Bucket(bucketProcessedTransactions).ForEach(func(_, val []byte) error {
+		var pt modules.ProcessedTransaction
+		if err := encoding.Unmarshal(val, &pt); err != nil {
+			return err
+		}
+		fn(pt)
+		return nil
+	})
+}
+
 // dbPutSiacoinOutput stores the output corresponding to the specified
 // SiacoinOutputID.
 func dbPutSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID, output types.SiacoinOutput) error {
@@ -112,6 +125,22 @@ func dbDeleteSiacoinOutput(tx *bolt.Tx, id types.SiacoinOutputID) error {
 	return dbDelete(tx.Bucket(bucketSiacoinOutputs), id)
 }
 
+// dbForEachSiacoinOutput iterates over the SiacoinOutputs bucket, calling fn
+// on each entry.
+func dbForEachSiacoinOutput(tx *bolt.Tx, fn func(types.SiacoinOutputID, types.SiacoinOutput)) error {
+	return tx.Bucket(bucketSiacoinOutputs).ForEach(func(key, val []byte) error {
+		var id types.SiacoinOutputID
+		var output types.SiacoinOutput
+		if err := encoding.Unmarshal(key, &id); err != nil {
+			return err
+		} else if err := encoding.Unmarshal(val, &output); err != nil {
+			return err
+		}
+		fn(id, output)
+		return nil
+	})
+}
+
 // dbPutSiafundOutput stores the output corresponding to the specified
 // SiafundOutputID.
 func dbPutSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID, output types.SiafundOutput) error {
@@ -129,6 +158,22 @@ func dbGetSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) (output types.Sia
 // SiafundOutputID.
 func dbDeleteSiafundOutput(tx *bolt.Tx, id types.SiafundOutputID) error {
 	return dbDelete(tx.Bucket(bucketSiafundOutputs), id)
+}
+
+// dbForEachSiafundOutput iterates over the SiafundOutputs bucket, calling fn
+// on each entry.
+func dbForEachSiafundOutput(tx *bolt.Tx, fn func(types.SiafundOutputID, types.SiafundOutput)) error {
+	return tx.Bucket(bucketSiafundOutputs).ForEach(func(key, val []byte) error {
+		var id types.SiafundOutputID
+		var output types.SiafundOutput
+		if err := encoding.Unmarshal(key, &id); err != nil {
+			return err
+		} else if err := encoding.Unmarshal(val, &output); err != nil {
+			return err
+		}
+		fn(id, output)
+		return nil
+	})
 }
 
 // dbPutSpentOutput registers an output as being spent as of the specified

--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -2,20 +2,24 @@ package wallet
 
 import (
 	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+
 	"github.com/NebulousLabs/bolt"
 )
 
 var (
-	bucketHistoricClaimStarts = []byte("bucketHistoricClaimStarts")
-	bucketHistoricOutputs     = []byte("bucketHistoricOutputs")
-	bucketSiacoinOutputs      = []byte("bucketSiacoinOutputs")
-	bucketSiafundOutputs      = []byte("bucketSiafundOutputs")
-	bucketSpentOutputs        = []byte("bucketSpentOutputs")
+	bucketHistoricClaimStarts   = []byte("bucketHistoricClaimStarts")
+	bucketHistoricOutputs       = []byte("bucketHistoricOutputs")
+	bucketProcessedTransactions = []byte("bucketProcessedTransactions")
+	bucketSiacoinOutputs        = []byte("bucketSiacoinOutputs")
+	bucketSiafundOutputs        = []byte("bucketSiafundOutputs")
+	bucketSpentOutputs          = []byte("bucketSpentOutputs")
 
 	dbBuckets = [][]byte{
 		bucketHistoricClaimStarts,
 		bucketHistoricOutputs,
+		bucketProcessedTransactions,
 		bucketSiacoinOutputs,
 		bucketSiafundOutputs,
 		bucketSpentOutputs,
@@ -68,6 +72,25 @@ func dbPutHistoricOutput(tx *bolt.Tx, id types.OutputID, c types.Currency) error
 func dbGetHistoricOutput(tx *bolt.Tx, id types.OutputID) (c types.Currency, err error) {
 	err = dbGet(tx.Bucket(bucketHistoricOutputs), id, &c)
 	return
+}
+
+// dbPutProcessedTransaction stores the ProcessedTransaction corresponding to the
+// specified TransactionID.
+func dbPutProcessedTransaction(tx *bolt.Tx, id types.TransactionID, pt modules.ProcessedTransaction) error {
+	return dbPut(tx.Bucket(bucketProcessedTransactions), id, pt)
+}
+
+// dbGetProcessedTransaction retrieves the ProcessedTransaction corresponding to the
+// specified TransactionID.
+func dbGetProcessedTransaction(tx *bolt.Tx, id types.TransactionID) (pt modules.ProcessedTransaction, err error) {
+	err = dbGet(tx.Bucket(bucketProcessedTransactions), id, &pt)
+	return
+}
+
+// dbDeleteProcessedTransaction deletes the ProcessedTransaction corresponding to the
+// specified TransactionID.
+func dbDeleteProcessedTransaction(tx *bolt.Tx, id types.TransactionID) error {
+	return dbDelete(tx.Bucket(bucketProcessedTransactions), id)
 }
 
 // dbPutSiacoinOutput stores the output corresponding to the specified

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -95,18 +95,9 @@ func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
 	return tb.wallet.db.Update(func(tx *bolt.Tx) error {
 		// Collect a value-sorted set of siacoin outputs.
 		var so sortedOutputs
-		err := tx.Bucket(bucketSiacoinOutputs).ForEach(func(idBytes, scoBytes []byte) error {
-			var scoid types.SiacoinOutputID
-			var sco types.SiacoinOutput
-			if err := encoding.Unmarshal(idBytes, &scoid); err != nil {
-				return err
-			}
-			if err := encoding.Unmarshal(scoBytes, &sco); err != nil {
-				return err
-			}
+		err := dbForEachSiacoinOutput(tx, func(scoid types.SiacoinOutputID, sco types.SiacoinOutput) {
 			so.ids = append(so.ids, scoid)
 			so.outputs = append(so.outputs, sco)
-			return nil
 		})
 		if err != nil {
 			return err

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -73,11 +73,13 @@ func (w *Wallet) AddressUnconfirmedTransactions(uh types.UnlockHash) (pts []modu
 func (w *Wallet) Transaction(txid types.TransactionID) (modules.ProcessedTransaction, bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	pt, exists := w.processedTransactionMap[txid]
-	if !exists {
-		return modules.ProcessedTransaction{}, exists
+
+	for _, pt := range w.processedTransactions {
+		if pt.TransactionID == txid {
+			return pt, true
+		}
 	}
-	return *pt, exists
+	return modules.ProcessedTransaction{}, false
 }
 
 // Transactions returns all transactions relevant to the wallet that were

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -21,7 +21,7 @@ func (w *Wallet) AddressTransactions(uh types.UnlockHash) (pts []modules.Process
 	defer w.mu.Unlock()
 
 	w.db.View(func(tx *bolt.Tx) error {
-		return dbForEachProcessedTransaction(tx, func(pt modules.ProcessedTransaction) {
+		return dbForEachProcessedTransaction(tx, func(_ types.TransactionID, pt modules.ProcessedTransaction) {
 			relevant := false
 			for _, input := range pt.Inputs {
 				relevant = relevant || input.RelatedAddress == uh
@@ -93,7 +93,7 @@ func (w *Wallet) Transactions(startHeight, endHeight types.BlockHeight) (pts []m
 	}
 
 	err = w.db.View(func(tx *bolt.Tx) error {
-		return dbForEachProcessedTransaction(tx, func(pt modules.ProcessedTransaction) {
+		return dbForEachProcessedTransaction(tx, func(_ types.TransactionID, pt modules.ProcessedTransaction) {
 			if startHeight <= pt.ConfirmationHeight && pt.ConfirmationHeight <= endHeight {
 				pts = append(pts, pt)
 			}

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -64,15 +64,12 @@ func (w *Wallet) updateConfirmedSet(tx *bolt.Tx, cc modules.ConsensusChange) err
 
 // revertHistory reverts any transaction history that was destroyed by reverted
 // blocks in the consensus change.
-// TODO: add test
 func (w *Wallet) revertHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 	for _, block := range cc.RevertedBlocks {
 		// Remove any transactions that have been reverted.
 		for i := len(block.Transactions) - 1; i >= 0; i-- {
 			// If the transaction is relevant to the wallet, it will be the
-			// most recent transaction appended to w.processedTransactions.
-			// Relevance can be determined just by looking at the last element
-			// of w.processedTransactions.
+			// most recent transaction in bucketProcessedTransactions.
 			txid := block.Transactions[i].ID()
 			pt, err := dbGetLastProcessedTransaction(tx)
 			if err != nil {

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -76,7 +76,6 @@ func (w *Wallet) revertHistory(cc modules.ConsensusChange) {
 			txid := txn.ID()
 			if len(w.processedTransactions) > 0 && txid == w.processedTransactions[len(w.processedTransactions)-1].TransactionID {
 				w.processedTransactions = w.processedTransactions[:len(w.processedTransactions)-1]
-				delete(w.processedTransactionMap, txid)
 			}
 		}
 
@@ -84,7 +83,6 @@ func (w *Wallet) revertHistory(cc modules.ConsensusChange) {
 		for _, mp := range block.MinerPayouts {
 			if w.isWalletAddress(mp.UnlockHash) {
 				w.processedTransactions = w.processedTransactions[:len(w.processedTransactions)-1]
-				delete(w.processedTransactionMap, types.TransactionID(block.ID()))
 				break
 			}
 		}
@@ -123,7 +121,6 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, applied []types.Block) error {
 				})
 			}
 			w.processedTransactions = append(w.processedTransactions, minerPT)
-			w.processedTransactionMap[minerPT.TransactionID] = &w.processedTransactions[len(w.processedTransactions)-1]
 		}
 		for _, txn := range block.Transactions {
 			// determine if transaction is relevant
@@ -233,7 +230,6 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, applied []types.Block) error {
 			}
 
 			w.processedTransactions = append(w.processedTransactions, pt)
-			w.processedTransactionMap[pt.TransactionID] = &w.processedTransactions[len(w.processedTransactions)-1]
 		}
 	}
 

--- a/modules/wallet/update_test.go
+++ b/modules/wallet/update_test.go
@@ -1,0 +1,73 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// TestUpdate tests that the wallet processes consensus updates properly.
+func TestUpdate(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	wt, err := createWalletTester("TestUpdate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mine a block and add it to the consensus set
+	b, err := wt.miner.FindBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wt.cs.AcceptBlock(b); err != nil {
+		t.Fatal(err)
+	}
+	// since the miner is mining into a wallet address, the wallet should have
+	// added a new transaction
+	_, ok := wt.wallet.Transaction(types.TransactionID(b.ID()))
+	if !ok {
+		t.Fatal("no record of miner transaction")
+	}
+
+	// revert the block
+	wt.wallet.ProcessConsensusChange(modules.ConsensusChange{
+		RevertedBlocks: []types.Block{b},
+	})
+	// transaction should no longer be present
+	_, ok = wt.wallet.Transaction(types.TransactionID(b.ID()))
+	if ok {
+		t.Fatal("miner transaction was not removed after block was reverted")
+	}
+
+	// create a transaction
+	addr, _ := wt.wallet.NextAddress()
+	txnSet, err := wt.wallet.SendSiacoins(types.SiacoinPrecision.Mul64(10), addr.UnlockHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// mine blocks until transaction is confirmed, while building up a cc that will revert all the blocks we add
+	var revertCC modules.ConsensusChange
+	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
+		b, _ := wt.miner.FindBlock()
+		if err := wt.cs.AcceptBlock(b); err != nil {
+			t.Fatal(err)
+		}
+		revertCC.RevertedBlocks = append([]types.Block{b}, revertCC.RevertedBlocks...)
+	}
+
+	// transaction should be present
+	_, ok = wt.wallet.Transaction(txnSet[0].ID())
+	if !ok {
+		t.Fatal("no record of transaction")
+	}
+
+	// revert all the blocks
+	wt.wallet.ProcessConsensusChange(revertCC)
+	_, ok = wt.wallet.Transaction(txnSet[0].ID())
+	if ok {
+		t.Fatal("transaction was not removed")
+	}
+}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -72,19 +72,7 @@ type Wallet struct {
 	keys  map[types.UnlockHash]spendableKey
 
 	// The following fields are kept to track transaction history.
-	// processedTransactions are stored in chronological order, and have a map for
-	// constant time random access. The set of full transactions is kept as
-	// well, ordering can be determined by the processedTransactions slice.
-	//
-	// The unconfirmed transactions are kept the same way, except without the
-	// random access. It is assumed that the list of unconfirmed transactions
-	// will be small enough that this will not be a problem.
-	//
-	// historicOutputs is kept so that the values of transaction inputs can be
-	// determined. historicOutputs is never cleared, but in general should be
-	// small compared to the list of transactions.
 	processedTransactions            []modules.ProcessedTransaction
-	processedTransactionMap          map[types.TransactionID]*modules.ProcessedTransaction
 	unconfirmedProcessedTransactions []modules.ProcessedTransaction
 
 	// The wallet's database tracks its seeds, keys, outputs, and
@@ -118,7 +106,6 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		tpool: tpool,
 
 		keys: make(map[types.UnlockHash]spendableKey),
-		processedTransactionMap: make(map[types.TransactionID]*modules.ProcessedTransaction),
 
 		persistDir: persistDir,
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -71,8 +71,7 @@ type Wallet struct {
 	seeds []modules.Seed
 	keys  map[types.UnlockHash]spendableKey
 
-	// The following fields are kept to track transaction history.
-	processedTransactions            []modules.ProcessedTransaction
+	// unconfirmedProcessedTransactions tracks unconfirmed transactions.
 	unconfirmedProcessedTransactions []modules.ProcessedTransaction
 
 	// The wallet's database tracks its seeds, keys, outputs, and


### PR DESCRIPTION
This only adds one new field to the db, but it's a weird field. I also reorganized the db helper functions.

Relying on proper transaction ordering feels brittle. Eventually I plan to cache the transactions in memory, and use a map so that transactions can be removed based on their ID, not their index. (You could do this now, but it would require lots of db I/O).