### PR TITLE
convert Critical sanity check to Println

### DIFF
--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -163,7 +163,7 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 		_, exists := c.cachedRevisions[contract.ID]
 		c.mu.RUnlock()
 		if !exists {
-			c.log.Critical("Cached revision does not exist for contract.")
+			c.log.Println("WARN: cached revision does not exist for contract", contract.ID)
 		}
 	}
 

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -227,7 +227,7 @@ func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 		_, exists := c.cachedRevisions[contract.ID]
 		c.mu.RUnlock()
 		if !exists {
-			c.log.Critical("Cached revision does not exist for contract.")
+			c.log.Println("WARN: cached revision does not exist for contract", contract.ID)
 		}
 	}
 


### PR DESCRIPTION
Otherwise this results in a panic when upgrading from v1.0.4. (Although the check is only run when running a debug build.)