### PR TITLE
Add individual contract metrics

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -83,9 +83,10 @@ type (
 
 // renterHandlerGET handles the API call to /renter.
 func (api *API) renterHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	renterMetrics, _ := api.renter.Metrics()
 	WriteJSON(w, RenterGET{
 		Settings:         api.renter.Settings(),
-		FinancialMetrics: api.renter.FinancialMetrics(),
+		FinancialMetrics: renterMetrics,
 	})
 }
 

--- a/api/renter.go
+++ b/api/renter.go
@@ -32,8 +32,9 @@ var (
 type (
 	// RenterGET contains various renter metrics.
 	RenterGET struct {
-		Settings         modules.RenterSettings         `json:"settings"`
-		FinancialMetrics modules.RenterFinancialMetrics `json:"financialmetrics"`
+		Settings         modules.RenterSettings          `json:"settings"`
+		FinancialMetrics modules.RenterFinancialMetrics  `json:"financialmetrics"`
+		ContractMetrics  []modules.RenterContractMetrics `json:"contractmetrics"`
 	}
 
 	// RenterContract represents a contract formed by the renter.
@@ -83,10 +84,11 @@ type (
 
 // renterHandlerGET handles the API call to /renter.
 func (api *API) renterHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	renterMetrics, _ := api.renter.Metrics()
+	renterMetrics, contractMetrics := api.renter.Metrics()
 	WriteJSON(w, RenterGET{
 		Settings:         api.renter.Settings(),
 		FinancialMetrics: renterMetrics,
+		ContractMetrics:  contractMetrics,
 	})
 }
 

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -249,3 +249,111 @@ func TestIntegrationUploadDownload(t *testing.T) {
 		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0], rf.Files[1])
 	}
 }
