### PR TITLE
HostDB tabbed print

### DIFF
--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
@@ -28,9 +30,12 @@ func hostdbcmd() {
 		fmt.Println("No known active hosts")
 		return
 	}
-	fmt.Println("Active hosts:")
+	fmt.Println(len(info.Hosts), "active hosts:")
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Address\tPrice")
 	for _, host := range info.Hosts {
 		price := host.StoragePrice.Mul(modules.BlockBytesPerMonthTerabyte)
-		fmt.Printf("\t%v - %v / TB / Month\n", host.NetAddress, currencyUnits(price))
+		fmt.Fprintf(w, "%v\t%v / TB / Month\n", host.NetAddress, currencyUnits(price))
 	}
+	w.Flush()
 }


### PR DESCRIPTION
Modified the `hostdb` command to print tabbed and show the number of hosts. I tried to follow the `gateway list` format.

![selection_034](https://cloud.githubusercontent.com/assets/729707/22393881/b3ee6d80-e4c5-11e6-8d2a-5582a77dffa6.png)
