### PR TITLE
invalidate editors/downloaders during renew

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -47,6 +47,7 @@ type Contractor struct {
 	editors         map[types.FileContractID]*hostEditor
 	lastChange      modules.ConsensusChangeID
 	renewHeight     types.BlockHeight             // height at which to renew contracts
+	renewing        map[types.FileContractID]bool // prevent revising during renewal
 	revising        map[types.FileContractID]bool // prevent overlapping revisions
 
 	financialMetrics modules.RenterFinancialMetrics
@@ -137,6 +138,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 		contracts:       make(map[types.FileContractID]modules.RenterContract),
 		downloaders:     make(map[types.FileContractID]*hostDownloader),
 		editors:         make(map[types.FileContractID]*hostEditor),
+		renewing:        make(map[types.FileContractID]bool),
 		revising:        make(map[types.FileContractID]bool),
 	}
 

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -32,21 +32,23 @@ type hostDownloader struct {
 	contractID types.FileContractID
 	contractor *Contractor
 	downloader *proto.Downloader
-	invalid    bool // set by contractor if contract is queued for renewal
+	invalid    bool // true if invalidate has been called
 	mu         sync.Mutex
 }
 
 // invalidate sets the invalid flag and closes the underlying
 // proto.Downloader. Once invalidate returns, the hostDownloader is guaranteed
 // to not further revise its contract. This is used during contract renewal to
-// prevent a Downloader from revising a contract mid-renewal. invalidate does
-// NOT delete the cache entry in the contractor, nor does it unset the
-// 'revising' flag -- these are left to the caller.
+// prevent a Downloader from revising a contract mid-renewal.
 func (hd *hostDownloader) invalidate() {
 	hd.mu.Lock()
-	hd.invalid = true
+	defer hd.mu.Unlock()
 	hd.downloader.Close()
-	hd.mu.Unlock()
+	hd.invalid = true
+	hd.contractor.mu.Lock()
+	delete(hd.contractor.downloaders, hd.contractID)
+	delete(hd.contractor.revising, hd.contractID)
+	hd.contractor.mu.Unlock()
 }
 
 // Sector retrieves the sector with the specified Merkle root, and revises
@@ -58,7 +60,6 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 	if hd.invalid {
 		return nil, errInvalidDownloader
 	}
