### PR TITLE
Support allowance canceling

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -182,7 +182,7 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 			WriteError(w, Error{"unable to parse hosts: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
-		if hosts < requiredHosts {
+		if hosts != 0 && hosts < requiredHosts {
 			WriteError(w, Error{fmt.Sprintf("insufficient number of hosts, need at least %v but have %v", recommendedHosts, hosts)}, http.StatusBadRequest)
 			return
 		}
@@ -206,7 +206,7 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 			WriteError(w, Error{"unable to parse renewwindow: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
-		if renewWindow < requiredRenewWindow {
+		if renewWindow != 0 && renewWindow < requiredRenewWindow {
 			WriteError(w, Error{fmt.Sprintf("renew window is too small, must be at least %v blocks but have %v blocks", requiredRenewWindow, renewWindow)}, http.StatusBadRequest)
 			return
 		}

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -202,12 +202,14 @@ func TestIntegrationSetAllowance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// bad args
+	// cancel allowance
 	var a modules.Allowance
 	err = c.SetAllowance(a)
-	if err != errAllowanceNoHosts {
-		t.Errorf("expected %q, got %q", errAllowanceNoHosts, err)
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	// bad args
 	a.Hosts = 1
 	err = c.SetAllowance(a)
 	if err != errAllowanceZeroPeriod {


### PR DESCRIPTION
The allowance can now be canceled via `SetAllowance(Allowance{})`. Doing so will cause all active contracts to be immediately archived. Archived contracts cannot be used to create Editors or Downloaders, and they are not renewed. And since the new value of `allowance.Hosts` is 0, the contractor will not attempt to form any new contracts.

Supporting this change in the API required relaxing the restrictions on `requiredHosts` and `requiredRenewWindow`.

An important consideration here is that `SetAllowance(Allowance{})` must invalidate all active editors and downloaders before archiving contracts and returning. Otherwise, an editor could save its updated contract to `c.contracts` after the previous version had been archived.

The test could be more comprehensive. It might be good enough to monitor the `Unspent` metric.