### PR TITLE
add hostdb subpackage `hosttree` for storing and retreiving weighted hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dependencies:
 run = Test
 pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/consensus \
        ./modules/explorer ./modules/gateway ./modules/host ./modules/host/storagemanager \
-       ./modules/renter ./modules/renter/contractor ./modules/renter/hostdb ./modules/renter/proto \
+       ./modules/renter ./modules/renter/contractor ./modules/renter/hostdb ./modules/renter/hostdb/hosttree ./modules/renter/proto \
        ./modules/miner ./modules/wallet ./modules/transactionpool ./persist ./siac ./siad ./sync ./types
 
 # fmt calls go fmt on all packages.

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,12 @@ dependencies:
 # pkgs changes which packages the makefile calls operate on. run changes which
 # tests are run during testing.
 run = Test
-pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/consensus \
-       ./modules/explorer ./modules/gateway ./modules/host ./modules/host/storagemanager \
-       ./modules/renter ./modules/renter/contractor ./modules/renter/hostdb ./modules/renter/hostdb/hosttree ./modules/renter/proto \
-       ./modules/miner ./modules/wallet ./modules/transactionpool ./persist ./siac ./siad ./sync ./types
+pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules \
+       ./modules/consensus ./modules/explorer ./modules/gateway ./modules/host \
+       ./modules/host/storagemanager ./modules/renter ./modules/renter/contractor \
+       ./modules/renter/hostdb ./modules/renter/hostdb/hosttree ./modules/renter/proto \
+       ./modules/miner ./modules/wallet ./modules/transactionpool ./persist ./siac \
+       ./siad ./sync ./types 
 
 # fmt calls go fmt on all packages.
 fmt:

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -46,8 +46,8 @@ type (
 		// hosts is a map of public keys to nodes.
 		hosts map[string]*node
 
-		// weight applies a weight to a hostEntry
-		weight WeightFunc
+		// weightFn calculates the weight of a hostEntry
+		weightFn WeightFunc
 
 		mu sync.Mutex
 	}
@@ -91,8 +91,8 @@ func New(wf WeightFunc) *HostTree {
 		root: &node{
 			count: 1,
 		},
-		weight: wf,
-		hosts:  make(map[string]*node),
+		weightFn: wf,
+		hosts:    make(map[string]*node),
 	}
 }
 
