### PR TITLE
Expand Host Contracts Visibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,4 +110,4 @@ whitepaper:
 	@pdflatex -output-directory=doc whitepaper.tex > /dev/null
 	pdflatex -output-directory=doc whitepaper.tex
 
-.PHONY: all dependencies fmt install release release-std xc clean test test-v test-long cover cover-integration cover-unit whitepaper
+.PHONY: all dependencies fmt install release release-std clean test test-v test-long cover cover-integration cover-unit whitepaper

--- a/api/api.go
+++ b/api/api.go
@@ -182,6 +182,9 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.POST("/host", RequirePassword(api.hostHandlerPOST, requiredPassword))              // Change the settings of the host.
 		router.POST("/host/announce", RequirePassword(api.hostAnnounceHandler, requiredPassword)) // Announce the host to the network.
 
+		// A call to view all of the contracts.
+		router.GET("/host/xcontracts", RequirePassword(api.hostXcontractsHandler, requiredPassword)) // X - experimental, not supported
+
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/host/storage", api.storageHandler)
 		router.POST("/host/storage/folders/add", RequirePassword(api.storageFoldersAddHandler, requiredPassword))

--- a/api/host.go
+++ b/api/host.go
@@ -37,6 +37,10 @@ type (
 	StorageGET struct {
 		Folders []modules.StorageFolderMetadata `json:"folders"`
 	}
+
+	XcontractsGET struct {
+		Contracts []modules.HostContract `json:"contracts"`
+	}
 )
 
 // folderIndex determines the index of the storage folder with the provided
@@ -122,6 +126,20 @@ func (api *API) hostAnnounceHandler(w http.ResponseWriter, req *http.Request, _ 
 		return
 	}
 	WriteSuccess(w)
+}
+
+// hostXcontractsHandler is an experimental/volatile api endpoint. App
+// developers are strongly discouraged from using it, as it will change and it
+// will break your software.
+func (api *API) hostXcontractsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	contracts, err := api.host.Contracts()
+	if err != nil {
+		WriteError(w, Error{err.Error()}, http.StatusInternalServerError)
+		return
+	}
+	WriteJSON(w, XcontractsGET{
+		Contracts: contracts,
+	})
 }
 
 // storageHandler returns a bunch of information about storage management on

--- a/api/host.go
+++ b/api/host.go
@@ -38,7 +38,7 @@ type (
 		Folders []modules.StorageFolderMetadata `json:"folders"`
 	}
 
-	XcontractsGET struct {
+	HostXcontractsGET struct {
 		Contracts []modules.HostContract `json:"contracts"`
 	}
 )
@@ -137,7 +137,7 @@ func (api *API) hostXcontractsHandler(w http.ResponseWriter, req *http.Request, 
 		WriteError(w, Error{err.Error()}, http.StatusInternalServerError)
 		return
 	}
