### PR TITLE
Save cachedRevisions properly

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -24,8 +24,8 @@ var (
 // as a safeguard against desynchronizing with the host.
 // TODO: save a diff of the Merkle roots instead of all of them.
 type cachedRevision struct {
-	revision    types.FileContractRevision
-	merkleRoots []crypto.Hash
+	Revision    types.FileContractRevision
+	MerkleRoots []crypto.Hash
 }
 
 // A Contractor negotiates, revises, renews, and provides access to file

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -185,10 +185,11 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 		c.mu.RUnlock()
 		if !ok {
 			// nothing we can do; return original error
+			c.log.Printf("wanted to recover contract %v with host %v, but no revision was cached", contract.ID, contract.NetAddress)
 			return nil, err
 		}
 		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
-		contract.LastRevision = cached.revision
+		contract.LastRevision = cached.Revision
 		d, err = proto.NewDownloader(host, contract)
 	}
 	if err != nil {

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -252,8 +252,8 @@ func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 			return nil, err
 		}
 		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
-		contract.LastRevision = cached.revision
-		contract.MerkleRoots = cached.merkleRoots
+		contract.LastRevision = cached.Revision
+		contract.MerkleRoots = cached.MerkleRoots
 		e, err = proto.NewEditor(host, contract, height)
 	}
 	if err != nil {

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -55,7 +55,7 @@ func (c *Contractor) load() error {
 	c.periodStart = data.PeriodStart
 	c.blockHeight = data.BlockHeight
 	for _, rev := range data.CachedRevisions {
-		c.cachedRevisions[rev.revision.ParentID] = rev
+		c.cachedRevisions[rev.Revision.ParentID] = rev
 	}
 	for _, m := range data.ContractMetrics {
 		c.contractMetrics[m.ID] = m

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -20,33 +20,42 @@ func (m memPersist) load(data *contractorPersist) error     { *data = contractor
 func TestSaveLoad(t *testing.T) {
 	// create contractor with mocked persist dependency
 	c := &Contractor{
-		contracts:  make(map[types.FileContractID]modules.RenterContract),
-		renewedIDs: make(map[types.FileContractID]types.FileContractID),
+		contracts:       make(map[types.FileContractID]modules.RenterContract),
+		renewedIDs:      make(map[types.FileContractID]types.FileContractID),
+		cachedRevisions: make(map[types.FileContractID]cachedRevision),
 	}
 	c.persist = new(memPersist)
 
 	// add some fake contracts
 	c.contracts = map[types.FileContractID]modules.RenterContract{
-		{0}: {NetAddress: "foo"},
-		{1}: {NetAddress: "bar"},
-		{2}: {NetAddress: "baz"},
+		{0}: {ID: types.FileContractID{0}, NetAddress: "foo"},
+		{1}: {ID: types.FileContractID{1}, NetAddress: "bar"},
+		{2}: {ID: types.FileContractID{2}, NetAddress: "baz"},
 	}
 	c.renewedIDs = map[types.FileContractID]types.FileContractID{
 		{0}: {1},
 		{1}: {2},
 		{2}: {3},
 	}
+	c.cachedRevisions = map[types.FileContractID]cachedRevision{
+		{0}: {Revision: types.FileContractRevision{ParentID: types.FileContractID{0}}},
+		{1}: {Revision: types.FileContractRevision{ParentID: types.FileContractID{1}}},
+		{2}: {Revision: types.FileContractRevision{ParentID: types.FileContractID{2}}},
+	}
 
-	// save and reload
+	// save, clear, and reload
 	err := c.save()
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.contracts = make(map[types.FileContractID]modules.RenterContract)
+	c.renewedIDs = make(map[types.FileContractID]types.FileContractID)
+	c.cachedRevisions = make(map[types.FileContractID]cachedRevision)
 	err = c.load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	// check that contracts were restored
+	// check that all fields were restored
 	_, ok0 := c.contracts[types.FileContractID{0}]
 	_, ok1 := c.contracts[types.FileContractID{1}]
 	_, ok2 := c.contracts[types.FileContractID{2}]
@@ -59,21 +68,30 @@ func TestSaveLoad(t *testing.T) {
 	if !ok0 || !ok1 || !ok2 {
 		t.Fatal("renewed IDs were not restored properly:", c.renewedIDs)
 	}
+	_, ok0 = c.cachedRevisions[types.FileContractID{0}]
+	_, ok1 = c.cachedRevisions[types.FileContractID{1}]
+	_, ok2 = c.cachedRevisions[types.FileContractID{2}]
+	if !ok0 || !ok1 || !ok2 {
+		t.Fatal("cached revisions were not restored properly:", c.cachedRevisions)
+	}
 
 	// use stdPersist instead of mock
 	c.persist = newPersist(build.TempDir("contractor", "TestSaveLoad"))
 	os.MkdirAll(build.TempDir("contractor", "TestSaveLoad"), 0700)
 
-	// save and reload
+	// save, clear, and reload
 	err = c.save()
 	if err != nil {
 		t.Fatal(err)
 	}
+	c.contracts = make(map[types.FileContractID]modules.RenterContract)
+	c.renewedIDs = make(map[types.FileContractID]types.FileContractID)
+	c.cachedRevisions = make(map[types.FileContractID]cachedRevision)
 	err = c.load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	// check that contracts were restored
+	// check that all fields were restored
 	_, ok0 = c.contracts[types.FileContractID{0}]
 	_, ok1 = c.contracts[types.FileContractID{1}]
 	_, ok2 = c.contracts[types.FileContractID{2}]
@@ -85,5 +103,11 @@ func TestSaveLoad(t *testing.T) {
 	_, ok2 = c.renewedIDs[types.FileContractID{2}]
 	if !ok0 || !ok1 || !ok2 {
 		t.Fatal("renewed IDs were not restored properly:", c.renewedIDs)
+	}
+	_, ok0 = c.cachedRevisions[types.FileContractID{0}]
+	_, ok1 = c.cachedRevisions[types.FileContractID{1}]
+	_, ok2 = c.cachedRevisions[types.FileContractID{2}]
+	if !ok0 || !ok1 || !ok2 {
+		t.Fatal("cached revisions were not restored properly:", c.cachedRevisions)
 	}
 }


### PR DESCRIPTION
The contractor's `cachedRevisions` map was not being properly saved. Because the fields of the `cachedRevision` type were not exported, the JSON encoder skipped over them when saving.

Testing should have caught this, but the `TestSaveLoad` test was deficient. Not only did it not check the `cachedRevisions` field, it also failed to clear the contractor's fields between saving and loading.