### PR TITLE
Fix RenterFunds panic

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -135,6 +136,10 @@ func (rc *RenterContract) EndHeight() types.BlockHeight {
 // RenterFunds returns the funds remaining in the contract's Renter payout as
 // of the most recent revision.
 func (rc *RenterContract) RenterFunds() types.Currency {
+	if len(rc.LastRevision.NewValidProofOutputs) < 2 {
+		build.Critical("malformed RenterContract:", rc)
+		return types.ZeroCurrency
+	}
 	return rc.LastRevision.NewValidProofOutputs[0].Value
 }
 

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -102,10 +102,8 @@ func (c *Contractor) AllContracts() (cs []modules.RenterContract) {
 	}
 	// COMPATv1.0.4-lts
 	// also return the special metrics contract (see persist.go)
-	for _, contract := range c.oldContracts {
-		if contract.ID == metricsContractID {
-			cs = append(cs, contract)
-		}
+	if contract, ok := c.oldContracts[metricsContractID]; ok {
+		cs = append(cs, contract)
 	}
 	return
 }

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -80,7 +80,7 @@ func (c *Contractor) load() error {
 	}
 	c.lastChange = data.LastChange
 	for _, contract := range data.OldContracts {
-		c.contracts[contract.ID] = contract
+		c.oldContracts[contract.ID] = contract
 	}
 	for oldString, newString := range data.RenewedIDs {
 		var oldHash, newHash crypto.Hash


### PR DESCRIPTION
Archived ("old") contracts were being incorrectly loaded as active contracts in the contractor persist. This, in combination with the special metrics contract, is probably what caused `RenterFunds` to panic. Regardless, additional safety has been added to `RenterFunds` as well.