-	WriteJSON(w, XcontractsGET{
+	WriteJSON(w, HostXcontractsGET{
 		Contracts: contracts,
 	})
 }

--- a/modules/host.go
+++ b/modules/host.go
@@ -18,6 +18,40 @@ var (
 )
 
 type (
+	// HostContract describes an active or historic storage contract that a
+	// host has made with a renter.
+	HostContract struct {
+		// General contract facts.
+		ID                types.FileContractID
+		SectorRootCount   uint64 // May be larger than the number of sectors the host is storing due to virtual sectors.
+		WindowStartHeight types.BlockHeight
+		WindowEndHeight   types.BlockHeight
+
+		// Financial metrics for the contract. Revenue is not realized unless
+		// the contract succeeds. Risked collateral is lost if the contract
+		// fails. Locked collateral has been returned if the status is not
+		// 'Contract Unresolved'.
+		ContractCost        types.Currency
+		LockedCollateral    types.Currency
+		DownloadRevenue     types.Currency
+		RiskedCollateral    types.Currency
+		StorageRevenue      types.Currency
+		TransactionFeesPaid types.Currency
+		UploadRevenue       types.Currency
+
+		// The confirmation progression of the storage contract.
+		FileContractConfirmed         bool
+		FileContractRevisionConfirmed bool
+		StorageProofConfirmed         bool
+
+		// The ultimate status of the file contract. Only one will be set to
+		// true. Equivalent to an enum, but with stronger type safety.
+		ContractUnresolved bool // Usually means it's too early to submit a storage proof.
+		ContractRejected   bool // The host was unable to get the file contract confirmed on the blockchain.
+		ContractSucceeded  bool // The host successfully submitted a storage proof.
+		ContractFailed     bool // The host was unable to complete the file contract, and lost money.
+	}
+
 	// HostFinancialMetrics provides financial statistics for the host,
 	// including money that is locked in contracts. Though verbose, these
 	// statistics should provide a clear picture of where the host's money is
@@ -88,6 +122,10 @@ type (
 
 		// AnnounceAddress submits an announcement using the given address.
 		AnnounceAddress(NetAddress) error
+
+		// Contracts returns a list of contracts in the host along with their
+		// stats.
+		Contracts() ([]HostContract, error)
 
 		// ExternalSettings returns the settings of the host as seen by an
 		// untrusted node querying the host for settings.

--- a/modules/host.go
+++ b/modules/host.go
@@ -22,34 +22,34 @@ type (
 	// host has made with a renter.
 	HostContract struct {
 		// General contract facts.
-		ID                types.FileContractID
-		SectorRootCount   uint64 // May be larger than the number of sectors the host is storing due to virtual sectors.
-		WindowStartHeight types.BlockHeight
-		WindowEndHeight   types.BlockHeight
+		ID                types.FileContractID `json:"id"`
+		SectorRootCount   uint64               `json:"sectorrootcount"` // May be larger than the number of sectors the host is storing due to virtual sectors.
+		WindowStartHeight types.BlockHeight    `json:"windowstartheight"`
+		WindowEndHeight   types.BlockHeight    `json:"windowendheight"`
 
 		// Financial metrics for the contract. Revenue is not realized unless
 		// the contract succeeds. Risked collateral is lost if the contract
 		// fails. Locked collateral has been returned if the status is not
 		// 'Contract Unresolved'.
-		ContractCost        types.Currency
-		LockedCollateral    types.Currency
-		DownloadRevenue     types.Currency
-		RiskedCollateral    types.Currency
-		StorageRevenue      types.Currency
-		TransactionFeesPaid types.Currency
-		UploadRevenue       types.Currency
+		ContractCost        types.Currency `json:"contractcost"`
+		LockedCollateral    types.Currency `json:"lockedcollateral"`
+		DownloadRevenue     types.Currency `json:"downloadrevenue"`
+		RiskedCollateral    types.Currency `json:"riskedcollateral"`
+		StorageRevenue      types.Currency `json:"storagerevenue"`
+		TransactionFeesPaid types.Currency `json:"transactionfeespaid"`
+		UploadRevenue       types.Currency `json:"uploadrevenue"`
 
 		// The confirmation progression of the storage contract.
-		FileContractConfirmed         bool
-		FileContractRevisionConfirmed bool
-		StorageProofConfirmed         bool
+		FileContractConfirmed         bool `json:"filecontractconfirmed"`
+		FileContractRevisionConfirmed bool `json:"filecontractrevisionconfirmed"`
+		StorageProofConfirmed         bool `json:"storageproofconfirmed"`
 
 		// The ultimate status of the file contract. Only one will be set to
 		// true. Equivalent to an enum, but with stronger type safety.
-		ContractUnresolved bool // Usually means it's too early to submit a storage proof.
-		ContractRejected   bool // The host was unable to get the file contract confirmed on the blockchain.
-		ContractSucceeded  bool // The host successfully submitted a storage proof.
-		ContractFailed     bool // The host was unable to complete the file contract, and lost money.
+		ContractUnresolved bool `json:"contractunresolved"` // Usually means it's too early to submit a storage proof.
+		ContractRejected   bool `json:"contractrejected"`   // The host was unable to get the file contract confirmed on the blockchain.
+		ContractSucceeded  bool `json:"contractsucceeded"`  // The host successfully submitted a storage proof.
+		ContractFailed     bool `json:"contractfailed"`     // The host was unable to complete the file contract, and lost money.
 	}
 
 	// HostFinancialMetrics provides financial statistics for the host,

--- a/modules/host.go
+++ b/modules/host.go
@@ -23,7 +23,7 @@ type (
 	HostContract struct {
 		// General contract facts.
 		ID                types.FileContractID `json:"id"`
-		SectorRootCount   uint64               `json:"sectorrootcount"` // May be larger than the number of sectors the host is storing due to virtual sectors.
+		SectorCount       uint64               `json:"sectorcount"` // May be larger than the number of sectors the host is storing due to virtual sectors.
 		WindowStartHeight types.BlockHeight    `json:"windowstartheight"`
 		WindowEndHeight   types.BlockHeight    `json:"windowendheight"`
 

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -339,7 +339,7 @@ func (h *Host) Contracts() ([]modules.HostContract, error) {
 			}
 
 			copy(hc.ID[:], k)
-			hc.SectorRootCount = uint64(len(so.SectorRoots))
+			hc.SectorCount = uint64(len(so.SectorRoots))
 			hc.WindowStartHeight = so.RevisionTransactionSet[len(so.RevisionTransactionSet)-1].FileContractRevisions[0].NewWindowStart
 			hc.WindowEndHeight = so.RevisionTransactionSet[len(so.RevisionTransactionSet)-1].FileContractRevisions[0].NewWindowEnd
 

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"os"
@@ -112,6 +113,13 @@ deleting a sector may impact host revenue.`,
 		Long: `Delete a sector, identified by its Merkle root. Note that deleting a
 sector may impact host revenue.`,
 		Run: wrap(hostsectordeletecmd),
+	}
+
+	hostXcontractsCmd = &cobra.Command{
+		Use: "xcontracts",
+		Short: "Don't use this command in scripts.",
+		Long: "Don't use this command in scripts.",
+		Run: wrap(hostxcontractscmd),
 	}
 )
 
@@ -422,4 +430,22 @@ func hostsectordeletecmd(root string) {
 		die("Could not delete sector:", err)
 	}
 	fmt.Println("Deleted sector", root)
+}
+
+// hostxcontractscmd displays the contracts in the host.
+func hostxcontractscmd(root string) {
+	xcGET := new(api.HostXcontractsGET)
+	err := getAPI("/host/xcontracts", xcGET)
+	if err != nil {
+		die("Could not fetch host contracts:", err)
+	}
+
+	// Print all the stuff?
+	fmt.Println("Experimental: don't use this command in scripts.")
+	fmt.Println()
+
+	for _, contract := range xcGET.Contracts {
+		fmt.Printf("Contract %v:\n", contract.ID)
+		fmt.Println(json.MarshalIndent(contract, "\t", "\t"))
+	}
 }

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -116,10 +116,10 @@ sector may impact host revenue.`,
 	}
 
 	hostXcontractsCmd = &cobra.Command{
-		Use: "xcontracts",
+		Use:   "xcontracts",
 		Short: "Don't use this command in scripts.",
-		Long: "Don't use this command in scripts.",
-		Run: wrap(hostxcontractscmd),
+		Long:  "Don't use this command in scripts.",
+		Run:   wrap(hostxcontractscmd),
 	}
 )
 
@@ -433,7 +433,7 @@ func hostsectordeletecmd(root string) {
 }
 
 // hostxcontractscmd displays the contracts in the host.
-func hostxcontractscmd(root string) {
+func hostxcontractscmd() {
 	xcGET := new(api.HostXcontractsGET)
 	err := getAPI("/host/xcontracts", xcGET)
 	if err != nil {
@@ -446,6 +446,11 @@ func hostxcontractscmd(root string) {
 
 	for _, contract := range xcGET.Contracts {
 		fmt.Printf("Contract %v:\n", contract.ID)
-		fmt.Println(json.MarshalIndent(contract, "\t", "\t"))
+		jsonBytes, err := json.MarshalIndent(contract, "\t", "\t")
+		if err != nil {
+			die("Could not fetch the contracts", err)
+		}
+		fmt.Println("\t" + string(jsonBytes))
+		fmt.Println()
 	}
 }

--- a/siac/main.go
+++ b/siac/main.go
@@ -245,7 +245,7 @@ func main() {
 	updateCmd.AddCommand(updateCheckCmd)
 
 	root.AddCommand(hostCmd)
-	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostFolderCmd, hostSectorCmd)
+	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostFolderCmd, hostSectorCmd, hostXcontractsCmd)
 	hostFolderCmd.AddCommand(hostFolderAddCmd, hostFolderRemoveCmd, hostFolderResizeCmd)
 	hostSectorCmd.AddCommand(hostSectorDeleteCmd)
 	hostCmd.Flags().BoolVarP(&hostVerbose, "verbose", "v", false, "Display detailed host info")


### PR DESCRIPTION
The host module now has a method `Contracts()` which is supported by the API, and by `siac`. It's all experimental, and we're not committing to compatibility for this. We want to get the first commit into the master branch though, I guess I'll open that in a different PR.

With this command you can see all of the contracts that the host has formed and has failed to form, as well as some information like how much potential revenue there is, and how many sectors there are.
