### PR TITLE
Contractor leeway

### DIFF
--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -59,11 +59,16 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		return errAllowanceWindowSize
 	}
 
-	// check that allowance is sufficient to store at least one sector
-	numSectors, err := maxSectors(a, c.hdb, c.tpool)
+	// calculate the maximum sectors this allowance can store
+	max, err := maxSectors(a, c.hdb, c.tpool)
 	if err != nil {
 		return err
-	} else if numSectors == 0 {
+	}
+	// Only allocate half as many sectors as the max. This leaves some leeway
+	// for replacing contracts, transaction fees, etc.
+	numSectors := max / 2
+	// check that this is sufficient to store at least one sector
+	if numSectors == 0 {
 		return ErrInsufficientAllowance
 	}
 

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -67,11 +67,14 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 			if remaining <= 0 {
 				return
 			}
-			numSectors, err := maxSectors(a, c.hdb, c.tpool)
+			max, err := maxSectors(a, c.hdb, c.tpool)
 			if err != nil {
 				c.log.Debugln("ERROR: couldn't calculate maxSectors after processing a consensus change:", err)
 				return
 			}
+			// Only allocate half as many sectors as the max. This leaves some leeway
+			// for replacing contracts, transaction fees, etc.
+			numSectors := max / 2
 			err = c.managedFormAllowanceContracts(remaining, numSectors, a)
 			if err != nil {
 				c.log.Debugln("WARN: failed to form contracts after processing a consensus change:", err)


### PR DESCRIPTION
The contractor will now form 30 contracts by default, and spend 50% less money on them. I have not added testing yet because I would like some feedback on how the lowballing was implemented. In short, I modified `maxSectors` to return half its previous value. The contractor calls `maxSectors` whenever it is calculating how much to spend on storage, so this seemed like an easy way to implement lowballing at the root, rather than modifying every function that forms or renews contracts. Still, I am wary that this may be too clever.