### PR TITLE
Gateway concurrency

### DIFF
--- a/modules/gateway.go
+++ b/modules/gateway.go
@@ -8,12 +8,8 @@ const (
 	// GatewayDir is the name of the directory used to store the gateway's
 	// persistent data.
 	GatewayDir = "gateway"
-	// WellConnectedThreshold is the number of outbound connections at which the
-	// gateway will not attempt to make new outbound connections.
-	WellConnectedThreshold = 8
 )
 
-// TODO: Move this and its functionality into the gateway package.
 var (
 	// BootstrapPeers is a list of peers that can be used to find other peers -
 	// when a client first connects to the network, the only options for

--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -17,3 +17,14 @@ type peerConn struct {
 func (pc peerConn) RPCAddr() modules.NetAddress {
 	return pc.dialbackAddr
 }
+
+// dial will dial the input address and return a connection. dial appropriately
+// handles things like clean shutdown, fast shutdown, and chooses the correct
+// communication protocol.
+func (g *Gateway) dial(addr modules.NetAddress) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout: dialTimeout,
+		Cancel:  g.threads.StopChan(),
+	}
+	return dialer.Dial("tcp", string(addr))
+}

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -7,6 +7,10 @@ import (
 )
 
 const (
+	// handshakeUpgradeVersion is the version where the gateway handshake RPC
+	// was altered to include adiitional information transfer.
+	handshakeUpgradeVersion = "1.0.0"
+
 	// minAcceptableVersion is the version below which the gateway will refuse to
 	// connect to peers and reject connection attempts.
 	//

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -18,7 +18,18 @@ const (
 var (
 	// maxSharedNodes defines the number of nodes that will be shared between
 	// peers when they are expanding their node lists.
-	maxSharedNodes uint64 = 10
+	maxSharedNodes = func() uint64 {
+		switch build.Release {
+		case "dev":
+			return 5
+		case "standard":
+			return 10
+		case "testing":
+			return 3
+		default:
+			panic("unrecognized build.Release in healthyNodeListLen")
+		}
+	}()
 
 	// nodePurgeDelay defines the amount of time that is waited between each
 	// iteration of the node purge loop.

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -1,0 +1,159 @@
+package gateway
+
+import (
+	"time"
+
+	"github.com/NebulousLabs/Sia/build"
+)
+
+const (
+	// minAcceptableVersion is the version below which the gateway will refuse to
+	// connect to peers and reject connection attempts.
+	//
+	// Reject peers < v0.4.0 as the previous version is v0.3.3 which is
+	// pre-hardfork.
+	minAcceptableVersion = "0.4.0"
+)
+
+var (
+	// maxSharedNodes defines the number of nodes that will be shared between
+	// peers when they are expanding their node lists.
+	maxSharedNodes uint64 = 10
+
+	// nodePurgeDelay defines the amount of time that is waited between each
+	// iteration of the node purge loop.
+	nodePurgeDelay = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 20 * time.Second
+		case "standard":
+			return 10 * time.Minute
+		case "testing":
+			return 2 * time.Second
+		default:
+			panic("unrecognized build.Release in nodePurgeDelay")
+		}
+	}()
+
+	// healthyNodeListLen defines the number of nodes that the gateway must
+	// have in the node list before it will stop asking peers for more nodes.
+	healthyNodeListLen = func() int {
+		switch build.Release {
+		case "dev":
+			return 30
+		case "standard":
+			return 200
+		case "testing":
+			return 15
+		default:
+			panic("unrecognized build.Release in healthyNodeListLen")
+		}
+	}()
+
+	// pruneNodeListLen defines the number of nodes that the gateway must have
+	// to be pruning nodes from the node list.
+	pruneNodeListLen = func() int {
+		switch build.Release {
+		case "dev":
+			return 15
+		case "standard":
+			return 50
+		case "testing":
+			return 10
+		default:
+			panic("unrecognized build.Release in pruneNodeListLen")
+		}
+	}()
+)
+
+var (
+	// fullyConnectedThreshold defines the number of peers that the gateway can
+	// have before it stops accepting inbound connections.
+	fullyConnectedThreshold = func() int {
+		switch build.Release {
+		case "dev":
+			return 20
+		case "standard":
+			return 128
+		case "testing":
+			return 10
+		default:
+			panic("unrecognized build.Release in fullyConnectedThreshold")
+		}
+	}()
+
+	// noPeersDelay defines the amount of time that is waited between
+	// iterations of the peer formation loop if the gateway is well connected.
+	noPeersDelay = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 10 * time.Second
+		case "standard":
+			return 20 * time.Second
+		case "testing":
+			return 3 * time.Second
+		default:
+			panic("unrecognized build.Release in noPeersDelay")
+		}
+	}()
+
+	// wellConnectedDelay defines the amount of time that is waited between
+	// iterations of the peer formation loop if the gateway is well connected.
+	wellConnectedDelay = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 1 * time.Minute
+		case "standard":
+			return 5 * time.Minute
+		case "testing":
+			return 5 * time.Second
+		default:
+			panic("unrecognized build.Release in wellConnectedDelay")
+		}
+	}()
+
+	// wellConnectedThreshold is the number of outbound connections at which
+	// the gateway will not attempt to make new outbound connections.
+	wellConnectedThreshold = func() int {
+		switch build.Release {
+		case "dev":
+			return 5
+		case "standard":
+			return 8
+		case "testing":
+			return 3
+		default:
+			panic("unrecognized build.Release in wellConnectedThreshold")
+		}
+	}()
+)
+
+var (
+	// The gateway will sleep this long between incoming connections.
+	acceptInterval = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 3 * time.Second
+		case "standard":
+			return 3 * time.Second
+		case "testing":
+			return 10 * time.Millisecond
+		default:
+			panic("unrecognized build.Release in acceptInterval")
+		}
+	}()
+
+	// the gateway will abort a connection attempt after this long
+	dialTimeout = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 45 * time.Second
+		case "standard":
+			return 2 * time.Minute
+		case "testing":
+			return 2 * time.Second
+		default:
+			panic("unrecognized build.Release in dialTimeout")
+		}
+	}()
+)

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -40,7 +40,7 @@ var (
 		case "standard":
 			return 10 * time.Minute
 		case "testing":
-			return 2 * time.Second
+			return 1 * time.Second
 		default:
 			panic("unrecognized build.Release in nodePurgeDelay")
 		}
