### PR TITLE
Unspent allowance

### DIFF
--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -308,14 +308,13 @@ func TestRenterHandlerContracts(t *testing.T) {
 	if err = st.getAPI("/renter", &get); err != nil {
 		t.Fatal(err)
 	}
-	var expectedContractSpending types.Currency
+	expectedContractSpending := get.Settings.Allowance.Funds.Sub(get.FinancialMetrics.Unspent)
 	for _, contract := range contracts.Contracts {
 		expectedContractSpending = expectedContractSpending.Add(contract.RenterFunds)
 	}
 	if got := get.FinancialMetrics.ContractSpending; got.Cmp(expectedContractSpending) != 0 {
 		t.Fatalf("expected contract spending to be %v; got %v", expectedContractSpending, got)
 	}
-
 }
 
 // TestRenterHandlerGetAndPost checks that valid /renter calls successfully set

--- a/doc/API.md
+++ b/doc/API.md
@@ -641,7 +641,8 @@ returns the current settings along with metrics on the renter's spending.
     "contractspending": "1234", // hastings
     "downloadspending": "5678", // hastings
     "storagespending":  "1234", // hastings
-    "uploadspending":   "5678"  // hastings
+    "uploadspending":   "5678", // hastings
+    "unspent":          "1234"  // hastings
   }
 }
 ```

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -63,11 +63,8 @@ returns the current settings along with metrics on the renter's spending.
   // Metrics about how much the Renter has spent on storage, uploads, and
   // downloads.
   "financialmetrics": {
-    // How much money, in hastings, the Renter has paid into file contracts
-    // formed with hosts. Note that some of this money may be returned to the
-    // Renter when the contract ends. To calculate how much will be returned,
-    // subtract the storage, upload, and download metrics from
-    // ContractSpending.
+    // How much money, in hastings, the Renter has spent on file contracts,
+    // including fees.
     "contractspending": "1234", // hastings
 
     // Amount of money spent on downloads.
@@ -77,7 +74,10 @@ returns the current settings along with metrics on the renter's spending.
     "storagespending": "1234", // hastings
 
     // Amount of money spent on uploads.
-    "uploadspending": "5678" // hastings
+    "uploadspending": "5678", // hastings
+
+    // Amount of money in the allowance that has not been spent.
+    "unspent": "1234" // hastings
   }
 }
 ```

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -79,21 +79,6 @@ type RenterSettings struct {
 	Allowance Allowance `json:"allowance"`
 }
 
