### PR TITLE
wallet defragmentation

### DIFF
--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -41,7 +41,7 @@ func (w *Wallet) defragWallet() {
 		totalOutputValue = totalOutputValue.Add(output.Value)
 	}
 
-	w.log.Printf("defragmenting wallet: %v outputs, %v total value\n", len(defragOutputs), totalOutputValue)
+	w.log.Printf("performing wallet defragmentation transaction: %v outputs, %v total value\n", len(defragOutputs), totalOutputValue)
 
 	// grab a new address from the wallet
 	addr, err := w.nextPrimarySeedAddress()
@@ -55,7 +55,8 @@ func (w *Wallet) defragWallet() {
 	go func() {
 		txns, err := w.SendSiacoins(totalOutputValue, addr.UnlockHash())
 		if err != nil {
-			w.log.Println("error after call to SendSiacoins: ", err)
+			w.log.Printf("error sending defrag transaction with value %v: %v\n ", totalOutputValue, err)
+			return
 		}
 
 		w.log.Println("defrag transaction size: ", len(encoding.Marshal(txns)))

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -41,12 +41,10 @@ func (w *Wallet) defragWallet() {
 		totalOutputValue = totalOutputValue.Add(output.Value)
 	}
 
-	w.log.Printf("performing wallet defragmentation transaction: %v outputs, %v total value\n", len(defragOutputs), totalOutputValue)
-
 	// grab a new address from the wallet
 	addr, err := w.nextPrimarySeedAddress()
 	if err != nil {
-		w.log.Println("error getting an address for defrag: ", err)
+		w.log.Println("Error getting an address for defragmentation: ", err)
 		return
 	}
 
@@ -55,10 +53,10 @@ func (w *Wallet) defragWallet() {
 	go func() {
 		txns, err := w.SendSiacoins(totalOutputValue, addr.UnlockHash())
 		if err != nil {
-			w.log.Printf("error sending defrag transaction with value %v: %v\n ", totalOutputValue, err)
+			w.log.Printf("Attempted to defragment wallet but failed. %v outputs used, %vH total coins. Error: %v.\n ", len(defragOutputs), totalOutputValue, err)
 			return
 		}
 
-		w.log.Println("defrag transaction size: ", len(encoding.Marshal(txns)))
+		w.log.Printf("Successfully defragmented wallet. %v outputs used, %vH coins defragmented. Defragment transaction size: %vB.\n", len(defragOutputs), totalOutputValue, len(encoding.Marshal(txns)))
 	}()
 }

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -33,7 +33,6 @@ func (w *Wallet) defragWallet() {
 	for _, output := range defragOutputs {
 		totalOutputValue = totalOutputValue.Add(output.Value)
 	}
-	totalOutputValue = totalOutputValue.Div64(uint64(len(defragOutputs)))
 
 	w.log.Printf("defragmenting wallet: %v outputs, %v total value\n", len(defragOutputs), totalOutputValue)
 

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -10,6 +10,9 @@ const (
 	// defragThreshold is the number of outputs a wallet is allowed before it is
 	// defragmented.
 	defragThreshold = 20
+
+	// defragBatchSize defines how many outputs are combined during one defrag.
+	defragBatchSize = 15
 )
 
 // defragWallet computes the sum of the 15 largest outputs in the wallet and
@@ -21,6 +24,8 @@ func (w *Wallet) defragWallet() {
 		return
 	}
 
+	// grab all the outputs from the wallet and sort them from
+	// largest -> smallest
 	var so sortedOutputs
 	for scoid, sco := range w.siacoinOutputs {
 		so.ids = append(so.ids, scoid)
@@ -28,7 +33,8 @@ func (w *Wallet) defragWallet() {
 	}
 	sort.Sort(sort.Reverse(so))
 
-	defragOutputs := so.outputs[:15]
+	// choose the defragBatchSizeth largest outputs from the wallet and sum them
+	defragOutputs := so.outputs[:defragBatchSize]
 	var totalOutputValue types.Currency
 	for _, output := range defragOutputs {
 		totalOutputValue = totalOutputValue.Add(output.Value)
@@ -36,14 +42,17 @@ func (w *Wallet) defragWallet() {
 
 	w.log.Printf("defragmenting wallet: %v outputs, %v total value\n", len(defragOutputs), totalOutputValue)
 
-	var dest types.UnlockHash
-	for h := range w.keys {
-		dest = h
-		break
+	// grab a new address from the wallet
+	addr, err := w.nextPrimarySeedAddress()
+	if err != nil {
+		w.log.Println("error getting an address for defrag: ", err)
+		return
 	}
 
+	// send the sum of the outputs to this wallet. This operation is done in a
+	// goroutine since defragWallet() is called under lock.
 	go func() {
-		_, err := w.SendSiacoins(totalOutputValue, dest)
+		_, err := w.SendSiacoins(totalOutputValue, addr.UnlockHash())
 		if err != nil {
 			w.log.Println("error after call to SendSiacoins: ", err)
 		}

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -3,16 +3,17 @@ package wallet
 import (
 	"sort"
 
+	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/types"
 )
 
 const (
 	// defragThreshold is the number of outputs a wallet is allowed before it is
 	// defragmented.
-	defragThreshold = 20
+	defragThreshold = 50
 
 	// defragBatchSize defines how many outputs are combined during one defrag.
-	defragBatchSize = 15
+	defragBatchSize = 40
 )
 
 // defragWallet computes the sum of the 15 largest outputs in the wallet and
@@ -52,9 +53,11 @@ func (w *Wallet) defragWallet() {
 	// send the sum of the outputs to this wallet. This operation is done in a
 	// goroutine since defragWallet() is called under lock.
 	go func() {
-		_, err := w.SendSiacoins(totalOutputValue, addr.UnlockHash())
+		txns, err := w.SendSiacoins(totalOutputValue, addr.UnlockHash())
 		if err != nil {
 			w.log.Println("error after call to SendSiacoins: ", err)
 		}
+
+		w.log.Println("defrag transaction size: ", len(encoding.Marshal(txns)))
 	}()
 }

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -1,0 +1,52 @@
+package wallet
+
+import (
+	"sort"
+
+	"github.com/NebulousLabs/Sia/types"
+)
+
+const (
+	// defragThreshold is the number of outputs a wallet is allowed before it is
+	// defragmented.
+	defragThreshold = 20
+)
+
+// defragWallet computes the sum of the 15 largest outputs in the wallet and
+// sends that sum to itself, effectively defragmenting the wallet. This defrag
+// operation is only performed if the wallet has greater than defragThreshold
+// outputs.
+func (w *Wallet) defragWallet() {
+	if len(w.siacoinOutputs) < defragThreshold {
+		return
+	}
+
+	var so sortedOutputs
+	for scoid, sco := range w.siacoinOutputs {
+		so.ids = append(so.ids, scoid)
+		so.outputs = append(so.outputs, sco)
+	}
+	sort.Sort(sort.Reverse(so))
+
+	defragOutputs := so.outputs[:15]
+	var totalOutputValue types.Currency
+	for _, output := range defragOutputs {
+		totalOutputValue = totalOutputValue.Add(output.Value)
+	}
+	totalOutputValue = totalOutputValue.Div64(uint64(len(defragOutputs)))
+
+	w.log.Printf("defragmenting wallet: %v outputs, %v total value\n", len(defragOutputs), totalOutputValue)
+
+	var dest types.UnlockHash
+	for h := range w.keys {
+		dest = h
+		break
+	}
+
+	go func() {
+		_, err := w.SendSiacoins(totalOutputValue, dest)
+		if err != nil {
+			w.log.Println("error after call to SendSiacoins: ", err)
+		}
+	}()
+}

--- a/modules/wallet/defrag_test.go
+++ b/modules/wallet/defrag_test.go
@@ -1,0 +1,45 @@
+package wallet
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefragWallet(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	wt, err := createWalletTester("TestDefragWallet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	// mine defragThreshold blocks, resulting in defragThreshold outputs
+	for i := 0; i < defragThreshold; i++ {
+		_, err := wt.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// add another block to push the number of outputs over the threshold
+	_, err = wt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// allow some time for the defrag transaction to occur, then mine another block
+	time.Sleep(time.Second)
+
+	_, err = wt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// defrag should keep the outputs below the threshold
+	if len(wt.wallet.siacoinOutputs) > defragThreshold {
+		t.Fatalf("defrag should result in fewer than defragThreshold outputs, got %v wanted %v\n", len(wt.wallet.siacoinOutputs), defragThreshold)
+	}
+}

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -221,6 +221,7 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 	w.updateConfirmedSet(cc)
 	w.revertHistory(cc)
 	w.applyHistory(cc)
+	w.defragWallet()
 }
 
 // ReceiveUpdatedUnconfirmedTransactions updates the wallet's unconfirmed


### PR DESCRIPTION
This PR introduces wallet defragmentation, in order to solve the problems noticed by some users, notably Poloniex, where wallets with many outputs would fail to send coins with `transaction too large`. This PR adds `defragWallet()`, which is called after every block and sends the sum of the 15 largest outputs to itself.