### PR TITLE
adjust constants given new capabilities

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -22,7 +22,7 @@ var (
 	// contracts with if the value is not specified explicity in the call to
 	// SetSettings.
 	recommendedHosts = build.Select(build.Var{
-		Standard: uint64(30),
+		Standard: uint64(42),
 		Dev:      uint64(2),
 		Testing:  uint64(1),
 	}).(uint64)
@@ -31,7 +31,7 @@ var (
 	// the renter settings for the renter settings to be valid. This minimum is
 	// there to prevent users from shooting themselves in the foot.
 	requiredHosts = build.Select(build.Var{
-		Standard: uint64(24),
+		Standard: uint64(20),
 		Dev:      uint64(1),
 		Testing:  uint64(1),
 	}).(uint64)

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -17,7 +17,7 @@ import (
 
 // TODO: Move to a consts file.
 const uploadFailureCooldown = time.Hour
-const minPiecesRepair = 6
+const minPiecesRepair = 5
 
 var (
 	// errFileDeleted indicates that a chunk which is trying to be repaired

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -23,7 +23,7 @@ var (
 		case "dev":
 			return 1
 		case "standard":
-			return 4
+			return 8
 		case "testing":
 			return 1
 		}
@@ -37,7 +37,7 @@ var (
 		case "dev":
 			return 1
 		case "standard":
-			return 20
+			return 24
 		case "testing":
 			return 8
 		}


### PR DESCRIPTION
The renter is a lot more stable now, and has the ability to replace offline
hosts. This means we can safely reduce the redundacny from 6x to 4x, which will
help upload times. We have also increased the total number of hosts in use from
24 to 32, which will increase overall reliability relative to the redundancy.
Filanny, we have increased the default number of hosts to 42, which is 10 more
hosts than are needed to get a chunk to full redundancy. This means that the
renter can largely tolerate a lot of failing hosts without the upload being
impacted. It also means a greater percentage of hosts on the network will be
getting data, which will help with host encouragement.