### PR TITLE
Build vars

### DIFF
--- a/build/var.go
+++ b/build/var.go
@@ -1,0 +1,27 @@
+package build
+
+// A Var represents a variable whose value depends on which Release is being
+// compiled. None of the fields may be nil, and all fields must have the same
+// underlying type.
+type Var struct {
+	Standard interface{}
+	Dev      interface{}
+	Testing  interface{}
+}
+
+// Select returns the field of v that corresponds to the current Release.
+func Select(v Var) interface{} {
+	if v.Standard == nil || v.Dev == nil || v.Testing == nil {
+		panic("nil value in build variable")
+	}
+	switch Release {
+	case "standard":
+		return v.Standard
+	case "dev":
+		return v.Dev
+	case "testing":
+		return v.Testing
+	default:
+		panic("unrecognized Release: " + Release)
+	}
+}

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -24,49 +24,28 @@ var (
 	// new block every 'headerMemory / blockMemory' times it is
 	// called. This reduces the amount of memory used, but comes at the cost of
 	// not always having the most recent transactions.
-	HeaderMemory = func() int {
-		if build.Release == "dev" {
-			return 500
-		}
-		if build.Release == "standard" {
-			return 10000
-		}
-		if build.Release == "testing" {
-			return 50
-		}
-		panic("unrecognized build.Release")
-	}()
+	HeaderMemory = build.Select(build.Var{
+		Standard: 10000,
+		Dev:      500,
+		Testing:  50,
+	}).(int)
 
 	// BlockMemory is the maximum number of blocks the miner will store
 	// Blocks take up to 2 megabytes of memory, which is why this number is
 	// limited.
-	BlockMemory = func() int {
-		if build.Release == "dev" {
-			return 10
-		}
-		if build.Release == "standard" {
-			return 50
-		}
-		if build.Release == "testing" {
-			return 5
-		}
-		panic("unrecognized build.Release")
-	}()
+	BlockMemory = build.Select(build.Var{
+		Standard: 50,
+		Dev:      10,
+		Testing:  5,
+	}).(int)
 
 	// MaxSourceBlockAge is the maximum amount of time that is allowed to
 	// elapse between generating source blocks.
-	MaxSourceBlockAge = func() time.Duration {
-		if build.Release == "dev" {
-			return 5 * time.Second
-		}
-		if build.Release == "standard" {
-			return 30 * time.Second
-		}
-		if build.Release == "testing" {
-			return 1 * time.Second
-		}
-		panic("unrecognized build.Release")
-	}()
+	MaxSourceBlockAge = build.Select(build.Var{
+		Standard: 30 * time.Second,
+		Dev:      5 * time.Second,
+		Testing:  1 * time.Second,
+	}).(time.Duration)
 )
 
 // Miner struct contains all variables the miner needs


### PR DESCRIPTION
This is a demonstration of how we might clean up our myriad release-dependent variables. The declarations are more compact, and no longer require a separate `panic` call. The downside is that a type assertion is required due to `Select` returning an `interface{}`. This type assertion will be hard to forget though, since any attempt to use the variable as e.g. an `int` will cause a compilation error.

I opted to only replace the vars in the miner package in order to avoid merge conflicts. If we decide to go ahead, we should also update the consensus set, gateway, transaction pool, and siad packages. The other packages are currently being overhauled, so we should delay updating them until their feature branches have been merged. Fortunately, it's easy to roll this out incrementally, since the existing method of selecting a build variable will continue to work as before.

EDIT: it occurred to me that we probably introduced some merge conflicts when we merged the Cmp64 PR. Drat :/