### PR TITLE
Uptime monitoring

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -95,10 +95,18 @@ type RenterFinancialMetrics struct {
 }
 
 // A HostDBEntry represents one host entry in the Renter's host DB. It
-// aggregates the host's external settings with its public key.
+// aggregates the host's external settings and metrics with its public key.
 type HostDBEntry struct {
 	HostExternalSettings
 	PublicKey types.SiaPublicKey `json:"publickey"`
+	// metrics
+	ScanHistory []HostDBScan
+}
+
+// HostDBScan represents a single scan event.
+type HostDBScan struct {
+	Timestamp time.Time
+	Success   bool
 }
 
 // A RenterContract contains all the metadata necessary to revise or renew a

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -99,8 +99,9 @@ type RenterFinancialMetrics struct {
 type HostDBEntry struct {
 	HostExternalSettings
 	PublicKey types.SiaPublicKey `json:"publickey"`
-	// metrics
-	ScanHistory []HostDBScan
+	// ScanHistory is the set of scans performed on the host. It should always
+	// be ordered according to the scan's Timestamp, oldest to newest.
+	ScanHistory HostDBScans
 }
 
 // HostDBScan represents a single scan event.
@@ -108,6 +109,13 @@ type HostDBScan struct {
 	Timestamp time.Time
 	Success   bool
 }
+
+// HostDBScans represents a sortable slice of scans.
+type HostDBScans []HostDBScan
+
+func (s HostDBScans) Len() int           { return len(s) }
+func (s HostDBScans) Less(i, j int) bool { return s[i].Timestamp.Before(s[j].Timestamp) }
+func (s HostDBScans) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // A RenterContract contains all the metadata necessary to revise or renew a
 // file contract.

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -85,14 +85,12 @@ func (c *Contractor) Contract(hostAddr modules.NetAddress) (modules.RenterContra
 	return modules.RenterContract{}, false
 }
 
-// Contracts returns the contracts formed by the contractor.
+// Contracts returns the contracts formed by the contractor. Only contracts
+// formed with currently online hosts are returned.
 func (c *Contractor) Contracts() (cs []modules.RenterContract) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	for _, c := range c.contracts {
-		cs = append(cs, c)
-	}
-	return
+	return c.onlineContracts()
 }
 
 // resolveID returns the ID of the most recent renewal of id.
@@ -167,9 +165,6 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 	if err != nil {
 		return nil, errors.New("contractor subscription failed: " + err.Error())
 	}
-
-	// spawn uptime loop
-	go c.threadedMonitorUptime()
 
 	return c, nil
 }

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -168,5 +168,8 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 		return nil, errors.New("contractor subscription failed: " + err.Error())
 	}
 
