### PR TITLE
fix tpool locking bug

### DIFF
--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -123,6 +123,12 @@ type (
 		// Synced indicates whether or not the ConsensusSet is synced with its
 		// peers.
 		Synced bool
+
+		// TryTransactionSet is an unlocked version of
+		// ConsensusSet.TryTransactionSet. This allows the TryTransactionSet
+		// function to be called by a subscriber during
+		// ProcessConsensusChange.
+		TryTransactionSet func([]types.Transaction) (ConsensusChange, error)
 	}
 
 	// A SiacoinOutputDiff indicates the addition or removal of a SiacoinOutput in

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -283,11 +283,10 @@ func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 	}
 
 	// Updates complete, demote the lock.
-	cs.mu.Demote()
-	defer cs.mu.DemotedUnlock()
 	if len(changeEntry.AppliedBlocks) > 0 {
 		cs.readlockUpdateSubscribers(changeEntry)
 	}
+	cs.mu.Unlock()
 	return nil
 }
 

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -86,6 +86,10 @@ func (cs *ConsensusSet) computeConsensusChange(tx *bolt.Tx, ce changeEntry) (mod
 	if cs.synced && recentBlock == currentBlock {
 		cc.Synced = true
 	}
+
+	// Add the unexported tryTransactionSet function.
+	cc.TryTransactionSet = cs.tryTransactionSet
+
 	return cc, nil
 }
 

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -313,20 +313,12 @@ func validTransaction(tx *bolt.Tx, t types.Transaction) error {
 	return nil
 }
 
-// TryTransactionSet applies the input transactions to the consensus set to
+// tryTransactionSet applies the input transactions to the consensus set to
 // determine if they are valid. An error is returned IFF they are not a valid
 // set in the current consensus set. The size of the transactions and the set
 // is not checked. After the transactions have been validated, a consensus
 // change is returned detailing the diffs that the transaciton set would have.
-func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.ConsensusChange, error) {
-	err := cs.tg.Add()
-	if err != nil {
-		return modules.ConsensusChange{}, err
-	}
-	defer cs.tg.Done()
-	cs.mu.RLock()
-	defer cs.mu.RUnlock()
-
+func (cs *ConsensusSet) tryTransactionSet(txns []types.Transaction) (modules.ConsensusChange, error) {
 	// applyTransaction will apply the diffs from a transaction and store them
 	// in a block node. diffHolder is the blockNode that tracks the temporary
 	// changes. At the end of the function, all changes that were made to the
@@ -339,7 +331,7 @@ func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.Con
 	// manually manage the tx instead of using 'Update', but that has safety
 	// concerns and is more difficult to implement correctly.
 	errSuccess := errors.New("success")
-	err = cs.db.Update(func(tx *bolt.Tx) error {
+	err := cs.db.Update(func(tx *bolt.Tx) error {
 		diffHolder.Height = blockHeight(tx)
 		for _, txn := range txns {
 			err := validTransaction(tx, txn)
@@ -361,4 +353,34 @@ func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.Con
 		SiafundPoolDiffs:          diffHolder.SiafundPoolDiffs,
 	}
 	return cc, nil
+}
+
+// TryTransactionSet applies the input transactions to the consensus set to
+// determine if they are valid. An error is returned IFF they are not a valid
+// set in the current consensus set. The size of the transactions and the set
+// is not checked. After the transactions have been validated, a consensus
+// change is returned detailing the diffs that the transaciton set would have.
+func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.ConsensusChange, error) {
+	err := cs.tg.Add()
+	if err != nil {
+		return modules.ConsensusChange{}, err
+	}
+	defer cs.tg.Done()
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return cs.tryTransactionSet(txns)
+}
+
+// LockedTryTransactionSet calls fn while under read-lock, passing it a
+// version of TryTransactionSet that can be called under read-lock. This fixes
+// an edge case in the transaction pool.
+func (cs *ConsensusSet) LockedTryTransactionSet(fn func(func(txns []types.Transaction) (modules.ConsensusChange, error)) error) error {
+	err := cs.tg.Add()
+	if err != nil {
+		return err
+	}
+	defer cs.tg.Done()
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	return fn(cs.tryTransactionSet)
 }

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -108,7 +108,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// processing consensus changes. Overall, the locking is pretty fragile and
 	// more rules need to be put in place.
 	for _, set := range unconfirmedSets {
-		tp.acceptTransactionSet(set) // Error is not checked.
+		tp.acceptTransactionSet(set, cc.TryTransactionSet) // Error is not checked.
 	}
 
 	// Inform subscribers that an update has executed.

--- a/modules/wallet/defrag_test.go
+++ b/modules/wallet/defrag_test.go
@@ -112,8 +112,6 @@ func TestDefragOutputExhaustion(t *testing.T) {
 		t.SkipNow()
 	}
 
-	t.Skip("skipping until consensus consistency bug is fixed")
-
 	wt, err := createWalletTester("TestDefragOutputExhaustion")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
There are two things going on here:

- `ConsensusChange` now has a `TryTransactionSet` field, which is an unexported (i.e. unlocked) version of the consensus set's `TryTransactionSet` function. This allows the transaction pool to call `TryTransactionSet` even under lock, namely during `ProcessConsensusChange`.
- The consensus set now has an exported method called `LockedTryTransactionSet`, which read-locks the consensus set and calls the supplied function, passing it an unlocked version of `TryTransactionSet`. However, this function is not part of the `ConsensusSet` interface. This allows the transaction pool to call `TryTransactionSet` multiple times without unlocking the consensus set. More importantly, it means the transaction pool can lock the consensus set first, before locking itself. This prevents a deadlock.

The effect of this is that the defrag test now passes. We may also see less NDFs.