### PR TITLE
Add Cmp64, Equals, and Equals64

### DIFF
--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -174,10 +174,10 @@ func TestIntegrationWalletGETSiacoins(t *testing.T) {
 	if wg.ConfirmedSiacoinBalance.Cmp(types.CalculateCoinbase(1)) != 0 {
 		t.Error("reported wallet balance does not reflect the single block that has been mined")
 	}
-	if wg.UnconfirmedOutgoingSiacoins.Cmp(types.NewCurrency64(0)) != 0 {
+	if wg.UnconfirmedOutgoingSiacoins.Cmp64(0) != 0 {
 		t.Error("there should not be unconfirmed outgoing siacoins")
 	}
-	if wg.UnconfirmedIncomingSiacoins.Cmp(types.NewCurrency64(0)) != 0 {
+	if wg.UnconfirmedIncomingSiacoins.Cmp64(0) != 0 {
 		t.Error("there should not be unconfirmed incoming siacoins")
 	}
 
@@ -209,10 +209,10 @@ func TestIntegrationWalletGETSiacoins(t *testing.T) {
 	if wg.ConfirmedSiacoinBalance.Cmp(types.CalculateCoinbase(1)) != 0 {
 		t.Error("reported wallet balance does not reflect the single block that has been mined")
 	}
-	if wg.UnconfirmedOutgoingSiacoins.Cmp(types.NewCurrency64(0)) <= 0 {
+	if wg.UnconfirmedOutgoingSiacoins.Cmp64(0) <= 0 {
 		t.Error("there should be unconfirmed outgoing siacoins")
 	}
-	if wg.UnconfirmedIncomingSiacoins.Cmp(types.NewCurrency64(0)) <= 0 {
+	if wg.UnconfirmedIncomingSiacoins.Cmp64(0) <= 0 {
 		t.Error("there should be unconfirmed incoming siacoins")
 	}
 	if wg.UnconfirmedOutgoingSiacoins.Cmp(wg.UnconfirmedIncomingSiacoins) <= 0 {
@@ -232,10 +232,10 @@ func TestIntegrationWalletGETSiacoins(t *testing.T) {
 	if wg.ConfirmedSiacoinBalance.Cmp(types.CalculateCoinbase(1).Add(types.CalculateCoinbase(2))) >= 0 {
 		t.Error("reported wallet balance does not reflect mining two blocks and eating a miner fee")
 	}
-	if wg.UnconfirmedOutgoingSiacoins.Cmp(types.NewCurrency64(0)) != 0 {
+	if wg.UnconfirmedOutgoingSiacoins.Cmp64(0) != 0 {
 		t.Error("there should not be unconfirmed outgoing siacoins")
 	}
-	if wg.UnconfirmedIncomingSiacoins.Cmp(types.NewCurrency64(0)) != 0 {
+	if wg.UnconfirmedIncomingSiacoins.Cmp64(0) != 0 {
 		t.Error("there should not be unconfirmed incoming siacoins")
 	}
 }

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -905,7 +905,7 @@ func TestTaxHardfork(t *testing.T) {
 
 	// Check that the siafund pool was increased by the faulty float amount.
 	siafundPool := cst.cs.dbGetSiafundPool()
-	if siafundPool.Cmp(types.NewCurrency64(15590e3)) != 0 {
+	if siafundPool.Cmp64(15590e3) != 0 {
 		t.Fatal("siafund pool was not increased correctly")
 	}
 
@@ -957,7 +957,7 @@ func TestTaxHardfork(t *testing.T) {
 
 	// Check that the siafund pool did not change after the submitted revision.
 	siafundPool = cst.cs.dbGetSiafundPool()
-	if siafundPool.Cmp(types.NewCurrency64(15590e3)) != 0 {
+	if siafundPool.Cmp64(15590e3) != 0 {
 		t.Fatal("siafund pool was not increased correctly")
 	}
 }

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -905,7 +905,7 @@ func TestTaxHardfork(t *testing.T) {
 
 	// Check that the siafund pool was increased by the faulty float amount.
 	siafundPool := cst.cs.dbGetSiafundPool()
-	if siafundPool.Cmp64(15590e3) != 0 {
+	if !siafundPool.Equals64(15590e3) {
 		t.Fatal("siafund pool was not increased correctly")
 	}
 
@@ -957,7 +957,7 @@ func TestTaxHardfork(t *testing.T) {
 
 	// Check that the siafund pool did not change after the submitted revision.
 	siafundPool = cst.cs.dbGetSiafundPool()
-	if siafundPool.Cmp64(15590e3) != 0 {
+	if !siafundPool.Equals64(15590e3) {
 		t.Fatal("siafund pool was not increased correctly")
 	}
 }

--- a/modules/consensus/accept_txntypes_test.go
+++ b/modules/consensus/accept_txntypes_test.go
@@ -133,7 +133,7 @@ func (cst *consensusSetTester) testSpendSiacoinsBlock() {
 	if err != nil {
 		panic(err)
 	}
-	if sco.Value.Cmp(txnValue) != 0 {
+	if !sco.Value.Equals(txnValue) {
 		panic("output added with wrong value")
 	}
 	if sco.UnlockHash != destAddr {
@@ -220,7 +220,7 @@ func (cst *consensusSetTester) testValidStorageProofBlocks() {
 
 	// Check that the siafund pool was increased by the tax on the payout.
 	siafundPool := cst.cs.dbGetSiafundPool()
-	if siafundPool.Cmp(oldSiafundPool.Add(types.Tax(cst.cs.dbBlockHeight()-1, payout))) != 0 {
+	if !siafundPool.Equals(oldSiafundPool.Add(types.Tax(cst.cs.dbBlockHeight()-1, payout))) {
 		panic("siafund pool was not increased correctly")
 	}
 
@@ -266,7 +266,7 @@ func (cst *consensusSetTester) testValidStorageProofBlocks() {
 
 	// Check that the siafund pool has not changed.
 	postProofPool := cst.cs.dbGetSiafundPool()
-	if postProofPool.Cmp(siafundPool) != 0 {
+	if !postProofPool.Equals(siafundPool) {
 		panic("siafund pool should not change after submitting a storage proof")
 	}
 
@@ -279,7 +279,7 @@ func (cst *consensusSetTester) testValidStorageProofBlocks() {
 	if dsco.UnlockHash != fc.ValidProofOutputs[0].UnlockHash {
 		panic("wrong unlock hash in dsco")
 	}
-	if dsco.Value.Cmp(fc.ValidProofOutputs[0].Value) != 0 {
+	if !dsco.Value.Equals(fc.ValidProofOutputs[0].Value) {
 		panic("wrong sco value in dsco")
 	}
 }
@@ -345,7 +345,7 @@ func (cst *consensusSetTester) testMissedStorageProofBlocks() {
 
 	// Check that the siafund pool was increased by the tax on the payout.
 	siafundPool := cst.cs.dbGetSiafundPool()
-	if siafundPool.Cmp(oldSiafundPool.Add(types.Tax(cst.cs.dbBlockHeight()-1, payout))) != 0 {
+	if !siafundPool.Equals(oldSiafundPool.Add(types.Tax(cst.cs.dbBlockHeight()-1, payout))) {
 		panic("siafund pool was not increased correctly")
 	}
 
@@ -371,7 +371,7 @@ func (cst *consensusSetTester) testMissedStorageProofBlocks() {
 
 	// Check that the siafund pool has not changed.
 	postProofPool := cst.cs.dbGetSiafundPool()
-	if postProofPool.Cmp(siafundPool) != 0 {
+	if !postProofPool.Equals(siafundPool) {
 		panic("siafund pool should not change after submitting a storage proof")
 	}
 
@@ -384,7 +384,7 @@ func (cst *consensusSetTester) testMissedStorageProofBlocks() {
 	if dsco.UnlockHash != fc.MissedProofOutputs[0].UnlockHash {
 		panic("wrong unlock hash in dsco")
 	}
-	if dsco.Value.Cmp(fc.MissedProofOutputs[0].Value) != 0 {
+	if !dsco.Value.Equals(fc.MissedProofOutputs[0].Value) {
 		panic("wrong sco value in dsco")
 	}
 }
@@ -622,13 +622,13 @@ func (cst *consensusSetTester) testSpendSiafunds() {
 	if err != nil {
 		panic(err)
 	}
-	if sfo.Value.Cmp(txnValue) != 0 {
+	if !sfo.Value.Equals(txnValue) {
 		panic("output added with wrong value")
 	}
 	if sfo.UnlockHash != destAddr {
 		panic("output sent to the wrong address")
 	}
-	if sfo.ClaimStart.Cmp(cst.cs.dbGetSiafundPool()) != 0 {
+	if !sfo.ClaimStart.Equals(cst.cs.dbGetSiafundPool()) {
 		panic("ClaimStart is not being set correctly")
 	}
 
@@ -639,7 +639,7 @@ func (cst *consensusSetTester) testSpendSiafunds() {
 		if err != nil {
 			panic(err)
 		}
-		if dsco.Value.Cmp(claimValues[i]) != 0 {
+		if !dsco.Value.Equals(claimValues[i]) {
 			panic("expected a different claim value on the siaclaim")
 		}
 	}

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -275,7 +275,7 @@ func TestApplyFileContracts(t *testing.T) {
 	if len(pb.FileContractDiffs) != 3 {
 		t.Error("block node was not updated correctly")
 	}
-	if cst.cs.siafundPool.Cmp(types.NewCurrency64(10e3)) != 0 {
+	if cst.cs.siafundPool.Cmp64(10e3) != 0 {
 		t.Error("siafund pool did not update correctly upon creation of a file contract")
 	}
 }
@@ -510,7 +510,7 @@ func TestApplyStorageProofs(t *testing.T) {
 		t.Error("storage proof output not created after applying a storage proof")
 	}
 	sco := cst.cs.db.getDelayedSiacoinOutputs(pb.Height+types.MaturityDelay, spoid0)
-	if sco.Value.Cmp(types.NewCurrency64(290e3)) != 0 {
+	if sco.Value.Cmp64(290e3) != 0 {
 		t.Error("storage proof output was created with the wrong value")
 	}
 
@@ -547,7 +547,7 @@ func TestApplyStorageProofs(t *testing.T) {
 		t.Error("no output created by first output of file contract")
 	}
 	sco = cst.cs.db.getDelayedSiacoinOutputs(pb.Height+types.MaturityDelay, spoid2)
-	if sco.Value.Cmp(types.NewCurrency64(280e3)) != 0 {
+	if sco.Value.Cmp64(280e3) != 0 {
 		t.Error("first siacoin output created has wrong value")
 	}
 	spoid3 := fcid2.StorageProofOutputID(types.ProofValid, 1)
@@ -556,10 +556,10 @@ func TestApplyStorageProofs(t *testing.T) {
 		t.Error("second output not created for storage proof")
 	}
 	sco = cst.cs.db.getDelayedSiacoinOutputs(pb.Height+types.MaturityDelay, spoid3)
-	if sco.Value.Cmp(types.NewCurrency64(300e3)) != 0 {
+	if sco.Value.Cmp64(300e3) != 0 {
 		t.Error("second siacoin output has wrong value")
 	}
-	if cst.cs.siafundPool.Cmp(types.NewCurrency64(30e3)) != 0 {
+	if cst.cs.siafundPool.Cmp64(30e3) != 0 {
 		t.Error("siafund pool not being added up correctly")
 	}
 }
@@ -770,7 +770,7 @@ func TestApplySiafundOutputs(t *testing.T) {
 	if pb.SiafundOutputDiffs[0].ID != sfoid {
 		t.Error("wrong id used when creating a siafund output")
 	}
-	if pb.SiafundOutputDiffs[0].SiafundOutput.ClaimStart.Cmp(types.NewCurrency64(101)) != 0 {
+	if pb.SiafundOutputDiffs[0].SiafundOutput.ClaimStart.Cmp64(101) != 0 {
 		t.Error("claim start set incorrectly when creating a siafund output")
 	}
 

--- a/modules/consensus/block_validation.go
+++ b/modules/consensus/block_validation.go
@@ -52,7 +52,7 @@ func checkMinerPayouts(b types.Block, height types.BlockHeight) bool {
 		}
 		payoutSum = payoutSum.Add(payout.Value)
 	}
-	return b.CalculateSubsidy(height).Cmp(payoutSum) == 0
+	return b.CalculateSubsidy(height).Equals(payoutSum)
 }
 
 // checkTarget returns true if the block's ID meets the given target.

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -74,7 +74,7 @@ func (cst *consensusSetTester) addSiafunds() {
 
 	// Check that the siafunds made it to the wallet.
 	_, siafundBalance, _ := cst.wallet.ConfirmedBalance()
-	if siafundBalance.Cmp64(1e3) != 0 {
+	if !siafundBalance.Equals64(1e3) {
 		panic("wallet does not have the siafunds")
 	}
 }

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -74,7 +74,7 @@ func (cst *consensusSetTester) addSiafunds() {
 
 	// Check that the siafunds made it to the wallet.
 	_, siafundBalance, _ := cst.wallet.ConfirmedBalance()
-	if siafundBalance.Cmp(types.NewCurrency64(1e3)) != 0 {
+	if siafundBalance.Cmp64(1e3) != 0 {
 		panic("wallet does not have the siafunds")
 	}
 }

--- a/modules/consensus/consistency.go
+++ b/modules/consensus/consistency.go
@@ -160,7 +160,7 @@ func checkSiacoinCount(tx *bolt.Tx) {
 
 	expectedSiacoins := types.CalculateNumSiacoins(blockHeight(tx))
 	totalSiacoins := dscoSiacoins.Add(scoSiacoins).Add(fcSiacoins).Add(claimSiacoins)
-	if totalSiacoins.Cmp(expectedSiacoins) != 0 {
+	if !totalSiacoins.Equals(expectedSiacoins) {
 		diagnostics := fmt.Sprintf("Wrong number of siacoins\nDsco: %v\nSco: %v\nFc: %v\nClaim: %v\n", dscoSiacoins, scoSiacoins, fcSiacoins, claimSiacoins)
 		if totalSiacoins.Cmp(expectedSiacoins) < 0 {
 			diagnostics += fmt.Sprintf("total: %v\nexpected: %v\n expected is bigger: %v", totalSiacoins, expectedSiacoins, expectedSiacoins.Sub(totalSiacoins))
@@ -187,7 +187,7 @@ func checkSiafundCount(tx *bolt.Tx) {
 	if err != nil {
 		manageErr(tx, err)
 	}
-	if total.Cmp(types.SiafundCount) != 0 {
+	if !total.Equals(types.SiafundCount) {
 		manageErr(tx, errors.New("wrong number if siafunds in the consensus set"))
 	}
 }

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -102,13 +102,13 @@ func commitSiafundPoolDiff(tx *bolt.Tx, sfpd modules.SiafundPoolDiff, dir module
 
 	if dir == modules.DiffApply {
 		// Sanity check - sfpd.Previous should equal the current siafund pool.
-		if build.DEBUG && getSiafundPool(tx).Cmp(sfpd.Previous) != 0 {
+		if build.DEBUG && !getSiafundPool(tx).Equals(sfpd.Previous) {
 			panic(errApplySiafundPoolDiffMismatch)
 		}
 		setSiafundPool(tx, sfpd.Adjusted)
 	} else {
 		// Sanity check - sfpd.Adjusted should equal the current siafund pool.
-		if build.DEBUG && getSiafundPool(tx).Cmp(sfpd.Adjusted) != 0 {
+		if build.DEBUG && !getSiafundPool(tx).Equals(sfpd.Adjusted) {
 			panic(errRevertSiafundPoolDiffMismatch)
 		}
 		setSiafundPool(tx, sfpd.Previous)

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -42,7 +42,7 @@ func TestApplyMinerPayouts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dsco.Value.Cmp(types.NewCurrency64(12)) != 0 {
+	if dsco.Value.Cmp64(12) != 0 {
 		t.Error("miner payout created with wrong currency value")
 	}
 	exists = cst.cs.db.inSiacoinOutputs(mpid0)

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -51,7 +51,7 @@ func validSiacoins(tx *bolt.Tx, t types.Transaction) error {
 
 		inputSum = inputSum.Add(sco.Value)
 	}
-	if inputSum.Cmp(t.SiacoinOutputSum()) != 0 {
+	if !inputSum.Equals(t.SiacoinOutputSum()) {
 		return errSiacoinInputOutputMismatch
 	}
 	return nil
@@ -244,10 +244,10 @@ func validFileContractRevisions(tx *bolt.Tx, t types.Transaction) error {
 		for _, output := range fc.ValidProofOutputs {
 			oldPayout = oldPayout.Add(output.Value)
 		}
-		if validPayout.Cmp(oldPayout) != 0 {
+		if !validPayout.Equals(oldPayout) {
 			return errAlteredRevisionPayouts
 		}
-		if missedPayout.Cmp(oldPayout) != 0 {
+		if !missedPayout.Equals(oldPayout) {
 			return errAlteredRevisionPayouts
 		}
 	}
@@ -276,7 +276,7 @@ func validSiafunds(tx *bolt.Tx, t types.Transaction) (err error) {
 	for _, sfo := range t.SiafundOutputs {
 		siafundOutputSum = siafundOutputSum.Add(sfo.Value)
 	}
-	if siafundOutputSum.Cmp(siafundInputSum) != 0 {
+	if !siafundOutputSum.Equals(siafundInputSum) {
 		return errSiafundInputOutputMismatch
 	}
 	return

--- a/modules/explorer/info_test.go
+++ b/modules/explorer/info_test.go
@@ -26,7 +26,7 @@ func TestImmediateBlockFacts(t *testing.T) {
 	if facts.Height != explorerHeight || explorerHeight == 0 {
 		t.Error("wrong height reported in facts object")
 	}
-	if facts.TotalCoins.Cmp(types.CalculateNumSiacoins(et.cs.Height())) != 0 {
+	if !facts.TotalCoins.Equals(types.CalculateNumSiacoins(et.cs.Height())) {
 		t.Error("wrong number of total coins:", facts.TotalCoins, et.cs.Height())
 	}
 }

--- a/modules/explorer/update_test.go
+++ b/modules/explorer/update_test.go
@@ -81,22 +81,22 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 	if !ok {
 		t.Fatal("couldn't get current facts")
 	}
-	if facts.ActiveContractCost.Cmp64(5e9) != 0 {
+	if !facts.ActiveContractCost.Equals64(5e9) {
 		t.Error("active resources providing wrong file contract cost")
 	}
 	if facts.ActiveContractCount != 1 {
 		t.Error("active contract count does not read correctly")
 	}
-	if facts.ActiveContractSize.Cmp64(5e3) != 0 {
+	if !facts.ActiveContractSize.Equals64(5e3) {
 		t.Error("active contract size is not correctly reported")
 	}
-	if facts.TotalContractCost.Cmp64(5e9) != 0 {
+	if !facts.TotalContractCost.Equals64(5e9) {
 		t.Error("total cost is not tallied correctly")
 	}
 	if facts.FileContractCount != 1 {
 		t.Error("total contract count is not accurate")
 	}
-	if facts.TotalContractSize.Cmp64(5e3) != 0 {
+	if !facts.TotalContractSize.Equals64(5e3) {
 		t.Error("total contract size is not accurate")
 	}
 
@@ -132,22 +132,22 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 	if !ok {
 		t.Fatal("couldn't get current facts")
 	}
-	if facts.ActiveContractCost.Cmp64(6e9) != 0 {
+	if !facts.ActiveContractCost.Equals64(6e9) {
 		t.Error("active resources providing wrong file contract cost")
 	}
 	if facts.ActiveContractCount != 2 {
 		t.Error("active contract count does not read correctly")
 	}
-	if facts.ActiveContractSize.Cmp64(20e3) != 0 {
+	if !facts.ActiveContractSize.Equals64(20e3) {
 		t.Error("active contract size is not correctly reported")
 	}
-	if facts.TotalContractCost.Cmp64(6e9) != 0 {
+	if !facts.TotalContractCost.Equals64(6e9) {
 		t.Error("total cost is not tallied correctly")
 	}
 	if facts.FileContractCount != 2 {
 		t.Error("total contract count is not accurate")
 	}
-	if facts.TotalContractSize.Cmp64(20e3) != 0 {
+	if !facts.TotalContractSize.Equals64(20e3) {
 		t.Error("total contract size is not accurate")
 	}
 
@@ -162,22 +162,22 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 	if !ok {
 		t.Fatal("couldn't get current facts")
 	}
-	if facts.ActiveContractCost.Cmp64(1e9) != 0 {
+	if !facts.ActiveContractCost.Equals64(1e9) {
 		t.Error("active resources providing wrong file contract cost", facts.ActiveContractCost)
 	}
 	if facts.ActiveContractCount != 1 {
 		t.Error("active contract count does not read correctly")
 	}
-	if facts.ActiveContractSize.Cmp64(15e3) != 0 {
+	if !facts.ActiveContractSize.Equals64(15e3) {
 		t.Error("active contract size is not correctly reported")
 	}
-	if facts.TotalContractCost.Cmp64(6e9) != 0 {
+	if !facts.TotalContractCost.Equals64(6e9) {
 		t.Error("total cost is not tallied correctly")
 	}
 	if facts.FileContractCount != 2 {
 		t.Error("total contract count is not accurate")
 	}
-	if facts.TotalContractSize.Cmp64(20e3) != 0 {
+	if !facts.TotalContractSize.Equals64(20e3) {
 		t.Error("total contract size is not accurate")
 	}
 

--- a/modules/explorer/update_test.go
+++ b/modules/explorer/update_test.go
@@ -81,22 +81,22 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 	if !ok {
 		t.Fatal("couldn't get current facts")
 	}
-	if facts.ActiveContractCost.Cmp(types.NewCurrency64(5e9)) != 0 {
+	if facts.ActiveContractCost.Cmp64(5e9) != 0 {
 		t.Error("active resources providing wrong file contract cost")
 	}
 	if facts.ActiveContractCount != 1 {
 		t.Error("active contract count does not read correctly")
 	}
-	if facts.ActiveContractSize.Cmp(types.NewCurrency64(5e3)) != 0 {
+	if facts.ActiveContractSize.Cmp64(5e3) != 0 {
 		t.Error("active contract size is not correctly reported")
 	}
-	if facts.TotalContractCost.Cmp(types.NewCurrency64(5e9)) != 0 {
+	if facts.TotalContractCost.Cmp64(5e9) != 0 {
 		t.Error("total cost is not tallied correctly")
 	}
 	if facts.FileContractCount != 1 {
 		t.Error("total contract count is not accurate")
 	}
-	if facts.TotalContractSize.Cmp(types.NewCurrency64(5e3)) != 0 {
+	if facts.TotalContractSize.Cmp64(5e3) != 0 {
 		t.Error("total contract size is not accurate")
 	}
 
@@ -132,22 +132,22 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 	if !ok {
 		t.Fatal("couldn't get current facts")
 	}
-	if facts.ActiveContractCost.Cmp(types.NewCurrency64(6e9)) != 0 {
+	if facts.ActiveContractCost.Cmp64(6e9) != 0 {
 		t.Error("active resources providing wrong file contract cost")
 	}
 	if facts.ActiveContractCount != 2 {
 		t.Error("active contract count does not read correctly")
 	}
-	if facts.ActiveContractSize.Cmp(types.NewCurrency64(20e3)) != 0 {
+	if facts.ActiveContractSize.Cmp64(20e3) != 0 {
 		t.Error("active contract size is not correctly reported")
 	}
-	if facts.TotalContractCost.Cmp(types.NewCurrency64(6e9)) != 0 {
+	if facts.TotalContractCost.Cmp64(6e9) != 0 {
 		t.Error("total cost is not tallied correctly")
 	}
 	if facts.FileContractCount != 2 {
 		t.Error("total contract count is not accurate")
 	}
-	if facts.TotalContractSize.Cmp(types.NewCurrency64(20e3)) != 0 {
+	if facts.TotalContractSize.Cmp64(20e3) != 0 {
 		t.Error("total contract size is not accurate")
 	}
 
@@ -162,22 +162,22 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 	if !ok {
 		t.Fatal("couldn't get current facts")
 	}
-	if facts.ActiveContractCost.Cmp(types.NewCurrency64(1e9)) != 0 {
+	if facts.ActiveContractCost.Cmp64(1e9) != 0 {
 		t.Error("active resources providing wrong file contract cost", facts.ActiveContractCost)
 	}
 	if facts.ActiveContractCount != 1 {
 		t.Error("active contract count does not read correctly")
 	}
-	if facts.ActiveContractSize.Cmp(types.NewCurrency64(15e3)) != 0 {
+	if facts.ActiveContractSize.Cmp64(15e3) != 0 {
 		t.Error("active contract size is not correctly reported")
 	}
-	if facts.TotalContractCost.Cmp(types.NewCurrency64(6e9)) != 0 {
+	if facts.TotalContractCost.Cmp64(6e9) != 0 {
 		t.Error("total cost is not tallied correctly")
 	}
 	if facts.FileContractCount != 2 {
 		t.Error("total contract count is not accurate")
 	}
-	if facts.TotalContractSize.Cmp(types.NewCurrency64(20e3)) != 0 {
+	if facts.TotalContractSize.Cmp64(20e3) != 0 {
 		t.Error("total contract size is not accurate")
 	}
 

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -355,25 +355,25 @@ func TestSetAndGetInternalSettings(t *testing.T) {
 	if settings.WindowSize != defaultWindowSize {
 		t.Error("settings retrieval did not return default value")
 	}
-	if settings.Collateral.Cmp(defaultCollateral) != 0 {
+	if !settings.Collateral.Equals(defaultCollateral) {
 		t.Error("settings retrieval did not return default value")
 	}
-	if settings.CollateralBudget.Cmp(defaultCollateralBudget) != 0 {
+	if !settings.CollateralBudget.Equals(defaultCollateralBudget) {
 		t.Error("settings retrieval did not return default value")
 	}
-	if settings.MaxCollateral.Cmp(defaultMaxCollateral) != 0 {
+	if !settings.MaxCollateral.Equals(defaultMaxCollateral) {
 		t.Error("settings retrieval did not return default value")
 	}
-	if settings.MinContractPrice.Cmp(defaultContractPrice) != 0 {
+	if !settings.MinContractPrice.Equals(defaultContractPrice) {
 		t.Error("settings retrieval did not return default value")
 	}
-	if settings.MinDownloadBandwidthPrice.Cmp(defaultDownloadBandwidthPrice) != 0 {
+	if !settings.MinDownloadBandwidthPrice.Equals(defaultDownloadBandwidthPrice) {
 		t.Error("settings retrieval did not return default value")
 	}
-	if settings.MinStoragePrice.Cmp(defaultStoragePrice) != 0 {
+	if !settings.MinStoragePrice.Equals(defaultStoragePrice) {
 		t.Error("settings retrieval did not return default value")
 	}
-	if settings.MinUploadBandwidthPrice.Cmp(defaultUploadBandwidthPrice) != 0 {
+	if !settings.MinUploadBandwidthPrice.Equals(defaultUploadBandwidthPrice) {
 		t.Error("settings retrieval did not return default value")
 	}
 

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -177,7 +177,7 @@ func verifyPaymentRevision(existingRevision, paymentRevision types.FileContractR
 	}
 	toHost := paymentRevision.NewValidProofOutputs[1].Value.Sub(existingRevision.NewValidProofOutputs[1].Value)
 	// Verify that enough money was transferred.
-	if toHost.Cmp(fromRenter) != 0 {
+	if !toHost.Equals(fromRenter) {
 		s := fmt.Sprintf("expected exactly %v to be transferred to the host, but %v was transferred: ", fromRenter, toHost)
 		return extendErr(s, errLowHostValidOutput)
 	}
@@ -223,7 +223,7 @@ func verifyPaymentRevision(existingRevision, paymentRevision types.FileContractR
 	if paymentRevision.NewUnlockHash != existingRevision.NewUnlockHash {
 		return errBadUnlockHash
 	}
-	if paymentRevision.NewMissedProofOutputs[1].Value.Cmp(existingRevision.NewMissedProofOutputs[1].Value) != 0 {
+	if !paymentRevision.NewMissedProofOutputs[1].Value.Equals(existingRevision.NewMissedProofOutputs[1].Value) {
 		return errLowHostMissedOutput
 	}
 	return nil

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -255,7 +255,7 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	// Check that the payouts for the valid proof outputs and the missed proof
 	// outputs are the same - this is important because no data has been added
 	// to the file contract yet.
-	if fc.ValidProofOutputs[1].Value.Cmp(fc.MissedProofOutputs[1].Value) != 0 {
+	if !fc.ValidProofOutputs[1].Value.Equals(fc.MissedProofOutputs[1].Value) {
 		return errMismatchedHostPayouts
 	}
 	// Check that there's enough payout for the host to cover at least the

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -278,7 +278,7 @@ func verifyRevision(so storageObligation, revision types.FileContractRevision, b
 	}
 	toHost := revision.NewValidProofOutputs[1].Value.Sub(oldFCR.NewValidProofOutputs[1].Value)
 	// Verify that enough money was transferred.
-	if toHost.Cmp(fromRenter) != 0 {
+	if !toHost.Equals(fromRenter) {
 		s := fmt.Sprintf("expected exactly %v to be transferred to the host, but %v was transferred: ", fromRenter, toHost)
 		return extendErr(s, errLowHostValidOutput)
 	}

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -345,7 +345,7 @@ func TestSingleSectorStorageObligationStack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ht.host.financialMetrics.StorageRevenue.Cmp(sectorCost) != 0 {
+	if !ht.host.financialMetrics.StorageRevenue.Equals(sectorCost) {
 		t.Fatal("the host should be reporting revenue after a successful storage proof")
 	}
 }
@@ -587,7 +587,7 @@ func TestMultiSectorStorageObligationStack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ht.host.financialMetrics.StorageRevenue.Cmp(sectorCost.Add(sectorCost2)) != 0 {
+	if !ht.host.financialMetrics.StorageRevenue.Equals(sectorCost.Add(sectorCost2)) {
 		t.Fatal("the host should be reporting revenue after a successful storage proof")
 	}
 }
@@ -741,7 +741,7 @@ func TestAutoRevisionSubmission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ht.host.financialMetrics.StorageRevenue.Cmp(sectorCost) != 0 {
+	if !ht.host.financialMetrics.StorageRevenue.Equals(sectorCost) {
 		t.Fatal("the host should be reporting revenue after a successful storage proof")
 	}
 }

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -108,7 +108,7 @@ func TestAverageContractPrice(t *testing.T) {
 	if len(hdb.activeHosts) != 2 {
 		t.Error("host was not added:", hdb.activeHosts)
 	}
-	if avg := hdb.AverageContractPrice(); avg.Cmp(types.NewCurrency64(200)) != 0 {
+	if avg := hdb.AverageContractPrice(); avg.Cmp64(200) != 0 {
 		t.Error("average of two hosts should be their sum/2:", avg)
 	}
 }

--- a/modules/renter/hostdb/weightedlist_test.go
+++ b/modules/renter/hostdb/weightedlist_test.go
@@ -237,7 +237,7 @@ func TestRandomHosts(t *testing.T) {
 	if len(hdb.activeHosts) != 3 {
 		t.Error("wrong number of hosts")
 	}
-	if hdb.hostTree.weight.Cmp(types.NewCurrency64(6)) != 0 {
+	if hdb.hostTree.weight.Cmp64(6) != 0 {
 		t.Error("unexpected weight at initialization")
 		t.Error(hdb.hostTree.weight)
 	}

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -44,7 +44,7 @@ func postEncryptionTesting(m modules.TestMiner, w *Wallet, masterKey crypto.Twof
 		}
 	}
 	siacoinBal, _, _ := w.ConfirmedBalance()
-	if siacoinBal.Cmp(types.NewCurrency64(0)) <= 0 {
+	if siacoinBal.Cmp64(0) <= 0 {
 		panic("wallet balance reported as 0 after maturing some mined blocks")
 	}
 	err = w.Unlock(masterKey)

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -215,7 +215,7 @@ func TestLock(t *testing.T) {
 	}
 	// Compare to the original balance.
 	siacoinBalance2, _, _ := wt.wallet.ConfirmedBalance()
-	if siacoinBalance2.Cmp(siacoinBalance) != 0 {
+	if !siacoinBalance2.Equals(siacoinBalance) {
 		t.Error("siacoin balance reporting changed upon closing the wallet")
 	}
 	// Check that the keys and seeds were wiped.

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -23,13 +23,13 @@ func TestSendSiacoins(t *testing.T) {
 	// should be 0.
 	confirmedBal, _, _ := wt.wallet.ConfirmedBalance()
 	unconfirmedOut, unconfirmedIn := wt.wallet.UnconfirmedBalance()
-	if confirmedBal.Cmp(types.CalculateCoinbase(1)) != 0 {
+	if !confirmedBal.Equals(types.CalculateCoinbase(1)) {
 		t.Error("unexpected confirmed balance")
 	}
-	if unconfirmedOut.Cmp(types.ZeroCurrency) != 0 {
+	if !unconfirmedOut.Equals(types.ZeroCurrency) {
 		t.Error("unconfirmed balance should be 0")
 	}
-	if unconfirmedIn.Cmp(types.ZeroCurrency) != 0 {
+	if !unconfirmedIn.Equals(types.ZeroCurrency) {
 		t.Error("unconfirmed balance should be 0")
 	}
 
@@ -43,10 +43,10 @@ func TestSendSiacoins(t *testing.T) {
 	}
 	confirmedBal2, _, _ := wt.wallet.ConfirmedBalance()
 	unconfirmedOut2, unconfirmedIn2 := wt.wallet.UnconfirmedBalance()
-	if confirmedBal2.Cmp(confirmedBal) != 0 {
+	if !confirmedBal2.Equals(confirmedBal) {
 		t.Error("confirmed balance changed without introduction of blocks")
 	}
-	if unconfirmedOut2.Cmp(unconfirmedIn2.Add(types.NewCurrency64(5000)).Add(tpoolFee)) != 0 {
+	if !unconfirmedOut2.Equals(unconfirmedIn2.Add(types.NewCurrency64(5000)).Add(tpoolFee)) {
 		t.Error("sending siacoins appears to be ineffective")
 	}
 
@@ -58,13 +58,13 @@ func TestSendSiacoins(t *testing.T) {
 	}
 	confirmedBal3, _, _ := wt.wallet.ConfirmedBalance()
 	unconfirmedOut3, unconfirmedIn3 := wt.wallet.UnconfirmedBalance()
-	if confirmedBal3.Cmp(confirmedBal2.Add(types.CalculateCoinbase(2)).Sub(types.NewCurrency64(5000)).Sub(tpoolFee)) != 0 {
+	if !confirmedBal3.Equals(confirmedBal2.Add(types.CalculateCoinbase(2)).Sub(types.NewCurrency64(5000)).Sub(tpoolFee)) {
 		t.Error("confirmed balance did not adjust to the expected value")
 	}
-	if unconfirmedOut3.Cmp(types.ZeroCurrency) != 0 {
+	if !unconfirmedOut3.Equals(types.ZeroCurrency) {
 		t.Error("unconfirmed balance should be 0")
 	}
-	if unconfirmedIn3.Cmp(types.ZeroCurrency) != 0 {
+	if !unconfirmedIn3.Equals(types.ZeroCurrency) {
 		t.Error("unconfirmed balance should be 0")
 	}
 }
@@ -177,7 +177,7 @@ func TestIntegrationSortedOutputsSorting(t *testing.T) {
 		if so.ids[i] != expectedIDSorting[i] {
 			t.Error("an id is out of place: ", i)
 		}
-		if so.outputs[i].Value.Cmp64(i) != 0 {
+		if !so.outputs[i].Value.Equals64(i) {
 			t.Error("a value is out of place: ", i)
 		}
 	}

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -177,7 +177,7 @@ func TestIntegrationSortedOutputsSorting(t *testing.T) {
 		if so.ids[i] != expectedIDSorting[i] {
 			t.Error("an id is out of place: ", i)
 		}
-		if so.outputs[i].Value.Cmp(types.NewCurrency64(i)) != 0 {
+		if so.outputs[i].Value.Cmp64(i) != 0 {
 			t.Error("a value is out of place: ", i)
 		}
 	}

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -123,7 +123,7 @@ func TestLoadSeed(t *testing.T) {
 	}
 	// Balance of wallet should be 0.
 	siacoinBal, _, _ := w.ConfirmedBalance()
-	if siacoinBal.Cmp(types.NewCurrency64(0)) != 0 {
+	if siacoinBal.Cmp64(0) != 0 {
 		t.Error("fresh wallet should not have a balance")
 	}
 	err = w.LoadSeed(crypto.TwofishKey(crypto.HashObject(newSeed)), seed)
@@ -156,7 +156,7 @@ func TestLoadSeed(t *testing.T) {
 		t.Fatal(err)
 	}
 	siacoinBal2, _, _ := w2.ConfirmedBalance()
-	if siacoinBal2.Cmp(types.NewCurrency64(0)) <= 0 {
+	if siacoinBal2.Cmp64(0) <= 0 {
 		t.Error("wallet failed to load a seed with money in it")
 	}
 	allSeeds, err = w2.AllSeeds()

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/types"
 )
 
 // TestPrimarySeed checks that the correct seed is returned when calling

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -123,7 +123,7 @@ func TestLoadSeed(t *testing.T) {
 	}
 	// Balance of wallet should be 0.
 	siacoinBal, _, _ := w.ConfirmedBalance()
-	if siacoinBal.Cmp64(0) != 0 {
+	if !siacoinBal.Equals64(0) {
 		t.Error("fresh wallet should not have a balance")
 	}
 	err = w.LoadSeed(crypto.TwofishKey(crypto.HashObject(newSeed)), seed)

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -174,7 +174,7 @@ func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
 	parentTxn.SiacoinOutputs = append(parentTxn.SiacoinOutputs, exactOutput)
 
 	// Create a refund output if needed.
-	if amount.Cmp(fund) != 0 {
+	if !amount.Equals(fund) {
 		refundUnlockConditions, err := tb.wallet.nextPrimarySeedAddress()
 		if err != nil {
 			return err
@@ -285,7 +285,7 @@ func (tb *transactionBuilder) FundSiafunds(amount types.Currency) error {
 	parentTxn.SiafundOutputs = append(parentTxn.SiafundOutputs, exactOutput)
 
 	// Create a refund output if needed.
-	if amount.Cmp(fund) != 0 {
+	if !amount.Equals(fund) {
 		refundUnlockConditions, err := tb.wallet.nextPrimarySeedAddress()
 		if err != nil {
 			return err

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -214,7 +214,7 @@ func TestConcurrentBuilders(t *testing.T) {
 
 	// Get a second reading on the wallet's balance.
 	fundedSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
-	if startingSCConfirmed.Cmp(fundedSCConfirmed) != 0 {
+	if !startingSCConfirmed.Equals(fundedSCConfirmed) {
 		t.Fatal("confirmed siacoin balance changed when no blocks have been mined", startingSCConfirmed, fundedSCConfirmed)
 	}
 
@@ -337,7 +337,7 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 
 	// Get a second reading on the wallet's balance.
 	fundedSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
-	if startingSCConfirmed.Cmp(fundedSCConfirmed) != 0 {
+	if !startingSCConfirmed.Equals(fundedSCConfirmed) {
 		t.Fatal("confirmed siacoin balance changed when no blocks have been mined", startingSCConfirmed, fundedSCConfirmed)
 	}
 
@@ -445,7 +445,7 @@ func TestParallelBuilders(t *testing.T) {
 	// Check the final balance.
 	endingSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
 	expected := startingSCConfirmed.Sub(funding.Mul(types.NewCurrency64(uint64(outputsDesired))))
-	if expected.Cmp(endingSCConfirmed) != 0 {
+	if !expected.Equals(endingSCConfirmed) {
 		t.Fatal("did not get the expected ending balance", expected, endingSCConfirmed, startingSCConfirmed)
 	}
 }

--- a/modules/wallet/unseeded_test.go
+++ b/modules/wallet/unseeded_test.go
@@ -37,7 +37,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ := w.ConfirmedBalance()
-	if siafundBal.Cmp64(2000) != 0 {
+	if !siafundBal.Equals64(2000) {
 		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
 	}
 
@@ -51,7 +51,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ = w.ConfirmedBalance()
-	if siafundBal.Cmp64(1988) != 0 {
+	if !siafundBal.Equals64(1988) {
 		t.Error("expecting balance of 1988 after sending siafunds to the void")
 	}
 }
@@ -87,7 +87,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ := w.ConfirmedBalance()
-	if siafundBal.Cmp64(7000) != 0 {
+	if !siafundBal.Equals64(7000) {
 		t.Error("expecting a siafund balance of 7000 from the 2of3 key")
 	}
 
@@ -101,7 +101,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ = w.ConfirmedBalance()
-	if siafundBal.Cmp64(6988) != 0 {
+	if !siafundBal.Equals64(6988) {
 		t.Error("expecting balance of 6988 after sending siafunds to the void")
 	}
 }

--- a/modules/wallet/unseeded_test.go
+++ b/modules/wallet/unseeded_test.go
@@ -37,7 +37,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ := w.ConfirmedBalance()
-	if siafundBal.Cmp(types.NewCurrency64(2000)) != 0 {
+	if siafundBal.Cmp64(2000) != 0 {
 		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
 	}
 
@@ -51,7 +51,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ = w.ConfirmedBalance()
-	if siafundBal.Cmp(types.NewCurrency64(1988)) != 0 {
+	if siafundBal.Cmp64(1988) != 0 {
 		t.Error("expecting balance of 1988 after sending siafunds to the void")
 	}
 }
@@ -87,7 +87,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ := w.ConfirmedBalance()
-	if siafundBal.Cmp(types.NewCurrency64(7000)) != 0 {
+	if siafundBal.Cmp64(7000) != 0 {
 		t.Error("expecting a siafund balance of 7000 from the 2of3 key")
 	}
 
@@ -101,7 +101,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, siafundBal, _ = w.ConfirmedBalance()
-	if siafundBal.Cmp(types.NewCurrency64(6988)) != 0 {
+	if siafundBal.Cmp64(6988) != 0 {
 		t.Error("expecting balance of 6988 after sending siafunds to the void")
 	}
 }

--- a/types/currency.go
+++ b/types/currency.go
@@ -96,6 +96,16 @@ func (x Currency) Div64(y uint64) (c Currency) {
 	return
 }
 
+// Equals returns true if x and y have the same value.
+func (x Currency) Equals(y Currency) bool {
+	return x.Cmp(y) == 0
+}
+
+// Equals64 returns true if x and y have the same value.
+func (x Currency) Equals64(y uint64) bool {
+	return x.Cmp64(y) == 0
+}
+
 // Mul returns a new Currency value c = x * y.
 func (x Currency) Mul(y Currency) (c Currency) {
 	c.i.Mul(&x.i, &y.i)

--- a/types/currency.go
+++ b/types/currency.go
@@ -78,6 +78,12 @@ func (x Currency) Cmp(y Currency) int {
 	return x.i.Cmp(&y.i)
 }
 
+// Cmp64 compares x to a uint64. The return value follows the convention of
+// math/big.
+func (x Currency) Cmp64(y uint64) int {
+	return x.Cmp(NewCurrency64(y))
+}
+
 // Div returns a new Currency value c = x / y.
 func (x Currency) Div(y Currency) (c Currency) {
 	c.i.Div(&x.i, &y.i)


### PR DESCRIPTION
Curious to see what people think about these. Took like 2 minutes to make these changes using `gofmt -w -r` so I won't be offended if we decide to reject them. If we do decide to add them, I'll write tests for the new functions.

I think there's a good case for `Cmp64`, but less so for `Equals`. The reason being that `Equals` exists alongside `Cmp`, which could be confusing since it's just a special case. We could go all the way and replace `Cmp` with a handful of comparison functions, but then you need separate functions for both `<` and `<=`. So you'd wind up with:
- `Equals`
- `LessThan`
- `LessThanOrEqualTo` (`AtMost`?)
- `GreaterThan`
- `GreaterThanOrEqualTo` (`AtLeast`?)

...plus `64` variants for all of them. That feels like too much, but I'm not totally sure. As far as readability goes, I'm sure we can agree that `x.Equals(y)` is much nicer than `x.Cmp(y) == 0`.