@@ -135,7 +135,7 @@ var (
 		case "standard":
 			return 5 * time.Minute
 		case "testing":
-			return 5 * time.Second
+			return 2 * time.Second
 		default:
 			panic("unrecognized build.Release in wellConnectedDelay")
 		}

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -16,6 +16,21 @@ const (
 )
 
 var (
+	// healthyNodeListLen defines the number of nodes that the gateway must
+	// have in the node list before it will stop asking peers for more nodes.
+	healthyNodeListLen = func() int {
+		switch build.Release {
+		case "dev":
+			return 30
+		case "standard":
+			return 200
+		case "testing":
+			return 15
+		default:
+			panic("unrecognized build.Release in healthyNodeListLen")
+		}
+	}()
+
 	// maxSharedNodes defines the number of nodes that will be shared between
 	// peers when they are expanding their node lists.
 	maxSharedNodes = func() uint64 {
@@ -40,24 +55,24 @@ var (
 		case "standard":
 			return 10 * time.Minute
 		case "testing":
-			return 1 * time.Second
+			return 500 * time.Millisecond
 		default:
 			panic("unrecognized build.Release in nodePurgeDelay")
 		}
 	}()
 
-	// healthyNodeListLen defines the number of nodes that the gateway must
-	// have in the node list before it will stop asking peers for more nodes.
-	healthyNodeListLen = func() int {
+	// nodeListDelay defines the amount of time that is waited between each
+	// iteration of the node list loop.
+	nodeListDelay = func() time.Duration {
 		switch build.Release {
 		case "dev":
-			return 30
+			return 3 * time.Second
 		case "standard":
-			return 200
+			return 5 * time.Second
 		case "testing":
-			return 15
+			return 500 * time.Millisecond
 		default:
-			panic("unrecognized build.Release in healthyNodeListLen")
+			panic("unrecognized build.Release in nodePurgeDelay")
 		}
 	}()
 
@@ -88,7 +103,7 @@ var (
 		case "standard":
 			return 5 * time.Second
 		case "testing":
-			return 1 * time.Second
+			return 500 * time.Millisecond
 		default:
 			panic("unrecognized build.Release in wellConnectedDelay")
 		}
@@ -135,7 +150,7 @@ var (
 		case "standard":
 			return 5 * time.Minute
 		case "testing":
-			return 2 * time.Second
+			return 3 * time.Second
 		default:
 			panic("unrecognized build.Release in wellConnectedDelay")
 		}

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -191,11 +191,11 @@ var (
 	dialTimeout = func() time.Duration {
 		switch build.Release {
 		case "dev":
-			return 45 * time.Second
+			return 20 * time.Second
 		case "standard":
 			return 2 * time.Minute
 		case "testing":
-			return 2 * time.Second
+			return 500 * time.Millisecond
 		default:
 			panic("unrecognized build.Release in dialTimeout")
 		}

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -165,7 +165,7 @@ var (
 		case "standard":
 			return 8
 		case "testing":
-			return 3
+			return 4
 		default:
 			panic("unrecognized build.Release in wellConnectedThreshold")
 		}

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -67,6 +67,22 @@ var (
 )
 
 var (
+	// acquiringPeersDelay defines the amount of time that is waited between
+	// iterations of the peer acquisition loop if the gateway is actively
+	// forming new connections with peers.
+	acquiringPeersDelay = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 3 * time.Minute
+		case "standard":
+			return 5 * time.Second
+		case "testing":
+			return 1 * time.Second
+		default:
+			panic("unrecognized build.Release in wellConnectedDelay")
+		}
+	}()
+
 	// fullyConnectedThreshold defines the number of peers that the gateway can
 	// have before it stops accepting inbound connections.
 	fullyConnectedThreshold = func() int {
@@ -83,7 +99,8 @@ var (
 	}()
 
 	// noPeersDelay defines the amount of time that is waited between
-	// iterations of the peer formation loop if the gateway is well connected.
+	// iterations of the peer acquisition loop if the gateway does not have
+	// enough nodes.
 	noPeersDelay = func() time.Duration {
 		switch build.Release {
 		case "dev":
@@ -98,7 +115,8 @@ var (
 	}()
 
 	// wellConnectedDelay defines the amount of time that is waited between
-	// iterations of the peer formation loop if the gateway is well connected.
+	// iterations of the peer acquisition loop if the gateway is well
+	// connected.
 	wellConnectedDelay = func() time.Duration {
 		switch build.Release {
 		case "dev":

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -123,7 +123,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	}
 
 	// Create the listener which will listen for new connections from peers.
-	threadedListenClosedChan := make(chan struct{})
+	permanentListenClosedChan := make(chan struct{})
 	g.listener, err = net.Listen("tcp", addr)
 	if err != nil {
 		return
@@ -134,7 +134,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 		if err != nil {
 			g.log.Println("WARN: closing the listener failed:", err)
 		}
-		<-threadedListenClosedChan
+		<-permanentListenClosedChan
 	})
 	// Set the address and port of the gateway.
 	_, g.port, err = net.SplitHostPort(g.listener.Addr().String())
@@ -146,7 +146,7 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 		g.myAddr = modules.NetAddress(g.listener.Addr().String())
 	}
 	// Spawn the peer connection listener.
-	go g.threadedListen(threadedListenClosedChan)
+	go g.permanentListen(permanentListenClosedChan)
 
 	// Spawn the peer manager and provide tools for ensuring clean shutdown.
 	peerManagerClosedChan := make(chan struct{})

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -70,10 +70,12 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	}
 
 	g = &Gateway{
-		handlers:   make(map[rpcID]modules.RPCFunc),
-		initRPCs:   make(map[string]modules.RPCFunc),
-		peers:      make(map[modules.NetAddress]*peer),
-		nodes:      make(map[modules.NetAddress]struct{}),
+		handlers: make(map[rpcID]modules.RPCFunc),
+		initRPCs: make(map[string]modules.RPCFunc),
+
+		peers: make(map[modules.NetAddress]*peer),
+		nodes: make(map[modules.NetAddress]struct{}),
+
 		persistDir: persistDir,
 	}
 

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -163,10 +163,10 @@ func New(addr string, persistDir string) (g *Gateway, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if build.Release == "testing" {
-		// TODO: This needs a docstring.
-		g.myAddr = modules.NetAddress(g.listener.Addr().String())
-	}
+	// Set myAddr equal to the address returned by the listener. It will be
+	// overwritten by threadedLearnHostname later on.
+	g.myAddr = modules.NetAddress(g.listener.Addr().String())
+
 	// Spawn the peer connection listener.
 	go g.permanentListen(permanentListenClosedChan)
 

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -17,7 +17,12 @@ import (
 func newTestingGateway(name string, t *testing.T) *Gateway {
 	g, err := New("localhost:0", build.TempDir("gateway", name))
 	if err != nil {
-		t.Fatal(err)
+		// TODO: the proper thing to do here is to return an error and not even
+		// take a `testing.T` as an arguement. Calling t.Fatal is insufficient
+		// because we aren't sure whether or not this function was called in
+		// the main goroutine of the test, which is required if the test is
+		// going to fail properly.
+		panic(err)
 	}
 	return g
 }
@@ -170,14 +175,14 @@ func TestParallelClose(t *testing.T) {
 	go func() {
 		err := g1.Connect(g2.myAddr)
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		wg.Done()
 	}()
 	go func() {
 		err := g2.Connect(g3.myAddr)
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		wg.Done()
 	}()
@@ -188,21 +193,21 @@ func TestParallelClose(t *testing.T) {
 	go func() {
 		err := g1.Close()
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		wg.Done()
 	}()
 	go func() {
 		err := g2.Close()
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		wg.Done()
 	}()
 	go func() {
 		err := g3.Close()
 		if err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		wg.Done()
 	}()

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -5,11 +5,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/sync"
+	siasync "github.com/NebulousLabs/Sia/sync"
 )
 
 // newTestingGateway returns a gateway read to use in a testing environment.
@@ -22,7 +23,7 @@ func newTestingGateway(name string, t *testing.T) *Gateway {
 }
 
 // TestExportedMethodsErrAfterClose tests that exported methods like Close and
-// Connect error with sync.ErrStopped after the gateway has been closed.
+// Connect error with siasync.ErrStopped after the gateway has been closed.
 func TestExportedMethodsErrAfterClose(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -32,11 +33,11 @@ func TestExportedMethodsErrAfterClose(t *testing.T) {
 	if err := g.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := g.Close(); err != sync.ErrStopped {
-		t.Fatalf("expected %q, got %q", sync.ErrStopped, err)
+	if err := g.Close(); err != siasync.ErrStopped {
+		t.Fatalf("expected %q, got %q", siasync.ErrStopped, err)
 	}
-	if err := g.Connect("localhost:1234"); err != sync.ErrStopped {
-		t.Fatalf("expected %q, got %q", sync.ErrStopped, err)
+	if err := g.Connect("localhost:1234"); err != siasync.ErrStopped {
+		t.Fatalf("expected %q, got %q", siasync.ErrStopped, err)
 	}
 }
 
@@ -99,6 +100,9 @@ func TestPeers(t *testing.T) {
 
 // TestNew checks that a call to New is effective.
 func TestNew(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	if _, err := New("", ""); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}
@@ -132,4 +136,75 @@ func TestClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestParallelClose spins up 3 gateways, connects them all, and then closes
+// them in parallel. The goal of this test is to make it more vulnerable to any
+// potential nondeterministic failures.
+func TestParallelClose(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	// Spin up three gateways in parallel.
+	var g1, g2, g3 *Gateway
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		g1 = newTestingGateway("TestParallelClose - 1", t)
+		wg.Done()
+	}()
+	go func() {
+		g2 = newTestingGateway("TestParallelClose - 2", t)
+		wg.Done()
+	}()
+	go func() {
+		g3 = newTestingGateway("TestParallelClose - 3", t)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// Connect g1 to g2, g2 to g3. They may connect to eachother further.
+	wg.Add(2)
+	go func() {
+		err := g1.Connect(g2.myAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Done()
+	}()
+	go func() {
+		err := g2.Connect(g3.myAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Done()
+	}()
+	wg.Wait()
+
+	// Close all three gateways in parallel.
+	wg.Add(3)
+	go func() {
+		err := g1.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Done()
+	}()
+	go func() {
+		err := g2.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Done()
+	}()
+	go func() {
+		err := g3.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		wg.Done()
+	}()
+	wg.Wait()
 }

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -35,6 +35,7 @@ func (g *Gateway) addNode(addr modules.NetAddress) error {
 	return nil
 }
 
+// removeNode will remove a node from the gateway.
 func (g *Gateway) removeNode(addr modules.NetAddress) error {
 	if _, exists := g.nodes[addr]; !exists {
 		return errors.New("no record of that node")
@@ -43,15 +44,26 @@ func (g *Gateway) removeNode(addr modules.NetAddress) error {
 	return nil
 }
 
+// randomNode returns a random node from the gateway. An error can be returned
 func (g *Gateway) randomNode() (modules.NetAddress, error) {
-	if len(g.nodes) > 0 {
-		r, _ := crypto.RandIntn(len(g.nodes))
-		for node := range g.nodes {
-			if r <= 0 {
-				return node, nil
-			}
-			r--
+	if len(g.nodes) == 0 {
+		return "", errNoPeers
+	}
+
+	// Select a random peer. Note that the algorithm below is roughly linear in
+	// the number of nodes known by the gateway, and this number can approach
+	// every node on the network. If the network gets large, this algorithm
+	// will either need to be refactored, or more likely a cap on the size of
+	// g.nodes will need to be added.
+	r, err := crypto.RandIntn(len(g.nodes))
+	if err != nil {
+		return err
+	}
+	for node := range g.nodes {
+		if r <= 0 {
+			return node, nil
 		}
+		r--
 	}
 
 	return "", errNoPeers

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -218,7 +218,7 @@ func (g *Gateway) permanentNodeManager(closeChan chan struct{}) {
 				continue
 			}
 		} else {
-			// There are enough peers in the gateway, no need to check for more
+			// There are enough nodes in the gateway, no need to check for more
 			// every 5 seconds. Wait a while before checking again.
 			select {
 			case <-time.After(wellConnectedDelay):

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -127,7 +127,7 @@ func (g *Gateway) permanentNodePurger(closeChan chan struct{}) {
 			// node list. Wait until the next iteration to try again.
 			continue
 		}
-		if numNodes < pruneNodeListLen {
+		if numNodes <= pruneNodeListLen {
 			// There are not enough nodes in the gateway - pruning more is
 			// probably a bad idea, and may affect the user's ability to
 			// connect to the network in the future.
@@ -186,10 +186,10 @@ func (g *Gateway) permanentNodeManager(closeChan chan struct{}) {
 	defer close(closeChan)
 
 	for {
-		// Wait 5 seconds so that a controlled number of peer requests are made
-		// to nodes in the node list.
+		// Wait 5 seconds so that a controlled number of node requests are made
+		// to peers.
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(nodeListDelay):
 		case <-g.threads.StopChan():
 			// Gateway is shutting down, close the thread.
 			return

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -137,7 +137,6 @@ func (g *Gateway) permanentNodePurger(closeChan chan struct{}) {
 		// Try connecting to the random node. If the node is not reachable,
 		// remove them from the node list. Make sure that the dial is stopped
 		// early if the gateway is shutting down.
-		var conn net.Conn
 		func() {
 			cancelDialChan := make(chan struct{})
 			dialDoneChan := make(chan struct{})
@@ -153,7 +152,7 @@ func (g *Gateway) permanentNodePurger(closeChan chan struct{}) {
 				Timeout: dialTimeout,
 				Cancel:  cancelDialChan,
 			}
-			conn, err = dialer.Dial("tcp", string(node))
+			conn, err := dialer.Dial("tcp", string(node))
 			if err != nil {
 				// NOTE: an error may be returned if the dial is cancelled
 				// partway through, which would cause the node to be pruned

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -203,10 +203,12 @@ func (g *Gateway) permanentNodeManager(closeChan chan struct{}) {
 		numNodes := len(g.nodes)
 		peer, err := g.randomPeer()
 		g.mu.RUnlock()
-		if err != nil {
-			// Most commonly the error indicates that there are no peers yet.
-			// Waiting through the next iteration gives the gateway time to
-			// bootstrap.
+		if err == errNoPeers {
+			// errNoPeers is a common and expected error, there's no need to
+			// log it.
+			continue
+		} else if err != nil {
+			g.log.Println("ERROR: could not fetch a random peer:", err)
 			continue
 		}
 

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -57,7 +57,7 @@ func (g *Gateway) randomNode() (modules.NetAddress, error) {
 	// g.nodes will need to be added.
 	r, err := crypto.RandIntn(len(g.nodes))
 	if err != nil {
-		return err
+		return "", err
 	}
 	for node := range g.nodes {
 		if r <= 0 {

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -40,6 +40,7 @@ func (g *Gateway) removeNode(addr modules.NetAddress) error {
 }
 
 // randomNode returns a random node from the gateway. An error can be returned
+// if there are no nodes in the node list.
 func (g *Gateway) randomNode() (modules.NetAddress, error) {
 	if len(g.nodes) == 0 {
 		return "", errNoPeers
@@ -60,7 +61,6 @@ func (g *Gateway) randomNode() (modules.NetAddress, error) {
 		}
 		r--
 	}
-
 	return "", errNoPeers
 }
 

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -429,7 +429,7 @@ func TestHealthyNodeListPruning(t *testing.T) {
 	// Wait for enough iterations of the node purge loop that over-pruning is
 	// possible. (Over-pruning does not need to be guaranteed, causing this
 	// test to fail once in a while is sufficient.)
-	time.Sleep(nodePurgeDelay * time.Duration(healthyNodeListLen-pruneNodeListLen) * 8)
+	time.Sleep(nodePurgeDelay * time.Duration(healthyNodeListLen-pruneNodeListLen) * 12)
 
 	// Check that the remaining gateways have pruned nodes.
 	gs[0].mu.RLock()

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -189,7 +189,7 @@ func TestShareNodes(t *testing.T) {
 	}
 
 	// sharing should be capped at maxSharedNodes
-	for i := 1; i < maxSharedNodes+11; i++ {
+	for i := 1; i < int(maxSharedNodes)+11; i++ {
 		g2.mu.Lock()
 		err := g2.addNode(modules.NetAddress("111.111.111.111:" + strconv.Itoa(i)))
 		g2.mu.Unlock()
@@ -203,7 +203,7 @@ func TestShareNodes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(nodes) != maxSharedNodes {
+	if uint64(len(nodes)) != maxSharedNodes {
 		t.Fatalf("gateway gave wrong number of nodes: expected %v, got %v", maxSharedNodes, len(nodes))
 	}
 }

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -279,26 +279,6 @@ func TestPruneNodeThreshold(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		// To help speed the test up, also connect this gateway to the peer two
-		// back.
-		if i > 1 {
-			err := gs[i].Connect(gs[i-2].myAddr)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		// To help speed the test up, also connect this gateway to a random
-		// previous peer.
-		if i > 2 {
-			choice, err := crypto.RandIntn(i - 2)
-			if err != nil {
-				t.Fatal(err)
-			}
-			err = gs[i].Connect(gs[choice].myAddr)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
 	}
 
 	// Spin until all gateways have a nearly full node list.
@@ -449,7 +429,7 @@ func TestHealthyNodeListPruning(t *testing.T) {
 	// Wait for enough iterations of the node purge loop that over-pruning is
 	// possible. (Over-pruning does not need to be guaranteed, causing this
 	// test to fail once in a while is sufficient.)
-	time.Sleep(nodePurgeDelay * time.Duration(healthyNodeListLen-pruneNodeListLen) * 2)
+	time.Sleep(nodePurgeDelay * time.Duration(healthyNodeListLen-pruneNodeListLen) * 4)
 
 	// Check that the remaining gateways have pruned nodes.
 	gs[0].mu.RLock()
@@ -458,11 +438,11 @@ func TestHealthyNodeListPruning(t *testing.T) {
 	gs[1].mu.RLock()
 	gs1Nodes := len(gs[1].nodes)
 	gs[1].mu.RUnlock()
-	if gs0Nodes >= healthyNodeListLen-1 {
-		t.Error("gateway is not pruning nodes")
+	if gs0Nodes >= healthyNodeListLen-2 {
+		t.Error("gateway is not pruning nodes", healthyNodeListLen, gs0Nodes)
 	}
-	if gs1Nodes >= healthyNodeListLen-1 {
-		t.Error("gateway is not pruning nodes")
+	if gs1Nodes >= healthyNodeListLen-2 {
+		t.Error("gateway is not pruning nodes", healthyNodeListLen, gs1Nodes)
 	}
 	if gs0Nodes < pruneNodeListLen {
 		t.Error("gateway is pruning too many nodes", gs0Nodes, pruneNodeListLen)

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -429,7 +429,7 @@ func TestHealthyNodeListPruning(t *testing.T) {
 	// Wait for enough iterations of the node purge loop that over-pruning is
 	// possible. (Over-pruning does not need to be guaranteed, causing this
 	// test to fail once in a while is sufficient.)
-	time.Sleep(nodePurgeDelay * time.Duration(healthyNodeListLen-pruneNodeListLen) * 4)
+	time.Sleep(nodePurgeDelay * time.Duration(healthyNodeListLen-pruneNodeListLen) * 8)
 
 	// Check that the remaining gateways have pruned nodes.
 	gs[0].mu.RLock()
@@ -438,10 +438,10 @@ func TestHealthyNodeListPruning(t *testing.T) {
 	gs[1].mu.RLock()
 	gs1Nodes := len(gs[1].nodes)
 	gs[1].mu.RUnlock()
-	if gs0Nodes >= healthyNodeListLen-2 {
+	if gs0Nodes >= healthyNodeListLen-1 {
 		t.Error("gateway is not pruning nodes", healthyNodeListLen, gs0Nodes)
 	}
-	if gs1Nodes >= healthyNodeListLen-2 {
+	if gs1Nodes >= healthyNodeListLen-1 {
 		t.Error("gateway is not pruning nodes", healthyNodeListLen, gs1Nodes)
 	}
 	if gs0Nodes < pruneNodeListLen {

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -310,7 +310,7 @@ func TestPruneNodeThreshold(t *testing.T) {
 		go func(i int) {
 			err := gs[i].Close()
 			if err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 			wg.Done()
 		}(i)
@@ -419,7 +419,7 @@ func TestHealthyNodeListPruning(t *testing.T) {
 		go func(i int) {
 			err := gs[i].Close()
 			if err != nil {
-				t.Fatal(err)
+				panic(err)
 			}
 			wg.Done()
 		}(i)

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -143,10 +143,10 @@ func (g *Gateway) randomInboundPeer() (modules.NetAddress, error) {
 	return "", errNoPeers
 }
 
-// threadedListen handles incoming connection requests. If the connection is
+// permanentListen handles incoming connection requests. If the connection is
 // accepted, the peer will be added to the Gateway's peer list.
-func (g *Gateway) threadedListen(closeChan chan struct{}) {
-	// Signal that the threadedListen thread has completed upon returning.
+func (g *Gateway) permanentListen(closeChan chan struct{}) {
+	// Signal that the permanentListen thread has completed upon returning.
 	defer close(closeChan)
 
 	for {
@@ -172,6 +172,7 @@ func (g *Gateway) threadedListen(closeChan chan struct{}) {
 // threadedAcceptConn adds a connecting node as a peer.
 func (g *Gateway) threadedAcceptConn(conn net.Conn) {
 	if g.threads.Add() != nil {
+		conn.Close()
 		return
 	}
 	defer g.threads.Done()

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -576,7 +576,7 @@ func (g *Gateway) threadedPeerManager(closedChan chan struct{}) {
 		if err != nil {
 			select {
 			case <-time.After(time.Second * 20):
-			case g.threads.StopChan():
+			case <-g.threads.StopChan():
 				// Interrupt the thread if the shutdown signal is issued.
 				return
 			}
@@ -586,13 +586,13 @@ func (g *Gateway) threadedPeerManager(closedChan chan struct{}) {
 		// Try connecting to that peer in a goroutine.
 		go func() {
 			if err := g.threads.Add(); err != nil {
-				return err
+				return
 			}
 			defer g.threads.Done()
 
 			err := g.managedConnect(addr)
 			if err != nil {
-				g.log.Debugln("WARN: automatic connect failed:", connectErr)
+				g.log.Debugln("WARN: automatic connect failed:", err)
 			}
 		}()
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -534,11 +534,11 @@ func (g *Gateway) permanentPeerManager(closedChan chan struct{}) {
 			}
 		}
 		g.mu.RUnlock()
-		// If the gateway is well connected, sleep for 5 minutes and then check
+		// If the gateway is well connected, sleep for a while and then try
 		// again.
 		if numOutboundPeers >= wellConnectedThreshold {
 			select {
-			case <-time.After(5 * time.Minute):
+			case <-time.After(wellConnectedDelay):
 			case <-g.threads.StopChan():
 				// Interrupt the thread if the shutdown signal is issued.
 				return
@@ -579,7 +579,7 @@ func (g *Gateway) permanentPeerManager(closedChan chan struct{}) {
 		// non-blocking, so they should be spaced out to avoid spinning up an
 		// uncontrolled number of threads and therefore peer connections.
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(acquiringPeersDelay):
 		case <-g.threads.StopChan():
 			// Interrupt the thread if the shutdown signal is issued.
 			return

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -177,22 +177,6 @@ func (g *Gateway) threadedAcceptConn(conn net.Conn) {
 	}
 	defer g.threads.Done()
 
-	// Establish code that will terminate the connection early in the event of
-	// gateway shutdown.
-	connectionSuccessChan := make(chan struct{})
-	go func() {
-		select {
-		case <-connectionSuccessChan:
-			// After the connection is successful, alternate code is in place
-			// to close the connection. Do nothing.
-		case <-g.threads.StopChan():
-			// The gateway is shutting down, but the connection has not
-			// finished forming. Interrupt the connection formation so the
-			// gateway can shut down quickly.
-			conn.Close()
-		}
-	}()
-
 	addr := modules.NetAddress(conn.RemoteAddr().String())
 	g.log.Debugf("INFO: %v wants to connect", addr)
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -493,7 +493,7 @@ func (g *Gateway) managedConnect(addr modules.NetAddress) error {
 			}
 			defer g.threads.Done()
 
-			err := g.RPC(addr, name, fn)
+			err := g.managedRPC(addr, name, fn)
 			if err != nil {
 				g.log.Debugf("INFO: RPC %q on peer %q failed: %v", name, addr, err)
 			}

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -14,11 +14,17 @@ import (
 )
 
 const (
-	// the gateway will not accept inbound connections above this threshold
+	// fullyConnectedThreshold defines the number of peers that the gateway can
+	// have before it stops accepting inbound connections.
 	fullyConnectedThreshold = 128
 
-	// the gateway will ask for more addresses below this threshold
-	minNodeListLen = 100
+	// pruneNodeListLen defines the number of nodes that the gateway must have
+	// to be pruning nodes from the node list.
+	pruneNodeListLen = 50
+
+	// minNodeListLen defines the number of nodes that the gateway must have in
+	// the node list before it will stop asking peers for more nodes.
+	minNodeListLen = 200
 
 	// minAcceptableVersion is the version below which the gateway will refuse to
 	// connect to peers and reject connection attempts.
@@ -539,9 +545,9 @@ func (g *Gateway) Disconnect(addr modules.NetAddress) error {
 	return nil
 }
 
-// threadedPeerManager tries to keep the Gateway well-connected. As long as
+// permanentPeerManager tries to keep the Gateway well-connected. As long as
 // the Gateway is not well-connected, it tries to connect to random nodes.
-func (g *Gateway) threadedPeerManager(closedChan chan struct{}) {
+func (g *Gateway) permanentPeerManager(closedChan chan struct{}) {
 	// Send a signal upon shutdown.
 	defer close(closedChan)
 

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -137,7 +137,7 @@ func (g *Gateway) threadedAcceptConn(conn net.Conn) {
 		return
 	}
 
-	if build.VersionCmp(remoteVersion, "1.0.0") < 0 {
+	if build.VersionCmp(remoteVersion, handshakeUpgradeVersion) < 0 {
 		err = g.managedAcceptConnOldPeer(conn, remoteVersion)
 	} else {
 		err = g.managedAcceptConnNewPeer(conn, remoteVersion)
@@ -432,7 +432,7 @@ func (g *Gateway) managedConnect(addr modules.NetAddress) error {
 		conn.Close()
 		return err
 	}
-	if build.VersionCmp(remoteVersion, "1.0.0") < 0 {
+	if build.VersionCmp(remoteVersion, handshakeUpgradeVersion) < 0 {
 		err = g.managedConnectOldPeer(conn, remoteVersion, addr)
 	} else {
 		err = g.managedConnectNewPeer(conn, remoteVersion, addr)

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -653,6 +653,8 @@ func TestDisconnect(t *testing.T) {
 		if err != nil {
 			t.Fatal("accept failed:", err)
 		}
+		// TODO: What's with the commented out line below?
+		//
 		// conn.Close()
 	}()
 	// skip standard connection protocol

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -651,11 +651,8 @@ func TestDisconnect(t *testing.T) {
 	go func() {
 		_, err := l.Accept()
 		if err != nil {
-			t.Fatal("accept failed:", err)
+			panic(err)
 		}
-		// TODO: What's with the commented out line below?
-		//
-		// conn.Close()
 	}()
 	// skip standard connection protocol
 	conn, err := net.Dial("tcp", l.Addr().String())

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -675,10 +675,13 @@ func TestDisconnect(t *testing.T) {
 	}
 }
 
+// TestPeerManager checks that the peer manager is properly spacing out peer
+// connection requests.
 func TestPeerManager(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	g1 := newTestingGateway("TestPeerManager1", t)
 	defer g1.Close()
@@ -694,7 +697,7 @@ func TestPeerManager(t *testing.T) {
 	g1.mu.Unlock()
 
 	// when peerManager wakes up, it should connect to g2.
-	time.Sleep(21 * time.Second)
+	time.Sleep(time.Second + noPeersDelay)
 
 	g1.mu.RLock()
 	defer g1.mu.RUnlock()

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -692,7 +692,7 @@ func TestPeerManager(t *testing.T) {
 	g1.mu.Unlock()
 
 	// when peerManager wakes up, it should connect to g2.
-	time.Sleep(6 * time.Second)
+	time.Sleep(21 * time.Second)
 
 	g1.mu.RLock()
 	defer g1.mu.RUnlock()

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -215,7 +215,7 @@ func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) 
 	}
 	defer g.threads.Done()
 
-	g.log.Printf("INFO: broadcasting RPC %q to %v peers", name, len(peers))
+	g.log.Debugf("INFO: broadcasting RPC %q to %v peers", name, len(peers))
 
 	// only encode obj once, instead of using WriteObject
 	enc := encoding.Marshal(obj)

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -11,7 +11,7 @@ import (
 )
 
 // rpcID is an 8-byte signature that is added to all RPCs to tell the gatway
-// what to do with the RPC.
+// what to do with the RPC. Empty elements of rpcID will be encoded as spaces.
 type rpcID [8]byte
 
 // String returns a string representation of an rpcID.

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -225,7 +225,7 @@ func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) 
 				case <-g.threads.StopChan():
 					return
 				}
-				err := g.RPC(addr, name, fn)
+				err := g.managedRPC(addr, name, fn)
 				if err != nil {
 					g.log.Debugf("WARN: broadcasting RPC %q to peer %q failed twice: %v", name, addr, err)
 				}

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -10,8 +10,11 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 )
 
+// rpcID is an 8-byte signature that is added to all RPCs to tell the gatway
+// what to do with the RPC.
 type rpcID [8]byte
 
+// String returns a string representation of an rpcID.
 func (id rpcID) String() string {
 	for i := range id {
 		if id[i] == 0 {

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -11,10 +11,11 @@ import (
 )
 
 // rpcID is an 8-byte signature that is added to all RPCs to tell the gatway
-// what to do with the RPC. Empty elements of rpcID will be encoded as spaces.
+// what to do with the RPC.
 type rpcID [8]byte
 
-// String returns a string representation of an rpcID.
+// String returns a string representation of an rpcID. Empty elements of rpcID
+// will be encoded as spaces.
 func (id rpcID) String() string {
 	for i := range id {
 		if id[i] == 0 {

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -109,15 +109,22 @@ func (g *Gateway) threadedForwardPort(port string) {
 	}
 
 	g.log.Println("INFO: successfully forwarded port", port)
+
+	// Establish port-clearing at shutdown.
+	g.threads.AfterStop(func() {
+		g.managedClearPort(g.myAddr.Port())
+	})
 }
 
-// clearPort removes a port mapping from the router.
-func (g *Gateway) clearPort(port string) {
+// managedClearPort removes a port mapping from the router.
+func (g *Gateway) managedClearPort(port string) {
 	if build.Release == "testing" {
 		return
 	}
 
-	//d, err := upnp.Load("http://192.168.1.1:5000/Public_UPNP_gatedesc.xml")
+	// TODO: Figure out what's with the commented out code below.
+	//
+	// d, err := upnp.Load("http://192.168.1.1:5000/Public_UPNP_gatedesc.xml")
 	d, err := upnp.Discover()
 	if err != nil {
 		return

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -113,7 +113,7 @@ func (g *Gateway) threadedForwardPort(port string) {
 
 	// Establish port-clearing at shutdown.
 	g.threads.AfterStop(func() {
-		g.managedClearPort(g.myAddr.Port())
+		g.managedClearPort(port)
 	})
 }
 
@@ -123,9 +123,6 @@ func (g *Gateway) managedClearPort(port string) {
 		return
 	}
 
-	// TODO: Figure out what's with the commented out code below.
-	//
-	// d, err := upnp.Load("http://192.168.1.1:5000/Public_UPNP_gatedesc.xml")
 	d, err := upnp.Discover()
 	if err != nil {
 		return

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -54,9 +54,8 @@ func (g *Gateway) threadedLearnHostname() {
 		return
 	}
 
-	var host string
-
 	// try UPnP first, then fallback to myexternalip.com
+	var host string
 	d, err := upnp.Discover()
 	if err == nil {
 		host, err = d.ExternalIP()
@@ -77,6 +76,8 @@ func (g *Gateway) threadedLearnHostname() {
 		return
 	}
 
+	// TODO: Is this safe? What happens to processes or nodes that have already
+	// request the IP address?
 	g.mu.Lock()
 	g.myAddr = addr
 	g.mu.Unlock()

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -98,6 +98,9 @@ func createMinerTester(name string) (*minerTester, error) {
 // TestIntegrationMiner creates a miner, mines a few blocks, and checks that
 // the wallet balance is updating as the blocks get mined.
 func TestIntegrationMiner(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	mt, err := createMinerTester("TestMiner")
 	if err != nil {
 		t.Fatal(err)
@@ -110,9 +113,6 @@ func TestIntegrationMiner(t *testing.T) {
 	}
 
 	// Mine a bunch of blocks.
-	if testing.Short() {
-		t.SkipNow()
-	}
 	for i := 0; i < 50; i++ {
 		b, _ := mt.miner.FindBlock()
 		err = mt.cs.AcceptBlock(b)

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -88,6 +88,9 @@ func postEncryptionTesting(m modules.TestMiner, w *Wallet, masterKey crypto.Twof
 // TestIntegrationPreEncryption checks that the wallet operates as expected
 // prior to encryption.
 func TestIntegrationPreEncryption(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	wt, err := createBlankWalletTester("TestIntegrationPreEncryption")
 	if err != nil {
 		t.Fatal(err)

--- a/sync/threadgroup_test.go
+++ b/sync/threadgroup_test.go
@@ -193,6 +193,9 @@ func TestThreadGroupStop(t *testing.T) {
 
 // TestThreadGroupConcurrentAdd tests that Add can be called concurrently with Stop.
 func TestThreadGroupConcurrentAdd(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	var tg ThreadGroup
 	for i := 0; i < 10; i++ {
 		go func() {
@@ -251,6 +254,9 @@ func TestThreadGroupOnce(t *testing.T) {
 // TestThreadGroupOnStop tests that Stop calls functions registered with
 // OnStop.
 func TestThreadGroupOnStop(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)

--- a/sync/trymutex_test.go
+++ b/sync/trymutex_test.go
@@ -27,6 +27,10 @@ func TestTryMutexBasicMutex(t *testing.T) {
 // TestTryMutexConcurrentLocking checks that doing lots of concurrent locks is
 // handled as expected.
 func TestTryMutexConcurrentLocking(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// Try executing multiple additions concurrently.
 	var tm TryMutex
 	var data int
@@ -73,6 +77,10 @@ func TestTryMutexBasicTryLock(t *testing.T) {
 // TestTryMutexConcurrentTries attempts to grab locks from many threads, giving
 // the race detector a chance to detect any issues.
 func TestTryMutexConncurrentTries(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	// Try executing multiple additions concurrently.
 	var tm TryMutex
 	var data int
@@ -97,6 +105,10 @@ func TestTryMutexConncurrentTries(t *testing.T) {
 // TestTryMutexTimed checks that a timed lock will correctly time out if it
 // cannot grab a lock.
 func TestTryMutexTimed(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	var tm TryMutex
 	tm.Lock()
 
@@ -122,6 +134,10 @@ func TestTryMutexTimed(t *testing.T) {
 // TestTryMutexTimedConcurrent checks that a timed lock will correctly time out
 // if it cannot grab a lock.
 func TestTryMutexTimedConcurrent(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
 	var tm TryMutex
 
 	// Engage a lock and launch a gothread to wait for a lock, fail, and then


### PR DESCRIPTION
This pull request is most easily digested going commit-to-commit. They are pretty cleanly separated.

I went through and fixed up a lot of the concurrency patterns in the gateway. None of the changes have proper tests, but all of the old tests are still passing. Several deadlocks have been removed, and the biggest offenders in terms of quick-shutdown have been removed.

Some things remain on my todo list:

1. `threadedListenPeer` is not fixed up yet, it violates the 'don't hold a `tg.Add()` for long periods of time` rule, and has some other weirdness to the concurrency that I don't like.
2. `managedConnectNewPeer`, `managedConnectOldPeer`, `managedAcceptConnectNewPeer`, and `managedAcceptConnectOldPeer` all don't support quick-shutdown. I may have slipped in a goroutine here or there that is not being correctly closed with regards to these functions, can clean that up tomorrow.
3. `threadedHandleConn` does not yet support clean shutdown.

I am considering abandoning the pursuit of clean shutdown for the code that does not have it yet. The biggest offenders have already been addressed. That would just leave `threadedListenPeer` on my todo list.

Oh, and testing, as a lot of this code is not tested well, even though the whole test suite is passing.