### PR TITLE
Don't break downloads when renewing

### DIFF
--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -799,3 +799,107 @@ func TestRenterParallelDelete(t *testing.T) {
 		t.Fatal("file was not deleted properly:", rf.Files)
 	}
 }
+
+// TestRenterRenew sets up an integration test where a renter renews a
+// contract with a host.
+func TestRenterRenew(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	st, err := createServerTester("TestRenterRenew")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// Announce the host and start accepting contracts.
+	err = st.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.acceptContracts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.setHostStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set an allowance for the renter, allowing a contract to be formed.
+	allowanceValues := url.Values{}
+	testFunds := "10000000000000000000000000000" // 10k SC
+	testPeriod := "10"
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file.
+	path := filepath.Join(st.dir, "test.dat")
+	err = createRandFile(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload the file to the renter.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	err = st.stdPostAPI("/renter/upload/test", uploadValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only one piece will be uploaded (10% at current redundancy).
+	var rf RenterFiles
+	for i := 0; i < 200 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
+		st.getAPI("/renter/files", &rf)
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10 {
+		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
+	}
+
+	// Get current contract ID.
+	var rc RenterContracts
+	err = st.getAPI("/renter/contracts", &rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractID := rc.Contracts[0].ID
+
+	// Mine 5 blocks so that we enter the renewal window.
+	for i := 0; i < 5; i++ {
+		st.miner.AddBlock()
+	}
+	// Wait for the contract to be renewed.
+	for i := 0; i < 200 && (len(rc.Contracts) != 1 || rc.Contracts[0].ID == contractID); i++ {
+		st.getAPI("/renter/contracts", &rc)
+		time.Sleep(100 * time.Millisecond)
+	}
+	if rc.Contracts[0].ID == contractID {
+		t.Fatal("contract was not renewed:", rc.Contracts[0])
+	}
+
+	// Try downloading the file.
+	downpath := filepath.Join(st.dir, "testdown.dat")
+	err = st.stdGetAPI("/renter/download/test?destination=" + downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the download has the right contents.
+	orig, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	download, err := ioutil.ReadFile(downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(orig, download) != 0 {
+		t.Fatal("data mismatch when downloading a file")
+	}
+
+}

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -83,6 +83,8 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 		return ErrInsufficientAllowance
 	}
 
+	c.log.Println("INFO: setting allowance to", a)
+
 	c.mu.RLock()
 	shouldRenew := a.Period != c.allowance.Period || !a.Funds.Equals(c.allowance.Funds)
 	shouldWait := c.blockHeight+a.Period < c.contractEndHeight()
@@ -125,7 +127,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	for _, contract := range renewSet {
 		newContract, err := c.managedRenew(contract, numSectors, endHeight)
 		if err != nil {
-			c.log.Printf("WARN: failed to renew contract with %v; a new contract will be formed in its place", contract.NetAddress)
+			c.log.Printf("WARN: failed to renew contract with %v (error: %v); a new contract will be formed in its place", contract.NetAddress, err)
 			remaining++
 			continue
 		}
@@ -211,6 +213,7 @@ func (c *Contractor) managedFormAllowanceContracts(n int, numSectors uint64, a m
 
 // managedCancelAllowance handles the special case where the allowance is empty.
 func (c *Contractor) managedCancelAllowance(a modules.Allowance) error {
+	c.log.Println("INFO: canceling allowance")
 	// first need to invalidate any active editors/downloaders
 	// NOTE: this code is the same as in managedRenewContracts
 	var ids []types.FileContractID

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -117,10 +117,10 @@ func (c *Contractor) CurrentPeriod() types.BlockHeight {
 	return c.currentPeriod
 }
 
-// resolveID returns the ID of the most recent renewal of id.
-func (c *Contractor) resolveID(id types.FileContractID) types.FileContractID {
+// ResolveID returns the ID of the most recent renewal of id.
+func (c *Contractor) ResolveID(id types.FileContractID) types.FileContractID {
 	if newID, ok := c.renewedIDs[id]; ok && newID != id {
-		return c.resolveID(newID)
+		return c.ResolveID(newID)
 	}
 	return id
 }

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -141,7 +141,7 @@ func TestContracts(t *testing.T) {
 	}
 }
 
-// TestResolveID tests the resolveID method.
+// TestResolveID tests the ResolveID method.
 func TestResolveID(t *testing.T) {
 	c := &Contractor{
 		renewedIDs: map[types.FileContractID]types.FileContractID{
@@ -163,7 +163,7 @@ func TestResolveID(t *testing.T) {
 		{types.FileContractID{5}, types.FileContractID{6}},
 	}
 	for _, test := range tests {
-		if r := c.resolveID(test.id); r != test.resolved {
+		if r := c.ResolveID(test.id); r != test.resolved {
 			t.Errorf("expected %v -> %v, got %v", test.id, test.resolved, r)
 		}
 	}

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -107,7 +107,7 @@ func (hd *hostDownloader) Close() error {
 // from a host.
 func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err error) {
 	c.mu.RLock()
-	id = c.resolveID(id)
+	id = c.ResolveID(id)
 	cachedDownloader, haveDownloader := c.downloaders[id]
 	height := c.blockHeight
 	contract, haveContract := c.contracts[id]

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -166,7 +166,7 @@ func (he *hostEditor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newDat
 // delete sectors on a host.
 func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 	c.mu.RLock()
-	id = c.resolveID(id)
+	id = c.ResolveID(id)
 	cachedEditor, haveEditor := c.editors[id]
 	height := c.blockHeight
 	contract, haveContract := c.contracts[id]

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -117,7 +117,7 @@ type (
 )
 
 // newDownload initializes and returns a download object.
-func newDownload(f *file, destination string, currentContracts map[modules.NetAddress]types.FileContractID) *download {
+func (r *Renter) newDownload(f *file, destination string, currentContracts map[modules.NetAddress]types.FileContractID) *download {
 	d := &download{
 		finishedChunks: make([]bool, f.numChunks()),
 
@@ -150,7 +150,11 @@ func newDownload(f *file, destination string, currentContracts map[modules.NetAd
 		// get latest contract ID
 		id, ok := currentContracts[contract.IP]
 		if !ok {
-			continue
+			// no matching NetAddress; try using a revised ID
+			id = r.hostContractor.ResolveID(contract.ID)
+			if id == contract.ID {
+				continue
+			}
 		}
 		for i := range contract.Pieces {
 			d.pieceSet[contract.Pieces[i].Chunk][id] = contract.Pieces[i]

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -117,7 +117,7 @@ type (
 )
 
 // newDownload initializes and returns a download object.
-func newDownload(f *file, destination string) *download {
+func newDownload(f *file, destination string, currentContracts map[modules.NetAddress]types.FileContractID) *download {
 	d := &download{
 		finishedChunks: make([]bool, f.numChunks()),
 
@@ -147,8 +147,13 @@ func newDownload(f *file, destination string) *download {
 	}
 	f.mu.RLock()
 	for _, contract := range f.contracts {
+		// get latest contract ID
+		id, ok := currentContracts[contract.IP]
+		if !ok {
+			continue
+		}
 		for i := range contract.Pieces {
-			d.pieceSet[contract.Pieces[i].Chunk][contract.ID] = contract.Pieces[i]
+			d.pieceSet[contract.Pieces[i].Chunk][id] = contract.Pieces[i]
 		}
 	}
 	f.mu.RUnlock()

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -26,7 +26,7 @@ func (r *Renter) Download(path, destination string) error {
 	}
 
 	// Create the download object and add it to the queue.
-	d := newDownload(file, destination, currentContracts)
+	d := r.newDownload(file, destination, currentContracts)
 	lockID = r.mu.Lock()
 	r.downloadQueue = append(r.downloadQueue, d)
 	r.mu.Unlock(lockID)

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // Download downloads a file, identified by its path, to the destination
@@ -18,8 +19,14 @@ func (r *Renter) Download(path, destination string) error {
 		return errors.New("no file with that path")
 	}
 
+	// Build current contracts map.
+	currentContracts := make(map[modules.NetAddress]types.FileContractID)
+	for _, contract := range r.hostContractor.Contracts() {
+		currentContracts[contract.NetAddress] = contract.ID
+	}
+
 	// Create the download object and add it to the queue.
-	d := newDownload(file, destination)
+	d := newDownload(file, destination, currentContracts)
 	lockID = r.mu.Lock()
 	r.downloadQueue = append(r.downloadQueue, d)
 	r.mu.Unlock(lockID)

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -100,6 +100,9 @@ type hostContractor interface {
 	// Downloader creates a Downloader from the specified contract ID,
 	// allowing the retrieval of sectors.
 	Downloader(types.FileContractID) (contractor.Downloader, error)
+
+	// ResolveID returns the most recent renewal of the specified ID.
+	ResolveID(types.FileContractID) types.FileContractID
 }
 
 // A trackedFile contains metadata about files being tracked by the Renter.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -201,6 +201,16 @@ func newRenter(cs modules.ConsensusSet, tpool modules.TransactionPool, hdb hostD
 	go r.threadedRepairLoop()
 	go r.threadedDownloadLoop()
 	go r.threadedQueueRepairs()
+
+	// Kill workers on shutdown.
+	r.tg.OnStop(func() {
+		id := r.mu.RLock()
+		for _, worker := range r.workerPool {
+			close(worker.killChan)
+		}
+		r.mu.RUnlock(id)
+	})
+
 	return r, nil
 }
 


### PR DESCRIPTION
This fixes a bug that caused files to become unretrievable after renewing or changing the allowance. It also fixes a deadlock in the renter.