-
 	oldSpending := hd.downloader.DownloadSpending
 	contract, sector, err := hd.downloader.Sector(root)
 	if err != nil {
@@ -81,9 +82,8 @@ func (hd *hostDownloader) Close() error {
 	hd.mu.Lock()
 	defer hd.mu.Unlock()
 	hd.clients--
-	// if invalid flag has been set, the hostDownloader has already been
-	// closed by invalidate(), so no further action is required. Close is also
-	// a no-op if there are other clients still using the hostDownloader.
+	// Close is a no-op if invalidate has been called, or if there are other
+	// clients still using the hostDownloader.
 	if hd.invalid || hd.clients > 0 {
 		return nil
 	}
@@ -101,7 +101,12 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 	cachedDownloader, haveDownloader := c.downloaders[id]
 	height := c.blockHeight
 	contract, haveContract := c.contracts[id]
+	renewing := c.renewing[id]
 	c.mu.RUnlock()
+
+	if renewing {
+		return nil, errors.New("currently renewing that contract")
+	}
 
 	if haveDownloader {
 		// increment number of clients and return

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -56,7 +56,6 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 			// renew any contracts that have entered the renew window
 			err := c.managedRenewContracts()
 			if err != nil {
-				println(err.Error())
 				c.log.Debugln("WARN: failed to renew contracts after processing a consensus chage:", err)
 			}
 
@@ -64,8 +63,11 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 			c.mu.RLock()
 			a := c.allowance
 			remaining := int(a.Hosts) - len(c.contracts)
-			numSectors, err := maxSectors(a, c.hdb, c.tpool)
 			c.mu.RUnlock()
+			if remaining <= 0 {
+				return
+			}
+			numSectors, err := maxSectors(a, c.hdb, c.tpool)
 			if err != nil {
 				c.log.Debugln("ERROR: couldn't calculate maxSectors after processing a consensus change:", err)
 				return

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -93,14 +93,6 @@ func TestIntegrationAutoRenew(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// set allowance to a lower period; Contractor will auto-renew when
-	// current contract expires
-	a.Period--
-	err = c.SetAllowance(a)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// mine until we enter the renew window
 	renewHeight := contract.EndHeight() - c.allowance.RenewWindow
 	for c.blockHeight < renewHeight {
@@ -125,4 +117,103 @@ func TestIntegrationAutoRenew(t *testing.T) {
 	} else if contract.FileContract.WindowStart != c.blockHeight+c.allowance.Period {
 		t.Fatal("wrong window start:", contract.FileContract.WindowStart)
 	}
+}
+
+// TestIntegrationRenewInvalidate tests that editors and downloaders are
+// properly invalidated when a renew is queued.
+func TestIntegrationRenewInvalidate(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	// create testing trio
+	_, c, m, err := newTestingTrio("TestIntegrationRenewInvalidate")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// form a contract with the host
+	a := modules.Allowance{
+		Funds:       types.SiacoinPrecision.Mul64(100), // 100 SC
+		Hosts:       1,
+		Period:      50,
+		RenewWindow: 10,
+	}
+	err = c.SetAllowance(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract := c.Contracts()[0]
+
+	// revise the contract
+	editor, err := c.Editor(contract.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := crypto.RandBytes(int(modules.SectorSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// insert the sector
+	root, err := editor.Upload(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// mine until we enter the renew window
+	renewHeight := contract.EndHeight() - c.allowance.RenewWindow
+	for c.blockHeight < renewHeight {
+		_, err := m.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// wait for goroutine in ProcessConsensusChange to finish
+	time.Sleep(100 * time.Millisecond)
+	c.editLock.Lock()
+	c.editLock.Unlock()
+
+	// check renewed contract
+	contract = c.Contracts()[0]
+	if contract.FileContract.FileMerkleRoot != root {
+		t.Error("wrong merkle root:", contract.FileContract.FileMerkleRoot)
+	} else if contract.FileContract.FileSize != modules.SectorSize {
+		t.Error("wrong file size:", contract.FileContract.FileSize)
+	} else if contract.FileContract.RevisionNumber != 0 {
+		t.Error("wrong revision number:", contract.FileContract.RevisionNumber)
+	} else if contract.FileContract.WindowStart != c.blockHeight+c.allowance.Period {
+		t.Error("wrong window start:", contract.FileContract.WindowStart)
+	}
+
+	// editor should have been invalidated
+	err = editor.Delete(crypto.Hash{})
+	if err != errInvalidEditor {
+		t.Error("expected invalid editor error; got", err)
+	}
+	editor.Close()
+
+	// create a downloader
+	downloader, err := c.Downloader(contract.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mine until we enter the renew window
+	renewHeight = contract.EndHeight() - c.allowance.RenewWindow
+	for c.blockHeight < renewHeight {
+		_, err := m.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// wait for goroutine in ProcessConsensusChange to finish
+	time.Sleep(100 * time.Millisecond)
+	c.editLock.Lock()
+	c.editLock.Unlock()
+
+	// downloader should have been invalidated
+	_, err = downloader.Sector(crypto.Hash{})
+	if err != errInvalidDownloader {
+		t.Error("expected invalid downloader error; got", err)
+	}
+	downloader.Close()
 }


### PR DESCRIPTION
`managedRenewContracts` will now mark each editor/downloader as invalid, then grab the latest revision of each contract and renew them. During renewal, attempting to create an editor or downloader will return an error. Trying to use an invalid editor/downloader will also result in an error, so the renter will just continually attempt to create editors and fail until the renewal has completed.

I'm not super happy with the locking here; a redesign is probably warranted. Specifically, the interaction between `managedRenewContracts` and `editor.Close` is ugly because `Close` locks the contractor. Ideally, editors/downloaders wouldn't lock the contractor at all, but that requires an alternative method of updating the contract after each revision. We can revisit this later.