### PR TITLE
Rc2 tweaks

### DIFF
--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -45,7 +45,7 @@ var (
 	// keep the data even if the price of siacoin fluctuates, the price of raw
 	// storage fluctuates, or the host realizes that there is unexpected
 	// opportunity cost in being a host.
-	defaultCollateral = types.SiacoinPrecision.Mul64(250).Div(modules.BlockBytesPerMonthTerabyte) // 250 SC / TB / Month
+	defaultCollateral = types.SiacoinPrecision.Mul64(500).Div(modules.BlockBytesPerMonthTerabyte) // 500 SC / TB / Month
 
 	// defaultCollateralBudget defines the maximum number of siacoins that the
 	// host is going to allocate towards collateral. The number has been chosen
@@ -57,7 +57,7 @@ var (
 	// with the host. The default is set to 30 siacoins, which the file
 	// contract revision can have 15 siacoins put towards it, and the storage
 	// proof can have 15 siacoins put towards it.
-	defaultContractPrice = types.SiacoinPrecision.Mul64(30) // 30 siacoins
+	defaultContractPrice = types.SiacoinPrecision.Mul64(20) // 20 siacoins
 
 	// defaultDownloadBandwidthPrice defines the default price of upload
 	// bandwidth. The default is set to 10 siacoins per gigabyte, because
@@ -94,7 +94,7 @@ var (
 	// defaultStoragePrice defines the starting price for hosts selling
 	// storage. We try to match a number that is both reasonably profitable and
 	// reasonably competitive.
-	defaultStoragePrice = types.SiacoinPrecision.Mul64(1e3).Div(modules.BlockBytesPerMonthTerabyte) // 1k SC / TB / Month
+	defaultStoragePrice = types.SiacoinPrecision.Mul64(500).Div(modules.BlockBytesPerMonthTerabyte) // 500 SC / TB / Month
 
 	// defaultUploadBandwidthPrice defines the default price of upload
 	// bandwidth. The default is set to 1 siacoin per GB, because the host is
@@ -102,7 +102,7 @@ var (
 	// the host is typically only downloading data if it is planning to store
 	// the data, meaning that the host serves to profit from accepting the
 	// data.
-	defaultUploadBandwidthPrice = types.SiacoinPrecision.Mul64(100).Div(modules.BytesPerTerabyte) // 100 SC / TB
+	defaultUploadBandwidthPrice = types.SiacoinPrecision.Mul64(10).Div(modules.BytesPerTerabyte) // 10 SC / TB
 
 	// defaultWindowSize is the size of the proof of storage window requested
 	// by the host. The host will not delete any obligations until the window
@@ -196,10 +196,10 @@ var (
 	// accept any more revisions once inside the submission buffer.
 	revisionSubmissionBuffer = func() types.BlockHeight {
 		if build.Release == "dev" {
-			return 20 // About 2 minutes
+			return 20 // About 4 minutes
 		}
 		if build.Release == "standard" {
-			return 288 // 2 days.
+			return 144 // 1 day.
 		}
 		if build.Release == "testing" {
 			return 4

--- a/modules/host/storagemanager/sector.go
+++ b/modules/host/storagemanager/sector.go
@@ -190,8 +190,11 @@ func (sm *StorageManager) AddSector(sectorRoot crypto.Hash, expiryHeight types.B
 		emptiestFolder, emptiestIndex := emptiestStorageFolder(potentialFolders)
 		for emptiestFolder != nil {
 			sectorPath := filepath.Join(sm.persistDir, emptiestFolder.uidString(), string(sectorKey))
-			err := sm.dependencies.writeFile(sectorPath, sectorData, 0700)
+			err := sm.dependencies.writeFile(sectorPath, sectorData, 0400)
 			if err != nil {
+				// Log the error.
+				sm.log.Println("Unable to accept sector", err, "into folder", emptiestFolder.uidString())
+
 				// Indicate to the user that the storage folder is having write
 				// trouble.
 				emptiestFolder.FailedWrites++

--- a/modules/renter/hostdb/hostweight_test.go
+++ b/modules/renter/hostdb/hostweight_test.go
@@ -8,6 +8,7 @@ import (
 
 func calculateWeightFromUInt64Price(price uint64) (weight types.Currency) {
 	var entry hostEntry
+	entry.RemainingStorage = 250e3
 	entry.StoragePrice = types.NewCurrency64(price)
 	return calculateHostWeight(entry)
 }


### PR DESCRIPTION
A quick change to the host to change sector file permissions from 0700 to 0400, tests seem to be coping with it well. Also added a logging statement to the storage manager if a sector write fails, as currently that failure is recorded but no reason is given for the failure.

Finally, I updated the hostdb to de-prioritize hosts that don't have much storage remaining. This is because those hosts have limited utility, especially given that contract fees are so high. I'm not sure if I calibrated the numbers correctly, the first penalty hits at 200GB (it's not too severe), and then below 50GB you get hit really hard. Below 1GB you are essentially ignored as a host.

I'm re-running the hostdb on my local machine to make sure this doesn't affect prices too dramatically. I'm not actually sure what percentage of hosts have more than 200GB available, but my initial checks suggest it's well above 50%, which is where it needs to be for this change to not be disruptive.