### PR TITLE
Sweep Siafunds

### DIFF
--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -349,7 +349,7 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 		})
 		err = tb.FundSiacoins(estFee)
 		if err != nil {
-			return types.Currency{}, types.Currency{}, err
+			return types.Currency{}, types.Currency{}, errors.New("couldn't pay transaction fee on swept funds: " + err.Error())
 		}
 
 	case !coins.IsZero() && !funds.IsZero():

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -254,14 +254,14 @@ func (w *Wallet) LoadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error 
 // transaction that transfers them to the wallet. Note that this incurs a
 // transaction fee. It returns the total value of the outputs, minus the fee.
 // TODO: support SiafundOutputs too
-func (w *Wallet) SweepSeed(seed modules.Seed) (payout types.Currency, err error) {
+func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err error) {
 	if err = w.tg.Add(); err != nil {
 		return
 	}
 	defer w.tg.Done()
 
 	if !w.cs.Synced() {
-		return types.Currency{}, errors.New("cannot sweep until blockchain is synced")
+		return types.Currency{}, types.Currency{}, errors.New("cannot sweep until blockchain is synced")
 	}
 
 	// get an address to spend into
@@ -288,41 +288,93 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (payout types.Currency, err error)
 	// construct a transaction that spends the outputs
 	// TODO: this may result in transactions that are too large.
 	tb := w.StartTransaction()
-	var swept types.Currency // total value of swept outputs
+	var sweptCoins, sweptFunds types.Currency // total values of swept outputs
 	for _, output := range s.siacoinOutputs {
-		// construct an input for the output
+		// construct a siacoin input that spends the output
 		sk := generateSpendableKey(seed, output.seedIndex)
 		tb.AddSiacoinInput(types.SiacoinInput{
 			ParentID:         types.SiacoinOutputID(output.id),
-			UnlockConditions: sk.UnlockConditions, // TODO: check timelock, etc.
+			UnlockConditions: sk.UnlockConditions,
 		})
 		// add a signature for the input
-		swept = swept.Add(output.value)
+		sweptCoins = sweptCoins.Add(output.value)
+	}
+	for _, output := range s.siafundOutputs {
+		// construct a siafund input that spends the output
+		sk := generateSpendableKey(seed, output.seedIndex)
+		tb.AddSiafundInput(types.SiafundInput{
+			ParentID:         types.SiafundOutputID(output.id),
+			UnlockConditions: sk.UnlockConditions,
+		})
+		// add a signature for the input
+		sweptFunds = sweptFunds.Add(output.value)
 	}
 
-	// estimate the transaction size. NOTE: this equation doesn't account for
-	// other fields in the transaction, but since we are multiplying by
-	// maxFee, lowballing is ok
+	// estimate the transaction size and fee. NOTE: this equation doesn't
+	// account for other fields in the transaction, but since we are
+	// multiplying by maxFee, lowballing is ok
 	estTxnSize := len(s.siacoinOutputs) * outputSize
 	estFee := maxFee.Mul64(uint64(estTxnSize))
-	if estFee.Cmp(swept) >= 0 {
-		return types.Currency{}, errors.New("transaction fee exceeds value of swept outputs")
-	}
 	tb.AddMinerFee(estFee)
 
-	// add the recipient output, equal to the sum of the inputs minus the
-	// transaction fee
-	payout = swept.Sub(estFee)
-	tb.AddSiacoinOutput(types.SiacoinOutput{
-		Value:      payout,
-		UnlockHash: uc.UnlockHash(),
-	})
+	// calculate total siacoin payout
+	if sweptCoins.Cmp(estFee) > 0 {
+		coins = sweptCoins.Sub(estFee)
+	}
+	funds = sweptFunds
 
-	// add signatures (manually, since tb doesn't have access to the signing key)
+	switch {
+	case coins.IsZero() && funds.IsZero():
+		// if we aren't sweeping any coins or funds, then just return an
+		// error; no reason to proceed
+		return types.Currency{}, types.Currency{}, errors.New("transaction fee exceeds value of swept outputs")
+
+	case !coins.IsZero() && funds.IsZero():
+		// if we're sweeping coins but not funds, add a siacoin output for
+		// them
+		tb.AddSiacoinOutput(types.SiacoinOutput{
+			Value:      coins,
+			UnlockHash: uc.UnlockHash(),
+		})
+
+	case coins.IsZero() && !funds.IsZero():
+		// if we're sweeping funds but not coins, add a siafund output for
+		// them. This is tricky because we still need to pay for the
+		// transaction fee, but we can't simply subtract the fee from the
+		// output value like we can with swept coins. Instead, we need to fund
+		// the fee using the existing wallet balance.
+		tb.AddSiafundOutput(types.SiafundOutput{
+			Value:      funds,
+			UnlockHash: uc.UnlockHash(),
+		})
+		err = tb.FundSiacoins(estFee)
+		if err != nil {
+			return types.Currency{}, types.Currency{}, err
+		}
+
+	case !coins.IsZero() && !funds.IsZero():
+		// if we're sweeping both coins and funds, add a siacoin output and a
+		// siafund output
+		tb.AddSiacoinOutput(types.SiacoinOutput{
+			Value:      coins,
+			UnlockHash: uc.UnlockHash(),
+		})
+		tb.AddSiafundOutput(types.SiafundOutput{
+			Value:      funds,
+			UnlockHash: uc.UnlockHash(),
+		})
+	}
+
+	// add signatures for all coins and funds (manually, since tb doesn't have
+	// access to the signing keys)
 	txn, parents := tb.View()
 	for _, output := range s.siacoinOutputs {
 		sk := generateSpendableKey(seed, output.seedIndex)
 		addSignatures(&txn, types.FullCoveredFields, sk.UnlockConditions, crypto.Hash(output.id), sk)
+	}
+	for _, sfo := range s.siafundOutputs {
+		sk := generateSpendableKey(seed, sfo.seedIndex)
+		addSignatures(&txn, types.FullCoveredFields, sk.UnlockConditions, crypto.Hash(sfo.id), sk)
 	}
 
 	// submit the transaction

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -194,14 +194,14 @@ func TestLoadSeed(t *testing.T) {
 	w2.Close()
 }
 
-// TestSweepSeed tests that sweeping a seed results in a transfer of its
-// outputs to the wallet.
-func TestSweepSeed(t *testing.T) {
+// TestSweepSeedCoins tests that sweeping a seed results in the transfer of
+// its siacoin outputs to the wallet.
+func TestSweepSeedCoins(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
 	// create a wallet with some money
-	wt, err := createWalletTester("TestSweepSeed0")
+	wt, err := createWalletTester("TestSweepSeedCoins0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestSweepSeed(t *testing.T) {
 	wt.miner.AddBlock()
 
 	// create a blank wallet
-	dir := filepath.Join(build.TempDir(modules.WalletDir, "TestSweepSeed1"), modules.WalletDir)
+	dir := filepath.Join(build.TempDir(modules.WalletDir, "TestSweepSeedCoins1"), modules.WalletDir)
 	w, err := New(wt.cs, wt.tpool, dir)
 	if err != nil {
 		t.Fatal(err)
@@ -255,6 +255,8 @@ func TestSweepSeed(t *testing.T) {
 	}
 }
 
+// TestSweepSeedFunds tests that sweeping a seed results in the transfer of
+// its siafund outputs to the wallet.
 func TestSweepSeedFunds(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/bolt"
 )
@@ -251,6 +252,108 @@ func TestSweepSeed(t *testing.T) {
 	_, incoming := w.UnconfirmedBalance()
 	if incoming.Cmp(sweptCoins) != 0 {
 		t.Fatalf("wallet should have correct balance after sweeping seed: wanted %v, got %v", sweptCoins, incoming)
+	}
+}
+
+func TestSweepSeedFunds(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	wt, err := createWalletTester("TestSweepSeedFunds")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	// Load the key into the wallet.
+	err = wt.wallet.LoadSiagKeys(wt.walletMasterKey, []string{"../../types/siag0of1of1.siakey"})
+	if err != nil {
+		t.Error(err)
+	}
+	wt.wallet.Close()
+
+	// Create a second wallet that loads the persist structures of the existing
+	// wallet. This wallet should have a siafund balance.
+	//
+	// TODO: when proper seed loading is implemented, this will be unnecessary.
+	w, err := New(wt.cs, wt.tpool, wt.wallet.persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	// reset the changeID
+	resetChangeID(w)
+	err = w.Unlock(wt.walletMasterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, siafundBal, _ := w.ConfirmedBalance()
+	if siafundBal.Cmp(types.NewCurrency64(2000)) != 0 {
+		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
+	}
+
+	// Create a seed and generate an address to send money to.
+	seed := modules.Seed{1, 2, 3}
+	sk := generateSpendableKey(seed, 1)
+
+	// Send some siafunds to the address.
+	_, err = w.SendSiafunds(types.NewCurrency64(12), sk.UnlockConditions.UnlockHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := miner.New(wt.cs, wt.tpool, w, w.persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mine blocks without earning payout until our balance is stable
+	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
+		block, target, err := m.BlockForWork()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range block.MinerPayouts {
+			block.MinerPayouts[i].UnlockHash = types.UnlockHash{}
+		}
+		solvedBlock, _ := m.SolveBlock(block, target)
+		err = wt.cs.AcceptBlock(solvedBlock)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldCoinBalance, siafundBal, _ := w.ConfirmedBalance()
+	if siafundBal.Cmp(types.NewCurrency64(1988)) != 0 {
+		t.Error("expecting balance of 1988 after sending siafunds to the void")
+	}
+
+	// Sweep the seed.
+	coins, funds, err := w.SweepSeed(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !coins.IsZero() {
+		t.Error("expected to sweep 0 coins, got", coins)
+	}
+	if funds.Cmp(types.NewCurrency64(12)) != 0 {
+		t.Errorf("expected to sweep %v funds, got %v", 12, funds)
+	}
+	// add a block without earning its payout
+	block, target, err := m.BlockForWork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range block.MinerPayouts {
+		block.MinerPayouts[i].UnlockHash = types.UnlockHash{}
+	}
+	solvedBlock, _ := m.SolveBlock(block, target)
+	err = wt.cs.AcceptBlock(solvedBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wallet balance should have decreased to pay for the sweep transaction.
+	newCoinBalance, _, _ := w.ConfirmedBalance()
+	if newCoinBalance.Cmp(oldCoinBalance) >= 0 {
+		t.Error("expecting balance to go down; instead, increased by", newCoinBalance.Sub(oldCoinBalance))
 	}
 }
 

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -242,15 +242,15 @@ func TestSweepSeed(t *testing.T) {
 	}
 
 	// sweep the seed of the first wallet into the second
-	swept, err := w.SweepSeed(seed)
+	sweptCoins, _, err := w.SweepSeed(seed)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// new wallet should have exactly 'swept' coins
+	// new wallet should have exactly 'sweptCoins' coins
 	_, incoming := w.UnconfirmedBalance()
-	if incoming.Cmp(swept) != 0 {
-		t.Fatalf("wallet should have correct balance after sweeping seed: wanted %v, got %v", swept, incoming)
+	if incoming.Cmp(sweptCoins) != 0 {
+		t.Fatalf("wallet should have correct balance after sweeping seed: wanted %v, got %v", sweptCoins, incoming)
 	}
 }
 

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -30,6 +30,7 @@ func TestPrimarySeed(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	// Start with a blank wallet tester.
 	wt, err := createBlankWalletTester("TestPrimarySeed")
 	if err != nil {
@@ -101,6 +102,7 @@ func TestLoadSeed(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	wt, err := createWalletTester("TestLoadSeed")
 	if err != nil {
 		t.Fatal(err)
@@ -200,6 +202,7 @@ func TestSweepSeedCoins(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	// create a wallet with some money
 	wt, err := createWalletTester("TestSweepSeedCoins0")
 	if err != nil {
@@ -261,7 +264,98 @@ func TestSweepSeedFunds(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	wt, err := createWalletTester("TestSweepSeedFunds")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	// Load the key into the wallet.
+	err = wt.wallet.LoadSiagKeys(wt.walletMasterKey, []string{"../../types/siag0of1of1.siakey"})
+	if err != nil {
+		t.Error(err)
+	}
+	wt.wallet.Close()
+
+	// Create a second wallet that loads the persist structures of the existing
+	// wallet. This wallet should have a siafund balance.
+	//
+	// TODO: when proper seed loading is implemented, this will be unnecessary.
+	wt.wallet, err = New(wt.cs, wt.tpool, wt.wallet.persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// reset the changeID
+	resetChangeID(wt.wallet)
+	err = wt.wallet.Unlock(wt.walletMasterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	if siafundBal.Cmp(types.NewCurrency64(2000)) != 0 {
+		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
+	}
+	// need to reset the miner as well, since it depends on the wallet
+	wt.miner, err = miner.New(wt.cs, wt.tpool, wt.wallet, wt.wallet.persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a seed and generate an address to send money to.
+	seed := modules.Seed{1, 2, 3}
+	sk := generateSpendableKey(seed, 1)
+
+	// Send some siafunds to the address.
+	_, err = wt.wallet.SendSiafunds(types.NewCurrency64(12), sk.UnlockConditions.UnlockHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Send some siacoins to the address, but not enough to cover the
+	// transaction fee.
+	_, err = wt.wallet.SendSiacoins(types.NewCurrency64(1), sk.UnlockConditions.UnlockHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mine blocks without earning payout until our balance is stable
+	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
+		wt.addBlockNoPayout()
+	}
+	oldCoinBalance, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	if siafundBal.Cmp(types.NewCurrency64(1988)) != 0 {
+		t.Errorf("expecting balance of %v after sending siafunds to the seed, got %v", 1988, siafundBal)
+	}
+
+	// Sweep the seed.
+	coins, funds, err := wt.wallet.SweepSeed(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !coins.IsZero() {
+		t.Error("expected to sweep 0 coins, got", coins)
+	}
+	if funds.Cmp(types.NewCurrency64(12)) != 0 {
+		t.Errorf("expected to sweep %v funds, got %v", 12, funds)
+	}
+	// add a block without earning its payout
+	wt.addBlockNoPayout()
+
+	// Wallet balance should have decreased to pay for the sweep transaction.
+	newCoinBalance, _, _ := wt.wallet.ConfirmedBalance()
+	if newCoinBalance.Cmp(oldCoinBalance) >= 0 {
+		t.Error("expecting balance to go down; instead, increased by", newCoinBalance.Sub(oldCoinBalance))
+	}
+}
+
+// TestSweepSeedSentFunds tests that sweeping a seed results in the transfer
+// of its siafund outputs to the wallet, even after the funds have been
+// transferred a few times.
+func TestSweepSeedSentFunds(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	wt, err := createWalletTester("TestSweepSeedSentFunds")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,12 +420,6 @@ func TestSweepSeedFunds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Send some siacoins to the address, but not enough to cover the
-	// transaction fee.
-	_, err = wt.wallet.SendSiacoins(types.NewCurrency64(1), sk.UnlockConditions.UnlockHash())
-	if err != nil {
-		t.Fatal(err)
-	}
 	// mine blocks without earning payout until our balance is stable
 	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
 		wt.addBlockNoPayout()
@@ -368,6 +456,7 @@ func TestSweepSeedCoinsAndFunds(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	wt, err := createWalletTester("TestSweepSeedCoinsAndFunds")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -317,12 +317,18 @@ func TestSweepSeedFunds(t *testing.T) {
 	}
 	wt.addBlockNoPayout()
 
-	// Create a seed and generate an address to send funds to.
+	// Create a seed and generate an address to send money to.
 	seed := modules.Seed{1, 2, 3}
 	sk := generateSpendableKey(seed, 1)
 
 	// Send some siafunds to the address.
 	_, err = wt.wallet.SendSiafunds(types.NewCurrency64(12), sk.UnlockConditions.UnlockHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Send some siacoins to the address, but not enough to cover the
+	// transaction fee.
+	_, err = wt.wallet.SendSiacoins(types.NewCurrency64(1), sk.UnlockConditions.UnlockHash())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,6 +359,94 @@ func TestSweepSeedFunds(t *testing.T) {
 	newCoinBalance, _, _ := wt.wallet.ConfirmedBalance()
 	if newCoinBalance.Cmp(oldCoinBalance) >= 0 {
 		t.Error("expecting balance to go down; instead, increased by", newCoinBalance.Sub(oldCoinBalance))
+	}
+}
+
+// TestSweepSeedCoinsAndFunds tests that sweeping a seed results in the
+// transfer of its siacoin and siafund outputs to the wallet.
+func TestSweepSeedCoinsAndFunds(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	wt, err := createWalletTester("TestSweepSeedCoinsAndFunds")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	// Load the key into the wallet.
+	err = wt.wallet.LoadSiagKeys(wt.walletMasterKey, []string{"../../types/siag0of1of1.siakey"})
+	if err != nil {
+		t.Error(err)
+	}
+	wt.wallet.Close()
+
+	// Create a second wallet that loads the persist structures of the existing
+	// wallet. This wallet should have a siafund balance.
+	//
+	// TODO: when proper seed loading is implemented, this will be unnecessary.
+	wt.wallet, err = New(wt.cs, wt.tpool, wt.wallet.persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// reset the changeID
+	resetChangeID(wt.wallet)
+	err = wt.wallet.Unlock(wt.walletMasterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	if siafundBal.Cmp(types.NewCurrency64(2000)) != 0 {
+		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
+	}
+	// need to reset the miner as well, since it depends on the wallet
+	wt.miner, err = miner.New(wt.cs, wt.tpool, wt.wallet, wt.wallet.persistDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a seed and generate an address to send money to.
+	seed := modules.Seed{1, 2, 3}
+	sk := generateSpendableKey(seed, 1)
+
+	// Send some siafunds to the address.
+	_, err = wt.wallet.SendSiafunds(types.NewCurrency64(12), sk.UnlockConditions.UnlockHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Send some siacoins to the address -- must be more than the transaction
+	// fee.
+	_, err = wt.wallet.SendSiacoins(types.SiacoinPrecision.Mul64(1000), sk.UnlockConditions.UnlockHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// mine blocks without earning payout until our balance is stable
+	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
+		wt.addBlockNoPayout()
+	}
+	oldCoinBalance, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	if siafundBal.Cmp(types.NewCurrency64(1988)) != 0 {
+		t.Errorf("expecting balance of %v after sending siafunds to the seed, got %v", 1988, siafundBal)
+	}
+
+	// Sweep the seed.
+	coins, funds, err := wt.wallet.SweepSeed(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if coins.IsZero() {
+		t.Error("expected to sweep coins, got 0")
+	}
+	if funds.Cmp(types.NewCurrency64(12)) != 0 {
+		t.Errorf("expected to sweep %v funds, got %v", 12, funds)
+	}
+	// add a block without earning its payout
+	wt.addBlockNoPayout()
+
+	// Wallet balance should have decreased to pay for the sweep transaction.
+	newCoinBalance, _, _ := wt.wallet.ConfirmedBalance()
+	if newCoinBalance.Cmp(oldCoinBalance) <= 0 {
+		t.Error("expecting balance to go up; instead, decreased by", oldCoinBalance.Sub(newCoinBalance))
 	}
 }
 


### PR DESCRIPTION
Previously `SweepSeed` did not support sweeping siafunds. This PR adds support for sweeping both coins and funds.

When sweeping coins, it is assumed that the user will want to abort the sweep if the value of the coins is less than the cost of the transaction fees. But when sweeping funds, it is assumed the user will never want to abort the sweep for this reason, since funds are much more valuable than coins.

A related complication arises if only funds are found in the scan. When sweeping coins, we can subtract the transaction fee from the total value swept. This is convenient because it means we don't need to touch the existing wallet outputs at all; you can sweep coins even if your balance is zero.
However, this is not the case if only funds are found (or if the value of coins found is less than the transaction fee). In this case, we must use the existing wallet outputs to pay for the transaction fee. To make this easier, I first refactored `SweepSeed` to use a transaction builder before adding siafund support.