-// RenterFinancialMetrics contains metrics about how much the Renter has
-// spent on storage, uploads, and downloads.
-type RenterFinancialMetrics struct {
-	// ContractSpending is how much the Renter has paid into file contracts
-	// formed with hosts. Note that some of this money may be returned to the
-	// Renter when the contract ends. To calculate how much will be returned,
-	// subtract the storage, upload, and download metrics from
-	// ContractSpending.
-	ContractSpending types.Currency `json:"contractspending"`
-
-	DownloadSpending types.Currency `json:"downloadspending"`
-	StorageSpending  types.Currency `json:"storagespending"`
-	UploadSpending   types.Currency `json:"uploadspending"`
-}
-
 // A HostDBEntry represents one host entry in the Renter's host DB. It
 // aggregates the host's external settings and metrics with its public key.
 type HostDBEntry struct {
@@ -167,6 +152,10 @@ type Renter interface {
 	// Contracts returns the contracts formed by the renter.
 	Contracts() []RenterContract
 
+	// CurrentPeriod returns the height at which the current allowance period
+	// began.
+	CurrentPeriod() types.BlockHeight
+
 	// DeleteFile deletes a file entry from the renter.
 	DeleteFile(path string) error
 
@@ -178,9 +167,6 @@ type Renter interface {
 
 	// FileList returns information on all of the files stored by the renter.
 	FileList() []FileInfo
-
-	// FinancialMetrics returns the financial metrics of the Renter.
-	FinancialMetrics() RenterFinancialMetrics
 
 	// LoadSharedFiles loads a '.sia' file into the renter. A .sia file may
 	// contain multiple files. The paths of the added files are returned.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -127,6 +127,16 @@ type RenterContract struct {
 	MerkleRoots     []crypto.Hash              `json:"merkleroots"`
 	NetAddress      NetAddress                 `json:"netaddress"`
 	SecretKey       crypto.SecretKey           `json:"secretkey"`
+	StartHeight     types.BlockHeight          `json:"startheight"`
+
+	DownloadSpending types.Currency `json:"downloadspending"`
+	StorageSpending  types.Currency `json:"storagespending"`
+	UploadSpending   types.Currency `json:"uploadspending"`
+
+	TotalCost   types.Currency `json:"totalcost"`
+	ContractFee types.Currency `json:"contractfee"`
+	TxnFee      types.Currency `json:"txnfee"`
+	SiafundFee  types.Currency `json:"siafundfee"`
 }
 
 // EndHeight returns the height at which the host is no longer obligated to

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -43,14 +43,13 @@ type Contractor struct {
 	blockHeight     types.BlockHeight
 	cachedRevisions map[types.FileContractID]cachedRevision
 	contracts       map[types.FileContractID]modules.RenterContract
+	currentPeriod   types.BlockHeight
 	downloaders     map[types.FileContractID]*hostDownloader
 	editors         map[types.FileContractID]*hostEditor
 	lastChange      modules.ConsensusChangeID
 	renewedIDs      map[types.FileContractID]types.FileContractID
 	renewing        map[types.FileContractID]bool // prevent revising during renewal
 	revising        map[types.FileContractID]bool // prevent overlapping revisions
-
-	financialMetrics modules.RenterFinancialMetrics
 
 	mu sync.RWMutex
 
@@ -64,13 +63,6 @@ func (c *Contractor) Allowance() modules.Allowance {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.allowance
-}
-
-// FinancialMetrics returns the financial metrics of the Contractor.
-func (c *Contractor) FinancialMetrics() modules.RenterFinancialMetrics {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.financialMetrics
 }
 
 // Contract returns the latest contract formed with the specified host.
@@ -91,6 +83,14 @@ func (c *Contractor) Contracts() (cs []modules.RenterContract) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.onlineContracts()
+}
+
+// CurrentPeriod returns the height at which the current allowance period
+// began.
+func (c *Contractor) CurrentPeriod() types.BlockHeight {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.currentPeriod
 }
 
 // resolveID returns the ID of the most recent renewal of id.

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -107,19 +107,11 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	if he.invalid {
 		return crypto.Hash{}, errInvalidEditor
 	}
-
-	oldUploadSpending := he.editor.UploadSpending
-	oldStorageSpending := he.editor.StorageSpending
 	contract, sectorRoot, err := he.editor.Upload(data)
 	if err != nil {
 		return crypto.Hash{}, err
 	}
-	uploadDelta := he.editor.UploadSpending.Sub(oldUploadSpending)
-	storageDelta := he.editor.StorageSpending.Sub(oldStorageSpending)
-
 	he.contractor.mu.Lock()
-	he.contractor.financialMetrics.UploadSpending = he.contractor.financialMetrics.UploadSpending.Add(uploadDelta)
-	he.contractor.financialMetrics.StorageSpending = he.contractor.financialMetrics.StorageSpending.Add(storageDelta)
 	he.contractor.contracts[contract.ID] = contract
 	he.contractor.saveSync()
 	he.contractor.mu.Unlock()
@@ -157,16 +149,11 @@ func (he *hostEditor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newDat
 	if he.invalid {
 		return errInvalidEditor
 	}
-
-	oldUploadSpending := he.editor.UploadSpending
 	contract, err := he.editor.Modify(oldRoot, newRoot, offset, newData)
 	if err != nil {
 		return err
 	}
-	uploadDelta := he.editor.UploadSpending.Sub(oldUploadSpending)
-
 	he.contractor.mu.Lock()
-	he.contractor.financialMetrics.UploadSpending = he.contractor.financialMetrics.UploadSpending.Add(uploadDelta)
 	he.contractor.contracts[contract.ID] = contract
 	he.contractor.saveSync()
 	he.contractor.mu.Unlock()

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -8,23 +8,23 @@ import (
 
 // contractorPersist defines what Contractor data persists across sessions.
 type contractorPersist struct {
-	Allowance        modules.Allowance
-	BlockHeight      types.BlockHeight
-	CachedRevisions  []cachedRevision
-	Contracts        []modules.RenterContract
-	FinancialMetrics modules.RenterFinancialMetrics
-	LastChange       modules.ConsensusChangeID
-	RenewedIDs       map[string]string
+	Allowance       modules.Allowance
+	BlockHeight     types.BlockHeight
+	CachedRevisions []cachedRevision
+	Contracts       []modules.RenterContract
+	CurrentPeriod   types.BlockHeight
+	LastChange      modules.ConsensusChangeID
+	RenewedIDs      map[string]string
 }
 
 // persistData returns the data in the Contractor that will be saved to disk.
 func (c *Contractor) persistData() contractorPersist {
 	data := contractorPersist{
-		Allowance:        c.allowance,
-		BlockHeight:      c.blockHeight,
-		FinancialMetrics: c.financialMetrics,
-		LastChange:       c.lastChange,
-		RenewedIDs:       make(map[string]string),
+		Allowance:     c.allowance,
+		BlockHeight:   c.blockHeight,
+		CurrentPeriod: c.currentPeriod,
+		LastChange:    c.lastChange,
+		RenewedIDs:    make(map[string]string),
 	}
 	for _, rev := range c.cachedRevisions {
 		data.CachedRevisions = append(data.CachedRevisions, rev)
@@ -53,7 +53,18 @@ func (c *Contractor) load() error {
 	for _, contract := range data.Contracts {
 		c.contracts[contract.ID] = contract
 	}
-	c.financialMetrics = data.FinancialMetrics
+	c.currentPeriod = data.CurrentPeriod
+	if c.currentPeriod == 0 {
+		// If loading old persist, current period will be unknown. Best we can
+		// do is guess based on contracts + allowance.
+		var highestEnd types.BlockHeight
+		for _, contract := range data.Contracts {
+			if h := contract.EndHeight(); h > highestEnd {
+				highestEnd = h
+			}
+		}
+		c.currentPeriod = highestEnd - c.allowance.Period
+	}
 	c.lastChange = data.LastChange
 	for oldString, newString := range data.RenewedIDs {
 		var oldHash, newHash crypto.Hash

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -55,6 +55,7 @@ func (c *Contractor) load() error {
 	}
 	c.currentPeriod = data.CurrentPeriod
 	if c.currentPeriod == 0 {
+		// COMPATv1.0.4-lts
 		// If loading old persist, current period will be unknown. Best we can
 		// do is guess based on contracts + allowance.
 		var highestEnd types.BlockHeight

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -36,8 +36,12 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	}
 
 	// if we have entered the next period, update currentPeriod
-	if c.blockHeight > c.currentPeriod+c.allowance.Period {
-		c.currentPeriod += c.allowance.Period
+	// NOTE: "period" refers to the duration of contracts, whereas "cycle"
+	// refers to how frequently the period metrics are reset. Should think
+	// about how to make this more explicit.
+	cycleLen := c.allowance.Period - c.allowance.RenewWindow
+	if c.blockHeight > c.currentPeriod+cycleLen {
+		c.currentPeriod += cycleLen
 	}
 
 	c.lastChange = cc.ID

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -35,6 +35,11 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 		c.log.Debugln("INFO: deleted expired contract", id)
 	}
 
+	// if we have entered the next period, update currentPeriod
+	if c.blockHeight > c.currentPeriod+c.allowance.Period {
+		c.currentPeriod += c.allowance.Period
+	}
+
 	c.lastChange = cc.ID
 	err := c.save()
 	if err != nil {

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -8,7 +8,6 @@ import (
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/types"
 )
 
 // A Downloader retrieves sectors by calling the download RPC on a host.
@@ -19,9 +18,6 @@ type Downloader struct {
 	conn     net.Conn
 
 	SaveFn revisionSaver
-
-	// metrics
-	DownloadSpending types.Currency
 }
 
 // Sector retrieves the sector with the specified Merkle root, and revises
@@ -94,7 +90,7 @@ func (hd *Downloader) Sector(root crypto.Hash) (modules.RenterContract, []byte, 
 	// update contract and metrics
 	hd.contract.LastRevision = rev
 	hd.contract.LastRevisionTxn = signedTxn
-	hd.DownloadSpending = hd.DownloadSpending.Add(sectorPrice)
+	hd.contract.DownloadSpending = hd.contract.DownloadSpending.Add(sectorPrice)
 
 	return hd.contract, sector, nil
 }

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -43,10 +43,6 @@ type Editor struct {
 	contract modules.RenterContract // updated after each revision
 
 	SaveFn revisionSaver
-
-	// metrics
-	StorageSpending types.Currency
-	UploadSpending  types.Currency
 }
 
 // Close cleanly terminates the revision loop with the host and closes the
@@ -151,8 +147,8 @@ func (he *Editor) Upload(data []byte) (modules.RenterContract, crypto.Hash, erro
 	}
 
 	// update metrics
-	he.StorageSpending = he.StorageSpending.Add(sectorStoragePrice)
-	he.UploadSpending = he.UploadSpending.Add(sectorBandwidthPrice)
+	he.contract.StorageSpending = he.contract.StorageSpending.Add(sectorStoragePrice)
+	he.contract.UploadSpending = he.contract.UploadSpending.Add(sectorBandwidthPrice)
 
 	return he.contract, sectorRoot, nil
 }
@@ -235,7 +231,7 @@ func (he *Editor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newData []
 	}
 
 	// update metrics
-	he.UploadSpending = he.UploadSpending.Add(sectorBandwidthPrice)
+	he.contract.UploadSpending = he.contract.UploadSpending.Add(sectorBandwidthPrice)
 
 	return he.contract, nil
 }

--- a/modules/renter/proto/formcontract.go
+++ b/modules/renter/proto/formcontract.go
@@ -83,17 +83,17 @@ func FormContract(params ContractParams, txnBuilder transactionBuilder, tpool tr
 
 	// calculate transaction fee
 	_, maxFee := tpool.FeeEstimation()
-	fee := maxFee.Mul64(estTxnSize)
+	txnFee := maxFee.Mul64(estTxnSize)
 
 	// build transaction containing fc
-	err = txnBuilder.FundSiacoins(renterCost.Add(fee))
+	err = txnBuilder.FundSiacoins(renterCost.Add(txnFee))
 	if err != nil {
 		return modules.RenterContract{}, err
 	}
 	txnBuilder.AddFileContract(fc)
 
 	// add miner fee
-	txnBuilder.AddMinerFee(fee)
+	txnBuilder.AddMinerFee(txnFee)
 
 	// create initial transaction set
 	txn, parentTxns := txnBuilder.View()
@@ -260,5 +260,11 @@ func FormContract(params ContractParams, txnBuilder transactionBuilder, tpool tr
 		LastRevisionTxn: revisionTxn,
 		NetAddress:      host.NetAddress,
 		SecretKey:       ourSK,
+		StartHeight:     startHeight,
+
+		TotalCost:   renterCost,
+		ContractFee: host.ContractPrice,
+		TxnFee:      txnFee,
+		SiafundFee:  types.Tax(startHeight, fc.Payout),
 	}, nil
 }

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -74,17 +74,17 @@ func Renew(contract modules.RenterContract, params ContractParams, txnBuilder tr
 
 	// calculate transaction fee
 	_, maxFee := tpool.FeeEstimation()
-	fee := maxFee.Mul64(estTxnSize)
+	txnFee := maxFee.Mul64(estTxnSize)
 
 	// build transaction containing fc
-	err := txnBuilder.FundSiacoins(renterCost.Add(fee))
+	err := txnBuilder.FundSiacoins(renterCost.Add(txnFee))
 	if err != nil {
 		return modules.RenterContract{}, err
 	}
 	txnBuilder.AddFileContract(fc)
 
 	// add miner fee
-	txnBuilder.AddMinerFee(fee)
+	txnBuilder.AddMinerFee(txnFee)
 
 	// create initial transaction set
 	txn, parentTxns := txnBuilder.View()
@@ -255,5 +255,11 @@ func Renew(contract modules.RenterContract, params ContractParams, txnBuilder tr
 		MerkleRoots:     contract.MerkleRoots,
 		NetAddress:      host.NetAddress,
 		SecretKey:       ourSK,
+		StartHeight:     startHeight,
+
+		TotalCost:   renterCost,
+		ContractFee: host.ContractPrice,
+		TxnFee:      txnFee,
+		SiafundFee:  types.Tax(startHeight, fc.Payout),
 	}, nil
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -56,12 +56,13 @@ type hostContractor interface {
 	// Contracts returns the contracts formed by the contractor.
 	Contracts() []modules.RenterContract
 
+	// CurrentPeriod returns the height at which the current allowance period
+	// began.
+	CurrentPeriod() types.BlockHeight
+
 	// Editor creates an Editor from the specified contract ID, allowing the
 	// insertion, deletion, and modification of sectors.
 	Editor(types.FileContractID) (contractor.Editor, error)
-
-	// FinancialMetrics returns the financial metrics of the contractor.
-	FinancialMetrics() modules.RenterFinancialMetrics
 
 	// IsOffline reports whether the specified host is considered offline.
 	IsOffline(modules.NetAddress) bool
@@ -162,9 +163,7 @@ func (r *Renter) AllHosts() []modules.HostDBEntry    { return r.hostDB.AllHosts(
 
 // contractor passthroughs
 func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
-func (r *Renter) FinancialMetrics() modules.RenterFinancialMetrics {
-	return r.hostContractor.FinancialMetrics()
-}
+func (r *Renter) CurrentPeriod() types.BlockHeight    { return r.hostContractor.CurrentPeriod() }
 func (r *Renter) Settings() modules.RenterSettings {
 	return modules.RenterSettings{
 		Allowance: r.hostContractor.Allowance(),

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -182,7 +182,7 @@ func (stubContractor) Contract(modules.NetAddress) (modules.RenterContract, bool
 	return modules.RenterContract{}, false
 }
 func (stubContractor) Contracts() []modules.RenterContract                    { return nil }
-func (stubContractor) FinancialMetrics() (m modules.RenterFinancialMetrics)   { return }
+func (stubContractor) CurrentPeriod() types.BlockHeight                       { return 0 }
 func (stubContractor) IsOffline(modules.NetAddress) bool                      { return false }
 func (stubContractor) Editor(types.FileContractID) (contractor.Editor, error) { return nil, nil }
 func (stubContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {


### PR DESCRIPTION
This took longer than expected because I had to track down a bug in the metrics reporting. The commit is pretty self-explanatory.

The only open question here is when to reset the metrics. I believe they should be reset as soon as we renew the first contract in a new allowance period, but how do we know when that is? We may need to keep track of `periodStart`, as before.