### PR TITLE
Account for transaction fees when allocating sectors

### DIFF
--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -60,7 +60,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	}
 
 	// check that allowance is sufficient to store at least one sector
-	numSectors, err := maxSectors(a, c.hdb)
+	numSectors, err := maxSectors(a, c.hdb, c.tpool)
 	if err != nil {
 		return err
 	} else if numSectors == 0 {

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -28,14 +28,6 @@ func (c *Contractor) contractEndHeight() types.BlockHeight {
 		endHeight = contract.EndHeight()
 		break
 	}
-	// sanity check: all contracts should have same EndHeight
-	if build.DEBUG {
-		for _, contract := range c.contracts {
-			if contract.EndHeight() != endHeight {
-				build.Critical("all contracts should have EndHeight", endHeight, "-- got", contract.EndHeight())
-			}
-		}
-	}
 	return endHeight
 }
 

--- a/modules/renter/contractor/consts.go
+++ b/modules/renter/contractor/consts.go
@@ -1,0 +1,42 @@
+package contractor
+
+import (
+	"github.com/NebulousLabs/Sia/build"
+)
+
+const (
+	// estimatedFileContractTransactionSize provides the estimated size of
+	// the average file contract in bytes.
+	estimatedFileContractTransactionSize = 1200
+)
+
+var (
+	// minHostsForEstimations describes the minimum number of hosts that
+	// are needed to make broad estimations such as the number of sectors
+	// that you can store on the network for a given allowance.
+	minHostsForEstimations = func() int {
+		switch build.Release {
+		case "dev":
+			// The number is set lower than standard so that it can
+			// be reached/exceeded easily within development
+			// environments, but set high enough that it's also
+			// easy to fall short within the development
+			// environments.
+			return 5
+		case "standard":
+			// Hosts can have a lot of variance. Selecting too many
+			// hosts will high-ball the price estimation, but users
+			// shouldn't be selecting rewer hosts, and if there are
+			// too few hosts being selected for estimation there is
+			// a risk of underestimating the actual price, which is
+			// something we'd rather avoid.
+			return 10
+		case "testing":
+			// Testing tries to happen as fast as possible,
+			// therefore tends to run with a lot fewer hosts.
+			return 4
+		default:
+			panic("unrecognized build.Release in minHostsForEstimations")
+		}
+	}()
+)

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -60,7 +60,7 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 	_, feeEstimation := tp.FeeEstimation()
 	costForTxnFees := types.NewCurrency64(estimatedFileContractTransactionSize).Mul(feeEstimation).Mul64(a.Hosts)
 	// Check for potential divide by zero
-	if a.Funds.Cmp(costForTxnFees.Add(costForContracts)) < 0 {
+	if a.Funds.Cmp(costForTxnFees.Add(costForContracts)) <= 0 {
 		return 0, errors.New("allowance is not large enough to cover the fees associated with creating file contracts")
 	}
 	sectorFunds := a.Funds.Sub(costForTxnFees).Sub(costForContracts)
@@ -68,7 +68,7 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 	// Divide total funds by cost per sector.
 	numSectors, err := sectorFunds.Div(costPerSector).Uint64()
 	if err != nil {
-		return 0, errors.New("error when totaling number of sectors that can be bought with an allowance: "+err.Error())
+		return 0, errors.New("error when totaling number of sectors that can be bought with an allowance: " + err.Error())
 	}
 	return numSectors, nil
 }

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -22,7 +22,7 @@ var (
 
 	// ErrInsufficientAllowance indicates that the renter's allowance is less
 	// than the amount necessary to store at least one sector
-	ErrInsufficientAllowance = errors.New("allowance is not large enough to perform contract creation")
+	ErrInsufficientAllowance = errors.New("allowance is not large enough to cover fees of contract creation")
 	errTooExpensive          = errors.New("host price was too high")
 )
 
