### PR TITLE
fix reporting for aggregate metrics

### DIFF
--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -23,7 +23,7 @@ type contractorPersist struct {
 		DownloadSpending types.Currency `json:"downloadspending"`
 		StorageSpending  types.Currency `json:"storagespending"`
 		UploadSpending   types.Currency `json:"uploadspending"`
-	}
+	} `json:",omitempty"`
 }
 
 // persistData returns the data in the Contractor that will be saved to disk.
@@ -99,6 +99,17 @@ func (c *Contractor) load() error {
 			DownloadSpending: fm.DownloadSpending,
 			StorageSpending:  fm.StorageSpending,
 			UploadSpending:   fm.UploadSpending,
+			// Give the contract a fake startheight so that it will included
+			// with the other contracts in the current period. Note that in
+			// update.go, the special contract is specifically deleted when a
+			// new period begins.
+			StartHeight: c.currentPeriod + 1,
+			// We also need to add a ValidProofOutput so that the RenterFunds
+			// method will not panic. The value should be 0, i.e. "all funds
+			// were spent."
+			LastRevision: types.FileContractRevision{
+				NewValidProofOutputs: make([]types.SiacoinOutput, 2),
+			},
 		}
 	}
 


### PR DESCRIPTION
The "empty metrics" bug was caused by this bit of code in the API:
```go
for _, c := range contracts {
	if c.StartHeight < periodStart {
		continue
	}
	// ...
}
```
The special metrics contract didn't have a start height, so the loop was skipping over it. This was fixed by setting the contract start height to `c.periodStart + 1`.
Later in the loop, `RenterFunds` is called on the contract. Since the special metrics contract doesn't have a proper revision, this caused a panic. This was fixed by adding zero-valued `ValidProofOutput`s.

During debugging, it occurred to me that old (pre-upgrade) contracts won't have a start height either. Thus they too will be skipped by the loop in the API. This means that any new uploads/downloads using the old contracts will not cause the metrics to change. I'm not sure what the best fix for this is.