### PR TITLE
host can batch sector add calls during renew

### DIFF
--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -338,16 +338,9 @@ func (h *Host) addStorageObligation(so storageObligation) error {
 		// file contract is being renewed, and that the sector should be
 		// re-added with a new expriation height. If there is an error at any
 		// point, all of the sectors should be removed.
-		for i, root := range so.SectorRoots {
-			err := h.AddSector(root, so.expiration(), nil)
+		if len(so.SectorRoots) != 0 {
+			err := h.AddSectorBatch(so.SectorRoots, so.expiration())
 			if err != nil {
-				// Remove all of the sectors that got added and return an error.
-				for j := 0; j < i; j++ {
-					removeErr := h.RemoveSector(so.SectorRoots[j], so.expiration())
-					if removeErr != nil {
-						h.log.Println(removeErr)
-					}
-				}
 				return err
 			}
 		}

--- a/modules/storagemanager.go
+++ b/modules/storagemanager.go
@@ -45,6 +45,13 @@ type (
 		// is expected to only store the data once.
 		AddSector(sectorRoot crypto.Hash, expiryHeight types.BlockHeight, sectorData []byte) error
 
+		// AddSectorBatch is a performance optimization over AddSector when
+		// adding a bunch of virtual sectors. It is necessary because otherwise
+		// potentially thousands or even tens-of-thousands of fsync calls would
+		// need to be made in serial, which would prevent renters from ever
+		// successfully renewing.
+		AddSectorBatch(sectorRoots []crypto.Hash, expiryHeight types.BlockHeight) error
+
 		// AddStorageFolder adds a storage folder to the manager. The manager
 		// may not check that there is enough space available on-disk to
 		// support as much storage as requested, though the manager should


### PR DESCRIPTION
A severe performance bottleneck previously existed during renew, meaning that
hosts with slower drives would stall out / fail if renewing file contracts
larger than 1 GB. This removes that bottleneck, hosts should now be good for
file contracts up to 100GB.