### PR TITLE
Some random stuff

### DIFF
--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -92,10 +92,6 @@ import (
 // is no public key exhcange, so communications cannot be effectively encrypted
 // or authenticated. The nodes must have some way to share keys.
 //
-// TODO: There is currently no way for a user to choose the bootstrap nodes
-// that the gateway uses, short of modifying the source code. A method for
-// manipulating the bootstrap node list (before startup) is desired.
-//
 // TODO: Gateway hostname discovery currently has significant centralization,
 // namely the fallback is a single third-party website that can easily form any
 // response it wants. Instead, multiple TLS-protected third party websites

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -250,6 +250,7 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 			fmt.Println("Failed to close the gateway logger:", err)
 		}
 	})
+	g.log.Println("INFO: gateway created, started logging")
 
 	// Establish that the peerTG must complete shutdown before the primary
 	// thread group completes shutdown.
@@ -336,7 +337,6 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 	go g.threadedForwardPort(g.port)
 	go g.threadedLearnHostname()
 
-	g.log.Println("INFO: gateway created, started logging")
 	return g, nil
 }
 

--- a/modules/gateway/gateway_test.go
+++ b/modules/gateway/gateway_test.go
@@ -32,8 +32,9 @@ func TestExportedMethodsErrAfterClose(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestCloseErrsSecondTime", t)
+
 	if err := g.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -52,9 +53,10 @@ func TestAddress(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestAddress", t)
 	defer g.Close()
+
 	if g.Address() != g.myAddr {
 		t.Fatal("Address does not return g.myAddr")
 	}
@@ -79,11 +81,12 @@ func TestPeers(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestRPC2", t)
 	defer g2.Close()
+
 	err := g1.Connect(g2.Address())
 	if err != nil {
 		t.Fatal("failed to connect:", err)
@@ -107,6 +110,8 @@ func TestNew(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
+
 	if _, err := New("", false, ""); err == nil {
 		t.Fatal("expecting persistDir error, got nil")
 	}

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -19,9 +19,10 @@ func TestAddNode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestAddNode", t)
 	defer g.Close()
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if err := g.addNode(dummyNode); err != nil {
@@ -49,9 +50,10 @@ func TestRemoveNode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	g := newTestingGateway("TestRemoveNode", t)
 	defer g.Close()
+	t.Parallel()
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if err := g.addNode(dummyNode); err != nil {
@@ -71,7 +73,7 @@ func TestRandomNode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestRandomNode", t)
 	defer g.Close()
 
@@ -149,6 +151,7 @@ func TestShareNodes(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g1 := newTestingGateway("TestShareNodes1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestShareNodes2", t)
@@ -224,6 +227,7 @@ func TestNodesAreSharedOnConnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g1 := newTestingGateway("TestNodesAreSharedOnConnect1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestNodesAreSharedOnConnect2", t)

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -32,9 +32,10 @@ func TestAddPeer(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestAddPeer", t)
 	defer g.Close()
+
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.addPeer(&peer{
@@ -54,11 +55,12 @@ func TestRandomOutboundPeer(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestRandomInboundPeer", t)
 	defer g.Close()
 	g.mu.Lock()
 	defer g.mu.Unlock()
+
 	_, err := g.randomOutboundPeer()
 	if err != errNoPeers {
 		t.Fatal("expected errNoPeers, got", err)
@@ -85,7 +87,7 @@ func TestListen(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestListen", t)
 	defer g.Close()
 
@@ -200,6 +202,7 @@ func TestConnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	// create bootstrap peer
 	bootstrap := newTestingGateway("TestConnect1", t)
 	defer bootstrap.Close()
@@ -353,6 +356,7 @@ func TestConnectRejectsInvalidAddrs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g := newTestingGateway("TestConnectRejectsInvalidAddrs", t)
 	defer g.Close()
 
@@ -538,6 +542,7 @@ func TestAcceptConnRejectsVersions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g := newTestingGateway("TestAcceptConnRejectsVersions", t)
 	defer g.Close()
 
@@ -650,7 +655,7 @@ func TestDisconnect(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestDisconnect", t)
 	defer g.Close()
 
@@ -694,7 +699,6 @@ func TestPeerManager(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-
 	g1 := newTestingGateway("TestPeerManager1", t)
 	defer g1.Close()
 

--- a/modules/gateway/peersmanager.go
+++ b/modules/gateway/peersmanager.go
@@ -35,6 +35,9 @@ func (g *Gateway) managedPeerManagerConnect(addr modules.NetAddress) {
 		g.mu.Unlock()
 	} else if err != nil {
 		g.log.Debugf("[PMC] [ERROR] [%v] WARN: removing peer because automatic connect failed: %v\n", addr, err)
+		g.mu.Lock()
+		g.removeNode(addr)
+		g.mu.Unlock()
 	} else {
 		g.log.Debugf("[PMC] [SUCCESS] [%v] peer successfully added", addr)
 	}

--- a/modules/gateway/peersmanager.go
+++ b/modules/gateway/peersmanager.go
@@ -35,8 +35,12 @@ func (g *Gateway) managedPeerManagerConnect(addr modules.NetAddress) {
 		g.mu.Unlock()
 	} else if err != nil {
 		g.log.Debugf("[PMC] [ERROR] [%v] WARN: removing peer because automatic connect failed: %v\n", addr, err)
+
+		// Remove the node, but only if there are enough nodes in the node list.
 		g.mu.Lock()
-		g.removeNode(addr)
+		if len(g.nodes) > pruneNodeListLen {
+			g.removeNode(addr)
+		}
 		g.mu.Unlock()
 	} else {
 		g.log.Debugf("[PMC] [SUCCESS] [%v] peer successfully added", addr)

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -8,8 +8,9 @@ func TestLoad(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g := newTestingGateway("TestLoad", t)
+
 	g.mu.Lock()
 	g.addNode(dummyNode)
 	g.save()

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -40,6 +40,7 @@ func TestRegisterRPC(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g := newTestingGateway("TestRegisterRPC", t)
 	defer g.Close()
 
@@ -58,6 +59,7 @@ func TestUnregisterRPC(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g1 := newTestingGateway("TestUnregisterRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestUnregisterRPC2", t)
@@ -103,6 +105,7 @@ func TestRegisterConnectCall(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g := newTestingGateway("TestRegisterConnectCall", t)
 	defer g.Close()
 
@@ -122,6 +125,7 @@ func TestUnregisterConnectCallPanics(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 	g1 := newTestingGateway("TestUnregisterConnectCall1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestUnregisterConnectCall2", t)
@@ -171,7 +175,7 @@ func TestRPC(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 
@@ -247,7 +251,7 @@ func TestThreadedHandleConn(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g1 := newTestingGateway("TestThreadedHandleConn1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestThreadedHandleConn2", t)
@@ -311,7 +315,7 @@ func TestBroadcast(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g1 := newTestingGateway("TestBroadcast1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestBroadcast2", t)
@@ -435,7 +439,7 @@ func TestOutboundAndInboundRPCs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g1 := newTestingGateway("TestRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestRPC2", t)
@@ -484,7 +488,7 @@ func TestCallingRPCFromRPC(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
+	t.Parallel()
 	g1 := newTestingGateway("TestCallingRPCFromRPC1", t)
 	defer g1.Close()
 	g2 := newTestingGateway("TestCallingRPCFromRPC2", t)

--- a/siad/main.go
+++ b/siad/main.go
@@ -132,6 +132,9 @@ Explorer (e):
 
 // main establishes a set of commands and flags using the cobra package.
 func main() {
+	if build.DEBUG {
+		fmt.Println("Running with debugging enabled")
+	}
 	root := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "Sia Daemon v" + build.Version,


### PR DESCRIPTION
My nodes tonight were having trouble finding peers and I was trying to figure out why. I didn't really get to the bottom of it, but I no longer thing that it's because the nodelist is mostly bad. Connection attempts seem to succeed, and then the peer gets tossed after a minute or so, perhaps less.

Maybe there is a bug in the communication code that makes it incompatible with certain versions? Seems like I'm only able to connect to v1.1.0, v1.0.0, and v1.0.1 for any lengthy period of time. Still investigating.

It might also be that all of our peers with open ports and high-propagation are saturated, having 128 peers each. Maybe we should increase the maximum? Or maybe we just announce to #contributors that it's a problem and ask people to open their ports? I don't want to do this though until we confirm that the problem is over-saturation. The errors don't help us on that front though.