### PR TITLE
Wallet addrs

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -277,7 +277,7 @@ func (api *API) walletSeedsHandler(w http.ResponseWriter, req *http.Request, _ h
 	}
 
 	// Get the primary seed information.
-	primarySeed, progress, err := api.wallet.PrimarySeed()
+	primarySeed, _, err := api.wallet.PrimarySeed()
 	if err != nil {
 		WriteError(w, Error{"error after call to /wallet/seeds: " + err.Error()}, http.StatusBadRequest)
 		return
@@ -305,7 +305,7 @@ func (api *API) walletSeedsHandler(w http.ResponseWriter, req *http.Request, _ h
 	}
 	WriteJSON(w, WalletSeedsGET{
 		PrimarySeed:        primarySeedStr,
-		AddressesRemaining: int(modules.PublicKeysPerSeed - progress),
+		AddressesRemaining: 1, // deprecated
 		AllSeeds:           allSeedsStrs,
 	})
 }

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -91,8 +91,8 @@ By default the wallet encryption / unlock password is the same as the generated 
 
 	walletSeedsCmd = &cobra.Command{
 		Use:   "seeds",
-		Short: "Retrieve information about your seeds",
-		Long:  "Retrieves the current seed, how many addresses are remaining, and the rest of your seeds from the wallet",
+		Short: "View information about your seeds",
+		Long:  "View your primary and auxiliary wallet seeds.",
 		Run:   wrap(walletseedscmd),
 	}
 
@@ -254,9 +254,9 @@ func walletseedscmd() {
 	if err != nil {
 		die("Error retrieving the current seed:", err)
 	}
-	fmt.Printf("Primary Seed: %s\n"+
-		"Addresses Remaining %d\n"+
-		"All Seeds:\n", seedInfo.PrimarySeed, seedInfo.AddressesRemaining)
+	fmt.Println("Primary Seed:")
+	fmt.Println(seedInfo.PrimarySeed)
+	fmt.Println("Auxilliary Seeds:")
 	for _, seed := range seedInfo.AllSeeds {
 		fmt.Println(seed)
 	}

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -256,8 +256,15 @@ func walletseedscmd() {
 	}
 	fmt.Println("Primary Seed:")
 	fmt.Println(seedInfo.PrimarySeed)
+	if len(seedInfo.AllSeeds) == 1 {
+		// AllSeeds includes the primary seed
+		return
+	}
 	fmt.Println("Auxilliary Seeds:")
 	for _, seed := range seedInfo.AllSeeds {
+		if seed == seedInfo.PrimarySeed {
+			continue
+		}
 		fmt.Println(seed)
 	}
 }


### PR DESCRIPTION
Fixes #1066. `/wallet/seeds` will now always report 1 address remaining. This value should be ignored.

We could alternatively have it return the seed progress in place of `AddressesRemaining`, but this would change the semantics of the field without changing its name, so it's probably a bad idea.