+	// spawn uptime loop
+	go c.threadedMonitorUptime()
+
 	return c, nil
 }

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -121,12 +121,16 @@ func TestContract(t *testing.T) {
 
 // TestContracts tests the Contracts method.
 func TestContracts(t *testing.T) {
-	c := &Contractor{
-		contracts: map[types.FileContractID]modules.RenterContract{
-			{1}: {ID: types.FileContractID{1}, NetAddress: "foo"},
-			{2}: {ID: types.FileContractID{2}, NetAddress: "bar"},
-			{3}: {ID: types.FileContractID{3}, NetAddress: "baz"},
-		},
+	var stub newStub
+	dir := build.TempDir("contractor", "TestNew")
+	c, err := New(stub, stub, stub, stub, dir)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	c.contracts = map[types.FileContractID]modules.RenterContract{
+		{1}: {ID: types.FileContractID{1}, NetAddress: "foo"},
+		{2}: {ID: types.FileContractID{2}, NetAddress: "bar"},
+		{3}: {ID: types.FileContractID{3}, NetAddress: "baz"},
 	}
 	for _, contract := range c.Contracts() {
 		if exp := c.contracts[contract.ID]; exp.NetAddress != contract.NetAddress {

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -33,7 +33,6 @@ func (newStub) FeeEstimation() (a types.Currency, b types.Currency) { return }
 
 // hdb stubs
 func (newStub) Host(modules.NetAddress) (settings modules.HostDBEntry, ok bool) { return }
-func (newStub) IsOffline(modules.NetAddress) bool                               { return false }
 func (newStub) RandomHosts(int, []modules.NetAddress) []modules.HostDBEntry     { return nil }
 
 // TestNew tests the New function.
@@ -186,7 +185,6 @@ func TestAllowance(t *testing.T) {
 type stubHostDB struct{}
 
 func (stubHostDB) Host(modules.NetAddress) (h modules.HostDBEntry, ok bool)         { return }
-func (stubHostDB) IsOffline(modules.NetAddress) (offline bool)                      { return }
 func (stubHostDB) RandomHosts(int, []modules.NetAddress) (hs []modules.HostDBEntry) { return }
 
 // TestIntegrationSetAllowance tests the SetAllowance method.

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -33,6 +33,7 @@ func (newStub) FeeEstimation() (a types.Currency, b types.Currency) { return }
 
 // hdb stubs
 func (newStub) Host(modules.NetAddress) (settings modules.HostDBEntry, ok bool) { return }
+func (newStub) IsOffline(modules.NetAddress) bool                               { return false }
 func (newStub) RandomHosts(int, []modules.NetAddress) []modules.HostDBEntry     { return nil }
 
 // TestNew tests the New function.
@@ -185,6 +186,7 @@ func TestAllowance(t *testing.T) {
 type stubHostDB struct{}
 
 func (stubHostDB) Host(modules.NetAddress) (h modules.HostDBEntry, ok bool)         { return }
+func (stubHostDB) IsOffline(modules.NetAddress) (offline bool)                      { return }
 func (stubHostDB) RandomHosts(int, []modules.NetAddress) (hs []modules.HostDBEntry) { return }
 
 // TestIntegrationSetAllowance tests the SetAllowance method.

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -47,7 +47,6 @@ type (
 
 	hostDB interface {
 		Host(modules.NetAddress) (modules.HostDBEntry, bool)
-		IsOffline(modules.NetAddress) bool
 		RandomHosts(n int, exclude []modules.NetAddress) []modules.HostDBEntry
 	}
 

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -47,6 +47,7 @@ type (
 
 	hostDB interface {
 		Host(modules.NetAddress) (modules.HostDBEntry, bool)
+		IsOffline(modules.NetAddress) bool
 		RandomHosts(n int, exclude []modules.NetAddress) []modules.HostDBEntry
 	}
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -59,8 +59,11 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 func (c *Contractor) managedRenewContracts() error {
 	c.mu.RLock()
 	// Renew contracts when they enter the renew window.
+	// NOTE: offline contracts are not considered here, since we may have
+	// replaced them (and we probably won't be able to connect to their host
+	// anyway)
 	var renewSet []types.FileContractID
-	for _, contract := range c.contracts {
+	for _, contract := range c.onlineContracts() {
 		if c.blockHeight+c.allowance.RenewWindow >= contract.EndHeight() {
 			renewSet = append(renewSet, contract.ID)
 		}

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -44,7 +44,7 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 
 	// only attempt contract formation/renewal if we are synced
 	// (harmless if not synced, since hosts will reject our renewal attempts,
-	// (but very slow)
+	// but very slow)
 	if cc.Synced {
 		go func() {
 			// only one goroutine should be editing contracts at a time

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -53,16 +53,16 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 			}
 			defer c.editLock.Unlock()
 
-			// renew any contracts that have entered the renew window
+			// renew any (online) contracts that have entered the renew window
 			err := c.managedRenewContracts()
 			if err != nil {
 				c.log.Debugln("WARN: failed to renew contracts after processing a consensus chage:", err)
 			}
 
-			// if we don't have enough contracts, form new ones
+			// if we don't have enough (online) contracts, form new ones
 			c.mu.RLock()
 			a := c.allowance
-			remaining := int(a.Hosts) - len(c.contracts)
+			remaining := int(a.Hosts) - len(c.onlineContracts())
 			c.mu.RUnlock()
 			if remaining <= 0 {
 				return

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -41,13 +41,11 @@ func (c *Contractor) threadedMonitorUptime() {
 		// delete contracts with bad hosts. When a new block arrives,
 		// ProcessConsensusChange will take care of forming new contracts as
 		// needed.
-		c.editLock.Lock()
 		c.mu.Lock()
 		for _, contract := range badContracts {
 			delete(c.contracts, contract.ID)
 		}
 		c.mu.Unlock()
-		c.editLock.Unlock()
 		c.log.Printf("INFO: deleted %v contracts because their hosts were offline", len(badContracts))
 	}
 }

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -1,0 +1,43 @@
+package contractor
+
+import (
+	"time"
+)
+
+const (
+	// uptimeInterval specifies how frequently hosts are checked.
+	uptimeInterval = 30 * time.Minute
+)
+
+// threadedMonitorUptime regularly checks host uptime, and deletes contracts
+// whose hosts fall below a minimum uptime threshold.
+func (c *Contractor) threadedMonitorUptime() {
+	for range time.Tick(uptimeInterval) {
+		// get current contracts
+		contracts := c.Contracts()
+
+		// identify hosts with poor uptime
+		badContracts := contracts[:0] // reuse memory during filter
+		for _, contract := range contracts {
+			if c.hdb.IsOffline(contract.NetAddress) {
+				badContracts = append(badContracts, contract)
+			}
+		}
+		if len(badContracts) == 0 {
+			// nothing to do
+			continue
+		}
+
+		// delete contracts with bad hosts. When a new block arrives,
+		// ProcessConsensusChange will take care of forming new contracts as
+		// needed.
+		c.editLock.Lock()
+		c.mu.Lock()
+		for _, contract := range badContracts {
+			delete(c.contracts, contract.ID)
+		}
+		c.mu.Unlock()
+		c.editLock.Unlock()
+		c.log.Println("INFO: deleted %v contracts because their hosts were offline", len(badContracts))
+	}
+}

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -7,61 +7,54 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 )
 
-// uptimeInterval specifies how frequently hosts are checked.
-var (
-	uptimeInterval = func() time.Duration {
-		switch build.Release {
-		case "dev":
-			return 1 * time.Minute
-		case "standard":
-			return 30 * time.Minute
-		case "testing":
-			return 100 * time.Millisecond
-		}
-		panic("undefined uptimeInterval")
-	}()
+// uptimeMinScans is the minimum number of scans required to judge whether a
+// host is offline or not.
+const uptimeMinScans = 3
 
-	// uptimeWindow specifies the duration in which host uptime is checked.
-	uptimeWindow = func() time.Duration {
-		switch build.Release {
-		case "dev":
-			return 30 * time.Minute
-		case "standard":
-			return 7 * 24 * time.Hour // 1 week
-		case "testing":
-			return 15 * time.Second
-		}
-		panic("undefined uptimeWindow")
-	}()
-)
+// uptimeWindow specifies the duration in which host uptime is checked.
+var uptimeWindow = func() time.Duration {
+	switch build.Release {
+	case "dev":
+		return 30 * time.Minute
+	case "standard":
+		return 7 * 24 * time.Hour // 1 week
+	case "testing":
+		return 15 * time.Second
+	}
+	panic("undefined uptimeWindow")
+}()
 
 // isOffline decides whether a host should be considered offline, based on its
 // scan metrics.
 func isOffline(host modules.HostDBEntry) bool {
 	// consider a host offline if:
-	// 1) The host has been scanned at least 3 times in the past uptimeWindow, and
-	// 2) The scans occurred over a period of at least 1/3 the uptimeWindow, and
-	// 3) None of the scans succeeded
-	var pastWeek []modules.HostDBScan
-	for _, scan := range host.ScanHistory {
-		if time.Since(scan.Timestamp) < uptimeWindow {
-			if scan.Success {
-				// at least one scan in the uptimeWindow succeeded
-				return false
-			}
-			pastWeek = append(pastWeek, scan)
-		}
-	}
-	if len(pastWeek) < 3 {
+	// 1) The host has been scanned at least three times, and
+	// 2) The three most recent scans have all failed, and
+	// 3) The time between the most recent scan and the last successful scan
+	//    (or first scan) is at least uptimeWindow
+	numScans := len(host.ScanHistory)
+	if numScans < uptimeMinScans {
 		// not enough data to make a fair judgment
 		return false
 	}
-	if pastWeek[len(pastWeek)-1].Timestamp.Sub(pastWeek[0].Timestamp) < uptimeWindow/3 {
-		// scans were not sufficiently far apart to make a fair judgment
-		return false
+	// NOTE: ScanHistory is ordered from oldest-newest
+	recent := host.ScanHistory[numScans-uptimeMinScans:]
+	for _, scan := range recent {
+		if scan.Success {
+			// one of the scans succeeded
+			return false
+		}
 	}
-	// all conditions satisfied
-	return true
+	// initialize window bounds
+	windowStart, windowEnd := host.ScanHistory[0].Timestamp, host.ScanHistory[numScans-1].Timestamp
+	// iterate from newest-oldest, seeking to last successful scan
+	for i := numScans - 1; i >= 0; i-- {
+		if scan := host.ScanHistory[i]; scan.Success {
+			windowStart = scan.Timestamp
+			break
+		}
+	}
+	return windowEnd.Sub(windowStart) >= uptimeWindow
 }
 
 // threadedMonitorUptime regularly checks host uptime, and deletes contracts

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -4,20 +4,58 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // uptimeInterval specifies how frequently hosts are checked.
-var uptimeInterval = func() time.Duration {
-	switch build.Release {
-	case "dev":
-		return 1 * time.Minute
-	case "standard":
-		return 30 * time.Minute
-	case "testing":
-		return 100 * time.Millisecond
+var (
+	uptimeInterval = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 1 * time.Minute
+		case "standard":
+			return 30 * time.Minute
+		case "testing":
+			return 100 * time.Millisecond
+		}
+		panic("undefined uptimeInterval")
+	}()
+
+	// uptimeWindow specifies the duration in which host uptime is checked.
+	uptimeWindow = func() time.Duration {
+		switch build.Release {
+		case "dev":
+			return 24 * time.Hour // 1 day
+		case "standard":
+			return 7 * 24 * time.Hour // 1 week
+		case "testing":
+			return 1 * time.Minute // 1 minute
+		}
+		panic("undefined uptimeWindow")
+	}()
+)
+
+// isOffline decides whether a host should be considered offline, based on its
+// scan metrics.
+func isOffline(host modules.HostDBEntry) bool {
+	// consider a host offline if:
+	// 1) it has been scanned at least 3 times within the uptime window, and
+	// 2) the 3 most recent scans all failed
+	var lastWeek []modules.HostDBScan
+	for _, scan := range host.ScanHistory {
+		if time.Since(scan.Timestamp) < uptimeWindow {
+			lastWeek = append(lastWeek, scan)
+		}
 	}
-	panic("undefined uptimeInterval")
-}()
+	// need at least 3 scans to make a fair judgment
+	if len(lastWeek) < 3 {
+		return false
+	}
+	// return true if all 3 most recent scans failed
+	// NOTE: lastWeek is ordered from oldest to newest
+	lastWeek = lastWeek[len(lastWeek)-3:]
+	return !lastWeek[0].Success && !lastWeek[1].Success && !lastWeek[2].Success
+}
 
 // threadedMonitorUptime regularly checks host uptime, and deletes contracts
 // whose hosts fall below a minimum uptime threshold.
@@ -27,9 +65,14 @@ func (c *Contractor) threadedMonitorUptime() {
 		contracts := c.Contracts()
 
 		// identify hosts with poor uptime
-		badContracts := contracts[:0] // reuse memory during filter
+		var badContracts []modules.RenterContract
 		for _, contract := range contracts {
-			if c.hdb.IsOffline(contract.NetAddress) {
+			host, ok := c.hdb.Host(contract.NetAddress)
+			if !ok {
+				c.log.Printf("WARN: missing host entry for %v", contract.NetAddress)
+				continue
+			}
+			if isOffline(host) {
 				badContracts = append(badContracts, contract)
 			}
 		}

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -1,6 +1,7 @@
 package contractor
 
 import (
+	"sort"
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -33,6 +34,12 @@ func (c *Contractor) IsOffline(addr modules.NetAddress) bool {
 		return false
 	}
 
+	// NOTE: ScanHistory should always be ordered from oldest to newest.
+	if build.DEBUG && !sort.IsSorted(host.ScanHistory) {
+		sort.Sort(host.ScanHistory)
+		build.Critical("host's scan history was not sorted")
+	}
+
 	// consider a host offline if:
 	// 1) The host has been scanned at least three times, and
 	// 2) The three most recent scans have all failed, and
@@ -43,7 +50,6 @@ func (c *Contractor) IsOffline(addr modules.NetAddress) bool {
 		// not enough data to make a fair judgment
 		return false
 	}
-	// NOTE: ScanHistory is ordered from oldest-newest
 	recent := host.ScanHistory[numScans-uptimeMinScans:]
 	for _, scan := range recent {
 		if scan.Success {

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -2,12 +2,22 @@ package contractor
 
 import (
 	"time"
+
+	"github.com/NebulousLabs/Sia/build"
 )
 
-const (
-	// uptimeInterval specifies how frequently hosts are checked.
-	uptimeInterval = 30 * time.Minute
-)
+// uptimeInterval specifies how frequently hosts are checked.
+var uptimeInterval = func() time.Duration {
+	switch build.Release {
+	case "dev":
+		return 1 * time.Minute
+	case "standard":
+		return 30 * time.Minute
+	case "testing":
+		return 100 * time.Millisecond
+	}
+	panic("undefined uptimeInterval")
+}()
 
 // threadedMonitorUptime regularly checks host uptime, and deletes contracts
 // whose hosts fall below a minimum uptime threshold.
@@ -38,6 +48,6 @@ func (c *Contractor) threadedMonitorUptime() {
 		}
 		c.mu.Unlock()
 		c.editLock.Unlock()
-		c.log.Println("INFO: deleted %v contracts because their hosts were offline", len(badContracts))
+		c.log.Printf("INFO: deleted %v contracts because their hosts were offline", len(badContracts))
 	}
 }

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -25,11 +25,11 @@ var (
 	uptimeWindow = func() time.Duration {
 		switch build.Release {
 		case "dev":
-			return 24 * time.Hour // 1 day
+			return 30 * time.Minute
 		case "standard":
 			return 7 * 24 * time.Hour // 1 week
 		case "testing":
-			return 1 * time.Minute // 1 minute
+			return 15 * time.Second
 		}
 		panic("undefined uptimeWindow")
 	}()

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -1,0 +1,97 @@
+package contractor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// uptimeHostDB overrides an existing hostDB so that it always returns
+// IsOffline == true for a specified address.
+type uptimeHostDB struct {
+	hostDB
+	addr modules.NetAddress
+}
+
+func (u uptimeHostDB) IsOffline(addr modules.NetAddress) bool {
+	if addr == u.addr {
+		return true
+	}
+	return u.hostDB.IsOffline(addr)
+}
+
+// TestIntegrationMonitorUptime tests that when a host goes offline, its
+// contract is eventually replaced.
+func TestIntegrationMonitorUptime(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	h, c, m, err := newTestingTrio("TestIntegrationMonitorUptime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+
+	// override IsOffline to always return true for h
+	c.hdb = uptimeHostDB{c.hdb, h.ExternalSettings().NetAddress}
+
+	// form a contract with h
+	c.SetAllowance(modules.Allowance{
+		Funds:       types.SiacoinPrecision.Mul64(100),
+		Hosts:       1,
+		Period:      100,
+		RenewWindow: 10,
+	})
+	// we should have a contract
+	if len(c.Contracts()) != 1 {
+		t.Fatal("contract not formed")
+	}
+
+	// close the host; contractor should eventually delete contract
+	h.Close()
+	for i := 0; i < 100 && len(c.Contracts()) != 0; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(c.Contracts()) != 0 {
+		t.Fatal("contract was not removed")
+	}
+
+	// create another host and announce it
+	dir := build.TempDir("contractor", "TestIntegrationMonitorUptime", "Host2")
+	h2, err := newTestingHost(dir, c.cs.(modules.ConsensusSet), c.tpool.(modules.TransactionPool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = h2.Announce()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// mine a block, processing the announcement
+	m.AddBlock()
+
+	// wait for hostdb to scan host
+	for i := 0; i < 100 && len(c.hdb.RandomHosts(2, nil)) != 2; i++ {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if len(c.hdb.RandomHosts(2, nil)) != 2 {
+		t.Fatal("host did not make it into the contractor hostdb in time", c.hdb.RandomHosts(2, nil))
+	}
+
+	// mine a new block. ProcessConsensusChange will trigger
+	// managedFormAllowanceContracts, which should form a new contract with h2
+	m.AddBlock()
+	for i := 0; i < 100 && len(c.Contracts()) != 1; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(c.Contracts()) != 1 {
+		t.Fatal("contract was not replaced")
+	}
+	if c.Contracts()[0].NetAddress != h2.ExternalSettings().NetAddress {
+		t.Fatal("contractor formed replacement contract with wrong host")
+	}
+}

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -9,16 +9,18 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// uptimeHostDB overrides an existing hostDB so that it always returns
+// offlineHostDB overrides an existing hostDB so that it always returns
 // isOffline == true for a specified address.
-type uptimeHostDB struct {
+type offlineHostDB struct {
 	hostDB
 	addr modules.NetAddress
 }
 
-func (u uptimeHostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, bool) {
-	host, ok := u.hostDB.Host(addr)
-	if ok && addr == u.addr {
+// Host returns the host with address addr. If addr matches hdb.addr, the
+// host's scan history will be modified to make the host appear offline.
+func (hdb offlineHostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, bool) {
+	host, ok := hdb.hostDB.Host(addr)
+	if ok && addr == hdb.addr {
 		// fake three scans over the past uptimeWindow, all of which failed
 		badScan1 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow * 2), Success: false}
 		badScan2 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow), Success: false}
@@ -42,7 +44,7 @@ func TestIntegrationReplaceOffline(t *testing.T) {
 	defer h.Close()
 
 	// override IsOffline to always return true for h
-	c.hdb = uptimeHostDB{c.hdb, h.ExternalSettings().NetAddress}
+	c.hdb = offlineHostDB{c.hdb, h.ExternalSettings().NetAddress}
 
 	// create another host
 	dir := build.TempDir("contractor", "TestIntegrationMonitorUptime", "Host2")
@@ -103,9 +105,11 @@ func TestIntegrationReplaceOffline(t *testing.T) {
 func TestIsOffline(t *testing.T) {
 	now := time.Now()
 	oldBadScan := modules.HostDBScan{Timestamp: now.Add(-uptimeWindow * 2), Success: false}
+	oldGoodScan := modules.HostDBScan{Timestamp: now.Add(-uptimeWindow * 2), Success: true}
 	newBadScan := modules.HostDBScan{Timestamp: now.Add(-uptimeWindow / 2), Success: false}
 	newGoodScan := modules.HostDBScan{Timestamp: now.Add(-uptimeWindow / 2), Success: true}
 	currentBadScan := modules.HostDBScan{Timestamp: now, Success: false}
+	currentGoodScan := modules.HostDBScan{Timestamp: now, Success: true}
 
 	tests := []struct {
 		scans   []modules.HostDBScan
@@ -121,6 +125,10 @@ func TestIsOffline(t *testing.T) {
 		{[]modules.HostDBScan{oldBadScan, newGoodScan, currentBadScan}, false},
 		// data covers large range, no scans succeded
 		{[]modules.HostDBScan{oldBadScan, newBadScan, currentBadScan}, true},
+		// recent scan was good (and within uptimeWindow of oldBadScan, but that shouldn't matter)
+		{[]modules.HostDBScan{oldBadScan, oldBadScan, oldBadScan, oldGoodScan}, false},
+		// recent scan was good (and outside uptimeWindow of oldBadScan, but that shouldn't matter)
+		{[]modules.HostDBScan{oldBadScan, oldBadScan, oldBadScan, currentGoodScan}, false},
 	}
 	for i, test := range tests {
 		h := modules.HostDBEntry{ScanHistory: test.scans}

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -20,8 +20,8 @@ func (u uptimeHostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, bool) 
 	host, ok := u.hostDB.Host(addr)
 	if ok && addr == u.addr {
 		// fake three scans over the past uptimeWindow, all of which failed
-		badScan1 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow / 2), Success: false}
-		badScan2 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow / 2), Success: false}
+		badScan1 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow * 2), Success: false}
+		badScan2 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow), Success: false}
 		badScan3 := modules.HostDBScan{Timestamp: time.Now(), Success: false}
 		host.ScanHistory = []modules.HostDBScan{badScan1, badScan2, badScan3}
 	}
@@ -115,14 +115,12 @@ func TestIsOffline(t *testing.T) {
 		{nil, false},
 		// not enough data
 		{[]modules.HostDBScan{oldBadScan, newGoodScan}, false},
-		// not recent enough data
+		// data covers small range
 		{[]modules.HostDBScan{oldBadScan, oldBadScan, oldBadScan}, false},
-		// recent data, but at least 1 scan succeded
-		{[]modules.HostDBScan{newGoodScan, newBadScan, currentBadScan}, false},
-		// recent data, but scans are too close together
-		{[]modules.HostDBScan{newBadScan, newBadScan, newBadScan}, false},
-		// recent data, no scans succeded
-		{[]modules.HostDBScan{newBadScan, newBadScan, currentBadScan}, true},
+		// data covers large range, but at least 1 scan succeded
+		{[]modules.HostDBScan{oldBadScan, newGoodScan, currentBadScan}, false},
+		// data covers large range, no scans succeded
+		{[]modules.HostDBScan{oldBadScan, newBadScan, currentBadScan}, true},
 	}
 	for i, test := range tests {
 		h := modules.HostDBEntry{ScanHistory: test.scans}

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -2,6 +2,7 @@ package hostdb
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -14,7 +15,8 @@ type hostEntry struct {
 	FirstSeen   types.BlockHeight
 	Weight      types.Currency
 	Reliability types.Currency
-	Online      bool
+	LastScanned time.Time
+	LastSeen    time.Time
 }
 
 // insertHost adds a host entry to the state. The host will be inserted into
@@ -113,19 +115,43 @@ func (hdb *HostDB) AverageContractPrice() types.Currency {
 	return totalPrice.Div64(uint64(len(hosts)))
 }
 
-// IsOffline reports whether a host is offline. If the HostDB has no record of
-// the host, IsOffline will return false.
-//
-// TODO: Is this behavior that makes sense?
+// IsOffline reports whether h is offline. A host is considered offline if it
+// has been scanned at least once in the last three days, but hasn't responded
+// to the scan during that period. If the host has not been scanned in the last
+// three days, IsOffline will scan it, so the caller should treat this call as
+// blocking. If the host is not present in the HostDB, IsOffline returns false.
 func (hdb *HostDB) IsOffline(addr modules.NetAddress) bool {
+	// lookup entry
 	hdb.mu.RLock()
-	defer hdb.mu.RUnlock()
-
-	if _, ok := hdb.activeHosts[addr]; ok {
+	var lastSeen, lastScanned time.Time
+	entry, ok := hdb.allHosts[addr]
+	if ok {
+		lastSeen, lastScanned = entry.LastSeen, entry.LastScanned
+	}
+	hdb.mu.RUnlock()
+	if !ok {
 		return false
 	}
-	if h, ok := hdb.allHosts[addr]; ok {
-		return !h.Online
+
+	if time.Since(lastScanned) > uptimeThreshold {
+		// if entry hasn't been scanned in the last 3 days, scan it now
+		hdb.managedScanHost(entry)
+
+		// update lastSeen
+		hdb.mu.RLock()
+		entry, ok := hdb.allHosts[addr]
+		if ok {
+			lastSeen = entry.LastSeen
+		}
+		hdb.mu.RUnlock()
+		if !ok {
+			// should (almost) never happen
+			hdb.log.Printf("WARN: no entry in allHosts for %v immediately after scanning", addr)
+			return false
+		}
 	}
-	return false
+
+	// at this point we know the host has been scanned at least once within the
+	// last 3 days, so return whether it has been seen during that time.
+	return time.Since(lastSeen) > uptimeThreshold
 }

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -112,34 +112,3 @@ func TestAverageContractPrice(t *testing.T) {
 		t.Error("average of two hosts should be their sum/2:", avg)
 	}
 }
-
-// TestIsOffline tests the IsOffline method.
-func TestIsOffline(t *testing.T) {
-	now := time.Now()
-	hdb := &HostDB{
-		allHosts: map[modules.NetAddress]*hostEntry{
-			"foo.com:1234": {LastScanned: now, LastSeen: now},
-			"bar.com:1234": {LastScanned: now, LastSeen: now.Add(-uptimeThreshold * 2)},
-			"baz.com:1234": {LastScanned: now, LastSeen: now.Add(-uptimeThreshold / 2)},
-		},
-		activeHosts: map[modules.NetAddress]*hostNode{
-			"foo.com:1234": nil,
-		},
-		scanPool: make(chan *hostEntry),
-	}
-
-	tests := []struct {
-		addr    modules.NetAddress
-		offline bool
-	}{
-		{"foo.com:1234", false},
-		{"bar.com:1234", true},
-		{"baz.com:1234", false},
-		{"quux.com:1234", false},
-	}
-	for _, test := range tests {
-		if offline := hdb.IsOffline(test.addr); offline != test.offline {
-			t.Errorf("IsOffline(%v) = %v, expected %v", test.addr, offline, test.offline)
-		}
-	}
-}

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -115,11 +115,12 @@ func TestAverageContractPrice(t *testing.T) {
 
 // TestIsOffline tests the IsOffline method.
 func TestIsOffline(t *testing.T) {
+	now := time.Now()
 	hdb := &HostDB{
 		allHosts: map[modules.NetAddress]*hostEntry{
-			"foo.com:1234": {Online: true},
-			"bar.com:1234": {Online: false},
-			"baz.com:1234": {Online: true},
+			"foo.com:1234": {LastScanned: now, LastSeen: now},
+			"bar.com:1234": {LastScanned: now, LastSeen: now.Add(-uptimeThreshold)},
+			"baz.com:1234": {LastScanned: now, LastSeen: now.Add(-uptimeThreshold / 2)},
 		},
 		activeHosts: map[modules.NetAddress]*hostNode{
 			"foo.com:1234": nil,

--- a/modules/renter/hostdb/hostentry_test.go
+++ b/modules/renter/hostdb/hostentry_test.go
@@ -119,7 +119,7 @@ func TestIsOffline(t *testing.T) {
 	hdb := &HostDB{
 		allHosts: map[modules.NetAddress]*hostEntry{
 			"foo.com:1234": {LastScanned: now, LastSeen: now},
-			"bar.com:1234": {LastScanned: now, LastSeen: now.Add(-uptimeThreshold)},
+			"bar.com:1234": {LastScanned: now, LastSeen: now.Add(-uptimeThreshold * 2)},
 			"baz.com:1234": {LastScanned: now, LastSeen: now.Add(-uptimeThreshold / 2)},
 		},
 		activeHosts: map[modules.NetAddress]*hostNode{

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"math/big"
 	"net"
+	"sort"
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -132,6 +133,10 @@ func (hdb *HostDB) managedUpdateEntry(entry *hostEntry, newSettings modules.Host
 		Timestamp: time.Now(),
 		Success:   netErr == nil,
 	})
+	// Ensure the scans are sorted.
+	if !sort.IsSorted(entry.ScanHistory) {
+		sort.Sort(entry.ScanHistory)
+	}
 
 	// Add the host to allHosts.
 	priorHost, exists := hdb.allHosts[entry.NetAddress]

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -34,8 +34,8 @@ type hostDB interface {
 	// Close closes the hostdb.
 	Close() error
 
-	// IsOffline reports whether a host is consider offline.
-	IsOffline(modules.NetAddress) bool
+	// Host returns the HostDBEntry for a given host.
+	Host(modules.NetAddress) (modules.HostDBEntry, bool)
 }
 
 // A hostContractor negotiates, revises, renews, and provides access to file

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -63,6 +63,9 @@ type hostContractor interface {
 	// FinancialMetrics returns the financial metrics of the contractor.
 	FinancialMetrics() modules.RenterFinancialMetrics
 
+	// IsOffline reports whether the specified host is considered offline.
+	IsOffline(modules.NetAddress) bool
+
 	// Downloader creates a Downloader from the specified contract ID,
 	// allowing the retrieval of sectors.
 	Downloader(types.FileContractID) (contractor.Downloader, error)

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -183,6 +183,7 @@ func (stubContractor) Contract(modules.NetAddress) (modules.RenterContract, bool
 }
 func (stubContractor) Contracts() []modules.RenterContract                    { return nil }
 func (stubContractor) FinancialMetrics() (m modules.RenterFinancialMetrics)   { return }
+func (stubContractor) IsOffline(modules.NetAddress) bool                      { return false }
 func (stubContractor) Editor(types.FileContractID) (contractor.Editor, error) { return nil, nil }
 func (stubContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {
 	return nil, nil

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -202,22 +202,29 @@ func (f *file) expiringContracts(height types.BlockHeight) []fileContract {
 // scan metrics.
 func isOffline(host modules.HostDBEntry) bool {
 	// consider a host offline if:
-	// 1) it has been scanned at least 3 times within the uptime window, and
-	// 2) the 3 most recent scans all failed
-	var lastWeek []modules.HostDBScan
+	// 1) The host has been scanned at least 3 times in the past uptimeWindow, and
+	// 2) The scans occurred over a period of at least 1/3 the uptimeWindow, and
+	// 3) None of the scans succeeded
+	var pastWeek []modules.HostDBScan
 	for _, scan := range host.ScanHistory {
 		if time.Since(scan.Timestamp) < uptimeWindow {
-			lastWeek = append(lastWeek, scan)
+			if scan.Success {
+				// at least one scan in the uptimeWindow succeeded
+				return false
+			}
+			pastWeek = append(pastWeek, scan)
 		}
 	}
-	// need at least 3 scans to make a fair judgment
-	if len(lastWeek) < 3 {
+	if len(pastWeek) < 3 {
+		// not enough data to make a fair judgment
 		return false
 	}
-	// return true if all 3 most recent scans failed
-	// NOTE: lastWeek is ordered from oldest to newest
-	lastWeek = lastWeek[len(lastWeek)-3:]
-	return !lastWeek[0].Success && !lastWeek[1].Success && !lastWeek[2].Success
+	if pastWeek[len(pastWeek)-1].Timestamp.Sub(pastWeek[0].Timestamp) < uptimeWindow/3 {
+		// scans were not sufficiently far apart to make a fair judgment
+		return false
+	}
+	// all conditions satisfied
+	return true
 }
 
 // offlineChunks returns the chunks belonging to "offline" hosts -- hosts that

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -34,11 +34,11 @@ var renewThreshold = func() types.BlockHeight {
 var uptimeWindow = func() time.Duration {
 	switch build.Release {
 	case "dev":
-		return 24 * time.Hour // 1 day
+		return 30 * time.Minute
 	case "standard":
 		return 7 * 24 * time.Hour // 1 week
 	case "testing":
-		return 1 * time.Minute // 1 minute
+		return 15 * time.Second
 	}
 	panic("undefined uptimeWindow")
 }()

--- a/modules/renter/repair_test.go
+++ b/modules/renter/repair_test.go
@@ -165,9 +165,9 @@ func (hdb offlineHostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, boo
 	if addr == hdb.addr {
 		return modules.HostDBEntry{}, false
 	}
-	// fake three scans over the past uptimeWindow, all of which failed
-	badScan1 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow / 2), Success: false}
-	badScan2 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow / 2), Success: false}
+	// fake three scans, all of which failed
+	badScan1 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow * 2), Success: false}
+	badScan2 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow), Success: false}
 	badScan3 := modules.HostDBScan{Timestamp: time.Now(), Success: false}
 	host := modules.HostDBEntry{ScanHistory: []modules.HostDBScan{badScan1, badScan2, badScan3}}
 	return host, true

--- a/modules/renter/repair_test.go
+++ b/modules/renter/repair_test.go
@@ -165,9 +165,11 @@ func (hdb offlineHostDB) Host(addr modules.NetAddress) (modules.HostDBEntry, boo
 	if addr == hdb.addr {
 		return modules.HostDBEntry{}, false
 	}
-	// fake three scans, all of which failed
-	badScan := modules.HostDBScan{Timestamp: time.Now(), Success: false}
-	host := modules.HostDBEntry{ScanHistory: []modules.HostDBScan{badScan, badScan, badScan}}
+	// fake three scans over the past uptimeWindow, all of which failed
+	badScan1 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow / 2), Success: false}
+	badScan2 := modules.HostDBScan{Timestamp: time.Now().Add(-uptimeWindow / 2), Success: false}
+	badScan3 := modules.HostDBScan{Timestamp: time.Now(), Success: false}
+	host := modules.HostDBEntry{ScanHistory: []modules.HostDBScan{badScan1, badScan2, badScan3}}
 	return host, true
 }
 

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -37,6 +37,10 @@ func (uc *uploadDownloadContractor) Editor(types.FileContractID) (contractor.Edi
 	return uc, nil
 }
 
+func (uc *uploadDownloadContractor) IsOffline(modules.NetAddress) bool {
+	return false
+}
+
 // Downloader simply returns the uploadDownloadContractor, since it also
 // implements the Downloader interface.
 func (uc *uploadDownloadContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {


### PR DESCRIPTION
The contractor now spawns a background loop that regularly deletes any contracts whose hosts have gone offline. Since the contractor already tries to form new contracts when it dips below `allowance.Hosts`, no further work is needed to ensure that the contractor will replace the offline hosts with new contracts. It is then the renter's job to reupload data to the new contracts.

This code relies on `hdb.IsOffline` being a good indicator of whether a host is truly offline. The current `IsOffline` algorithm is too simple and will result in contracts being deleted too aggressively. For example, if the hostdb is turned off for a week, and a host is momentarily offline when the hostdb turns on, then it will consider the host to be offline.