### PR TITLE
restore gateway default conn timeout behavior

### DIFF
--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -24,13 +24,13 @@ func (pc peerConn) RPCAddr() modules.NetAddress {
 // communication protocol.
 func (g *Gateway) dial(addr modules.NetAddress) (net.Conn, error) {
 	dialer := &net.Dialer{
-		Cancel:   g.threads.StopChan(),
-		Deadline: time.Now().Add(connStdDeadline),
-		Timeout:  dialTimeout,
+		Cancel:  g.threads.StopChan(),
+		Timeout: dialTimeout,
 	}
 	conn, err := dialer.Dial("tcp", string(addr))
 	if err != nil {
 		return nil, err
 	}
+	conn.SetDeadline(time.Now().Add(connStdDeadline))
 	return conn, nil
 }


### PR DESCRIPTION
Originally, the behavior was altered because it was assumed that the
gateway could be reusing conns during Dial. This was a misunderstanding,
some http frameworks will reuse conns but the standard dialer.Dial will
not (from my best understanding).

It turns out that other techniques were responsible for fixing the
gateway desync issues, not this particular change.

I have run some tests in the antfarm, and it seems like reverting this
change has not re-introduced the desynchronization that we were
struggling with earlier.