### PR TITLE
always decode Currency into new memory

### DIFF
--- a/types/currency.go
+++ b/types/currency.go
@@ -236,7 +236,9 @@ func (c *Currency) UnmarshalSia(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	c.i.SetBytes(b)
+	var dec Currency
+	dec.i.SetBytes(b)
+	*c = dec
 	return nil
 }
 
@@ -248,12 +250,14 @@ func (c Currency) String() string {
 // Scan implements the fmt.Scanner interface, allowing Currency values to be
 // scanned from text.
 func (c *Currency) Scan(s fmt.ScanState, ch rune) error {
-	err := c.i.Scan(s, ch)
+	var dec Currency
+	err := dec.i.Scan(s, ch)
 	if err != nil {
 		return err
 	}
-	if c.i.Sign() < 0 {
+	if dec.i.Sign() < 0 {
 		return ErrNegativeCurrency
 	}
+	*c = dec
 	return nil
 }

--- a/types/currency_test.go
+++ b/types/currency_test.go
@@ -447,3 +447,26 @@ func TestCurrencyUint64(t *testing.T) {
 		t.Error("result is not being zeroed in the event of an error")
 	}
 }
+
+// TestCurrencyUnsafeDecode tests that decoding into an existing Currency
+// value does not overwrite its contents.
+func TestCurrencyUnsafeDecode(t *testing.T) {
+	// Scan
+	backup := SiacoinPrecision.Mul64(1)
+	c := SiacoinPrecision
+	_, err := fmt.Sscan("7", &c)
+	if err != nil {
+		t.Error(err)
+	} else if !SiacoinPrecision.Equals(backup) {
+		t.Errorf("Scan changed value of SiacoinPrecision: %v -> %v", backup, SiacoinPrecision)
+	}
+
+	// UnmarshalSia
+	c = SiacoinPrecision
+	err = encoding.Unmarshal(encoding.Marshal(NewCurrency64(7)), &c)
+	if err != nil {
+		t.Error(err)
+	} else if !SiacoinPrecision.Equals(backup) {
+		t.Errorf("UnmarshalSia changed value of SiacoinPrecision: %v -> %v", backup, SiacoinPrecision)
+	}
+}


### PR DESCRIPTION
Decoding into existing memory caused problems with global variables, because decoding into a global affects all other users of the global. This bug didn't rear its head until now because we very rarely decode into global variables. It also is not triggered when decoding into `types.ZeroCurrency`, since the internal slice is `nil`. In other words, it can only affect shared state when decoding modifies the previously-allocated memory of an internal slice.

Originally I thought we would need to need to resort to `build.Critical` here, but that turns out to be unnecessary. Allocating a new Currency for each decode works just fine.

There is one caveat, though, which is that you can still modify a global variable by decoding into it explicitly. For example, this code will change the global value of `types.SiacoinPrecision`:
```go
fmt.Sscan("7", &types.SiacoinPrecision)
```
However, this code is quite obviously wrong, and not much different from writing something like `types.SiacoinPrecision = types.ZeroCurrency`. In both cases it is clear that the variable itself is being modified, so I think this is acceptable.