### PR TITLE
Archive contracts instead of deleting them

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -136,10 +136,14 @@ type (
 func (api *API) renterHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	settings := api.renter.Settings()
 	periodStart := api.renter.CurrentPeriod()
-	// calculate financial metrics from contracts
+	// calculate financial metrics from contracts. We use the special
+	// AllContracts method to include contracts that are offline.
 	var fm RenterFinancialMetrics
 	fm.Unspent = settings.Allowance.Funds
-	for _, c := range api.renter.Contracts() {
+	contracts := api.renter.(interface {
+		AllContracts() []modules.RenterContract
+	}).AllContracts()
+	for _, c := range contracts {
 		if c.StartHeight < periodStart {
 			continue
 		}

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -144,9 +144,14 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		return errors.New("unable to form or renew any contracts")
 	}
 
-	// Set the allowance and replace the contract set
 	c.mu.Lock()
+	// update the allowance
 	c.allowance = a
+	// archive the current contract set
+	for id, contract := range c.contracts {
+		c.oldContracts[id] = contract
+	}
+	// replace the current contract set with new contracts
 	c.contracts = newContracts
 	// if the currentPeriod was previously unset, set it now
 	if c.currentPeriod == 0 {

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -78,12 +78,24 @@ func (c *Contractor) Contract(hostAddr modules.NetAddress) (modules.RenterContra
 	return modules.RenterContract{}, false
 }
 
-// Contracts returns the contracts formed by the contractor. Only contracts
-// formed with currently online hosts are returned.
+// Contracts returns the contracts formed by the contractor in the current
+// allowance period. Only contracts formed with currently online hosts are
+// returned.
 func (c *Contractor) Contracts() (cs []modules.RenterContract) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.onlineContracts()
+}
+
+// AllContracts returns the contracts formed by the contractor in the current
+// allowance period.
+func (c *Contractor) AllContracts() (cs []modules.RenterContract) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, contract := range c.contracts {
+		cs = append(cs, contract)
+	}
+	return
 }
 
 // CurrentPeriod returns the height at which the current allowance period

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -47,6 +47,7 @@ type Contractor struct {
 	downloaders     map[types.FileContractID]*hostDownloader
 	editors         map[types.FileContractID]*hostEditor
 	lastChange      modules.ConsensusChangeID
+	oldContracts    map[types.FileContractID]modules.RenterContract
 	renewedIDs      map[types.FileContractID]types.FileContractID
 	renewing        map[types.FileContractID]bool // prevent revising during renewal
 	revising        map[types.FileContractID]bool // prevent overlapping revisions
@@ -144,6 +145,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 		contracts:       make(map[types.FileContractID]modules.RenterContract),
 		downloaders:     make(map[types.FileContractID]*hostDownloader),
 		editors:         make(map[types.FileContractID]*hostEditor),
+		oldContracts:    make(map[types.FileContractID]modules.RenterContract),
 		renewedIDs:      make(map[types.FileContractID]types.FileContractID),
 		renewing:        make(map[types.FileContractID]bool),
 		revising:        make(map[types.FileContractID]bool),

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -17,6 +17,11 @@ var (
 	errNilCS     = errors.New("cannot create contractor with nil consensus set")
 	errNilWallet = errors.New("cannot create contractor with nil wallet")
 	errNilTpool  = errors.New("cannot create contractor with nil transaction pool")
+
+	// COMPATv1.0.4-lts
+	// metricsContractID identifies a special contract that contains aggregate
+	// financial metrics from older contractors
+	metricsContractID = types.FileContractID{'m', 'e', 't', 'r', 'i', 'c', 's'}
 )
 
 // A cachedRevision contains changes that would be applied to a RenterContract
@@ -94,6 +99,13 @@ func (c *Contractor) AllContracts() (cs []modules.RenterContract) {
 	defer c.mu.RUnlock()
 	for _, contract := range c.contracts {
 		cs = append(cs, contract)
+	}
+	// COMPATv1.0.4-lts
+	// also return the special metrics contract (see persist.go)
+	for _, contract := range c.oldContracts {
+		if contract.ID == metricsContractID {
+			cs = append(cs, contract)
+		}
 	}
 	return
 }

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -14,6 +14,7 @@ type contractorPersist struct {
 	Contracts       []modules.RenterContract
 	CurrentPeriod   types.BlockHeight
 	LastChange      modules.ConsensusChangeID
+	OldContracts    []modules.RenterContract
 	RenewedIDs      map[string]string
 }
 
@@ -31,6 +32,9 @@ func (c *Contractor) persistData() contractorPersist {
 	}
 	for _, contract := range c.contracts {
 		data.Contracts = append(data.Contracts, contract)
+	}
+	for _, contract := range c.oldContracts {
+		data.OldContracts = append(data.OldContracts, contract)
 	}
 	for oldID, newID := range c.renewedIDs {
 		data.RenewedIDs[oldID.String()] = newID.String()
@@ -67,6 +71,9 @@ func (c *Contractor) load() error {
 		c.currentPeriod = highestEnd - c.allowance.Period
 	}
 	c.lastChange = data.LastChange
+	for _, contract := range data.OldContracts {
+		c.contracts[contract.ID] = contract
+	}
 	for oldString, newString := range data.RenewedIDs {
 		var oldHash, newHash crypto.Hash
 		oldHash.LoadString(oldString)

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -150,10 +150,16 @@ func (c *Contractor) managedRenewContracts() error {
 
 	// replace old contracts with renewed ones
 	c.mu.Lock()
-	for id, contract := range newContracts {
-		delete(c.contracts, id)
+	for oldID, contract := range newContracts {
+		// archive the old contract
+		if oldContract, ok := c.contracts[oldID]; ok {
+			c.oldContracts[oldID] = oldContract
+			delete(c.contracts, oldID)
+		}
+		// insert the new contract
 		c.contracts[contract.ID] = contract
-		c.renewedIDs[id] = contract.ID
+		// add a mapping from old->new contract
+		c.renewedIDs[oldID] = contract.ID
 	}
 	err = c.saveSync()
 	c.mu.Unlock()

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -45,6 +45,10 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	cycleLen := c.allowance.Period - c.allowance.RenewWindow
 	if c.blockHeight > c.currentPeriod+cycleLen {
 		c.currentPeriod += cycleLen
+		// COMPATv1.0.4-lts
+		// if we were storing a special metrics contract, it will be invalid
+		// after we enter the next period.
+		delete(c.oldContracts, metricsContractID)
 	}
 
 	c.lastChange = cc.ID

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -20,7 +20,7 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 		}
 	}
 
-	// delete expired contracts
+	// archive expired contracts
 	var expired []types.FileContractID
 	for id, contract := range c.contracts {
 		if c.blockHeight > contract.EndHeight() {
@@ -28,11 +28,14 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 			// depend on this contract should have taken care of any issues
 			// already.
 			expired = append(expired, id)
+			// move to oldContracts
+			c.oldContracts[id] = contract
 		}
 	}
+	// delete expired contracts (can't delete while iterating)
 	for _, id := range expired {
 		delete(c.contracts, id)
-		c.log.Debugln("INFO: deleted expired contract", id)
+		c.log.Println("INFO: archived expired contract", id)
 	}
 
 	// if we have entered the next period, update currentPeriod

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -25,8 +25,9 @@ func TestProcessConsensusUpdate(t *testing.T) {
 		contracts: map[types.FileContractID]modules.RenterContract{
 			rc.ID: rc,
 		},
-		persist: new(memPersist),
-		log:     persist.NewLogger(ioutil.Discard),
+		oldContracts: make(map[types.FileContractID]modules.RenterContract),
+		persist:      new(memPersist),
+		log:          persist.NewLogger(ioutil.Discard),
 	}
 
 	// process 20 blocks; contract should remain

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -211,6 +211,11 @@ func (r *Renter) Settings() modules.RenterSettings {
 		Allowance: r.hostContractor.Allowance(),
 	}
 }
+func (r *Renter) AllContracts() []modules.RenterContract {
+	return r.hostContractor.(interface {
+		AllContracts() []modules.RenterContract
+	}).AllContracts()
+}
 
 // enforce that Renter satisfies the modules.Renter interface
 var _ modules.Renter = (*Renter)(nil)


### PR DESCRIPTION
Contracts are now moved to a new contractor map, `oldContracts`, instead of being deleted. This map is not used anywhere, but it may be used in the future (e.g. for calculating historic metrics).

An alternative would be to store _all_ contracts (including current ones) in this new map. I haven't thought through what the tradeoffs of that approach are.

Also, a new "secret" method has been added to the contractor, `AllContracts`. This method returns all the contracts in the current period, whereas `Contracts` filters out offline contracts. It's "secret" because it's not actually part of the contractor (or renter) interface; the API uses a type assertion to access it. This is because the method isn't intended to stick around.

I am much more in favor of moving the offline filtering into the renter, and having `Contracts` return the offline contracts. Since determining the offline status of a host doesn't require any unexported contractor functionality, the renter could define its own `onlineContracts` helper function and call it wherever we call `r.hostContractor.Contracts`, which is only 3 places. The only reason not to do this is to avoid code duplication between the renter and contractor. (The contract still needs to filter out offline contracts so that it can replace them.) We could, however, move this functionality to the `modules` package.