### PR TITLE
replace goxc with release.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ dependencies:
 	# Developer Dependencies
 	go install -race std
 	go get -u github.com/golang/lint/golint
-	go get -u github.com/laher/goxc
 
 # pkgs changes which packages the makefile calls operate on. run changes which
 # tests are run during testing.
@@ -63,13 +62,6 @@ release-race:
 	go install -race -tags='debug profile' $(pkgs)
 release-std:
 	go install $(pkgs)
-
-# xc builds and packages release binaries for all systems by using goxc.
-# Cross Compile - makes binaries for windows, linux, and mac, 64 bit only.
-xc: dependencies test test-long
-	goxc -arch="amd64" -bc="darwin linux windows" -d=release \
-	     -pv=v1.0.1 -include=LICENSE,README.md,doc/API.md \
-	     -tasks-=archive,rmbin,deb,deb-dev,deb-source,go-test -n=Sia
 
 # clean removes all directories that get automatically created during
 # development.

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# version and private key are supplied as arguments
+version="$1"
+keyfile="$2"
+if [[ -z $version || -z $keyfile ]]; then
+	echo "Usage: $0 VERSION KEYFILE"
+	exit 1
+fi
+
+# check for keyfile before proceeding
+if [ ! -f $keyfile ]; then
+    echo "Key file not found: $keyfile"
+    exit 1
+fi
+
+for os in darwin linux windows; do
+	echo Packaging ${os}...
+	# create workspace
+	root=$(pwd)
+	folder=$root/release/Sia-$version-$os-amd64
+	rm -rf $folder
+	mkdir -p $folder
+	# compile and sign binaries
+	for pkg in siac siad; do
+		bin=$pkg
+		if [ "$os" == "windows" ]; then
+			bin=${pkg}.exe
+		fi
+		GOOS=${os} go build -o $folder/$bin ./$pkg
+		openssl dgst -sha256 -sign $keyfile -out $folder/${bin}.sig $folder/$bin
+	done
+	# add other artifacts
+	cp -r $root/doc $root/LICENSE $root/README.md $folder
+	# zip
+	zip -rq release/Sia-$version-$os-amd64.zip $folder
+done

--- a/release.sh
+++ b/release.sh
@@ -14,7 +14,7 @@ if [ ! -f $keyfile ]; then
     echo "Key file not found: $keyfile"
     exit 1
 fi
-keysum=$(sha256sum $keyfile | cut -c -64)
+keysum=$(shasum -a 256 $keyfile | cut -c -64)
 if [ $keysum != "735320b4698010500d230c487e970e12776e88f33ad777ab380a493691dadb1b" ]; then
     echo "Wrong key file: checksum does not match developer key file."
     exit 1
@@ -23,8 +23,7 @@ fi
 for os in darwin linux windows; do
 	echo Packaging ${os}...
 	# create workspace
-	root=$(pwd)
-	folder=$root/release/Sia-$version-$os-amd64
+	folder=release/Sia-$version-$os-amd64
 	rm -rf $folder
 	mkdir -p $folder
 	# compile and sign binaries
@@ -37,7 +36,7 @@ for os in darwin linux windows; do
 		openssl dgst -sha256 -sign $keyfile -out $folder/${bin}.sig $folder/$bin
 	done
 	# add other artifacts
-	cp -r $root/doc $root/LICENSE $root/README.md $folder
+	cp -r doc LICENSE README.md $folder
 	# zip
 	zip -rq release/Sia-$version-$os-amd64.zip $folder
 done

--- a/release.sh
+++ b/release.sh
@@ -14,6 +14,11 @@ if [ ! -f $keyfile ]; then
     echo "Key file not found: $keyfile"
     exit 1
 fi
+keysum=$(sha256sum $keyfile | cut -c -64)
+if [ $keysum != "735320b4698010500d230c487e970e12776e88f33ad777ab380a493691dadb1b" ]; then
+    echo "Wrong key file: checksum does not match developer key file."
+    exit 1
+fi
 
 for os in darwin linux windows; do
 	echo Packaging ${os}...


### PR DESCRIPTION
goxc is overkill for our purposes.

Note that you will need the developer private key in order to sign binaries. (Well, technically you can sign them with any key.)

Maybe `siac` should include a command for verifying signed release binaries.