### PR TITLE
Add siac export command to support leaderboard

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -161,7 +161,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 	// Consensus API Calls
 	if api.cs != nil {
 		router.GET("/consensus", api.consensusHandler)
-		router.POST("/consensus/validate/transactionset", api.consensusValidateTransactionSetHandler)
+		router.POST("/consensus/validate/transactionset", api.consensusValidateTransactionsetHandler)
 	}
 
 	// Explorer API Calls

--- a/api/api.go
+++ b/api/api.go
@@ -161,6 +161,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 	// Consensus API Calls
 	if api.cs != nil {
 		router.GET("/consensus", api.consensusHandler)
+		router.POST("/consensus/validate/transactionset", api.consensusValidateTransactionSetHandler)
 	}
 
 	// Explorer API Calls

--- a/api/consensus.go
+++ b/api/consensus.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/NebulousLabs/Sia/types"
@@ -27,4 +28,21 @@ func (api *API) consensusHandler(w http.ResponseWriter, req *http.Request, _ htt
 		CurrentBlock: cbid,
 		Target:       currentTarget,
 	})
+}
+
+// consensusValidateTransactionSetHandler handles the API calls to
+// /consensus/validate/transactionset.
+func (api *API) consensusValidateTransactionSetHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	var txnset []types.Transaction
+	err := json.NewDecoder(req.Body).Decode(&txnset)
+	if err != nil {
+		WriteError(w, Error{"could not decode transaction set: " + err.Error()}, http.StatusBadRequest)
+		return
+	}
+	_, err = api.cs.TryTransactionSet(txnset)
+	if err != nil {
+		WriteError(w, Error{"transaction set validation failed: " + err.Error()}, http.StatusBadRequest)
+		return
+	}
+	WriteSuccess(w)
 }

--- a/api/consensus.go
+++ b/api/consensus.go
@@ -30,9 +30,9 @@ func (api *API) consensusHandler(w http.ResponseWriter, req *http.Request, _ htt
 	})
 }
 
-// consensusValidateTransactionSetHandler handles the API calls to
+// consensusValidateTransactionsetHandler handles the API calls to
 // /consensus/validate/transactionset.
-func (api *API) consensusValidateTransactionSetHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+func (api *API) consensusValidateTransactionsetHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	var txnset []types.Transaction
 	err := json.NewDecoder(req.Body).Decode(&txnset)
 	if err != nil {

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"encoding/json"
+	"net/url"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/types"
@@ -32,5 +34,78 @@ func TestIntegrationConsensusGET(t *testing.T) {
 	expectedTarget := types.Target{128}
 	if cg.Target != expectedTarget {
 		t.Error("wrong target returned in consensus GET call")
+	}
+}
+
+// TestConsensusValidateTransactionSet probes the POST call to
+// /consensus/validate/transactionset.
+func TestConsensusValidateTransactionSet(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	st, err := createServerTester("TestConsensusValidateTransactionSet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Anounce the host and start accepting contracts.
+	if err := st.announceHost(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.acceptContracts(); err != nil {
+		t.Fatal(err)
+	}
+	if err = st.setHostStorage(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
+		t.Fatal(err)
+	}
+	st.miner.AddBlock()
+
+	// Get the contract
+	var cs RenterContracts
+	if err = st.getAPI("/renter/contracts", &cs); err != nil {
+		t.Fatal(err)
+	}
+	if len(cs.Contracts) != 1 {
+		t.Fatalf("expected renter to have 1 contracts; got %v", len(cs.Contracts))
+	}
+	contract := cs.Contracts[0]
+
+	// Validate the contract
+	jsonTxns, err := json.Marshal([]types.Transaction{contract.LastTransaction})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := HttpPOST("http://"+st.server.listener.Addr().String()+"/consensus/validate/transactionset", string(jsonTxns))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if non2xx(resp.StatusCode) {
+		t.Fatal(decodeError(resp))
+	}
+
+	// Try again with an invalid contract
+	contract.LastTransaction.FileContractRevisions[0].NewFileSize++
+	jsonTxns, err = json.Marshal([]types.Transaction{contract.LastTransaction})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = HttpPOST("http://"+st.server.listener.Addr().String()+"/consensus/validate/transactionset", string(jsonTxns))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if !non2xx(resp.StatusCode) {
+		t.Fatal("expected validation error")
 	}
 }

--- a/api/renter.go
+++ b/api/renter.go
@@ -89,11 +89,12 @@ type (
 
 	// RenterContract represents a contract formed by the renter.
 	RenterContract struct {
-		EndHeight   types.BlockHeight    `json:"endheight"`
-		ID          types.FileContractID `json:"id"`
-		NetAddress  modules.NetAddress   `json:"netaddress"`
-		RenterFunds types.Currency       `json:"renterfunds"`
-		Size        uint64               `json:"size"`
+		EndHeight       types.BlockHeight    `json:"endheight"`
+		ID              types.FileContractID `json:"id"`
+		LastTransaction types.Transaction    `json:"lasttransaction"`
+		NetAddress      modules.NetAddress   `json:"netaddress"`
+		RenterFunds     types.Currency       `json:"renterfunds"`
+		Size            uint64               `json:"size"`
 	}
 
 	// RenterContracts contains the renter's contracts.
@@ -235,11 +236,12 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 	contracts := []RenterContract{}
 	for _, c := range api.renter.Contracts() {
 		contracts = append(contracts, RenterContract{
-			EndHeight:   c.EndHeight(),
-			ID:          c.ID,
-			NetAddress:  c.NetAddress,
-			RenterFunds: c.RenterFunds(),
-			Size:        modules.SectorSize * uint64(len(c.MerkleRoots)),
+			EndHeight:       c.EndHeight(),
+			ID:              c.ID,
+			NetAddress:      c.NetAddress,
+			LastTransaction: c.LastRevisionTxn,
+			RenterFunds:     c.RenterFunds(),
+			Size:            modules.SectorSize * uint64(len(c.MerkleRoots)),
 		})
 	}
 	WriteJSON(w, RenterContracts{

--- a/api/renter.go
+++ b/api/renter.go
@@ -241,7 +241,7 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 			NetAddress:      c.NetAddress,
 			LastTransaction: c.LastRevisionTxn,
 			RenterFunds:     c.RenterFunds(),
-			Size:            modules.SectorSize * uint64(len(c.MerkleRoots)),
+			Size:            c.LastRevision.NewFileSize,
 		})
 	}
 	WriteJSON(w, RenterContracts{

--- a/doc/API.md
+++ b/doc/API.md
@@ -155,9 +155,10 @@ returns the version of the Sia daemon currently running.
 Consensus
 ---------
 
-| Route                        | HTTP verb |
-| ---------------------------- | --------- |
-| [/consensus](#consensus-get) | GET       |
+| Route                                                                       | HTTP verb |
+| --------------------------------------------------------------------------- | --------- |
+| [/consensus](#consensus-get)                                                | GET       |
+| [/consensus/validate/transactionset](#consensusvalidatetransactionset-post) | POST      |
 
 For examples and detailed descriptions of request and response parameters,
 refer to [Consensus.md](/doc/api/Consensus.md).
@@ -175,6 +176,19 @@ returns information about the consensus set, such as the current block height.
   "target":       [0,0,0,0,0,0,11,48,125,79,116,89,136,74,42,27,5,14,10,31,23,53,226,238,202,219,5,204,38,32,59,165]
 }
 ```
+
+#### /consensus/validate/transactionset [POST]
+
+validates a set of transactions using the current utxo set.
+
+###### Request Body Bytes
+
+Since transactions may be large, the transaction set is supplied in the POST
+body, encoded in JSON format.
+
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
 
 Gateway
 -------

--- a/doc/API.md
+++ b/doc/API.md
@@ -672,11 +672,12 @@ returns active contracts. Expired contracts are not included.
 {
   "contracts": [
     {
-      "endheight":   50000, // block height
-      "id":          "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-      "netaddress":  "12.34.56.78:9",
-      "renterfunds": "1234", // hastings
-      "size":        8192    // bytes
+      "endheight":       50000, // block height
+      "id":              "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "lasttransaction": {}, // types.Transaction
+      "netaddress":      "12.34.56.78:9",
+      "renterfunds":     "1234", // hastings
+      "size":            8192    // bytes
     }
   ]
 }

--- a/doc/File Contract Negotiation.md
+++ b/doc/File Contract Negotiation.md
@@ -190,7 +190,7 @@ File Contract Revision
 
 8. The renter signs the revision and sends the signature to the host.
 
-9. The host signs the revision and sends the siganture to the renter. Both
+9. The host signs the revision and sends the signature to the renter. Both
    parties submit the new revision to the transaction pool. The connection
    deadline is reset to 600 seconds (unless the maximum deadline has been
    reached), and the loop restarts.

--- a/doc/api/Consensus.md
+++ b/doc/api/Consensus.md
@@ -20,9 +20,10 @@ endpoint returns information about the state of the blockchain.
 Index
 -----
 
-| Route                        | HTTP verb |
-| ---------------------------- | --------- |
-| [/consensus](#consensus-get) | GET       |
+| Route                                                                       | HTTP verb |
+| --------------------------------------------------------------------------- | --------- |
+| [/consensus](#consensus-get)                                                | GET       |
+| [/consensus/validate/transactionset](#consensusvalidatetransactionset-post) | POST      |
 
 #### /consensus [GET]
 
@@ -45,3 +46,16 @@ returns information about the consensus set, such as the current block height.
   "target": [0,0,0,0,0,0,11,48,125,79,116,89,136,74,42,27,5,14,10,31,23,53,226,238,202,219,5,204,38,32,59,165]
 }
 ```
+
+#### /consensus/validate/transactionset [POST]
+
+validates a set of transactions using the current utxo set.
+
+###### Request Body Bytes
+
+Since transactions may be large, the transaction set is supplied in the POST
+body, encoded in JSON format.
+
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -129,6 +129,9 @@ returns active contracts. Expired contracts are not included.
       // Address of the host the file contract was formed with.
       "netaddress": "12.34.56.78:9",
 
+      // A signed transaction containing the most recent contract revision.
+      "lasttransaction": {},
+
       // Remaining funds left for the renter to spend on uploads & downloads.
       "renterfunds": "1234", // hastings
 

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -107,7 +107,7 @@ func (h *Host) managedDownloadIteration(conn net.Conn, so *storageObligation) er
 		return extendErr("failed to write acceptance for renter revision: ", ErrorConnection(err.Error()))
 	}
 
-	// Renter will send a transaction siganture for the file contract revision.
+	// Renter will send a transaction signature for the file contract revision.
 	var renterSignature types.TransactionSignature
 	err = encoding.ReadObject(conn, &renterSignature, modules.NegotiateMaxTransactionSignatureSize)
 	if err != nil {

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -143,7 +143,7 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	// The renter will now send a negotiation response, followed by transaction
 	// signatures for the file contract transaction in the case of acceptance.
 	// The transaction signatures will be followed by another transaction
-	// siganture, to sign a no-op file contract revision.
+	// signature, to sign a no-op file contract revision.
 	err = modules.ReadNegotiationAcceptance(conn)
 	if err != nil {
 		return extendErr("renter did not accept updated transactions: ", ErrorCommunication(err.Error()))
@@ -166,7 +166,7 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	// send the signatures so that the renter can immediately have the
 	// completed file contract.
 	//
-	// During finalization, the siganture for the revision is also checked, and
+	// During finalization, the signature for the revision is also checked, and
 	// signatures for the revision transaction are created.
 	h.mu.RLock()
 	hostCollateral := contractCollateral(h.settings, txnSet[len(txnSet)-1].FileContracts[0])

--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -176,7 +176,7 @@ func (h *Host) managedRPCRenewContract(conn net.Conn) error {
 	// transaction and submits it to the blockchain, creating a storage
 	// obligation in the process. The host's part is now complete and the
 	// contract is finalized, but to give confidence to the renter the host
-	// will send the sigantures so that the renter can immediately have the
+	// will send the signatures so that the renter can immediately have the
 	// completed file contract.
 	//
 	// During finalization the signatures sent by the renter are all checked.

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -71,7 +71,7 @@ func (tp *TransactionPool) IsStandardTransaction(t types.Transaction) error {
 	// of the UnlockConditions, which currently can appear in 3 separate fields
 	// of the transaction. Unrecognized types are ignored because a softfork
 	// may make certain unrecognized signatures invalid, and this node cannot
-	// tell which sigantures are the invalid ones.
+	// tell which signatures are the invalid ones.
 	for _, sci := range t.SiacoinInputs {
 		err := tp.checkUnlockConditions(sci.UnlockConditions)
 		if err != nil {

--- a/siac/export.go
+++ b/siac/export.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/NebulousLabs/Sia/api"
+	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	renterExportCmd = &cobra.Command{
+		Use:   "export",
+		Short: "export renter data to various formats",
+		Long:  "Export renter data in various formats.",
+		// Run field not provided; export requires a subcommand
+	}
+
+	renterExportContractsCmd = &cobra.Command{
+		Use:   "contracts [destination]",
+		Short: "export the renter's contracts",
+		Long:  "Export the renter's current contract set in JSON format to the specified file.",
+		Run:   wrap(renterexportcontractscmd),
+	}
+)
+
+// renterexportcontractscmd is the handler for the command `siac renter export contracts`.
+// Exports the current contract set to JSON.
+func renterexportcontractscmd(destination string) {
+	var cs api.RenterContracts
+	err := getAPI("/renter/contracts", &cs)
+	if err != nil {
+		die("Could not retrieve contracts:", err)
+	}
+	var contractTxns []types.Transaction
+	for _, c := range cs.Contracts {
+		contractTxns = append(contractTxns, c.LastTransaction)
+	}
+	// NOTE: don't need to use abs() here, since path is not passed to siad
+	file, err := os.Create(destination)
+	if err != nil {
+		die("Could not export to file:", err)
+	}
+	err = json.NewEncoder(file).Encode(contractTxns)
+	if err != nil {
+		die("Could not export to file:", err)
+	}
+	fmt.Println("Exported contract data to", destination)
+}

--- a/siac/main.go
+++ b/siac/main.go
@@ -257,10 +257,11 @@ func main() {
 	renterCmd.AddCommand(renterFilesDeleteCmd, renterFilesDownloadCmd,
 		renterDownloadsCmd, renterAllowanceCmd, renterSetAllowanceCmd,
 		renterContractsCmd, renterFilesListCmd, renterFilesRenameCmd,
-		renterFilesUploadCmd, renterUploadsCmd)
+		renterFilesUploadCmd, renterUploadsCmd, renterExportCmd)
 	renterCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
 	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
 	renterFilesListCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
+	renterExportCmd.AddCommand(renterExportContractsCmd)
 
 	root.AddCommand(gatewayCmd)
 	gatewayCmd.AddCommand(gatewayConnectCmd, gatewayDisconnectCmd, gatewayAddressCmd, gatewayListCmd)

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -53,16 +53,16 @@ type (
 	// cannot sign itself).
 	CoveredFields struct {
 		WholeTransaction      bool     `json:"wholetransaction"`
-		SiacoinInputs         []uint64 `json:"siacoininputs"`
-		SiacoinOutputs        []uint64 `json:"siacoinoutputs"`
-		FileContracts         []uint64 `json:"filecontracts"`
-		FileContractRevisions []uint64 `json:"filecontractrevisions"`
-		StorageProofs         []uint64 `json:"storageproofs"`
-		SiafundInputs         []uint64 `json:"siafundinputs"`
-		SiafundOutputs        []uint64 `json:"siafundoutputs"`
-		MinerFees             []uint64 `json:"minerfees"`
-		ArbitraryData         []uint64 `json:"arbitrarydata"`
-		TransactionSignatures []uint64 `json:"transactionsignatures"`
+		SiacoinInputs         []uint64 `json:"siacoininputs,omitempty"`
+		SiacoinOutputs        []uint64 `json:"siacoinoutputs,omitempty"`
+		FileContracts         []uint64 `json:"filecontracts,omitempty"`
+		FileContractRevisions []uint64 `json:"filecontractrevisions,omitempty"`
+		StorageProofs         []uint64 `json:"storageproofs,omitempty"`
+		SiafundInputs         []uint64 `json:"siafundinputs,omitempty"`
+		SiafundOutputs        []uint64 `json:"siafundoutputs,omitempty"`
+		MinerFees             []uint64 `json:"minerfees,omitempty"`
+		ArbitraryData         []uint64 `json:"arbitrarydata,omitempty"`
+		TransactionSignatures []uint64 `json:"transactionsignatures,omitempty"`
 	}
 
 	// A SiaPublicKey is a public key prefixed by a Specifier. The Specifier

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -23,7 +23,7 @@ var (
 	SignatureEd25519 = Specifier{'e', 'd', '2', '5', '5', '1', '9'}
 
 	ErrEntropyKey                = errors.New("transaction tries to sign an entproy public key")
-	ErrFrivilousSignature        = errors.New("transaction contains a frivilous siganture")
+	ErrFrivolousSignature        = errors.New("transaction contains a frivolous signature")
 	ErrInvalidPubKeyIndex        = errors.New("transaction contains a signature that points to a nonexistent public key")
 	ErrInvalidUnlockHashChecksum = errors.New("provided unlock hash has an invalid checksum")
 	ErrMissingSignatures         = errors.New("transaction has inputs with missing signatures")
@@ -327,7 +327,7 @@ func (t *Transaction) validSignatures(currentHeight BlockHeight) error {
 		// Check that sig corresponds to an entry in sigMap.
 		inSig, exists := sigMap[crypto.Hash(sig.ParentID)]
 		if !exists || inSig.remainingSignatures == 0 {
-			return ErrFrivilousSignature
+			return ErrFrivolousSignature
 		}
 		// Check that sig's key hasn't already been used.
 		_, exists = inSig.usedKeys[sig.PublicKeyIndex]

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -53,16 +53,16 @@ type (
 	// cannot sign itself).
 	CoveredFields struct {
 		WholeTransaction      bool     `json:"wholetransaction"`
-		SiacoinInputs         []uint64 `json:"siacoininputs,omitempty"`
-		SiacoinOutputs        []uint64 `json:"siacoinoutputs,omitempty"`
-		FileContracts         []uint64 `json:"filecontracts,omitempty"`
-		FileContractRevisions []uint64 `json:"filecontractrevisions,omitempty"`
-		StorageProofs         []uint64 `json:"storageproofs,omitempty"`
-		SiafundInputs         []uint64 `json:"siafundinputs,omitempty"`
-		SiafundOutputs        []uint64 `json:"siafundoutputs,omitempty"`
-		MinerFees             []uint64 `json:"minerfees,omitempty"`
-		ArbitraryData         []uint64 `json:"arbitrarydata,omitempty"`
-		TransactionSignatures []uint64 `json:"transactionsignatures,omitempty"`
+		SiacoinInputs         []uint64 `json:"siacoininputs"`
+		SiacoinOutputs        []uint64 `json:"siacoinoutputs"`
+		FileContracts         []uint64 `json:"filecontracts"`
+		FileContractRevisions []uint64 `json:"filecontractrevisions"`
+		StorageProofs         []uint64 `json:"storageproofs"`
+		SiafundInputs         []uint64 `json:"siafundinputs"`
+		SiafundOutputs        []uint64 `json:"siafundoutputs"`
+		MinerFees             []uint64 `json:"minerfees"`
+		ArbitraryData         []uint64 `json:"arbitrarydata"`
+		TransactionSignatures []uint64 `json:"transactionsignatures"`
 	}
 
 	// A SiaPublicKey is a public key prefixed by a Specifier. The Specifier

--- a/types/signatures_test.go
+++ b/types/signatures_test.go
@@ -250,7 +250,7 @@ func TestTransactionValidSignatures(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Corrupt one of the sigantures.
+	// Corrupt one of the signatures.
 	sig0[0]++
 	txn.TransactionSignatures[0].Signature = sig0[:]
 	err = txn.validSignatures(10)
@@ -288,10 +288,10 @@ func TestTransactionValidSignatures(t *testing.T) {
 	}
 	txn.SiafundInputs = txn.SiafundInputs[:len(txn.SiafundInputs)-1]
 
-	// Add a frivilous signature
+	// Add a frivolous signature
 	txn.TransactionSignatures = append(txn.TransactionSignatures, TransactionSignature{})
 	err = txn.validSignatures(10)
-	if err != ErrFrivilousSignature {
+	if err != ErrFrivolousSignature {
 		t.Error(err)
 	}
 	txn.TransactionSignatures = txn.TransactionSignatures[:len(txn.TransactionSignatures)-1]

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -67,16 +67,16 @@ type (
 	// but transactions cannot spend outputs that they create or otherwise be
 	// self-dependent.
 	Transaction struct {
-		SiacoinInputs         []SiacoinInput         `json:"siacoininputs,omitempty"`
-		SiacoinOutputs        []SiacoinOutput        `json:"siacoinoutputs,omitempty"`
-		FileContracts         []FileContract         `json:"filecontracts,omitempty"`
-		FileContractRevisions []FileContractRevision `json:"filecontractrevisions,omitempty"`
-		StorageProofs         []StorageProof         `json:"storageproofs,omitempty"`
-		SiafundInputs         []SiafundInput         `json:"siafundinputs,omitempty"`
-		SiafundOutputs        []SiafundOutput        `json:"siafundoutputs,omitempty"`
-		MinerFees             []Currency             `json:"minerfees,omitempty"`
-		ArbitraryData         [][]byte               `json:"arbitrarydata,omitempty"`
-		TransactionSignatures []TransactionSignature `json:"transactionsignatures,omitempty"`
+		SiacoinInputs         []SiacoinInput         `json:"siacoininputs"`
+		SiacoinOutputs        []SiacoinOutput        `json:"siacoinoutputs"`
+		FileContracts         []FileContract         `json:"filecontracts"`
+		FileContractRevisions []FileContractRevision `json:"filecontractrevisions"`
+		StorageProofs         []StorageProof         `json:"storageproofs"`
+		SiafundInputs         []SiafundInput         `json:"siafundinputs"`
+		SiafundOutputs        []SiafundOutput        `json:"siafundoutputs"`
+		MinerFees             []Currency             `json:"minerfees"`
+		ArbitraryData         [][]byte               `json:"arbitrarydata"`
+		TransactionSignatures []TransactionSignature `json:"transactionsignatures"`
 	}
 
 	// A SiacoinInput consumes a SiacoinOutput and adds the siacoins to the set of

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -67,16 +67,16 @@ type (
 	// but transactions cannot spend outputs that they create or otherwise be
 	// self-dependent.
 	Transaction struct {
-		SiacoinInputs         []SiacoinInput         `json:"siacoininputs"`
-		SiacoinOutputs        []SiacoinOutput        `json:"siacoinoutputs"`
-		FileContracts         []FileContract         `json:"filecontracts"`
-		FileContractRevisions []FileContractRevision `json:"filecontractrevisions"`
-		StorageProofs         []StorageProof         `json:"storageproofs"`
-		SiafundInputs         []SiafundInput         `json:"siafundinputs"`
-		SiafundOutputs        []SiafundOutput        `json:"siafundoutputs"`
-		MinerFees             []Currency             `json:"minerfees"`
-		ArbitraryData         [][]byte               `json:"arbitrarydata"`
-		TransactionSignatures []TransactionSignature `json:"transactionsignatures"`
+		SiacoinInputs         []SiacoinInput         `json:"siacoininputs,omitempty"`
+		SiacoinOutputs        []SiacoinOutput        `json:"siacoinoutputs,omitempty"`
+		FileContracts         []FileContract         `json:"filecontracts,omitempty"`
+		FileContractRevisions []FileContractRevision `json:"filecontractrevisions,omitempty"`
+		StorageProofs         []StorageProof         `json:"storageproofs,omitempty"`
+		SiafundInputs         []SiafundInput         `json:"siafundinputs,omitempty"`
+		SiafundOutputs        []SiafundOutput        `json:"siafundoutputs,omitempty"`
+		MinerFees             []Currency             `json:"minerfees,omitempty"`
+		ArbitraryData         [][]byte               `json:"arbitrarydata,omitempty"`
+		TransactionSignatures []TransactionSignature `json:"transactionsignatures,omitempty"`
 	}
 
 	// A SiacoinInput consumes a SiacoinOutput and adds the siacoins to the set of

--- a/types/validtransaction.go
+++ b/types/validtransaction.go
@@ -184,9 +184,9 @@ func (t Transaction) followsStorageProofRules() error {
 
 // noRepeats checks that a transaction does not spend multiple outputs twice,
 // submit two valid storage proofs for the same file contract, etc. We
-// frivilously check that a file contract termination and storage proof don't
+// frivolously check that a file contract termination and storage proof don't
 // act on the same file contract. There is very little overhead for doing so,
-// and the check is only frivilous because of the current rule that file
+// and the check is only frivolous because of the current rule that file
 // contract terminations are not valid after the proof window opens.
 func (t Transaction) noRepeats() error {
 	// Check that there are no repeat instances of siacoin outputs, storage


### PR DESCRIPTION
This involved adding a field to the `api.RenterContract` struct. Since it's JSON, there shouldn't be any compatibility issues with the current frontends.