### PR TITLE
add thread saftey to TransactionList() call

### DIFF
--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -135,6 +135,9 @@ func (tp *TransactionPool) FeeEstimation() (min, max types.Currency) {
 // The transactions are provided in an order that can acceptably be put into a
 // block.
 func (tp *TransactionPool) TransactionList() []types.Transaction {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+
 	var txns []types.Transaction
 	for _, tSet := range tp.transactionSets {
 		txns = append(txns, tSet...)


### PR DESCRIPTION
We have apparently missed for a long time the fact that this call is not actually thread safe.