### PR TITLE
Update r.tracking in RenameFile

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -264,6 +264,10 @@ func (r *Renter) RenameFile(currentName, newName string) error {
 	// Update the entries in the renter.
 	delete(r.files, currentName)
 	r.files[newName] = file
+	if t, ok := r.tracking[currentName]; ok {
+		delete(r.tracking, currentName)
+		r.tracking[newName] = t
+	}
 	err = r.saveSync()
 	if err != nil {
 		return err

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -338,4 +338,16 @@ func TestRenterRenameFile(t *testing.T) {
 	if err != ErrPathOverload {
 		t.Error("Expecting ErrPathOverload, got", err)
 	}
+
+	// Renaming should also update the tracking set
+	rt.renter.tracking["1"] = trackedFile{"foo"}
+	err = rt.renter.RenameFile("1", "1b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, oldexists := rt.renter.tracking["1"]
+	_, newexists := rt.renter.tracking["1b"]
+	if oldexists || !newexists {
+		t.Error("renaming should have updated the entry in the tracking set")
+	}
 }


### PR DESCRIPTION
Previously, renaming a file would cause that file to stop uploading.

As discussed OOB, going forward, all file-related info should be stored in one place in the renter. The "right thing to do" in this case is probably to move the `RepairPath` field to the `file` type, rather than maintaining a separate map in the renter.