### PR TITLE
Prune nodes more rapidly when there are many

### DIFF
--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -41,9 +41,9 @@ var (
 	// healthyNodeListLen defines the number of nodes that the gateway must
 	// have in the node list before it will stop asking peers for more nodes.
 	healthyNodeListLen = build.Select(build.Var{
-		Standard: 200,
-		Dev:      30,
-		Testing:  15,
+		Standard: int(200),
+		Dev:      int(30),
+		Testing:  int(15),
 	}).(int)
 
 	// maxSharedNodes defines the number of nodes that will be shared between
@@ -73,17 +73,17 @@ var (
 	// pruneNodeListLen defines the number of nodes that the gateway must have
 	// to be pruning nodes from the node list.
 	pruneNodeListLen = build.Select(build.Var{
-		Standard: 50,
-		Dev:      15,
-		Testing:  10,
+		Standard: int(50),
+		Dev:      int(15),
+		Testing:  int(10),
 	}).(int)
 
 	// quickPruneListLen defines the number of nodes that the gateway must have
 	// to be pruning nodes quickly from the node list.
 	quickPruneListLen = build.Select(build.Var{
-		Standard: 250,
-		Dev:      40,
-		Testing:  20,
+		Standard: int(250),
+		Dev:      int(40),
+		Testing:  int(20),
 	}).(int)
 )
 

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -29,6 +29,15 @@ const (
 )
 
 var (
+	// fastNodePurgeDelay defines the amount of time that is waited between each
+	// iteration of the purge loop when the gateway has enough nodes to be
+	// needing to purge quickly.
+	fastNodePurgeDelay = build.Select(build.Var{
+		Standard: 1 * time.Minute,
+		Dev:      5 * time.Second,
+		Testing:  200 * time.Millisecond,
+	}).(time.Duration)
+
 	// healthyNodeListLen defines the number of nodes that the gateway must
 	// have in the node list before it will stop asking peers for more nodes.
 	healthyNodeListLen = build.Select(build.Var{
@@ -67,6 +76,14 @@ var (
 		Standard: 50,
 		Dev:      15,
 		Testing:  10,
+	}).(int)
+
+	// quickPruneListLen defines the number of nodes that the gateway must have
+	// to be pruning nodes quickly from the node list.
+	quickPruneListLen = build.Select(build.Var{
+		Standard: 250,
+		Dev:      40,
+		Testing:  20,
 	}).(int)
 )
 


### PR DESCRIPTION
The gateway was having a problem with a large node list, where many of the nodes
on that list were unconnectable, but the pruning was not happening fast enough
to keep the node list reasonably useful. Now, the gateway will prune nodes at a
more rapid rate when there are a lot of nodes.

This is an incomplete fix, we also need to extend the dial bit to do the full
handshake, merely seeing that a node is online is not enough if that node is not
running a recent version.

-----

This PR needs two additional things, first it needs an extension of the `g.dial` bit in the purge loop to verify that the other node is in fact a node running Sia, and on a recent enough version. Secondly, it needs testing.