### PR TITLE
Improve siac's `wallet load` ux

### DIFF
--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -61,7 +61,7 @@ By default the wallet encryption / unlock password is the same as the generated 
 	}
 
 	walletLoad033xCmd = &cobra.Command{
-		Use:   "033x",
+		Use:   "033x [filepath]",
 		Short: "Load a v0.3.3.x wallet",
 		Long:  "Load a v0.3.3.x wallet into the current wallet",
 		Run:   wrap(walletload033xcmd),
@@ -75,11 +75,11 @@ By default the wallet encryption / unlock password is the same as the generated 
 	}
 
 	walletLoadSiagCmd = &cobra.Command{
-		Use:   `siag [filepaths]`,
-		Short: "Load a siag keyset into the wallet",
-		Long: `Load a set of siag keys into the wallet - typically used for siafunds.
-Example: 'siac wallet load siag key1.siakey,key2.siakey'`,
-		Run: wrap(walletloadsiagcmd),
+		Use:     `siag [filepath,...]`,
+		Short:   "Load siag key(s) into the wallet",
+		Long:    "Load siag key(s) into the wallet - typically used for siafunds.",
+		Example: "siac wallet load siag key1.siakey,key2.siakey",
+		Run:     wrap(walletloadsiagcmd),
 	}
 
 	walletLockCmd = &cobra.Command{

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/bgentry/speakeasy"
 	"github.com/spf13/cobra"
@@ -62,7 +61,7 @@ By default the wallet encryption / unlock password is the same as the generated 
 	}
 
 	walletLoad033xCmd = &cobra.Command{
-		Use:   "033x [filepath]",
+		Use:   "033x",
 		Short: "Load a v0.3.3.x wallet",
 		Long:  "Load a v0.3.3.x wallet into the current wallet",
 		Run:   wrap(walletload033xcmd),
@@ -193,11 +192,11 @@ func walletinitcmd() {
 }
 
 // walletload033xcmd loads a v0.3.3.x wallet into the current wallet.
-func walletload033xcmd(source string) {
-	fmt.Println("Loading 033x...")
-	time.Sleep(time.Second * 3)
-	fmt.Println("Load successful.  Encrypting with current encryption password")
-	password, err := speakeasy.Ask("Need Password: ")
+func walletload033xcmd() {
+	fmt.Print("Enter 033x Location: ")
+	var source string
+	fmt.Scanln(&source)
+	password, err := speakeasy.Ask("Current Password: ")
 	if err != nil {
 		die("Reading password failed:", err)
 	}
@@ -211,16 +210,13 @@ func walletload033xcmd(source string) {
 
 // walletloadseedcmd adds a seed to the wallet's list of seeds
 func walletloadseedcmd() {
-	fmt.Println("Loading seed...")
-	time.Sleep(time.Second * 3)
-	fmt.Println("Load successful.  Encrypting with current encryption password")
-	password, err := speakeasy.Ask("Need Password: ")
-	if err != nil {
-		die("Reading password failed:", err)
-	}
 	seed, err := speakeasy.Ask("New Seed: ")
 	if err != nil {
 		die("Reading seed failed:", err)
+	}
+	password, err := speakeasy.Ask("Current Password: ")
+	if err != nil {
+		die("Reading password failed:", err)
 	}
 	qs := fmt.Sprintf("encryptionpassword=%s&seed=%s&dictionary=%s", password, seed, "english")
 	err = post("/wallet/seed", qs)
@@ -231,11 +227,11 @@ func walletloadseedcmd() {
 }
 
 // walletloadsiagcmd loads a siag key set into the wallet.
-func walletloadsiagcmd(keyfiles string) {
-	fmt.Println("Loading siag...")
-	time.Sleep(time.Second * 3)
-	fmt.Println("Load successful.  Encrypting with current encryption password")
-	password, err := speakeasy.Ask("Need Password: ")
+func walletloadsiagcmd() {
+	fmt.Print("Enter Siag Location: ")
+	var keyfiles string
+	fmt.Scanln(&keyfiles)
+	password, err := speakeasy.Ask("Current Password: ")
 	if err != nil {
 		die("Reading password failed:", err)
 	}

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/bgentry/speakeasy"
 	"github.com/spf13/cobra"
@@ -193,7 +194,10 @@ func walletinitcmd() {
 
 // walletload033xcmd loads a v0.3.3.x wallet into the current wallet.
 func walletload033xcmd(source string) {
-	password, err := speakeasy.Ask("Wallet password: ")
+	fmt.Println("Loading 033x...")
+	time.Sleep(time.Second * 3)
+	fmt.Println("Load successful.  Encrypting with current encryption password")
+	password, err := speakeasy.Ask("Need Password: ")
 	if err != nil {
 		die("Reading password failed:", err)
 	}
@@ -207,7 +211,10 @@ func walletload033xcmd(source string) {
 
 // walletloadseedcmd adds a seed to the wallet's list of seeds
 func walletloadseedcmd() {
-	password, err := speakeasy.Ask("Wallet password: ")
+	fmt.Println("Loading seed...")
+	time.Sleep(time.Second * 3)
+	fmt.Println("Load successful.  Encrypting with current encryption password")
+	password, err := speakeasy.Ask("Need Password: ")
 	if err != nil {
 		die("Reading password failed:", err)
 	}
@@ -225,7 +232,10 @@ func walletloadseedcmd() {
 
 // walletloadsiagcmd loads a siag key set into the wallet.
 func walletloadsiagcmd(keyfiles string) {
-	password, err := speakeasy.Ask("Wallet password: ")
+	fmt.Println("Loading siag...")
+	time.Sleep(time.Second * 3)
+	fmt.Println("Load successful.  Encrypting with current encryption password")
+	password, err := speakeasy.Ask("Need Password: ")
 	if err != nil {
 		die("Reading password failed:", err)
 	}

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -145,6 +145,8 @@ Run 'wallet send --help' to see a list of available units.`,
 	}
 )
 
+const askPasswordText = "We need to encrypt the new data using the current wallet password, please provide: "
+
 // walletaddresscmd fetches a new address from the wallet that will be able to
 // receive coins.
 func walletaddresscmd() {
@@ -192,11 +194,8 @@ func walletinitcmd() {
 }
 
 // walletload033xcmd loads a v0.3.3.x wallet into the current wallet.
-func walletload033xcmd() {
-	fmt.Print("Enter 033x Location: ")
-	var source string
-	fmt.Scanln(&source)
-	password, err := speakeasy.Ask("Current Password: ")
+func walletload033xcmd(source string) {
+	password, err := speakeasy.Ask(askPasswordText)
 	if err != nil {
 		die("Reading password failed:", err)
 	}
@@ -210,11 +209,11 @@ func walletload033xcmd() {
 
 // walletloadseedcmd adds a seed to the wallet's list of seeds
 func walletloadseedcmd() {
-	seed, err := speakeasy.Ask("New Seed: ")
+	seed, err := speakeasy.Ask("New seed: ")
 	if err != nil {
 		die("Reading seed failed:", err)
 	}
-	password, err := speakeasy.Ask("Current Password: ")
+	password, err := speakeasy.Ask(askPasswordText)
 	if err != nil {
 		die("Reading password failed:", err)
 	}
@@ -227,11 +226,8 @@ func walletloadseedcmd() {
 }
 
 // walletloadsiagcmd loads a siag key set into the wallet.
-func walletloadsiagcmd() {
-	fmt.Print("Enter Siag Location: ")
-	var keyfiles string
-	fmt.Scanln(&keyfiles)
-	password, err := speakeasy.Ask("Current Password: ")
+func walletloadsiagcmd(keyfiles string) {
+	password, err := speakeasy.Ask(askPasswordText)
 	if err != nil {
 		die("Reading password failed:", err)
 	}


### PR DESCRIPTION
Numerous users have reported being confused by the `wallet load` ux, expecting the `Password: ` input to be the wallet password of the seed, 033x, or siag that they are loading.  This PR adds some interactivity that should hopefully make it more clear that the user should provide their _current_ wallet password.