@@ -189,7 +189,7 @@ func (ht *HostTree) Insert(hdbe modules.HostDBEntry) error {
 
 	entry := &hostEntry{
 		HostDBEntry: hdbe,
-		weight:      ht.weight(hdbe),
+		weight:      ht.weightFn(hdbe),
 	}
 
 	if _, exists := ht.hosts[string(entry.PublicKey.Key)]; exists {
@@ -232,7 +232,7 @@ func (ht *HostTree) Modify(hdbe modules.HostDBEntry) error {
 
 	entry := &hostEntry{
 		HostDBEntry: hdbe,
-		weight:      ht.weight(hdbe),
+		weight:      ht.weightFn(hdbe),
 	}
 
 	_, node = ht.root.recursiveInsert(entry)

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -97,7 +97,6 @@ func (n *node) recursiveInsert(entry *HostEntry) (nodesAdded int, newnode *node)
 		n.entry = entry
 		n.taken = true
 		n.weight = entry.Weight
-		nodesAdded = 0
 		newnode = n
 		return
 	}
@@ -251,7 +250,10 @@ func (ht *HostTree) Fetch(n int, ignore []types.SiaPublicKey) ([]modules.HostDBE
 	}
 
 	for _, entry := range removedEntries {
-		ht.Insert(entry)
+		err := ht.Insert(entry)
+		if err != nil {
+			return hosts, err
+		}
 	}
 
 	return hosts, nil

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -36,7 +36,7 @@ type (
 	// `HostEntries`, and provides methods for inserting, retreiving, and
 	// modifing entries.
 	HostTree struct {
-		*node
+		root *node
 
 		// hosts is a map of public keys to nodes.
 		hosts map[string]*node
@@ -80,7 +80,7 @@ func createNode(parent *node, entry *HostEntry) *node {
 // New creates a new, empty, HostTree.
 func New() *HostTree {
 	return &HostTree{
-		node: &node{
+		root: &node{
 			count: 1,
 		},
 		hosts: make(map[string]*node),
@@ -179,7 +179,7 @@ func (ht *HostTree) Insert(entry *HostEntry) error {
 		return ErrHostExists
 	}
 
-	_, node := ht.recursiveInsert(entry)
+	_, node := ht.root.recursiveInsert(entry)
 
 	ht.hosts[entry.PublicKey.String()] = node
 	return nil
@@ -206,7 +206,7 @@ func (ht *HostTree) Modify(entry *HostEntry) error {
 	}
 
 	node.remove()
-	_, node = ht.recursiveInsert(entry)
+	_, node = ht.root.recursiveInsert(entry)
 
 	ht.hosts[entry.PublicKey.String()] = node
 	return nil
@@ -231,11 +231,11 @@ func (ht *HostTree) Fetch(n int, ignore []types.SiaPublicKey) ([]modules.HostDBE
 	}
 
 	for len(hosts) < n && len(ht.hosts) > 0 {
-		randWeight, err := rand.Int(rand.Reader, ht.weight.Big())
+		randWeight, err := rand.Int(rand.Reader, ht.root.weight.Big())
 		if err != nil {
 			return hosts, err
 		}
-		node, err := ht.nodeAtWeight(types.NewCurrency(randWeight))
+		node, err := ht.root.nodeAtWeight(types.NewCurrency(randWeight))
 		if err != nil {
 			return hosts, err
 		}

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// errWeightTooHeavy is returned from a Fetch() call if a weight that exceeds
+	// errWeightTooHeavy is returned from a SelectRandom() call if a weight that exceeds
 	// the total weight of the tree is requested.
 	errWeightTooHeavy = errors.New("requested a too-heavy weight")
 
@@ -241,11 +241,11 @@ func (ht *HostTree) Modify(hdbe modules.HostDBEntry) error {
 	return nil
 }
 
-// Fetch grabs a random `n` hosts from the tree. There will be no repeats, but
-// the length of the slice returned may be less than `n`, and may even be zero.
+// SelectRandom grabs a random n hosts from the tree. There will be no repeats, but
+// the length of the slice returned may be less than n, and may even be zero.
 // The hosts that are returned first have the higher priority. Hosts passed to
-// `ignore` will not be considered; pass `nil` if no blacklist is desired.
-func (ht *HostTree) Fetch(n int, ignore []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
+// 'ignore' will not be considered; pass `nil` if no blacklist is desired.
+func (ht *HostTree) SelectRandom(n int, ignore []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
 	ht.mu.Lock()
 	defer ht.mu.Unlock()
 

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -175,24 +175,24 @@ func (n *node) remove() {
 // Insert inserts the entry provided to `entry` into the host tree. Insert will
 // return an error if the input host already exists.
 func (ht *HostTree) Insert(entry *HostEntry) error {
-	if _, exists := ht.hosts[entry.PublicKey.String()]; exists {
+	if _, exists := ht.hosts[string(entry.PublicKey.Key)]; exists {
 		return ErrHostExists
 	}
 
 	_, node := ht.root.recursiveInsert(entry)
 
-	ht.hosts[entry.PublicKey.String()] = node
+	ht.hosts[string(entry.PublicKey.Key)] = node
 	return nil
 }
 
 // Remove removes the host with the public key provided by `pk`.
 func (ht *HostTree) Remove(pk types.SiaPublicKey) error {
-	node, exists := ht.hosts[pk.String()]
+	node, exists := ht.hosts[string(pk.Key)]
 	if !exists {
 		return ErrNoSuchHost
 	}
 	node.remove()
-	delete(ht.hosts, pk.String())
+	delete(ht.hosts, string(pk.Key))
 
 	return nil
 }
@@ -200,7 +200,7 @@ func (ht *HostTree) Remove(pk types.SiaPublicKey) error {
 // Modify updates a host entry at the given public key, replacing the old entry
 // with the entry provided by `newEntry`.
 func (ht *HostTree) Modify(entry *HostEntry) error {
-	node, exists := ht.hosts[entry.PublicKey.String()]
+	node, exists := ht.hosts[string(entry.PublicKey.Key)]
 	if !exists {
 		return ErrNoSuchHost
 	}
@@ -208,7 +208,7 @@ func (ht *HostTree) Modify(entry *HostEntry) error {
 	node.remove()
 	_, node = ht.root.recursiveInsert(entry)
 
-	ht.hosts[entry.PublicKey.String()] = node
+	ht.hosts[string(entry.PublicKey.Key)] = node
 	return nil
 }
 
@@ -221,12 +221,12 @@ func (ht *HostTree) Fetch(n int, ignore []types.SiaPublicKey) ([]modules.HostDBE
 	var removedEntries []*HostEntry
 
 	for _, pubkey := range ignore {
-		node, exists := ht.hosts[pubkey.String()]
+		node, exists := ht.hosts[string(pubkey.Key)]
 		if !exists {
 			continue
 		}
 		node.remove()
-		delete(ht.hosts, pubkey.String())
+		delete(ht.hosts, string(pubkey.Key))
 		removedEntries = append(removedEntries, node.entry)
 	}
 
@@ -246,7 +246,7 @@ func (ht *HostTree) Fetch(n int, ignore []types.SiaPublicKey) ([]modules.HostDBE
 
 		removedEntries = append(removedEntries, node.entry)
 		node.remove()
-		delete(ht.hosts, node.entry.PublicKey.String())
+		delete(ht.hosts, string(node.entry.PublicKey.Key))
 	}
 
 	for _, entry := range removedEntries {

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -57,8 +57,8 @@ type (
 		left   *node
 		right  *node
 
-		count int
-		taken bool
+		count int  // cumulative count of this node and all children
+		taken bool // `taken` indicates whether there is an active host at this node or not.
 
 		weight types.Currency
 		entry  *HostEntry

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -45,9 +45,9 @@ type (
 	// HostEntry is an entry in the host tree.
 	HostEntry struct {
 		modules.HostDBEntry
+		weight types.Currency
 
 		FirstSeen   types.BlockHeight
-		Weight      types.Currency
 		Reliability types.Currency
 	}
 
@@ -69,7 +69,7 @@ type (
 func createNode(parent *node, entry *HostEntry) *node {
 	return &node{
 		parent: parent,
-		weight: entry.Weight,
+		weight: entry.weight,
 		count:  1,
 
 		taken: true,
@@ -96,12 +96,12 @@ func (n *node) recursiveInsert(entry *HostEntry) (nodesAdded int, newnode *node)
 	if n.parent == nil && n.left == nil && n.right == nil && !n.taken {
 		n.entry = entry
 		n.taken = true
-		n.weight = entry.Weight
+		n.weight = entry.weight
 		newnode = n
 		return
 	}
 
-	n.weight = n.weight.Add(entry.Weight)
+	n.weight = n.weight.Add(entry.weight)
 
 	// If the current node is empty, add the entry but don't increase the
 	// count.
@@ -163,11 +163,11 @@ func (n *node) nodeAtWeight(weight types.Currency) (*node, error) {
 // remove takes a node and removes it from the tree by climbing through the
 // list of parents. remove does not delete nodes.
 func (n *node) remove() {
-	n.weight = n.weight.Sub(n.entry.Weight)
+	n.weight = n.weight.Sub(n.entry.weight)
 	n.taken = false
 	current := n.parent
 	for current != nil {
-		current.weight = current.weight.Sub(n.entry.Weight)
+		current.weight = current.weight.Sub(n.entry.weight)
 		current = current.parent
 	}
 }

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -1,0 +1,258 @@
+package hosttree
+
+import (
+	"crypto/rand"
+	"errors"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+var (
+	// ErrWeightTooHeavy is returned from a Fetch() call if a weight that exceeds
+	// the total weight of the tree is requested.
+	ErrWeightTooHeavy = errors.New("requested a too-heavy weight")
+
+	// ErrNegativeWeight is returned from an Insert() call if an entry with a
+	// negative weight is added to the tree. Entries must always have a positive
+	// weight.
+	ErrNegativeWeight = errors.New("cannot insert using a negative weight")
+
+	// ErrNilEntry is returned if a fetch call results in a nil tree entry. nodes
+	// should always have a non-nil entry, unless they have been Delete()ed.
+	ErrNilEntry = errors.New("node has a nil entry")
+
+	// ErrHostExists is returned if an Insert is called with a public key that
+	// already exists in the tree.
+	ErrHostExists = errors.New("host already exists in the tree")
+
+	// ErrNoSuchHost is returned if Remove is called with a public key that does
+	// not exist in the tree.
+	ErrNoSuchHost = errors.New("no host with specified public key")
+)
+
+type (
+	// HostTree is a data structure that contains a weighted tree of
+	// `HostEntries`, and provides methods for inserting, retreiving, and
+	// modifing entries.
+	HostTree struct {
+		*node
+
+		// hosts is a map of public keys to nodes.
+		hosts map[string]*node
+	}
+
+	// HostEntry is an entry in the host tree.
+	HostEntry struct {
+		modules.HostDBEntry
+
+		FirstSeen   types.BlockHeight
+		Weight      types.Currency
+		Reliability types.Currency
+	}
+
+	// node is a node in the tree.
+	node struct {
+		parent *node
+		left   *node
+		right  *node
+
+		count int
+		taken bool
+
+		weight types.Currency
+		entry  *HostEntry
+	}
+)
+
+// createNode creates a new node using the provided `parent` and `entry`.
+func createNode(parent *node, entry *HostEntry) *node {
+	return &node{
+		parent: parent,
+		weight: entry.Weight,
+		count:  1,
+
+		taken: true,
+		entry: entry,
+	}
+}
+
+// New creates a new, empty, HostTree.
+func New() *HostTree {
+	return &HostTree{
+		node: &node{
+			count: 1,
+		},
+		hosts: make(map[string]*node),
+	}
+}
+
+// recursiveInsert inserts an entry into the appropriate place in the tree. The
+// running time of recursiveInsert is log(n) in the maximum number of elements
+// that have ever been in the tree.
+func (n *node) recursiveInsert(entry *HostEntry) (nodesAdded int, newnode *node) {
+	// If there is no parent and no children, and the node is not taken, assign
+	// this entry to this node.
+	if n.parent == nil && n.left == nil && n.right == nil && !n.taken {
+		n.entry = entry
+		n.taken = true
+		n.weight = entry.Weight
+		nodesAdded = 0
+		newnode = n
+		return
+	}
+
+	n.weight = n.weight.Add(entry.Weight)
+
+	// If the current node is empty, add the entry but don't increase the
+	// count.
+	if !n.taken {
+		n.taken = true
+		n.entry = entry
+		newnode = n
+		return
+	}
+
+	// Insert the element into the lest populated side.
+	if n.left == nil {
+		n.left = createNode(n, entry)
+		nodesAdded = 1
+		newnode = n.left
+	} else if n.right == nil {
+		n.right = createNode(n, entry)
+		nodesAdded = 1
+		newnode = n.right
+	} else if n.left.count <= n.right.count {
+		nodesAdded, newnode = n.left.recursiveInsert(entry)
+	} else {
+		nodesAdded, newnode = n.right.recursiveInsert(entry)
+	}
+
+	n.count += nodesAdded
+	return
+}
+
+// nodeAtWeight grabs an element in the tree that appears at the given weight.
+// Though the tree has an arbitrary sorting, a sufficiently random weight will
+// pull a random element. The tree is searched through in a post-ordered way.
+func (n *node) nodeAtWeight(weight types.Currency) (*node, error) {
+	// Sanity check - weight must be less than the total weight of the tree.
+	if weight.Cmp(n.weight) > 0 {
+		return nil, ErrWeightTooHeavy
+	}
+
+	// Check if the left or right child should be returned.
+	if n.left != nil {
+		if weight.Cmp(n.left.weight) < 0 {
+			return n.left.nodeAtWeight(weight)
+		}
+		weight = weight.Sub(n.left.weight) // Search from the 0th index of the right side.
+	}
+	if n.right != nil && weight.Cmp(n.right.weight) < 0 {
+		return n.right.nodeAtWeight(weight)
+	}
+
+	// Should we panic here instead?
+	if !n.taken {
+		return nil, ErrNilEntry
+	}
+
+	// Return the root entry.
+	return n, nil
+}
+
+// remove takes a node and removes it from the tree by climbing through the
+// list of parents. remove does not delete nodes.
+func (n *node) remove() {
+	n.weight = n.weight.Sub(n.entry.Weight)
+	n.taken = false
+	current := n.parent
+	for current != nil {
+		current.weight = current.weight.Sub(n.entry.Weight)
+		current = current.parent
+	}
+}
+
+// Insert inserts the entry provided to `entry` into the host tree. Insert will
+// return an error if the input host already exists.
+func (ht *HostTree) Insert(entry *HostEntry) error {
+	if _, exists := ht.hosts[entry.PublicKey.String()]; exists {
+		return ErrHostExists
+	}
+
+	_, node := ht.recursiveInsert(entry)
+
+	ht.hosts[entry.PublicKey.String()] = node
+	return nil
+}
+
+// Remove removes the host with the public key provided by `pk`.
+func (ht *HostTree) Remove(pk types.SiaPublicKey) error {
+	node, exists := ht.hosts[pk.String()]
+	if !exists {
+		return ErrNoSuchHost
+	}
+	node.remove()
+	delete(ht.hosts, pk.String())
+
+	return nil
+}
+
+// Modify updates a host entry at the given public key, replacing the old entry
+// with the entry provided by `newEntry`.
+func (ht *HostTree) Modify(pk types.SiaPublicKey, newEntry *HostEntry) error {
+	node, exists := ht.hosts[pk.String()]
+	if !exists {
+		return ErrNoSuchHost
+	}
+
+	node.remove()
+	_, node = ht.recursiveInsert(newEntry)
+
+	ht.hosts[pk.String()] = node
+	return nil
+}
+
+// Fetch grabs a random `n` hosts from the tree. There will be no repeats, but
+// the length of the slice returned may be less than `n`, and may even be zero.
+// The hosts that are returned first have the higher priority. Hosts passed to
+// `ignore` will not be considered; pass `nil` if no blacklist is desired.
+func (ht *HostTree) Fetch(n int, ignore []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
+	var hosts []modules.HostDBEntry
+	var removedEntries []*HostEntry
+
+	for _, pubkey := range ignore {
+		node, exists := ht.hosts[pubkey.String()]
+		if !exists {
+			continue
+		}
+		node.remove()
+		delete(ht.hosts, pubkey.String())
+		removedEntries = append(removedEntries, node.entry)
+	}
+
+	for len(hosts) < n && len(ht.hosts) > 0 {
+		randWeight, err := rand.Int(rand.Reader, ht.weight.Big())
+		if err != nil {
+			return hosts, err
+		}
+		node, err := ht.nodeAtWeight(types.NewCurrency(randWeight))
+		if err != nil {
+			return hosts, err
+		}
+
+		if node.entry.HostDBEntry.AcceptingContracts {
+			hosts = append(hosts, node.entry.HostDBEntry)
+		}
+
+		removedEntries = append(removedEntries, node.entry)
+		node.remove()
+		delete(ht.hosts, node.entry.PublicKey.String())
+	}
+
+	for _, entry := range removedEntries {
+		ht.Insert(entry)
+	}
+
+	return hosts, nil
+}

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -200,16 +200,16 @@ func (ht *HostTree) Remove(pk types.SiaPublicKey) error {
 
 // Modify updates a host entry at the given public key, replacing the old entry
 // with the entry provided by `newEntry`.
-func (ht *HostTree) Modify(pk types.SiaPublicKey, newEntry *HostEntry) error {
-	node, exists := ht.hosts[pk.String()]
+func (ht *HostTree) Modify(entry *HostEntry) error {
+	node, exists := ht.hosts[entry.PublicKey.String()]
 	if !exists {
 		return ErrNoSuchHost
 	}
 
 	node.remove()
-	_, node = ht.recursiveInsert(newEntry)
+	_, node = ht.recursiveInsert(entry)
 
-	ht.hosts[pk.String()] = node
+	ht.hosts[entry.PublicKey.String()] = node
 	return nil
 }
 

--- a/modules/renter/hostdb/hosttree/hosttree.go
+++ b/modules/renter/hostdb/hosttree/hosttree.go
@@ -45,8 +45,8 @@ type (
 		// hosts is a map of public keys to nodes.
 		hosts map[string]*node
 
-		// wf applies a weight to a hostEntry
-		wf WeightFunc
+		// weight applies a weight to a hostEntry
+		weight WeightFunc
 
 		mu sync.Mutex
 	}
@@ -90,8 +90,8 @@ func New(wf WeightFunc) *HostTree {
 		root: &node{
 			count: 1,
 		},
-		wf:    wf,
-		hosts: make(map[string]*node),
+		weight: wf,
+		hosts:  make(map[string]*node),
 	}
 }
 
@@ -188,7 +188,7 @@ func (ht *HostTree) Insert(hdbe modules.HostDBEntry) error {
 
 	entry := &hostEntry{
 		HostDBEntry: hdbe,
-		weight:      ht.wf(hdbe),
+		weight:      ht.weight(hdbe),
 	}
 
 	if _, exists := ht.hosts[string(entry.PublicKey.Key)]; exists {
@@ -231,7 +231,7 @@ func (ht *HostTree) Modify(hdbe modules.HostDBEntry) error {
 
 	entry := &hostEntry{
 		HostDBEntry: hdbe,
-		weight:      ht.wf(hdbe),
+		weight:      ht.weight(hdbe),
 	}
 
 	_, node = ht.root.recursiveInsert(entry)

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -1,0 +1,439 @@
+package hosttree
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+func verifyTree(tree *HostTree, nentries int) error {
+	expectedWeight := tree.entry.Weight.Mul64(uint64(nentries))
+	if tree.weight.Cmp(expectedWeight) != 0 {
+		return fmt.Errorf("expected weight is incorrect: got %v wanted %v\n", tree.weight, expectedWeight)
+	}
+
+	// Check that the length of activeHosts and the count of hostTree are
+	// consistent.
+	if len(tree.hosts) != nentries {
+		return fmt.Errorf("unexpected number of hosts: got %v wanted %v\n", len(tree.hosts), nentries)
+	}
+
+	// Select many random hosts and do naive statistical analysis on the
+	// results.
+	if !testing.Short() {
+		// Pull a bunch of random hosts and count how many times we pull each
+		// host.
+		selectionMap := make(map[string]int)
+		expected := 100
+		for i := 0; i < expected*nentries; i++ {
+			entries, err := tree.Fetch(1, nil)
+			if err != nil {
+				return err
+			}
+			if len(entries) == 0 {
+				return errors.New("no hosts")
+			}
+			selectionMap[entries[0].PublicKey.String()]++
+		}
+
+		// See if each host was selected enough times.
+		errorBound := 64 // Pretty large, but will still detect if something is seriously wrong.
+		for _, count := range selectionMap {
+			if count < expected-errorBound || count > expected+errorBound {
+				return errors.New("error bound was breached")
+			}
+		}
+	}
+
+	// Try removing an re-adding all hosts.
+	var removedEntries []*HostEntry
+	for {
+		if tree.weight.IsZero() {
+			break
+		}
+		randWeight, err := rand.Int(rand.Reader, tree.weight.Big())
+		if err != nil {
+			break
+		}
+		node, err := tree.nodeAtWeight(types.NewCurrency(randWeight))
+		if err != nil {
+			break
+		}
+		node.remove()
+		delete(tree.hosts, node.entry.PublicKey.String())
+
+		// remove the entry from the hostdb so it won't be selected as a
+		// repeat
+		removedEntries = append(removedEntries, node.entry)
+	}
+	for _, entry := range removedEntries {
+		tree.Insert(entry)
+	}
+	return nil
+}
+
+// makeHostEntry makes a new host entry with a random public key and the weight
+// provided to `weight`.
+func makeHostEntry(weight types.Currency) *HostEntry {
+	pk := types.SiaPublicKey{
+		Algorithm: types.SignatureEd25519,
+		Key:       make([]byte, 32),
+	}
+	_, err := io.ReadFull(rand.Reader, pk.Key)
+	if err != nil {
+		panic(err)
+	}
+
+	dbe := modules.HostDBEntry{}
+	dbe.AcceptingContracts = true
+	dbe.PublicKey = pk
+
+	return &HostEntry{
+		HostDBEntry: dbe,
+		Weight:      weight,
+	}
+}
+
+func TestHostTree(t *testing.T) {
+	tree := New()
+
+	// Create a bunch of host entries of equal weight.
+	firstInsertions := 64
+	var keys []types.SiaPublicKey
+	for i := 0; i < firstInsertions; i++ {
+		entry := makeHostEntry(types.NewCurrency64(10))
+		keys = append(keys, entry.PublicKey)
+		err := tree.Insert(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := verifyTree(tree, firstInsertions)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var removed []types.SiaPublicKey
+	// Randomly remove hosts from the tree and check that it is still in order.
+	for _, key := range keys {
+		shouldRemove := func() bool {
+			n, err := rand.Int(rand.Reader, big.NewInt(1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n.Cmp(big.NewInt(0)) == 0 {
+				return true
+			}
+			return false
+		}()
+
+		if shouldRemove {
+			err := tree.Remove(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			removed = append(removed, key)
+		}
+	}
+
+	err = verifyTree(tree, firstInsertions-len(removed))
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Do some more insertions.
+	secondInsertions := 64
+	for i := firstInsertions; i < firstInsertions+secondInsertions; i++ {
+		entry := makeHostEntry(types.NewCurrency64(10))
+		tree.Insert(entry)
+	}
+	err = verifyTree(tree, firstInsertions-len(removed)+secondInsertions)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestHostTreeModify(t *testing.T) {
+	tree := New()
+
+	treeSize := 100
+	var keys []types.SiaPublicKey
+	for i := 0; i < treeSize; i++ {
+		entry := makeHostEntry(types.NewCurrency64(20))
+		keys = append(keys, entry.PublicKey)
+		err := tree.Insert(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	randIndex, err := rand.Int(rand.Reader, big.NewInt(int64(treeSize)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// should fail with a nonexistent key
+	err = tree.Modify(types.SiaPublicKey{}, &HostEntry{})
+	if err != ErrNoSuchHost {
+		t.Fatalf("modify should fail with ErrNoSuchHost when provided a nonexistent public key. Got error: %v\n")
+	}
+
+	targetKey := keys[randIndex.Uint64()]
+
+	oldDBEntry := tree.hosts[targetKey.String()].entry
+
+	newDBEntry := &HostEntry{}
+	newDBEntry.PublicKey = oldDBEntry.PublicKey
+	newDBEntry.AcceptingContracts = false
+
+	err = tree.Modify(targetKey, newDBEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tree.hosts[targetKey.String()].entry.AcceptingContracts {
+		t.Fatal("modify did not update host entry")
+	}
+}
+
+// TestVariedWeights runs broad statistical tests on selecting hosts with
+// multiple different weights.
+func TestVariedWeights(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	tree := New()
+
+	// insert i hosts with the weights 0, 1, ..., i-1. 100e3 selections will be made
+	// per weight added to the tree, the total number of selections necessary
+	// will be tallied up as hosts are created.
+	var dbe modules.HostDBEntry
+	dbe.AcceptingContracts = true
+	hostCount := 5
+	expectedPerWeight := int(10e3)
+	selections := 0
+	for i := 0; i < hostCount; i++ {
+		entry := makeHostEntry(types.NewCurrency64(uint64(i)))
+		tree.Insert(entry)
+		selections += i * expectedPerWeight
+	}
+
+	// Perform many random selections, noting which host was selected each
+	// time.
+	selectionMap := make(map[string]int)
+	for i := 0; i < selections; i++ {
+		randEntry, err := tree.Fetch(1, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(randEntry) == 0 {
+			t.Fatal("no hosts!")
+		}
+		node, exists := tree.hosts[randEntry[0].PublicKey.String()]
+		if !exists {
+			t.Fatal("can't find randomly selected node in tree")
+		}
+		selectionMap[node.entry.Weight.String()]++
+	}
+
+	// Check that each host was selected an expected number of times. An error
+	// will be reported if the host of 0 weight is ever selected.
+	acceptableError := 0.2
+	for weight, timesSelected := range selectionMap {
+		intWeight, err := strconv.Atoi(weight)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedSelected := float64(intWeight * expectedPerWeight)
+		if float64(expectedSelected)*acceptableError > float64(timesSelected) || float64(expectedSelected)/acceptableError < float64(timesSelected) {
+			t.Error("weighted list not selecting in a uniform distribution based on weight")
+			t.Error(expectedSelected)
+			t.Error(timesSelected)
+		}
+	}
+}
+
+// TestRepeatInsert inserts 2 hosts with the same public key.
+func TestRepeatInsert(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	tree := New()
+
+	entry1 := makeHostEntry(types.NewCurrency64(1))
+	entry2 := entry1
+
+	tree.Insert(entry1)
+
+	entry2.Weight = types.NewCurrency64(100)
+
+	tree.Insert(entry2)
+	if len(tree.hosts) != 1 {
+		t.Error("insterting the same entry twice should result in only 1 entry")
+	}
+}
+
+// TestNodeAtWeight tests the nodeAtWeight method.
+func TestNodeAtWeight(t *testing.T) {
+	// create hostTree
+	tree := New()
+
+	entry := makeHostEntry(types.NewCurrency64(100))
+	err := tree.Insert(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// overweight
+	_, err = tree.nodeAtWeight(entry.Weight.Mul64(2))
+	if err != ErrWeightTooHeavy {
+		t.Errorf("expected %v, got %v", ErrWeightTooHeavy, err)
+	}
+
+	h, err := tree.nodeAtWeight(entry.Weight)
+	if err != nil {
+		t.Error(err)
+	} else if h.entry != entry {
+		t.Errorf("nodeAtWeight returned wrong node: expected %v, got %v", entry, h.entry)
+	}
+}
+
+// TestRandomHosts probes the Fetch method.
+func TestRandomHosts(t *testing.T) {
+	// Create the tree.
+	tree := New()
+
+	// Empty.
+	hosts, err := tree.Fetch(1, nil)
+	if len(hosts) != 0 {
+		t.Errorf("empty hostdb returns %v hosts: %v", len(hosts), hosts)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert 3 hosts to be selected.
+	entry1 := makeHostEntry(types.NewCurrency64(1))
+	entry2 := makeHostEntry(types.NewCurrency64(2))
+	entry3 := makeHostEntry(types.NewCurrency64(3))
+
+	if err = tree.Insert(entry1); err != nil {
+		t.Fatal(err)
+	}
+	if err = tree.Insert(entry2); err != nil {
+		t.Fatal(err)
+	}
+	if err = tree.Insert(entry3); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tree.hosts) != 3 {
+		t.Error("wrong number of hosts")
+	}
+	if tree.weight.Cmp(types.NewCurrency64(6)) != 0 {
+		t.Error("unexpected weight at initialization")
+		t.Error(tree.weight)
+	}
+
+	// Grab 1 random host.
+	randHosts, err := tree.Fetch(1, nil)
+	if len(randHosts) != 1 {
+		t.Error("didn't get 1 hosts")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Grab 2 random hosts.
+	randHosts, err = tree.Fetch(2, nil)
+	if len(randHosts) != 2 {
+		t.Error("didn't get 2 hosts")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if randHosts[0].PublicKey.String() == randHosts[1].PublicKey.String() {
+		t.Error("doubled up")
+	}
+
+	// Grab 3 random hosts.
+	randHosts, err = tree.Fetch(3, nil)
+	if len(randHosts) != 3 {
+		t.Error("didn't get 3 hosts")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if randHosts[0].PublicKey.String() == randHosts[1].PublicKey.String() || randHosts[0].PublicKey.String() == randHosts[2].PublicKey.String() || randHosts[1].PublicKey.String() == randHosts[2].PublicKey.String() {
+		t.Error("doubled up")
+	}
+
+	// Grab 4 random hosts. 3 should be returned.
+	randHosts, err = tree.Fetch(4, nil)
+	if len(randHosts) != 3 {
+		t.Error("didn't get 3 hosts")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if randHosts[0].PublicKey.String() == randHosts[1].PublicKey.String() || randHosts[0].PublicKey.String() == randHosts[2].PublicKey.String() || randHosts[1].PublicKey.String() == randHosts[2].PublicKey.String() {
+		t.Error("doubled up")
+	}
+
+	// Ask for 3 hosts that are not in randHosts. No hosts should be
+	// returned.
+	uniqueHosts, err := tree.Fetch(3, []types.SiaPublicKey{
+		randHosts[0].PublicKey,
+		randHosts[1].PublicKey,
+		randHosts[2].PublicKey,
+	})
+	if len(uniqueHosts) != 0 {
+		t.Error("didn't get 0 hosts")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ask for 3 hosts, blacklisting non-existent hosts. 3 should be returned.
+	randHosts, err = tree.Fetch(3, []types.SiaPublicKey{{}, {}, {}})
+	if len(randHosts) != 3 {
+		t.Error("didn't get 3 hosts")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if randHosts[0].PublicKey.String() == randHosts[1].PublicKey.String() || randHosts[0].PublicKey.String() == randHosts[2].PublicKey.String() || randHosts[1].PublicKey.String() == randHosts[2].PublicKey.String() {
+		t.Error("doubled up")
+	}
+
+	// entry4 should not every be returned by RandomHosts because it is not
+	// accepting contracts.
+	entry4 := makeHostEntry(types.NewCurrency64(4))
+	entry4.AcceptingContracts = false
+	tree.Insert(entry4)
+
+	// Grab 4 random hosts. 3 should be returned.
+	randHosts, err = tree.Fetch(4, nil)
+	if len(randHosts) != 3 {
+		t.Error("didn't get 3 hosts")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if randHosts[0].PublicKey.String() == randHosts[1].PublicKey.String() || randHosts[0].PublicKey.String() == randHosts[2].PublicKey.String() || randHosts[1].PublicKey.String() == randHosts[2].PublicKey.String() {
+		t.Error("doubled up")
+	}
+}

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -180,20 +180,19 @@ func TestHostTreeModify(t *testing.T) {
 	}
 
 	// should fail with a nonexistent key
-	err = tree.Modify(types.SiaPublicKey{}, &HostEntry{})
+	err = tree.Modify(&HostEntry{})
 	if err != ErrNoSuchHost {
 		t.Fatalf("modify should fail with ErrNoSuchHost when provided a nonexistent public key. Got error: %v\n", err)
 	}
 
 	targetKey := keys[randIndex.Uint64()]
 
-	oldDBEntry := tree.hosts[targetKey.String()].entry
+	oldEntry := tree.hosts[targetKey.String()].entry
+	newEntry := makeHostEntry(types.NewCurrency64(30))
+	newEntry.AcceptingContracts = false
+	newEntry.PublicKey = oldEntry.PublicKey
 
-	newDBEntry := &HostEntry{}
-	newDBEntry.PublicKey = oldDBEntry.PublicKey
-	newDBEntry.AcceptingContracts = false
-
-	err = tree.Modify(targetKey, newDBEntry)
+	err = tree.Modify(newEntry)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -195,7 +195,7 @@ func TestHostTreeParallel(t *testing.T) {
 
 			for {
 				select {
-				case <-time.After(time.Second * 50):
+				case <-time.After(time.Millisecond * 50):
 				case <-tg.StopChan():
 					return
 				default:

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -40,7 +40,7 @@ func verifyTree(tree *HostTree, nentries int) error {
 			if len(entries) == 0 {
 				return errors.New("no hosts")
 			}
-			selectionMap[entries[0].PublicKey.String()]++
+			selectionMap[string(entries[0].PublicKey.Key)]++
 		}
 
 		// See if each host was selected enough times.
@@ -67,7 +67,7 @@ func verifyTree(tree *HostTree, nentries int) error {
 			break
 		}
 		node.remove()
-		delete(tree.hosts, node.entry.PublicKey.String())
+		delete(tree.hosts, string(node.entry.PublicKey.Key))
 
 		// remove the entry from the hostdb so it won't be selected as a
 		// repeat
@@ -187,7 +187,7 @@ func TestHostTreeModify(t *testing.T) {
 
 	targetKey := keys[randIndex.Uint64()]
 
-	oldEntry := tree.hosts[targetKey.String()].entry
+	oldEntry := tree.hosts[string(targetKey.Key)].entry
 	newEntry := makeHostEntry(types.NewCurrency64(30))
 	newEntry.AcceptingContracts = false
 	newEntry.PublicKey = oldEntry.PublicKey
@@ -197,7 +197,7 @@ func TestHostTreeModify(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if tree.hosts[targetKey.String()].entry.AcceptingContracts {
+	if tree.hosts[string(targetKey.Key)].entry.AcceptingContracts {
 		t.Fatal("modify did not update host entry")
 	}
 }
@@ -236,7 +236,7 @@ func TestVariedWeights(t *testing.T) {
 		if len(randEntry) == 0 {
 			t.Fatal("no hosts!")
 		}
-		node, exists := tree.hosts[randEntry[0].PublicKey.String()]
+		node, exists := tree.hosts[string(randEntry[0].PublicKey.Key)]
 		if !exists {
 			t.Fatal("can't find randomly selected node in tree")
 		}

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -195,7 +195,6 @@ func TestHostTreeParallel(t *testing.T) {
 
 			for {
 				select {
-				case <-time.After(time.Millisecond * 50):
 				case <-tg.StopChan():
 					return
 				default:

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -36,7 +36,7 @@ func verifyTree(tree *HostTree, nentries int) error {
 		selectionMap := make(map[string]int)
 		expected := 100
 		for i := 0; i < expected*nentries; i++ {
-			entries, err := tree.Fetch(1, nil)
+			entries, err := tree.SelectRandom(1, nil)
 			if err != nil {
 				return err
 			}
@@ -254,7 +254,7 @@ func TestHostTreeParallel(t *testing.T) {
 
 					// FETCH
 					if randInt.Uint64() == 3 {
-						_, err := tree.Fetch(3, nil)
+						_, err := tree.SelectRandom(3, nil)
 						if err != nil {
 							t.Error(err)
 						}
@@ -350,7 +350,7 @@ func TestVariedWeights(t *testing.T) {
 	// time.
 	selectionMap := make(map[string]int)
 	for i := 0; i < selections; i++ {
-		randEntry, err := tree.Fetch(1, nil)
+		randEntry, err := tree.SelectRandom(1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -430,7 +430,7 @@ func TestNodeAtWeight(t *testing.T) {
 	}
 }
 
-// TestRandomHosts probes the Fetch method.
+// TestRandomHosts probes the SelectRandom method.
 func TestRandomHosts(t *testing.T) {
 	calls := 0
 	// Create the tree.
@@ -440,7 +440,7 @@ func TestRandomHosts(t *testing.T) {
 	})
 
 	// Empty.
-	hosts, err := tree.Fetch(1, nil)
+	hosts, err := tree.SelectRandom(1, nil)
 	if len(hosts) != 0 {
 		t.Errorf("empty hostdb returns %v hosts: %v", len(hosts), hosts)
 	}
@@ -472,7 +472,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 1 random host.
-	randHosts, err := tree.Fetch(1, nil)
+	randHosts, err := tree.SelectRandom(1, nil)
 	if len(randHosts) != 1 {
 		t.Error("didn't get 1 hosts")
 	}
@@ -481,7 +481,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 2 random hosts.
-	randHosts, err = tree.Fetch(2, nil)
+	randHosts, err = tree.SelectRandom(2, nil)
 	if len(randHosts) != 2 {
 		t.Error("didn't get 2 hosts")
 	}
@@ -493,7 +493,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 3 random hosts.
-	randHosts, err = tree.Fetch(3, nil)
+	randHosts, err = tree.SelectRandom(3, nil)
 	if len(randHosts) != 3 {
 		t.Error("didn't get 3 hosts")
 	}
@@ -506,7 +506,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Grab 4 random hosts. 3 should be returned.
-	randHosts, err = tree.Fetch(4, nil)
+	randHosts, err = tree.SelectRandom(4, nil)
 	if len(randHosts) != 3 {
 		t.Error("didn't get 3 hosts")
 	}
@@ -520,7 +520,7 @@ func TestRandomHosts(t *testing.T) {
 
 	// Ask for 3 hosts that are not in randHosts. No hosts should be
 	// returned.
-	uniqueHosts, err := tree.Fetch(3, []types.SiaPublicKey{
+	uniqueHosts, err := tree.SelectRandom(3, []types.SiaPublicKey{
 		randHosts[0].PublicKey,
 		randHosts[1].PublicKey,
 		randHosts[2].PublicKey,
@@ -533,7 +533,7 @@ func TestRandomHosts(t *testing.T) {
 	}
 
 	// Ask for 3 hosts, blacklisting non-existent hosts. 3 should be returned.
-	randHosts, err = tree.Fetch(3, []types.SiaPublicKey{{}, {}, {}})
+	randHosts, err = tree.SelectRandom(3, []types.SiaPublicKey{{}, {}, {}})
 	if len(randHosts) != 3 {
 		t.Error("didn't get 3 hosts")
 	}
@@ -552,7 +552,7 @@ func TestRandomHosts(t *testing.T) {
 	tree.Insert(entry4)
 
 	// Grab 4 random hosts. 3 should be returned.
-	randHosts, err = tree.Fetch(4, nil)
+	randHosts, err = tree.SelectRandom(4, nil)
 	if len(randHosts) != 3 {
 		t.Error("didn't get 3 hosts")
 	}

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -182,7 +182,7 @@ func TestHostTreeModify(t *testing.T) {
 	// should fail with a nonexistent key
 	err = tree.Modify(types.SiaPublicKey{}, &HostEntry{})
 	if err != ErrNoSuchHost {
-		t.Fatalf("modify should fail with ErrNoSuchHost when provided a nonexistent public key. Got error: %v\n")
+		t.Fatalf("modify should fail with ErrNoSuchHost when provided a nonexistent public key. Got error: %v\n", err)
 	}
 
 	targetKey := keys[randIndex.Uint64()]

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -300,7 +300,7 @@ func TestHostTreeModify(t *testing.T) {
 
 	// should fail with a nonexistent key
 	err = tree.Modify(modules.HostDBEntry{})
-	if err != ErrNoSuchHost {
+	if err != errNoSuchHost {
 		t.Fatalf("modify should fail with ErrNoSuchHost when provided a nonexistent public key. Got error: %v\n", err)
 	}
 
@@ -418,8 +418,8 @@ func TestNodeAtWeight(t *testing.T) {
 
 	// overweight
 	_, err = tree.root.nodeAtWeight(weight.Mul64(2))
-	if err != ErrWeightTooHeavy {
-		t.Errorf("expected %v, got %v", ErrWeightTooHeavy, err)
+	if err != errWeightTooHeavy {
+		t.Errorf("expected %v, got %v", errWeightTooHeavy, err)
 	}
 
 	h, err := tree.root.nodeAtWeight(weight)

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func verifyTree(tree *HostTree, nentries int) error {
-	expectedWeight := tree.entry.Weight.Mul64(uint64(nentries))
-	if tree.weight.Cmp(expectedWeight) != 0 {
-		return fmt.Errorf("expected weight is incorrect: got %v wanted %v\n", tree.weight, expectedWeight)
+	expectedWeight := tree.root.entry.Weight.Mul64(uint64(nentries))
+	if tree.root.weight.Cmp(expectedWeight) != 0 {
+		return fmt.Errorf("expected weight is incorrect: got %v wanted %v\n", tree.root.weight, expectedWeight)
 	}
 
 	// Check that the length of activeHosts and the count of hostTree are
@@ -55,14 +55,14 @@ func verifyTree(tree *HostTree, nentries int) error {
 	// Try removing an re-adding all hosts.
 	var removedEntries []*HostEntry
 	for {
-		if tree.weight.IsZero() {
+		if tree.root.weight.IsZero() {
 			break
 		}
-		randWeight, err := rand.Int(rand.Reader, tree.weight.Big())
+		randWeight, err := rand.Int(rand.Reader, tree.root.weight.Big())
 		if err != nil {
 			break
 		}
-		node, err := tree.nodeAtWeight(types.NewCurrency(randWeight))
+		node, err := tree.root.nodeAtWeight(types.NewCurrency(randWeight))
 		if err != nil {
 			break
 		}
@@ -294,12 +294,12 @@ func TestNodeAtWeight(t *testing.T) {
 	}
 
 	// overweight
-	_, err = tree.nodeAtWeight(entry.Weight.Mul64(2))
+	_, err = tree.root.nodeAtWeight(entry.Weight.Mul64(2))
 	if err != ErrWeightTooHeavy {
 		t.Errorf("expected %v, got %v", ErrWeightTooHeavy, err)
 	}
 
-	h, err := tree.nodeAtWeight(entry.Weight)
+	h, err := tree.root.nodeAtWeight(entry.Weight)
 	if err != nil {
 		t.Error(err)
 	} else if h.entry != entry {
@@ -339,9 +339,9 @@ func TestRandomHosts(t *testing.T) {
 	if len(tree.hosts) != 3 {
 		t.Error("wrong number of hosts")
 	}
-	if tree.weight.Cmp(types.NewCurrency64(6)) != 0 {
+	if tree.root.weight.Cmp(types.NewCurrency64(6)) != 0 {
 		t.Error("unexpected weight at initialization")
-		t.Error(tree.weight)
+		t.Error(tree.root.weight)
 	}
 
 	// Grab 1 random host.

--- a/modules/renter/hostdb/hosttree/hosttree_test.go
+++ b/modules/renter/hostdb/hosttree/hosttree_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func verifyTree(tree *HostTree, nentries int) error {
-	expectedWeight := tree.root.entry.Weight.Mul64(uint64(nentries))
+	expectedWeight := tree.root.entry.weight.Mul64(uint64(nentries))
 	if tree.root.weight.Cmp(expectedWeight) != 0 {
 		return fmt.Errorf("expected weight is incorrect: got %v wanted %v\n", tree.root.weight, expectedWeight)
 	}
@@ -97,7 +97,7 @@ func makeHostEntry(weight types.Currency) *HostEntry {
 
 	return &HostEntry{
 		HostDBEntry: dbe,
-		Weight:      weight,
+		weight:      weight,
 	}
 }
 
@@ -240,7 +240,7 @@ func TestVariedWeights(t *testing.T) {
 		if !exists {
 			t.Fatal("can't find randomly selected node in tree")
 		}
-		selectionMap[node.entry.Weight.String()]++
+		selectionMap[node.entry.weight.String()]++
 	}
 
 	// Check that each host was selected an expected number of times. An error
@@ -274,7 +274,7 @@ func TestRepeatInsert(t *testing.T) {
 
 	tree.Insert(entry1)
 
-	entry2.Weight = types.NewCurrency64(100)
+	entry2.weight = types.NewCurrency64(100)
 
 	tree.Insert(entry2)
 	if len(tree.hosts) != 1 {
@@ -294,12 +294,12 @@ func TestNodeAtWeight(t *testing.T) {
 	}
 
 	// overweight
-	_, err = tree.root.nodeAtWeight(entry.Weight.Mul64(2))
+	_, err = tree.root.nodeAtWeight(entry.weight.Mul64(2))
 	if err != ErrWeightTooHeavy {
 		t.Errorf("expected %v, got %v", ErrWeightTooHeavy, err)
 	}
 
-	h, err := tree.root.nodeAtWeight(entry.Weight)
+	h, err := tree.root.nodeAtWeight(entry.weight)
 	if err != nil {
 		t.Error(err)
 	} else if h.entry != entry {


### PR DESCRIPTION
This PR introduces the `hosttree` subpackage to the renter's hostdb. This package exposes a minimal interface for inserting, deleting, modifying, and fetching hosts from the tree. A later PR will implement this package with the `hostdb`. Most of the testing from the previous `weightedlist` implementation has been preserved. Hosts are now indexed by Public Key instead of NetAddress.