+
+// TestIntegrationRenterMetrics tests that the renter's metrics are properly
+// reported after uploading and downloading.
+func TestIntegrationRenterMetrics(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestIntegrationRenterMetrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Announce the host and start accepting contracts.
+	err = st.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.acceptContracts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.setHostStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Renter metrics should be zero.
+	var metrics RenterGET
+	err = st.getAPI("/renter", &metrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !metrics.FinancialMetrics.ContractSpending.IsZero() || len(metrics.ContractMetrics) > 0 {
+		t.Error("renter should not have formed any contracts yet:", metrics.FinancialMetrics)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	testFunds := "10000000000000000000000000000" // 10k SC
+	testPeriod := "5"
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Metrics should reflect new allowance.
+	err = st.getAPI("/renter", &metrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metrics.FinancialMetrics.ContractSpending.IsZero() || len(metrics.ContractMetrics) == 0 {
+		t.Error("renter metrics should reflect contract spending:", metrics.FinancialMetrics)
+	}
+
+	// Create a file.
+	path := filepath.Join(st.dir, "test.dat")
+	err = createRandFile(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload to host.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	err = st.stdPostAPI("/renter/upload/test", uploadValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only one piece will be uploaded (10% at current redundancy).
+	var rf RenterFiles
+	for i := 0; i < 200 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
+		st.getAPI("/renter/files", &rf)
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10 {
+		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
+	}
+
+	// Metrics should reflect upload spending and storage spending.
+	err = st.getAPI("/renter", &metrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metrics.FinancialMetrics.UploadSpending.IsZero() || !metrics.FinancialMetrics.UploadSpending.Equals(metrics.ContractMetrics[0].UploadSpending) {
+		t.Error("renter metrics should reflect upload spending:", metrics.FinancialMetrics)
+	}
+	if metrics.FinancialMetrics.StorageSpending.IsZero() || !metrics.FinancialMetrics.StorageSpending.Equals(metrics.ContractMetrics[0].StorageSpending) {
+		t.Error("renter metrics should reflect storage spending:", metrics.FinancialMetrics)
+	}
+
+	// Download the first file.
+	err = st.stdGetAPI("/renter/download/test?destination=" + filepath.Join(st.dir, "testdown.dat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Metrics should reflect upload spending and storage spending.
+	err = st.getAPI("/renter", &metrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metrics.FinancialMetrics.DownloadSpending.IsZero() || !metrics.FinancialMetrics.DownloadSpending.Equals(metrics.ContractMetrics[0].DownloadSpending) {
+		t.Error("renter metrics should reflect download spending:", metrics.FinancialMetrics)
+	}
+}

--- a/doc/API.md
+++ b/doc/API.md
@@ -645,12 +645,6 @@ returns the current settings along with metrics on the renter's spending.
   },
   "contractmetrics": [
     {
-      "allowance": {
-        "funds":       "1234", // hastings
-        "hosts":       24,
-        "period":      6048, // blocks
-        "renewwindow": 3024  // blocks
-      },
       "contractfee":      "1234", // hastings
       "downloadspending": "9876", // hastings
       "endheight":        5678,   // blocks

--- a/doc/API.md
+++ b/doc/API.md
@@ -638,11 +638,27 @@ returns the current settings along with metrics on the renter's spending.
     }
   },
   "financialmetrics": {
-    "contractspending": "1234", // hastings
-    "downloadspending": "5678", // hastings
-    "storagespending":  "1234", // hastings
-    "uploadspending":   "5678"  // hastings
-  }
+    "allowanceperiodstart": 5678, // blocks
+    "contractspending":     "1234", // hastings
+    "downloadspending":     "5678", // hastings
+    "storagespending":      "1234", // hastings
+    "uploadspending":       "5678"  // hastings
+  },
+  "contractmetrics": [
+    {
+      "contractfee":      "1234", // hastings
+      "downloadspending": "9876", // hastings
+      "endheight":        5678,   // blocks
+      "id":               "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "siafundfee":       "5678", // hastings
+      "startheight":      1234,   // blocks
+      "storagespending":  "5432", // hastings
+      "totalcost":        "9876", // hastings
+      "txnfee":           "5432", // hastings
+      "unspent":          "5678", // hastings
+      "uploadspending":   "1234"  // hastings
+    }
+  ]
 }
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -655,6 +655,7 @@ returns the current settings along with metrics on the renter's spending.
       "downloadspending": "9876", // hastings
       "endheight":        5678,   // blocks
       "id":               "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "periodstart":      5678,   // blocks
       "siafundfee":       "5678", // hastings
       "startheight":      1234,   // blocks
       "storagespending":  "5432", // hastings

--- a/doc/API.md
+++ b/doc/API.md
@@ -638,7 +638,6 @@ returns the current settings along with metrics on the renter's spending.
     }
   },
   "financialmetrics": {
-    "allowanceperiodstart": 5678, // blocks
     "contractspending":     "1234", // hastings
     "downloadspending":     "5678", // hastings
     "storagespending":      "1234", // hastings
@@ -646,6 +645,12 @@ returns the current settings along with metrics on the renter's spending.
   },
   "contractmetrics": [
     {
+      "allowance": {
+        "funds":       "1234", // hastings
+        "hosts":       24,
+        "period":      6048, // blocks
+        "renewwindow": 3024  // blocks
+      },
       "contractfee":      "1234", // hastings
       "downloadspending": "9876", // hastings
       "endheight":        5678,   // blocks

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -63,6 +63,9 @@ returns the current settings along with metrics on the renter's spending.
   // Metrics about how much the Renter has spent on storage, uploads, and
   // downloads.
   "financialmetrics": {
+    // Blockheight at which the current allowance period began.
+    "allowanceperiodstart": 5678,
+
     // How much money, in hastings, the Renter has paid into file contracts
     // formed with hosts. Note that some of this money may be returned to the
     // Renter when the contract ends. To calculate how much will be returned,
@@ -78,7 +81,47 @@ returns the current settings along with metrics on the renter's spending.
 
     // Amount of money spent on uploads.
     "uploadspending": "5678" // hastings
-  }
+  },
+
+  // Metrics pertaining to each contract formed by the Renter.
+  "contractmetrics": [
+    {
+      // Flat fee required by the host for forming a contract.
+      "contractfee": "1234",
+
+      // Amount of money spent on downloads.
+      "downloadspending": "9876",
+
+      // Ending height of the contract.
+      "endheight": 5678,
+
+      // ID of the associated contract.
+      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
+      // Tax paid out to siafund holders.
+      "siafundfee": "5678",
+
+      // Starting height of the contract.
+      "startheight": 1234,
+
+      // Amount of money spend on storage.
+      "storagespending": "5432",
+
+      // Total amount of money that the Renter spent to create the contract
+      // and submit it to the blockchain.
+      "totalcost": "9876",
+
+      // Transaction fee on the transaction that contained the contract.
+      "txnfee": "5432",
+
+      // Amount of money in the contract that can still spend on storage,
+      // downloads, and uploads.
+      "unspent": "5678",
+
+      // Amount of money spent on uploads.
+      "uploadspending": "1234"
+    }
+  ]
 }
 ```
 

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -83,15 +83,6 @@ returns the current settings along with metrics on the renter's spending.
   // Metrics pertaining to each contract formed by the Renter.
   "contractmetrics": [
     {
-      // Allowance that the contract was formed under. See settings.allowance
-      // for a description of each allowance field.
-      "allowance": {
-        "funds":       "1234", // hastings
-        "hosts":       24,
-        "period":      6048, // blocks
-        "renewwindow": 3024  // blocks
-      },
-
       // Flat fee required by the host for forming a contract.
       "contractfee": "1234", // hastings
 

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -63,9 +63,6 @@ returns the current settings along with metrics on the renter's spending.
   // Metrics about how much the Renter has spent on storage, uploads, and
   // downloads.
   "financialmetrics": {
-    // Blockheight at which the current allowance period began.
-    "allowanceperiodstart": 5678,
-
     // How much money, in hastings, the Renter has paid into file contracts
     // formed with hosts. Note that some of this money may be returned to the
     // Renter when the contract ends. To calculate how much will be returned,
@@ -86,6 +83,15 @@ returns the current settings along with metrics on the renter's spending.
   // Metrics pertaining to each contract formed by the Renter.
   "contractmetrics": [
     {
+      // Allowance that the contract was formed under. See settings.allowance
+      // for a description of each allowance field.
+      "allowance": {
+        "funds":       "1234", // hastings
+        "hosts":       24,
+        "period":      6048, // blocks
+        "renewwindow": 3024  // blocks
+      },
+
       // Flat fee required by the host for forming a contract.
       "contractfee": "1234",
 

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -93,39 +93,42 @@ returns the current settings along with metrics on the renter's spending.
       },
 
       // Flat fee required by the host for forming a contract.
-      "contractfee": "1234",
+      "contractfee": "1234", // hastings
 
       // Amount of money spent on downloads.
-      "downloadspending": "9876",
+      "downloadspending": "9876", // hastings
 
       // Ending height of the contract.
-      "endheight": 5678,
+      "endheight": 5678, // blocks
 
       // ID of the associated contract.
       "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 
+      // Start of the allowance period that the contract was formed in.
+      "periodstart": 1234, // blocks
+
       // Tax paid out to siafund holders.
-      "siafundfee": "5678",
+      "siafundfee": "5678", // hastings
 
       // Starting height of the contract.
-      "startheight": 1234,
+      "startheight": 1234, // blocks
 
       // Amount of money spend on storage.
-      "storagespending": "5432",
+      "storagespending": "5432", // hastings
 
       // Total amount of money that the Renter spent to create the contract
       // and submit it to the blockchain.
-      "totalcost": "9876",
+      "totalcost": "9876", // hastings
 
       // Transaction fee on the transaction that contained the contract.
-      "txnfee": "5432",
+      "txnfee": "5432", // hastings
 
       // Amount of money in the contract that can still spend on storage,
       // downloads, and uploads.
-      "unspent": "5678",
+      "unspent": "5678", // hastings
 
       // Amount of money spent on uploads.
-      "uploadspending": "1234"
+      "uploadspending": "1234" // hastings
     }
   ]
 }

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -94,6 +94,32 @@ type RenterFinancialMetrics struct {
 	UploadSpending   types.Currency `json:"uploadspending"`
 }
 
+// RenterContractMetrics contains metrics relevant to a single file contract.
+type RenterContractMetrics struct {
+	// The ID of the associated contract.
+	ID types.FileContractID
+
+	// The total amount of money that the Renter spent to create the contract
+	// and submit it to the blockchain.
+	TotalCost types.Currency `json:"totalcost"`
+
+	// The transaction fee on the transaction that contained the contract.
+	TxnFee types.Currency `json:"txnfee"`
+	// The flat fee required by the host for forming a contract.
+	ContractFee types.Currency `json:"contractfee"`
+	// The tax paid out to siafund holders.
+	SiafundFee types.Currency `json:"siafundfee"`
+
+	DownloadSpending types.Currency `json:"downloadspending"`
+	StorageSpending  types.Currency `json:"storagespending"`
+	UploadSpending   types.Currency `json:"uploadspending"`
+
+	// TotalCost minus all the preceeding fields; in other words, the amount
+	// of money that the Renter can still spend on storage, downloads, and
+	// uploads. Note that this is the same as RenterContract.RenterFunds.
+	Unspent types.Currency `json:"unspent"`
+}
+
 // A HostDBEntry represents one host entry in the Renter's host DB. It
 // aggregates the host's external settings and metrics with its public key.
 type HostDBEntry struct {
@@ -169,9 +195,6 @@ type Renter interface {
 	// FileList returns information on all of the files stored by the renter.
 	FileList() []FileInfo
 
-	// FinancialMetrics returns the financial metrics of the Renter.
-	FinancialMetrics() RenterFinancialMetrics
-
 	// LoadSharedFiles loads a '.sia' file into the renter. A .sia file may
 	// contain multiple files. The paths of the added files are returned.
 	LoadSharedFiles(source string) ([]string, error)
@@ -179,6 +202,9 @@ type Renter interface {
 	// LoadSharedFilesAscii loads an ASCII-encoded '.sia' file into the
 	// renter.
 	LoadSharedFilesAscii(asciiSia string) ([]string, error)
+
+	// Metrics returns the metrics of the Renter.
+	Metrics() (RenterFinancialMetrics, []RenterContractMetrics)
 
 	// RenameFile changes the path of a file.
 	RenameFile(path, newPath string) error

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -103,6 +103,9 @@ type RenterContractMetrics struct {
 	// The ID of the associated contract.
 	ID types.FileContractID `json:"id"`
 
+	// The allowance that the contract was formed under.
+	Allowance Allowance `json:"allowance"`
+
 	// The starting and ending height of the contract. Note that EndHeight is
 	// the same as RenterContract.EndHeight.
 	StartHeight types.BlockHeight `json:"startheight"`

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -92,6 +92,10 @@ type RenterFinancialMetrics struct {
 	DownloadSpending types.Currency `json:"downloadspending"`
 	StorageSpending  types.Currency `json:"storagespending"`
 	UploadSpending   types.Currency `json:"uploadspending"`
+
+	// AllowancePeriodStart is the blockheight at which the current allowance
+	// period began.
+	AllowancePeriodStart types.BlockHeight `json:"allowanceperiodstart"`
 }
 
 // RenterContractMetrics contains metrics relevant to a single file contract.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -103,9 +103,6 @@ type RenterContractMetrics struct {
 	// The ID of the associated contract.
 	ID types.FileContractID `json:"id"`
 
-	// The allowance that the contract was formed under.
-	Allowance Allowance `json:"allowance"`
-
 	// The starting height of the allowance period that the contract was
 	// formed in.
 	PeriodStart types.BlockHeight `json:"allowanceperiodstart"`

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -106,6 +106,10 @@ type RenterContractMetrics struct {
 	// The allowance that the contract was formed under.
 	Allowance Allowance `json:"allowance"`
 
+	// The starting height of the allowance period that the contract was
+	// formed in.
+	PeriodStart types.BlockHeight `json:"allowanceperiodstart"`
+
 	// The starting and ending height of the contract. Note that EndHeight is
 	// the same as RenterContract.EndHeight.
 	StartHeight types.BlockHeight `json:"startheight"`

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -97,7 +97,12 @@ type RenterFinancialMetrics struct {
 // RenterContractMetrics contains metrics relevant to a single file contract.
 type RenterContractMetrics struct {
 	// The ID of the associated contract.
-	ID types.FileContractID
+	ID types.FileContractID `json:"id"`
+
+	// The starting and ending height of the contract. Note that EndHeight is
+	// the same as RenterContract.EndHeight.
+	StartHeight types.BlockHeight `json:"startheight"`
+	EndHeight   types.BlockHeight `json:"endheight"`
 
 	// The total amount of money that the Renter spent to create the contract
 	// and submit it to the blockchain.

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -87,6 +87,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		// They will be renewed with the new allowance when they expire.
 		c.mu.Lock()
 		c.allowance = a
+		c.periodStart = c.blockHeight
 		err = c.saveSync()
 		c.mu.Unlock()
 		return err
@@ -153,6 +154,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		spending = spending.Add(contract.RenterFunds())
 	}
 	c.financialMetrics.ContractSpending = spending
+	c.periodStart = endHeight - a.Period
 	err = c.saveSync()
 	c.mu.Unlock()
 

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -87,7 +87,6 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		// They will be renewed with the new allowance when they expire.
 		c.mu.Lock()
 		c.allowance = a
-		c.financialMetrics.AllowancePeriodStart = c.blockHeight
 		err = c.saveSync()
 		c.mu.Unlock()
 		return err
@@ -154,7 +153,6 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		spending = spending.Add(contract.RenterFunds())
 	}
 	c.financialMetrics.ContractSpending = spending
-	c.financialMetrics.AllowancePeriodStart = endHeight - a.Period
 	err = c.saveSync()
 	c.mu.Unlock()
 

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -87,6 +87,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		// They will be renewed with the new allowance when they expire.
 		c.mu.Lock()
 		c.allowance = a
+		c.financialMetrics.AllowancePeriodStart = c.blockHeight
 		err = c.saveSync()
 		c.mu.Unlock()
 		return err
@@ -153,6 +154,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		spending = spending.Add(contract.RenterFunds())
 	}
 	c.financialMetrics.ContractSpending = spending
+	c.financialMetrics.AllowancePeriodStart = endHeight - a.Period
 	err = c.saveSync()
 	c.mu.Unlock()
 

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -102,7 +102,8 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 
 	// calculate new endHeight; if the period has not changed, the endHeight
 	// should not change either
-	endHeight := c.blockHeight + a.Period
+	periodStart := c.blockHeight
+	endHeight := periodStart + a.Period
 	if a.Period == c.allowance.Period && len(c.contracts) > 0 {
 		// COMPAT v0.6.0 - old hosts require end height increase by at least 1
 		endHeight = c.contractEndHeight() + 1
@@ -154,7 +155,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		spending = spending.Add(contract.RenterFunds())
 	}
 	c.financialMetrics.ContractSpending = spending
-	c.periodStart = endHeight - a.Period
+	c.periodStart = periodStart
 	err = c.saveSync()
 	c.mu.Unlock()
 

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -51,6 +51,7 @@ type Contractor struct {
 	revising        map[types.FileContractID]bool // prevent overlapping revisions
 
 	financialMetrics modules.RenterFinancialMetrics
+	contractMetrics  map[types.FileContractID]modules.RenterContractMetrics
 
 	mu sync.RWMutex
 
@@ -66,11 +67,15 @@ func (c *Contractor) Allowance() modules.Allowance {
 	return c.allowance
 }
 
-// FinancialMetrics returns the financial metrics of the Contractor.
-func (c *Contractor) FinancialMetrics() modules.RenterFinancialMetrics {
+// Metrics returns the metrics of the Contractor.
+func (c *Contractor) Metrics() (modules.RenterFinancialMetrics, []modules.RenterContractMetrics) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.financialMetrics
+	contractMetrics := make([]modules.RenterContractMetrics, 0, len(c.contractMetrics))
+	for _, m := range c.contractMetrics {
+		contractMetrics = append(contractMetrics, m)
+	}
+	return c.financialMetrics, contractMetrics
 }
 
 // Contract returns the latest contract formed with the specified host.
@@ -142,6 +147,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 
 		cachedRevisions: make(map[types.FileContractID]cachedRevision),
 		contracts:       make(map[types.FileContractID]modules.RenterContract),
+		contractMetrics: make(map[types.FileContractID]modules.RenterContractMetrics),
 		downloaders:     make(map[types.FileContractID]*hostDownloader),
 		editors:         make(map[types.FileContractID]*hostEditor),
 		renewedIDs:      make(map[types.FileContractID]types.FileContractID),

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -40,6 +40,7 @@ type Contractor struct {
 	wallet  wallet
 
 	allowance       modules.Allowance
+	periodStart     types.BlockHeight // start of current allowance period
 	blockHeight     types.BlockHeight
 	cachedRevisions map[types.FileContractID]cachedRevision
 	contracts       map[types.FileContractID]modules.RenterContract

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -87,6 +87,7 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 	c.mu.Lock()
 	metrics := c.contractMetrics[contract.ID]
 	metrics.DownloadSpending = metrics.DownloadSpending.Add(delta)
+	metrics.Unspent = metrics.Unspent.Sub(delta)
 	c.contractMetrics[contract.ID] = metrics
 	c.financialMetrics.DownloadSpending = c.financialMetrics.DownloadSpending.Add(delta)
 	c.contracts[contract.ID] = contract

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -83,11 +83,15 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 
 	hd.speed = uint64(duration.Seconds()) / modules.SectorSize
 
-	hd.contractor.mu.Lock()
-	hd.contractor.financialMetrics.DownloadSpending = hd.contractor.financialMetrics.DownloadSpending.Add(delta)
-	hd.contractor.contracts[contract.ID] = contract
-	hd.contractor.saveSync()
-	hd.contractor.mu.Unlock()
+	c := hd.contractor
+	c.mu.Lock()
+	metrics := c.contractMetrics[contract.ID]
+	metrics.DownloadSpending = metrics.DownloadSpending.Add(delta)
+	c.contractMetrics[contract.ID] = metrics
+	c.financialMetrics.DownloadSpending = c.financialMetrics.DownloadSpending.Add(delta)
+	c.contracts[contract.ID] = contract
+	c.saveSync()
+	c.mu.Unlock()
 
 	return sector, nil
 }

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -122,6 +122,7 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	metrics := c.contractMetrics[contract.ID]
 	metrics.UploadSpending = metrics.UploadSpending.Add(uploadDelta)
 	metrics.StorageSpending = metrics.StorageSpending.Add(storageDelta)
+	metrics.Unspent = metrics.Unspent.Sub(uploadDelta.Add(storageDelta))
 	c.contractMetrics[contract.ID] = metrics
 	c.financialMetrics.UploadSpending = c.financialMetrics.UploadSpending.Add(uploadDelta)
 	c.financialMetrics.StorageSpending = c.financialMetrics.StorageSpending.Add(storageDelta)

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -122,7 +122,7 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	metrics := c.contractMetrics[contract.ID]
 	metrics.UploadSpending = metrics.UploadSpending.Add(uploadDelta)
 	metrics.StorageSpending = metrics.StorageSpending.Add(storageDelta)
-	metrics.Unspent = metrics.Unspent.Sub(uploadDelta.Add(storageDelta))
+	metrics.Unspent = metrics.Unspent.Sub(uploadDelta).Sub(storageDelta)
 	c.contractMetrics[contract.ID] = metrics
 	c.financialMetrics.UploadSpending = c.financialMetrics.UploadSpending.Add(uploadDelta)
 	c.financialMetrics.StorageSpending = c.financialMetrics.StorageSpending.Add(storageDelta)

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -73,6 +73,8 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 	return numSectors, nil
 }
 
+// initialContractMetrics returns the metrics for a newly-formed (or renewed)
+// contract. Download/Upload/Storage spending is assumed to be zero.
 func initialContractMetrics(contract modules.RenterContract, host modules.HostDBEntry, txn types.Transaction) modules.RenterContractMetrics {
 	metrics := modules.RenterContractMetrics{
 		ID:          contract.ID,

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -75,9 +75,11 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 
 // initialContractMetrics returns the metrics for a newly-formed (or renewed)
 // contract. Download/Upload/Storage spending is assumed to be zero.
-func initialContractMetrics(contract modules.RenterContract, host modules.HostDBEntry, txn types.Transaction) modules.RenterContractMetrics {
+func initialContractMetrics(contract modules.RenterContract, host modules.HostDBEntry, txn types.Transaction, startHeight types.BlockHeight) modules.RenterContractMetrics {
 	metrics := modules.RenterContractMetrics{
 		ID:          contract.ID,
+		StartHeight: startHeight,
+		EndHeight:   contract.EndHeight(),
 		ContractFee: host.ContractPrice,
 		SiafundFee:  types.Tax(contract.EndHeight(), contract.FileContract.Payout),
 		Unspent:     contract.RenterFunds(),
@@ -129,7 +131,7 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, numSectors uin
 	}
 	// add metrics entry for contract
 	txn, _ := txnBuilder.View()
-	metrics := initialContractMetrics(contract, host, txn)
+	metrics := initialContractMetrics(contract, host, txn, currentHeight)
 	c.mu.Lock()
 	c.contractMetrics[contract.ID] = metrics
 	c.mu.Unlock()

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -79,6 +79,7 @@ func (c *Contractor) initialContractMetrics(contract modules.RenterContract, hos
 	metrics := modules.RenterContractMetrics{
 		ID:          contract.ID,
 		Allowance:   c.allowance,
+		PeriodStart: c.periodStart,
 		StartHeight: c.blockHeight,
 		EndHeight:   contract.EndHeight(),
 		ContractFee: host.ContractPrice,

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -78,7 +78,6 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 func (c *Contractor) initialContractMetrics(contract modules.RenterContract, host modules.HostDBEntry, txn types.Transaction) modules.RenterContractMetrics {
 	metrics := modules.RenterContractMetrics{
 		ID:          contract.ID,
-		Allowance:   c.allowance,
 		PeriodStart: c.periodStart,
 		StartHeight: c.blockHeight,
 		EndHeight:   contract.EndHeight(),

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -11,6 +11,7 @@ type contractorPersist struct {
 	Allowance        modules.Allowance
 	BlockHeight      types.BlockHeight
 	CachedRevisions  []cachedRevision
+	ContractMetrics  []modules.RenterContractMetrics
 	Contracts        []modules.RenterContract
 	FinancialMetrics modules.RenterFinancialMetrics
 	LastChange       modules.ConsensusChangeID
@@ -28,6 +29,9 @@ func (c *Contractor) persistData() contractorPersist {
 	}
 	for _, rev := range c.cachedRevisions {
 		data.CachedRevisions = append(data.CachedRevisions, rev)
+	}
+	for _, m := range c.contractMetrics {
+		data.ContractMetrics = append(data.ContractMetrics, m)
 	}
 	for _, contract := range c.contracts {
 		data.Contracts = append(data.Contracts, contract)
@@ -49,6 +53,9 @@ func (c *Contractor) load() error {
 	c.blockHeight = data.BlockHeight
 	for _, rev := range data.CachedRevisions {
 		c.cachedRevisions[rev.revision.ParentID] = rev
+	}
+	for _, m := range data.ContractMetrics {
+		c.contractMetrics[m.ID] = m
 	}
 	for _, contract := range data.Contracts {
 		c.contracts[contract.ID] = contract

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -9,6 +9,7 @@ import (
 // contractorPersist defines what Contractor data persists across sessions.
 type contractorPersist struct {
 	Allowance        modules.Allowance
+	PeriodStart      types.BlockHeight
 	BlockHeight      types.BlockHeight
 	CachedRevisions  []cachedRevision
 	ContractMetrics  []modules.RenterContractMetrics
@@ -22,6 +23,7 @@ type contractorPersist struct {
 func (c *Contractor) persistData() contractorPersist {
 	data := contractorPersist{
 		Allowance:        c.allowance,
+		PeriodStart:      c.periodStart,
 		BlockHeight:      c.blockHeight,
 		FinancialMetrics: c.financialMetrics,
 		LastChange:       c.lastChange,
@@ -50,6 +52,7 @@ func (c *Contractor) load() error {
 		return err
 	}
 	c.allowance = data.Allowance
+	c.periodStart = data.PeriodStart
 	c.blockHeight = data.BlockHeight
 	for _, rev := range data.CachedRevisions {
 		c.cachedRevisions[rev.revision.ParentID] = rev

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -51,6 +51,13 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 		return modules.RenterContract{}, err
 	}
 
+	// add metrics entry for contract
+	txn, _ := txnBuilder.View()
+	metrics := initialContractMetrics(newContract, host, txn)
+	c.mu.Lock()
+	c.contractMetrics[newContract.ID] = metrics
+	c.mu.Unlock()
+
 	return newContract, nil
 }
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -84,7 +84,8 @@ func (c *Contractor) managedRenewContracts() error {
 	c.log.Printf("renewing %v contracts", len(renewSet))
 
 	c.mu.RLock()
-	endHeight := c.blockHeight + c.allowance.Period
+	periodStart := c.blockHeight
+	endHeight := periodStart + c.allowance.Period
 	max, err := maxSectors(c.allowance, c.hdb, c.tpool)
 	c.mu.RUnlock()
 	if err != nil {
@@ -162,6 +163,8 @@ func (c *Contractor) managedRenewContracts() error {
 		c.contracts[contract.ID] = contract
 		c.renewedIDs[id] = contract.ID
 	}
+	// update periodStart
+	c.periodStart = periodStart
 	err = c.saveSync()
 	c.mu.Unlock()
 	return err

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -54,9 +54,8 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 
 	// add metrics entry for contract
 	txn, _ := txnBuilder.View()
-	metrics := initialContractMetrics(newContract, host, txn, currentHeight)
 	c.mu.Lock()
-	c.contractMetrics[newContract.ID] = metrics
+	c.contractMetrics[newContract.ID] = c.initialContractMetrics(newContract, host, txn)
 	c.mu.Unlock()
 
 	return newContract, nil

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -33,10 +33,11 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 
 	// create contract params
 	c.mu.RLock()
+	currentHeight := c.blockHeight
 	params := proto.ContractParams{
 		Host:          host,
 		Filesize:      numSectors * modules.SectorSize,
-		StartHeight:   c.blockHeight,
+		StartHeight:   currentHeight,
 		EndHeight:     newEndHeight,
 		RefundAddress: uc.UnlockHash(),
 	}
@@ -53,7 +54,7 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 
 	// add metrics entry for contract
 	txn, _ := txnBuilder.View()
-	metrics := initialContractMetrics(newContract, host, txn)
+	metrics := initialContractMetrics(newContract, host, txn, currentHeight)
 	c.mu.Lock()
 	c.contractMetrics[newContract.ID] = metrics
 	c.mu.Unlock()

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -60,8 +60,8 @@ type hostContractor interface {
 	// insertion, deletion, and modification of sectors.
 	Editor(types.FileContractID) (contractor.Editor, error)
 
-	// FinancialMetrics returns the financial metrics of the contractor.
-	FinancialMetrics() modules.RenterFinancialMetrics
+	// Metrics returns the financial metrics of the contractor.
+	Metrics() (modules.RenterFinancialMetrics, []modules.RenterContractMetrics)
 
 	// IsOffline reports whether the specified host is considered offline.
 	IsOffline(modules.NetAddress) bool
@@ -162,8 +162,8 @@ func (r *Renter) AllHosts() []modules.HostDBEntry    { return r.hostDB.AllHosts(
 
 // contractor passthroughs
 func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
-func (r *Renter) FinancialMetrics() modules.RenterFinancialMetrics {
-	return r.hostContractor.FinancialMetrics()
+func (r *Renter) Metrics() (modules.RenterFinancialMetrics, []modules.RenterContractMetrics) {
+	return r.hostContractor.Metrics()
 }
 func (r *Renter) Settings() modules.RenterSettings {
 	return modules.RenterSettings{

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -182,9 +182,11 @@ func (stubContractor) Contract(modules.NetAddress) (modules.RenterContract, bool
 	return modules.RenterContract{}, false
 }
 func (stubContractor) Contracts() []modules.RenterContract                    { return nil }
-func (stubContractor) FinancialMetrics() (m modules.RenterFinancialMetrics)   { return }
 func (stubContractor) IsOffline(modules.NetAddress) bool                      { return false }
 func (stubContractor) Editor(types.FileContractID) (contractor.Editor, error) { return nil, nil }
 func (stubContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {
 	return nil, nil
+}
+func (stubContractor) Metrics() (m modules.RenterFinancialMetrics, cs []modules.RenterContractMetrics) {
+	return
 }

--- a/sync/threadgroup_test.go
+++ b/sync/threadgroup_test.go
@@ -417,7 +417,7 @@ func TestThreadGroupSiaExample(t *testing.T) {
 		tg.Done()
 	}()
 	tg.Stop()
-	if !threadFinished || !listenerCleanedUp || !fileClosed {
+	if !threadFinished2 || !listenerCleanedUp || !fileClosed {
 		t.Error("stop did not block until all running resources had closed")
 	}
 }


### PR DESCRIPTION
The contractor (and by extension, the renter) now returns per-contract metrics, defined by `modules.RenterContractMetrics`.

Unresolved questions:
- How do we group per-contract metrics according to their allowance period?
- How should these metrics be reported in the API?
- What should be done with the existing `RenterFinancialMetrics` type?

re: grouping: The easiest approach right now would be to use `contract.EndHeight()`. Using the start height makes more intuitive sense for the user (since it's the height at which their funds were locked away), but currently the contractor doesn't store any info about when the allowance period began. I suppose you could just subtract the period from the end height, but then what if the allowance period is changed?