### PR TITLE
Prevent concurrent contract revision

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -43,6 +43,7 @@ type Contractor struct {
 	blockHeight     types.BlockHeight
 	cachedRevisions map[types.FileContractID]cachedRevision
 	contracts       map[types.FileContractID]modules.RenterContract
+	downloaders     map[types.FileContractID]*hostDownloader
 	lastChange      modules.ConsensusChangeID
 	renewHeight     types.BlockHeight             // height at which to renew contracts
 	revising        map[types.FileContractID]bool // prevent overlapping revisions
@@ -133,6 +134,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 
 		cachedRevisions: make(map[types.FileContractID]cachedRevision),
 		contracts:       make(map[types.FileContractID]modules.RenterContract),
+		downloaders:     make(map[types.FileContractID]*hostDownloader),
 		revising:        make(map[types.FileContractID]bool),
 	}
 

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -44,7 +44,8 @@ type Contractor struct {
 	cachedRevisions map[types.FileContractID]cachedRevision
 	contracts       map[types.FileContractID]modules.RenterContract
 	lastChange      modules.ConsensusChangeID
-	renewHeight     types.BlockHeight // height at which to renew contracts
+	renewHeight     types.BlockHeight             // height at which to renew contracts
+	revising        map[types.FileContractID]bool // prevent overlapping revisions
 
 	financialMetrics modules.RenterFinancialMetrics
 
@@ -132,6 +133,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 
 		cachedRevisions: make(map[types.FileContractID]cachedRevision),
 		contracts:       make(map[types.FileContractID]modules.RenterContract),
+		revising:        make(map[types.FileContractID]bool),
 	}
 
 	// Load the prior persistence structures.

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/proto"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // An Downloader retrieves sectors from with a host. It requests one sector at
@@ -27,6 +28,7 @@ type Downloader interface {
 type hostDownloader struct {
 	downloader *proto.Downloader
 	contractor *Contractor
+	contractID types.FileContractID
 }
 
 // Sector retrieves the sector with the specified Merkle root, and revises
@@ -51,7 +53,13 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 
 // Close cleanly terminates the download loop with the host and closes the
 // connection.
-func (hd *hostDownloader) Close() error { return hd.downloader.Close() }
+func (hd *hostDownloader) Close() error {
+	// release revising lock
+	hd.contractor.mu.Lock()
+	delete(hd.contractor.revising, hd.contractID)
+	hd.contractor.mu.Unlock()
+	return hd.downloader.Close()
+}
 
 // Downloader initiates the download request loop with a host, and returns a
 // Downloader.
@@ -70,6 +78,21 @@ func (c *Contractor) Downloader(contract modules.RenterContract) (Downloader, er
 		return nil, errTooExpensive
 	}
 
+	// acquire revising lock
+	c.mu.Lock()
+	alreadyRevising := c.revising[contract.ID]
+	if alreadyRevising {
+		c.mu.Unlock()
+		return nil, errors.New("already revising that contract")
+	}
+	c.revising[contract.ID] = true
+	c.mu.Unlock()
+	releaseLock := func() {
+		c.mu.Lock()
+		delete(c.revising, contract.ID)
+		c.mu.Unlock()
+	}
+
 	// create downloader
 	d, err := proto.NewDownloader(host, contract)
 	if proto.IsRevisionMismatch(err) {
@@ -79,6 +102,7 @@ func (c *Contractor) Downloader(contract modules.RenterContract) (Downloader, er
 		c.mu.RUnlock()
 		if !ok {
 			// nothing we can do; return original error
+			releaseLock()
 			return nil, err
 		}
 		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
@@ -86,6 +110,7 @@ func (c *Contractor) Downloader(contract modules.RenterContract) (Downloader, er
 		d, err = proto.NewDownloader(host, contract)
 	}
 	if err != nil {
+		releaseLock()
 		return nil, err
 	}
 	// supply a SaveFn that saves the revision to the contractor's persist
@@ -95,5 +120,6 @@ func (c *Contractor) Downloader(contract modules.RenterContract) (Downloader, er
 	return &hostDownloader{
 		downloader: d,
 		contractor: c,
+		contractID: contract.ID,
 	}, nil
 }

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -63,7 +63,13 @@ func (he *hostEditor) EndHeight() types.BlockHeight { return he.contract.EndHeig
 
 // Close cleanly terminates the revision loop with the host and closes the
 // connection.
-func (he *hostEditor) Close() error { return he.editor.Close() }
+func (he *hostEditor) Close() error {
+	// release revising lock
+	he.contractor.mu.Lock()
+	delete(he.contractor.revising, he.contract.ID)
+	he.contractor.mu.Unlock()
+	return he.editor.Close()
+}
 
 // Upload negotiates a revision that adds a sector to a file contract.
 func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
@@ -145,6 +151,21 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 		}
 	}
 
+	// acquire revising lock
+	c.mu.Lock()
+	alreadyRevising := c.revising[contract.ID]
+	if alreadyRevising {
+		c.mu.Unlock()
+		return nil, errors.New("already revising that contract")
+	}
+	c.revising[contract.ID] = true
+	c.mu.Unlock()
+	releaseLock := func() {
+		c.mu.Lock()
+		delete(c.revising, contract.ID)
+		c.mu.Unlock()
+	}
+
 	// create editor
 	e, err := proto.NewEditor(host, contract, height)
 	if proto.IsRevisionMismatch(err) {
@@ -154,6 +175,8 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 		c.mu.RUnlock()
 		if !ok {
 			// nothing we can do; return original error
+			c.log.Printf("wanted to recover contract %v with host %v, but no revision was cached", contract.ID, contract.NetAddress)
+			releaseLock()
 			return nil, err
 		}
 		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
@@ -162,6 +185,7 @@ func (c *Contractor) Editor(contract modules.RenterContract) (Editor, error) {
 		e, err = proto.NewEditor(host, contract, height)
 	}
 	if err != nil {
+		releaseLock()
 		return nil, err
 	}
 	// supply a SaveFn that saves the revision to the contractor's persist

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -830,4 +830,5 @@ func TestDownloaderCaching(t *testing.T) {
 	if d4 == d1 {
 		t.Fatal("downloader should not have been cached after all clients were closed")
 	}
+	d4.Close()
 }

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -186,6 +186,7 @@ func TestIntegrationFormContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -216,6 +217,7 @@ func TestIntegrationReviseContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -260,6 +262,7 @@ func TestIntegrationUploadDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -292,8 +295,7 @@ func TestIntegrationUploadDownload(t *testing.T) {
 	}
 
 	// download the data
-	contract = c.contracts[contract.ID]
-	downloader, err := c.Downloader(contract)
+	downloader, err := c.Downloader(contract.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,6 +324,7 @@ func TestIntegrationDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -381,6 +384,7 @@ func TestIntegrationInsertDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -437,6 +441,7 @@ func TestIntegrationModify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -501,6 +506,7 @@ func TestIntegrationRenew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -539,6 +545,9 @@ func TestIntegrationRenew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.mu.Lock()
+	c.contracts[contract.ID] = contract
+	c.mu.Unlock()
 
 	// check renewed contract
 	if contract.FileContract.FileMerkleRoot != root {
@@ -556,7 +565,7 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 
 	// download the renewed contract
-	downloader, err := c.Downloader(contract)
+	downloader, err := c.Downloader(contract.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -618,6 +627,7 @@ func TestResync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer h.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
@@ -650,8 +660,7 @@ func TestResync(t *testing.T) {
 	}
 
 	// download the data
-	contract = c.contracts[contract.ID]
-	downloader, err := c.Downloader(contract)
+	downloader, err := c.Downloader(contract.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -677,12 +686,8 @@ func TestResync(t *testing.T) {
 	delete(c.cachedRevisions, contract.ID)
 	c.mu.Unlock()
 
-	// Editor and Downloader should fail with the bad contract
+	// Editor should fail with the bad contract
 	_, err = c.Editor(badContract)
-	if !proto.IsRevisionMismatch(err) {
-		t.Fatal("expected revision mismatch, got", err)
-	}
-	_, err = c.Downloader(badContract)
 	if !proto.IsRevisionMismatch(err) {
 		t.Fatal("expected revision mismatch, got", err)
 	}
@@ -700,7 +705,7 @@ func TestResync(t *testing.T) {
 	}
 	editor.Close()
 
-	downloader, err = c.Downloader(badContract)
+	downloader, err = c.Downloader(badContract.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -715,12 +720,8 @@ func TestResync(t *testing.T) {
 	delete(c.cachedRevisions, contract.ID)
 	c.mu.Unlock()
 
-	// Editor and Downloader should fail with the bad contract
+	// Editor should fail with the bad contract
 	_, err = c.Editor(badContract)
-	if !proto.IsRevisionMismatch(err) {
-		t.Fatal("expected revision mismatch, got", err)
-	}
-	_, err = c.Downloader(badContract)
 	if !proto.IsRevisionMismatch(err) {
 		t.Fatal("expected revision mismatch, got", err)
 	}
@@ -740,4 +741,79 @@ func TestResync(t *testing.T) {
 		t.Fatal(err)
 	}
 	editor.Close()
+}
+
+func TestDownloaderCaching(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	// create testing trio
+	h, c, _, err := newTestingTrio("TestDownloaderCaching")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+
+	// get the host's entry from the db
+	hostEntry, ok := c.hdb.Host(h.ExternalSettings().NetAddress)
+	if !ok {
+		t.Fatal("no entry for host in db")
+	}
+
+	// form a contract with the host
+	contract, err := c.managedNewContract(hostEntry, 10, c.blockHeight+100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.mu.Lock()
+	c.contracts[contract.ID] = contract
+	c.mu.Unlock()
+
+	// create a downloader
+	d1, err := c.Downloader(contract.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create another downloader
+	d2, err := c.Downloader(contract.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// downloaders should match
+	if d1 != d2 {
+		t.Fatal("downloader was not cached")
+	}
+
+	// close one of the downloaders; it should not fully close, since d1 is
+	// still using it
+	d2.Close()
+
+	// create another downloader
+	d3, err := c.Downloader(contract.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// downloaders should match
+	if d3 != d1 {
+		t.Fatal("closing one client should not fully close the downloader")
+	}
+
+	// close both downloaders
+	d1.Close()
+	d2.Close()
+
+	// create another downloader
+	d4, err := c.Downloader(contract.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// downloaders should match
+	if d4 == d1 {
+		t.Fatal("downloader should not have been cached after all clients were closed")
+	}
 }

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -743,6 +743,9 @@ func TestResync(t *testing.T) {
 	editor.Close()
 }
 
+// TestDownloaderCaching tests that downloaders are properly cached by the
+// contractor. When two downloaders are requested for the same contract, only
+// one underlying downloader should be created.
 func TestDownloaderCaching(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -791,6 +791,13 @@ func TestDownloaderCaching(t *testing.T) {
 	// still using it
 	d2.Close()
 
+	c.mu.RLock()
+	_, ok = c.downloaders[contract.ID]
+	c.mu.RUnlock()
+	if !ok {
+		t.Fatal("expected downloader to still be present")
+	}
+
 	// create another downloader
 	d3, err := c.Downloader(contract.ID)
 	if err != nil {
@@ -805,6 +812,13 @@ func TestDownloaderCaching(t *testing.T) {
 	// close both downloaders
 	d1.Close()
 	d2.Close()
+
+	c.mu.RLock()
+	_, ok = c.downloaders[contract.ID]
+	c.mu.RUnlock()
+	if ok {
+		t.Fatal("did not expect downloader to still be present")
+	}
 
 	// create another downloader
 	d4, err := c.Downloader(contract.ID)

--- a/modules/renter/contractor/upload_test.go
+++ b/modules/renter/contractor/upload_test.go
@@ -27,7 +27,8 @@ func TestEditor(t *testing.T) {
 		hosts: make(map[modules.NetAddress]modules.HostDBEntry),
 	}
 	c := &Contractor{
-		hdb: hdb,
+		hdb:      hdb,
+		revising: make(map[types.FileContractID]bool),
 	}
 
 	// empty contract

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -189,46 +189,31 @@ func (r *Renter) Download(path, destination string) error {
 		return errors.New("no file with that path")
 	}
 
-	// Look up the most recent contract for each host.
-	// NOTE: this assumes that only one contract is made with each host.
-	var contractPieces []struct {
-		contract modules.RenterContract
-		pieces   []pieceData
-	}
+	// copy file contracts
 	file.mu.RLock()
-	for _, fc := range file.contracts {
-		rc, ok := r.hostContractor.Contract(fc.IP)
-		if ok {
-			contractPieces = append(contractPieces, struct {
-				contract modules.RenterContract
-				pieces   []pieceData
-			}{rc, fc.Pieces})
-		}
+	contracts := make([]fileContract, 0, len(file.contracts))
+	for _, c := range file.contracts {
+		contracts = append(contracts, c)
 	}
 	file.mu.RUnlock()
-	r.log.Debugf("Starting Download, found %v contracts\n", len(contractPieces))
-
-	if len(contractPieces) == 0 {
-		return errors.New("no record of that file's contracts")
-	} else if len(contractPieces) < file.erasureCode.MinPieces() {
-		return fmt.Errorf("not enough contracts: needed %v, found %v", file.erasureCode.MinPieces(), len(contractPieces))
-	}
 
 	// Initiate connections to each host.
 	var hosts []fetcher
 	var errs []string
-	for _, cp := range contractPieces {
-		// TODO: connect in parallel
-		d, err := r.hostContractor.Downloader(cp.contract)
+	for _, c := range file.contracts {
+		d, err := r.hostContractor.Downloader(c.ID)
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("\t%v: %v", cp.contract.NetAddress, err))
+			errs = append(errs, fmt.Sprintf("\t%v: %v", c.IP, err))
 			continue
 		}
 		defer d.Close()
-		hosts = append(hosts, newHostFetcher(d, cp.pieces, file.masterKey))
+		hosts = append(hosts, newHostFetcher(d, c.Pieces, file.masterKey))
+	}
+	if len(hosts) == 0 {
+		return errors.New("no record of that file's contracts")
 	}
 	if len(hosts) < file.erasureCode.MinPieces() {
-		return errors.New("Could not connect to enough hosts:\n" + strings.Join(errs, "\n"))
+		return errors.New("could not connect to enough hosts:\n" + strings.Join(errs, "\n"))
 	}
 
 	// Check that this host set is sufficient to download the file.

--- a/modules/renter/download_test.go
+++ b/modules/renter/download_test.go
@@ -150,7 +150,7 @@ func (dc *downloadContractor) Contract(modules.NetAddress) (modules.RenterContra
 }
 
 // Downloader increments dc.downloaders and returns a generic error.
-func (dc *downloadContractor) Downloader(modules.RenterContract) (contractor.Downloader, error) {
+func (dc *downloadContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {
 	dc.downloaders++
 	return nil, errInsufficientContracts
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -63,9 +63,9 @@ type hostContractor interface {
 	// FinancialMetrics returns the financial metrics of the contractor.
 	FinancialMetrics() modules.RenterFinancialMetrics
 
-	// Downloader creates a Downloader from the specified contract, allowing
-	// the retrieval of sectors.
-	Downloader(modules.RenterContract) (contractor.Downloader, error)
+	// Downloader creates a Downloader from the specified contract ID,
+	// allowing the retrieval of sectors.
+	Downloader(types.FileContractID) (contractor.Downloader, error)
 }
 
 // A trackedFile contains metadata about files being tracked by the Renter.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -92,6 +92,8 @@ type Renter struct {
 	files         map[string]*file
 	tracking      map[string]trackedFile // map from nickname to metadata
 	downloadQueue []*download
+	uploading     bool
+	downloading   bool
 
 	// constants
 	persistDir string

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -39,7 +39,7 @@ func (uc *uploadDownloadContractor) Editor(modules.RenterContract) (contractor.E
 
 // Downloader simply returns the uploadDownloadContractor, since it also
 // implements the Downloader interface.
-func (uc *uploadDownloadContractor) Downloader(modules.RenterContract) (contractor.Downloader, error) {
+func (uc *uploadDownloadContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {
 	return uc, nil
 }
 


### PR DESCRIPTION
Also, downloaders are now thread-safe and cached by the contractor. They are referenced by their ID rather than the full contract object. This means less contract objects floating around and therefore less chance of saving/revising the wrong contract. It also opens the door for a future change: the contractor should be able to invalidate any active downloaders/editors as soon as it starts renewing their underlying contract. Generally speaking, the contractor should be the only package that deals with contracts directly.

One downside of caching, however, is that it complicates the question of when the connection should be closed. In this PR, I added a counter to the downloader object. Each time another goroutine starts using the downloader, the counter is incremented, and each time `Close` is called, the counter is decremented. `Close` only closes the underlying connection when the counter reaches zero.

Another complication is timeouts. The download RPC has a hard deadline, after which it will close. The existing download code essentially ignores this possibility, but the likelihood of hitting the deadline increases if connections are being cached and reused. To address this, the download code should attempt to reconnect when the deadline is reached. Ideally, it would detect timeout errors and only retry in that case, but it may work fine to simply retry after any failure.

My next step is to give downloads a way to interrupt uploads in the renter. I will use a simplistic approach because it appears the uploading process may shortly be subject to more dramatic changes.