### PR TITLE
Renter period metrics

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -34,6 +34,7 @@ type (
 	RenterGET struct {
 		Settings         modules.RenterSettings          `json:"settings"`
 		FinancialMetrics modules.RenterFinancialMetrics  `json:"financialmetrics"`
+		PeriodMetrics    []modules.RenterPeriodMetrics   `json:"periodmetrics"`
 		ContractMetrics  []modules.RenterContractMetrics `json:"contractmetrics"`
 	}
 
@@ -84,10 +85,11 @@ type (
 
 // renterHandlerGET handles the API call to /renter.
 func (api *API) renterHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	renterMetrics, contractMetrics := api.renter.Metrics()
+	renterMetrics, periodMetrics, contractMetrics := api.renter.Metrics()
 	WriteJSON(w, RenterGET{
 		Settings:         api.renter.Settings(),
 		FinancialMetrics: renterMetrics,
+		PeriodMetrics:    periodMetrics,
 		ContractMetrics:  contractMetrics,
 	})
 }

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -92,10 +92,35 @@ type RenterFinancialMetrics struct {
 	DownloadSpending types.Currency `json:"downloadspending"`
 	StorageSpending  types.Currency `json:"storagespending"`
 	UploadSpending   types.Currency `json:"uploadspending"`
+}
 
-	// AllowancePeriodStart is the blockheight at which the current allowance
-	// period began.
-	AllowancePeriodStart types.BlockHeight `json:"allowanceperiodstart"`
+// RenterPeriodMetrics contains metrics relevant to an allowance period.
+type RenterPeriodMetrics struct {
+	// The specified Allowance for the period, and the height at which it went
+	// into effect. If the allowance was changed mid-period, this field
+	// reflects the most recent version. The PeriodStart, however, is
+	// unchanged.
+	Allowance   Allowance         `json:"allowance"`
+	PeriodStart types.BlockHeight `json:"periodstart"`
+
+	// The amount of money spent on fees during the period.
+	TxnFeeSpending      types.Currency `json:"txnfeespending"`
+	ContractFeeSpending types.Currency `json:"contractfeespending"`
+	SiafundFeeSpending  types.Currency `json:"siafundfeespending"`
+
+	// The amount of money allocated for uploads, downloads, and storage
+	// during the period.
+	ContractAllocations types.Currency `json:"contractallocations"`
+
+	// The amount of money spent on uploads, downloads, and storage during the
+	// period.
+	DownloadSpending types.Currency `json:"downloadspending"`
+	StorageSpending  types.Currency `json:"storagespending"`
+	UploadSpending   types.Currency `json:"uploadspending"`
+
+	// The portion of the allowance funds that were not spent. Note that this
+	// includes money that was allocated in contracts but not spent.
+	Unspent types.Currency `json:"unspent"`
 }
 
 // RenterContractMetrics contains metrics relevant to a single file contract.
@@ -217,7 +242,7 @@ type Renter interface {
 	LoadSharedFilesAscii(asciiSia string) ([]string, error)
 
 	// Metrics returns the metrics of the Renter.
-	Metrics() (RenterFinancialMetrics, []RenterContractMetrics)
+	Metrics() (RenterFinancialMetrics, []RenterPeriodMetrics, []RenterContractMetrics)
 
 	// RenameFile changes the path of a file.
 	RenameFile(path, newPath string) error

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -89,6 +89,8 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 	metrics.DownloadSpending = metrics.DownloadSpending.Add(delta)
 	metrics.Unspent = metrics.Unspent.Sub(delta)
 	c.contractMetrics[contract.ID] = metrics
+	c.currentPeriodMetrics.DownloadSpending = c.currentPeriodMetrics.DownloadSpending.Add(delta)
+	c.currentPeriodMetrics.Unspent = c.currentPeriodMetrics.Unspent.Sub(delta)
 	c.financialMetrics.DownloadSpending = c.financialMetrics.DownloadSpending.Add(delta)
 	c.contracts[contract.ID] = contract
 	c.saveSync()

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -124,6 +124,9 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	metrics.StorageSpending = metrics.StorageSpending.Add(storageDelta)
 	metrics.Unspent = metrics.Unspent.Sub(uploadDelta).Sub(storageDelta)
 	c.contractMetrics[contract.ID] = metrics
+	c.currentPeriodMetrics.UploadSpending = c.currentPeriodMetrics.UploadSpending.Add(uploadDelta)
+	c.currentPeriodMetrics.StorageSpending = c.currentPeriodMetrics.StorageSpending.Add(storageDelta)
+	c.currentPeriodMetrics.Unspent = c.currentPeriodMetrics.Unspent.Sub(uploadDelta).Sub(storageDelta)
 	c.financialMetrics.UploadSpending = c.financialMetrics.UploadSpending.Add(uploadDelta)
 	c.financialMetrics.StorageSpending = c.financialMetrics.StorageSpending.Add(storageDelta)
 	c.contracts[contract.ID] = contract

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -154,6 +154,8 @@ func newTestingTrio(name string) (modules.Host, *Contractor, modules.TestMiner, 
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	// prevent metrics math from causing an underflow
+	c.currentPeriodMetrics.Unspent = types.SiacoinPrecision.Mul64(100000)
 
 	// announce the host
 	err = h.Announce()

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -71,6 +71,18 @@ func (c *Contractor) load() error {
 		newHash.LoadString(newString)
 		c.renewedIDs[types.FileContractID(oldHash)] = types.FileContractID(newHash)
 	}
+	// For any contracts that we don't have metrics about, create a "best
+	// effort" metrics entry. This will at least prevent negative currency
+	// errors when money is subtracted from the Unspent field.
+	for id, contract := range c.contracts {
+		if _, ok := c.contractMetrics[id]; !ok && len(contract.LastRevision.NewValidProofOutputs) > 0 {
+			c.contractMetrics[id] = modules.RenterContractMetrics{
+				ID:        id,
+				EndHeight: contract.EndHeight(),
+				Unspent:   contract.RenterFunds(),
+			}
+		}
+	}
 	return nil
 }
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -165,6 +165,9 @@ func (c *Contractor) managedRenewContracts() error {
 	}
 	// update periodStart
 	c.periodStart = periodStart
+	// archive the old metrics and recalculate current metrics
+	c.periodMetrics = append(c.periodMetrics, c.currentPeriodMetrics)
+	c.currentPeriodMetrics = c.calculatePeriodMetrics()
 	err = c.saveSync()
 	c.mu.Unlock()
 	return err

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -61,7 +61,7 @@ type hostContractor interface {
 	Editor(types.FileContractID) (contractor.Editor, error)
 
 	// Metrics returns the financial metrics of the contractor.
-	Metrics() (modules.RenterFinancialMetrics, []modules.RenterContractMetrics)
+	Metrics() (modules.RenterFinancialMetrics, []modules.RenterPeriodMetrics, []modules.RenterContractMetrics)
 
 	// IsOffline reports whether the specified host is considered offline.
 	IsOffline(modules.NetAddress) bool
@@ -162,7 +162,7 @@ func (r *Renter) AllHosts() []modules.HostDBEntry    { return r.hostDB.AllHosts(
 
 // contractor passthroughs
 func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
-func (r *Renter) Metrics() (modules.RenterFinancialMetrics, []modules.RenterContractMetrics) {
+func (r *Renter) Metrics() (modules.RenterFinancialMetrics, []modules.RenterPeriodMetrics, []modules.RenterContractMetrics) {
 	return r.hostContractor.Metrics()
 }
 func (r *Renter) Settings() modules.RenterSettings {

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -187,6 +187,6 @@ func (stubContractor) Editor(types.FileContractID) (contractor.Editor, error) { 
 func (stubContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {
 	return nil, nil
 }
-func (stubContractor) Metrics() (m modules.RenterFinancialMetrics, cs []modules.RenterContractMetrics) {
+func (stubContractor) Metrics() (m modules.RenterFinancialMetrics, ps []modules.RenterPeriodMetrics, cs []modules.RenterContractMetrics) {
 	return
 }


### PR DESCRIPTION
I didn't update the API docs because I'm not sure this is how we want to organize things. I'm not seeing the need for a separate `FinancialMetrics` object if we have `PeriodMetrics`. We can't outright remove those fields, but we could deprecate them.

There was also a suggestion that we record the set of contract IDs in the `PeriodMetrics` to enable easy lookup.

Also, the allowance code seemed to have some bugs around setting `periodStart`.