@@ -61,7 +61,7 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 	costForTxnFees := types.NewCurrency64(estimatedFileContractTransactionSize).Mul(feeEstimation).Mul64(a.Hosts)
 	// Check for potential divide by zero
 	if a.Funds.Cmp(costForTxnFees.Add(costForContracts)) <= 0 {
-		return 0, errors.New("allowance is not large enough to cover the fees associated with creating file contracts")
+		return 0, ErrInsufficientAllowance
 	}
 	sectorFunds := a.Funds.Sub(costForTxnFees).Sub(costForContracts)
 

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -28,34 +28,47 @@ var (
 
 // maxSectors is the estimated maximum number of sectors that the allowance
 // can support.
-func maxSectors(a modules.Allowance, hdb hostDB) (uint64, error) {
-	if a.Hosts == 0 || a.Period == 0 {
+func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, error) {
+	if a.Hosts <= 0 || a.Period <= 0 {
 		return 0, errors.New("invalid allowance")
 	}
 
 	// Sample at least 10 hosts.
 	nRandomHosts := int(a.Hosts)
-	if nRandomHosts < 10 {
-		nRandomHosts = 10
+	if nRandomHosts < minHostsForEstimations {
+		nRandomHosts = minHostsForEstimations
 	}
 	hosts := hdb.RandomHosts(nRandomHosts, nil)
 	if len(hosts) < int(a.Hosts) {
 		return 0, fmt.Errorf("not enough hosts in hostdb for sector calculation, got %v but needed %v", len(hosts), int(a.Hosts))
 	}
 
-	// Calculate cost of storing 1 sector per host for the allowance period.
-	var sum types.Currency
+	// Calculate cost of creating contracts with each host, and the cost of
+	// storing sectors on each host.
+	var sectorSum types.Currency
+	var contractCostSum types.Currency
 	for _, h := range hosts {
-		sum = sum.Add(h.StoragePrice)
+		sectorSum = sectorSum.Add(h.StoragePrice)
+		contractCostSum = contractCostSum.Add(h.ContractPrice)
 	}
-	averagePrice := sum.Div64(uint64(len(hosts)))
-	costPerSector := averagePrice.Mul64(a.Hosts).Mul64(modules.SectorSize).Mul64(uint64(a.Period))
+	averageSectorPrice := sectorSum.Div64(uint64(len(hosts)))
+	averageContractPrice := contractCostSum.Div64(uint64(len(hosts)))
+	costPerSector := averageSectorPrice.Mul64(a.Hosts).Mul64(modules.SectorSize).Mul64(uint64(a.Period))
+	costForContracts := averageContractPrice.Mul64(a.Hosts)
+
+	// Subtract fees for creating the file contracts from the allowance.
+	_, feeEstimation := tp.FeeEstimation()
+	costForTxnFees := types.NewCurrency64(estimatedFileContractTransactionSize).Mul(feeEstimation).Mul64(a.Hosts)
+	// Check for potential divide by zero
+	if a.Funds.Cmp(costForTxnFees.Add(costForContracts)) < 0 {
+		return 0, errors.New("allowance is not large enough to cover the fees associated with creating file contracts")
+	}
+	sectorFunds := a.Funds.Sub(costForTxnFees).Sub(costForContracts)
 
 	// Divide total funds by cost per sector.
-	numSectors, err := a.Funds.Div(costPerSector).Uint64()
+	numSectors, err := sectorFunds.Div(costPerSector).Uint64()
 	if err != nil {
-		// if there was an overflow, something is definitely wrong
-		return 0, errors.New("allowance can fund suspiciously large number of sectors")
+		return 0, errors.New("error when totaling number of sectors that can be bought with an allowance: "+err.Error())
 	}
 	return numSectors, nil
 }

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -73,7 +73,7 @@ func (c *Contractor) managedRenewContracts() error {
 
 	c.mu.RLock()
 	endHeight := c.blockHeight + c.allowance.Period
-	numSectors, err := maxSectors(c.allowance, c.hdb)
+	numSectors, err := maxSectors(c.allowance, c.hdb, c.tpool)
 	c.mu.RUnlock()
 	if err != nil {
 		return err

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -55,7 +55,7 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 		c.mu.RLock()
 		a := c.allowance
 		remaining := int(a.Hosts) - len(c.contracts)
-		numSectors, err := maxSectors(a, c.hdb)
+		numSectors, err := maxSectors(a, c.hdb, c.tpool)
 		c.mu.RUnlock()
 		if err != nil {
 			c.log.Debugln("ERROR: couldn't calculate maxSectors after processing a consensus change:", err)

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -128,7 +128,7 @@ func (tp *TransactionPool) FeeEstimation() (min, max types.Currency) {
 	// a much lower value, which means hosts would be incompatible if the
 	// minimum recommended were set to 10. The value has been set to 1, which
 	// should be okay temporarily while the renters are given time to upgrade.
-	return types.SiacoinPrecision.Mul64(1).Div64(1e3), types.SiacoinPrecision.Mul64(25).Div64(1e3)
+	return types.SiacoinPrecision.Mul64(1).Div64(1e3), types.SiacoinPrecision.Mul64(5).Div64(1e3)
 }
 
 // TransactionList returns a list of all transactions in the transaction pool.

--- a/sync/threadgroup_test.go
+++ b/sync/threadgroup_test.go
@@ -69,8 +69,8 @@ func TestThreadGroupWait(t *testing.T) {
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatal(err)
-	} else if elapsed < time.Second {
-		t.Fatal("Stop did not wait for goroutines")
+	} else if elapsed < time.Millisecond*950 {
+		t.Fatal("Stop did not wait for goroutines:", elapsed)
 	}
 }
 

--- a/sync/trymutex_test.go
+++ b/sync/trymutex_test.go
@@ -117,11 +117,12 @@ func TestTryMutexTimed(t *testing.T) {
 		t.Error("was able to grab a locked lock")
 	}
 
-	if time.Now().Sub(startTime) < time.Millisecond*500 {
-		t.Error("lock did not wait the correct amount of time before timing out")
+	wait := time.Now().Sub(startTime)
+	if wait < time.Millisecond*450 {
+		t.Error("lock did not wait the correct amount of time before timing out", wait)
 	}
-	if time.Now().Sub(startTime) > time.Millisecond*750 {
-		t.Error("lock waited too long before timing out")
+	if wait > time.Millisecond*700 {
+		t.Error("lock waited too long before timing out", wait)
 	}
 
 	tm.Unlock()
@@ -149,11 +150,12 @@ func TestTryMutexTimedConcurrent(t *testing.T) {
 			t.Error("was able to grab a locked lock")
 		}
 
-		if time.Now().Sub(startTime) < time.Millisecond*500 {
-			t.Error("lock did not wait the correct amount of time before timing out")
+		wait := time.Now().Sub(startTime)
+		if wait < time.Millisecond*450 {
+			t.Error("lock did not wait the correct amount of time before timing out:", wait)
 		}
-		if time.Now().Sub(startTime) > time.Millisecond*750 {
-			t.Error("lock waited too long before timing out")
+		if wait > time.Millisecond*700 {
+			t.Error("lock waited too long before timing out", wait)
 		}
 
 		tm.Unlock()


### PR DESCRIPTION
The contractor will now account for transaction fees and for contract fees when it is allocating sectors, which means it should be much less likely to allocate too much storage and much less likely to over-charge substantially.

I also cut the fee by a factor of 5, because we don't need fees as high as 25 SC / kb, especially not after the price spike.