### PR TITLE
Add HostPublicKey to RenterContract

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -143,6 +143,7 @@ func (s HostDBScans) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // file contract.
 type RenterContract struct {
 	FileContract    types.FileContract         `json:"filecontract"`
+	HostPublicKey   types.SiaPublicKey         `json:"hostpublickey"`
 	ID              types.FileContractID       `json:"id"`
 	LastRevision    types.FileContractRevision `json:"lastrevision"`
 	LastRevisionTxn types.Transaction          `json:"lastrevisiontxn"`

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -62,7 +62,6 @@ type Contractor struct {
 	cachedRevisions map[types.FileContractID]cachedRevision
 	contracts       map[types.FileContractID]modules.RenterContract
 	oldContracts    map[types.FileContractID]modules.RenterContract
-	relationships   map[types.FileContractID]types.SiaPublicKey
 	renewedIDs      map[types.FileContractID]types.FileContractID
 }
 
@@ -170,7 +169,6 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 		downloaders:     make(map[types.FileContractID]*hostDownloader),
 		editors:         make(map[types.FileContractID]*hostEditor),
 		oldContracts:    make(map[types.FileContractID]modules.RenterContract),
-		relationships:   make(map[types.FileContractID]types.SiaPublicKey),
 		renewedIDs:      make(map[types.FileContractID]types.FileContractID),
 		renewing:        make(map[types.FileContractID]bool),
 		revising:        make(map[types.FileContractID]bool),

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -191,5 +191,12 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, p 
 		return nil, errors.New("contractor subscription failed: " + err.Error())
 	}
 
+	// We may have upgraded persist or resubscribed. Save now so that we don't
+	// lose our work.
+	err = c.save()
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
 }

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -126,8 +126,7 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 		return cachedDownloader, nil
 	}
 
-	hpk := c.relationships[contract.ID]
-	host, haveHost := c.hdb.Host(hpk)
+	host, haveHost := c.hdb.Host(contract.HostPublicKey)
 	if !haveContract {
 		return nil, errors.New("no record of that contract")
 	} else if height > contract.EndHeight() {

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -185,8 +185,7 @@ func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 		return cachedEditor, nil
 	}
 
-	hpk := c.relationships[contract.ID]
-	host, haveHost := c.hdb.Host(hpk)
+	host, haveHost := c.hdb.Host(contract.HostPublicKey)
 	if !haveContract {
 		return nil, errors.New("no record of that contract")
 	} else if height > contract.EndHeight() {

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -228,7 +228,6 @@ func TestIntegrationReviseContract(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -277,7 +276,6 @@ func TestIntegrationUploadDownload(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -343,7 +341,6 @@ func TestIntegrationDelete(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -409,7 +406,6 @@ func TestIntegrationInsertDelete(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -470,7 +466,6 @@ func TestIntegrationModify(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -538,7 +533,6 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -568,7 +562,6 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = c.relationships[oldContract.ID]
 	c.mu.Unlock()
 
 	// check renewed contract
@@ -618,7 +611,6 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -668,7 +660,6 @@ func TestIntegrationResync(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// revise the contract
@@ -807,7 +798,6 @@ func TestIntegrationDownloaderCaching(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// create a downloader
@@ -901,7 +891,6 @@ func TestIntegrationEditorCaching(t *testing.T) {
 	}
 	c.mu.Lock()
 	c.contracts[contract.ID] = contract
-	c.relationships[contract.ID] = hostEntry.PublicKey
 	c.mu.Unlock()
 
 	// create an editor

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -1,10 +1,13 @@
 package contractor
 
 import (
+	"bytes"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -126,5 +129,105 @@ func TestSaveLoad(t *testing.T) {
 	_, ok2 = c.oldContracts[types.FileContractID{2}]
 	if !ok0 || !ok1 || !ok2 {
 		t.Fatal("oldContracts were not restored properly:", c.oldContracts)
+	}
+}
+
+// blockCS is a consensusSet that calls ProcessConsensusChange on its blocks.
+type blockCS struct {
+	blocks []types.Block
+}
+
+func (cs blockCS) ConsensusSetSubscribe(s modules.ConsensusSetSubscriber, _ modules.ConsensusChangeID) error {
+	s.ProcessConsensusChange(modules.ConsensusChange{
+		AppliedBlocks: cs.blocks,
+	})
+	return nil
+}
+
+func (blockCS) Synced() bool { return true }
+
+// TestPubKeyScanner tests that the pubkeyScanner type correctly identifies
+// public keys in the blockchain.
+func TestPubKeyScanner(t *testing.T) {
+	// create pubkeys, announcements, and contracts
+	contracts := make(map[types.FileContractID]modules.RenterContract)
+	var blocks []types.Block
+	var pubkeys []types.SiaPublicKey
+	for i := 0; i < 3; i++ {
+		// generate a keypair
+		sk, pk, err := crypto.GenerateKeyPair()
+		if err != nil {
+			t.Fatal(err)
+		}
+		spk := types.SiaPublicKey{
+			Algorithm: types.SignatureEd25519,
+			Key:       pk[:],
+		}
+		pubkeys = append(pubkeys, spk)
+
+		// create an announcement and add it to cs
+		addr := modules.NetAddress("foo.bar:999" + strconv.Itoa(i))
+		ann, err := modules.CreateAnnouncement(addr, spk, sk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		blocks = append(blocks, types.Block{
+			Transactions: []types.Transaction{{
+				ArbitraryData: [][]byte{ann},
+			}},
+		})
+
+		id := types.FileContractID{byte(i)}
+		contracts[id] = modules.RenterContract{ID: id, NetAddress: addr}
+	}
+	// overwrite the first pubkey with a new one, using the same netaddress.
+	// The contractor should use the newer pubkey.
+	sk, pk, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spk := types.SiaPublicKey{
+		Algorithm: types.SignatureEd25519,
+		Key:       pk[:],
+	}
+	pubkeys[0] = spk
+	ann, err := modules.CreateAnnouncement("foo.bar:9990", spk, sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks = append(blocks, types.Block{
+		Transactions: []types.Transaction{{
+			ArbitraryData: [][]byte{ann},
+		}},
+	})
+
+	// create contractor with mocked persist and cs dependencies
+	c := &Contractor{
+		persist:   new(memPersist),
+		cs:        blockCS{blocks},
+		contracts: contracts,
+	}
+
+	// save, clear, and reload
+	err = c.save()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.contracts = make(map[types.FileContractID]modules.RenterContract)
+	err = c.load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check that contracts were loaded and have their pubkeys filled in
+	for i, pk := range pubkeys {
+		id := types.FileContractID{byte(i)}
+		contract, ok := c.contracts[id]
+		if !ok {
+			t.Fatal("contracts were not restored properly:", c.contracts)
+		}
+		// check that pubkey was filled in
+		if !bytes.Equal(contract.HostPublicKey.Key, pk.Key) {
+			t.Errorf("contract has wrong pubkey: expected %q, got %q", pk.String(), contract.HostPublicKey.String())
+		}
 	}
 }

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -128,3 +128,60 @@ func TestSaveLoad(t *testing.T) {
 		t.Fatal("oldContracts were not restored properly:", c.oldContracts)
 	}
 }
+
+// allHostDB is a hostDB that implements the AllHosts method via a simple
+// slice.
+type allHostDB struct {
+	stubHostDB
+	hosts []modules.HostDBEntry
+}
+
+func (a allHostDB) AllHosts() []modules.HostDBEntry { return a.hosts }
+
+// TestLoadContractPubKeys tests that the contractor correctly fills in the
+// public keys of old contracts.
+func TestLoadContractPubKeys(t *testing.T) {
+	// create set of contracts and hosts
+	var hdb allHostDB
+	contracts := make(map[types.FileContractID]modules.RenterContract)
+	strs := []string{"foo", "bar", "baz"}
+	for i, str := range strs {
+		var entry modules.HostDBEntry
+		entry.NetAddress = modules.NetAddress(str)
+		entry.PublicKey = types.SiaPublicKey{Key: []byte(str)}
+		hdb.hosts = append(hdb.hosts, entry)
+
+		id := types.FileContractID{byte(i)}
+		contracts[id] = modules.RenterContract{ID: id, NetAddress: modules.NetAddress(str)}
+	}
+
+	// create contractor with mocked persist and hostdb dependencies
+	c := &Contractor{
+		persist:   new(memPersist),
+		hdb:       hdb,
+		contracts: contracts,
+	}
+
+	// save, clear, and reload
+	err := c.save()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.contracts = make(map[types.FileContractID]modules.RenterContract)
+	err = c.load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check that contracts were loaded
+	for i, str := range strs {
+		id := types.FileContractID{byte(i)}
+		contract, ok := c.contracts[id]
+		if !ok {
+			t.Fatal("contracts were not restored properly:", c.contracts)
+		}
+		// check that pubkey was filled in
+		if string(contract.HostPublicKey.Key) != str {
+			t.Errorf("contract has wrong pubkey: expected %q, got %q", str, contract.HostPublicKey.Key)
+		}
+	}
+}

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -25,9 +25,9 @@ func TestSaveLoad(t *testing.T) {
 
 	// add some fake contracts
 	c.contracts = map[types.FileContractID]modules.RenterContract{
-		{0}: {ID: types.FileContractID{0}, NetAddress: "foo"},
-		{1}: {ID: types.FileContractID{1}, NetAddress: "bar"},
-		{2}: {ID: types.FileContractID{2}, NetAddress: "baz"},
+		{0}: {ID: types.FileContractID{0}, HostPublicKey: types.SiaPublicKey{Key: []byte("foo")}},
+		{1}: {ID: types.FileContractID{1}, HostPublicKey: types.SiaPublicKey{Key: []byte("bar")}},
+		{2}: {ID: types.FileContractID{2}, HostPublicKey: types.SiaPublicKey{Key: []byte("baz")}},
 	}
 	c.renewedIDs = map[types.FileContractID]types.FileContractID{
 		{0}: {1},
@@ -40,9 +40,9 @@ func TestSaveLoad(t *testing.T) {
 		{2}: {Revision: types.FileContractRevision{ParentID: types.FileContractID{2}}},
 	}
 	c.oldContracts = map[types.FileContractID]modules.RenterContract{
-		{0}: {ID: types.FileContractID{0}, NetAddress: "foo"},
-		{1}: {ID: types.FileContractID{1}, NetAddress: "bar"},
-		{2}: {ID: types.FileContractID{2}, NetAddress: "baz"},
+		{0}: {ID: types.FileContractID{0}, HostPublicKey: types.SiaPublicKey{Key: []byte("foo")}},
+		{1}: {ID: types.FileContractID{1}, HostPublicKey: types.SiaPublicKey{Key: []byte("bar")}},
+		{2}: {ID: types.FileContractID{2}, HostPublicKey: types.SiaPublicKey{Key: []byte("baz")}},
 	}
 
 	// save, clear, and reload
@@ -126,62 +126,5 @@ func TestSaveLoad(t *testing.T) {
 	_, ok2 = c.oldContracts[types.FileContractID{2}]
 	if !ok0 || !ok1 || !ok2 {
 		t.Fatal("oldContracts were not restored properly:", c.oldContracts)
-	}
-}
-
-// allHostDB is a hostDB that implements the AllHosts method via a simple
-// slice.
-type allHostDB struct {
-	stubHostDB
-	hosts []modules.HostDBEntry
-}
-
-func (a allHostDB) AllHosts() []modules.HostDBEntry { return a.hosts }
-
-// TestLoadContractPubKeys tests that the contractor correctly fills in the
-// public keys of old contracts.
-func TestLoadContractPubKeys(t *testing.T) {
-	// create set of contracts and hosts
-	var hdb allHostDB
-	contracts := make(map[types.FileContractID]modules.RenterContract)
-	strs := []string{"foo", "bar", "baz"}
-	for i, str := range strs {
-		var entry modules.HostDBEntry
-		entry.NetAddress = modules.NetAddress(str)
-		entry.PublicKey = types.SiaPublicKey{Key: []byte(str)}
-		hdb.hosts = append(hdb.hosts, entry)
-
-		id := types.FileContractID{byte(i)}
-		contracts[id] = modules.RenterContract{ID: id, NetAddress: modules.NetAddress(str)}
-	}
-
-	// create contractor with mocked persist and hostdb dependencies
-	c := &Contractor{
-		persist:   new(memPersist),
-		hdb:       hdb,
-		contracts: contracts,
-	}
-
-	// save, clear, and reload
-	err := c.save()
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.contracts = make(map[types.FileContractID]modules.RenterContract)
-	err = c.load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// check that contracts were loaded
-	for i, str := range strs {
-		id := types.FileContractID{byte(i)}
-		contract, ok := c.contracts[id]
-		if !ok {
-			t.Fatal("contracts were not restored properly:", c.contracts)
-		}
-		// check that pubkey was filled in
-		if string(contract.HostPublicKey.Key) != str {
-			t.Errorf("contract has wrong pubkey: expected %q, got %q", str, contract.HostPublicKey.Key)
-		}
 	}
 }

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -14,8 +14,7 @@ import (
 // It returns the new contract. This is a blocking call that performs network
 // I/O.
 func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors uint64, newEndHeight types.BlockHeight) (modules.RenterContract, error) {
-	hpk := c.relationships[contract.ID]
-	host, ok := c.hdb.Host(hpk)
+	host, ok := c.hdb.Host(contract.HostPublicKey)
 	if !ok {
 		return modules.RenterContract{}, errors.New("no record of that host")
 	} else if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
@@ -159,8 +158,6 @@ func (c *Contractor) managedRenewContracts() error {
 		}
 		// insert the new contract
 		c.contracts[contract.ID] = contract
-		hpk := c.relationships[oldID]
-		c.relationships[contract.ID] = hpk
 		// add a mapping from old->new contract
 		c.renewedIDs[oldID] = contract.ID
 	}

--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -37,8 +37,11 @@ func (c *Contractor) IsOffline(id types.FileContractID) bool {
 // isOffline indicates whether a contract's host should be considered offline,
 // based on its scan metrics.
 func (c *Contractor) isOffline(id types.FileContractID) bool {
-	hpk := c.relationships[id]
-	host, ok := c.hdb.Host(hpk)
+	contract, ok := c.contracts[id]
+	if !ok {
+		return false
+	}
+	host, ok := c.hdb.Host(contract.HostPublicKey)
 	if !ok {
 		return false
 	}

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -38,7 +38,7 @@ func TestIntegrationReplaceOffline(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	h, c, m, err := newTestingTrio("TestIntegrationMonitorUptime")
+	h, c, m, err := newTestingTrio("TestIntegrationReplaceOffline")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestIntegrationReplaceOffline(t *testing.T) {
 	c.hdb = offlineHostDB{c.hdb, h.PublicKey()}
 
 	// create another host
-	dir := build.TempDir("contractor", "TestIntegrationMonitorUptime", "Host2")
+	dir := build.TempDir("contractor", "TestIntegrationReplaceOffline", "Host2")
 	h2, err := newTestingHost(dir, c.cs.(modules.ConsensusSet), c.tpool.(modules.TransactionPool))
 	if err != nil {
 		t.Fatal(err)
@@ -148,10 +148,7 @@ func TestIsOffline(t *testing.T) {
 		// construct a contractor with a hostdb containing the scans
 		c := &Contractor{
 			contracts: map[types.FileContractID]modules.RenterContract{
-				types.FileContractID{1}: {NetAddress: "foo"},
-			},
-			relationships: map[types.FileContractID]types.SiaPublicKey{
-				types.FileContractID{1}: {Key: []byte("foo")},
+				types.FileContractID{1}: {HostPublicKey: types.SiaPublicKey{Key: []byte("foo")}},
 			},
 			hdb: mapHostDB{
 				hosts: map[string]modules.HostDBEntry{

--- a/modules/renter/proto/formcontract.go
+++ b/modules/renter/proto/formcontract.go
@@ -255,6 +255,7 @@ func FormContract(params ContractParams, txnBuilder transactionBuilder, tpool tr
 
 	return modules.RenterContract{
 		FileContract:    fc,
+		HostPublicKey:   host.PublicKey,
 		ID:              fcid,
 		LastRevision:    initRevision,
 		LastRevisionTxn: revisionTxn,

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -249,6 +249,7 @@ func Renew(contract modules.RenterContract, params ContractParams, txnBuilder tr
 
 	return modules.RenterContract{
 		FileContract:    fc,
+		HostPublicKey:   host.PublicKey,
 		ID:              fcid,
 		LastRevision:    initRevision,
 		LastRevisionTxn: revisionTxn,


### PR DESCRIPTION
This is basically the bare minimum required to add the field. It is not present in the API, though we can easily add it.
I will write a test to confirm that loading old contracts correctly fills in their pubkey. I will also test this manually using my personal contracts.

I encountered a NDF in TestIntegrationReplaceOffline. It appears to be a deadlock in the host/miner:
```
goroutine 193 [semacquire, 8 minutes]:
sync.runtime_Semacquire(0xc420c03074)
	/usr/local/go/src/runtime/sema.go:47 +0x30
sync.(*Mutex).Lock(0xc420c03070)
	/usr/local/go/src/sync/mutex.go:85 +0xde
sync.(*RWMutex).Lock(0xc420c03070)
	/usr/local/go/src/sync/rwmutex.go:86 +0x49
github.com/NebulousLabs/Sia/modules/host.(*Host).ProcessConsensusChange(0xc420c02c00, 0x63bd18682e3289b6, 0xdc1a11c279864276, 0xb9cceb18752726a, 0x7f507ae4b192fbf7, 0x0, 0x0, 0x0, 0xc420a342a0, 0x1, ...)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/host/update.go:125 +0x80
github.com/NebulousLabs/Sia/modules/consensus.(*ConsensusSet).readlockUpdateSubscribers(0xc420cd3b80, 0x0, 0x0, 0x0, 0xc4203daea0, 0x1, 0x1)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/consensus/subscribe.go:113 +0x240
github.com/NebulousLabs/Sia/modules/consensus.(*ConsensusSet).managedAcceptBlock(0xc420cd3b80, 0x3bfd9c4fc594a60f, 0xc55132422bc5fbf5, 0xc64015502004e225, 0x644048ee8465f732, 0x1, 0x589d01d3, 0xc4210bfd80, 0x1, 0x1, ...)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/consensus/accept.go:287 +0x2f5
github.com/NebulousLabs/Sia/modules/consensus.(*ConsensusSet).AcceptBlock(0xc420cd3b80, 0x3bfd9c4fc594a60f, 0xc55132422bc5fbf5, 0xc64015502004e225, 0x644048ee8465f732, 0x1, 0x589d01d3, 0xc4210bfd80, 0x1, 0x1, ...)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/consensus/accept.go:307 +0x11c
github.com/NebulousLabs/Sia/modules/miner.(*Miner).AddBlock(0xc420bb6fc0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/miner/testminer.go:73 +0x189
github.com/NebulousLabs/Sia/modules/renter/contractor.TestIntegrationReplaceOffline(0xc4203b46c0)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/renter/contractor/uptime_test.go:100 +0xb59
```
```
goroutine 2070 [semacquire, 8 minutes]:
sync.runtime_Semacquire(0xc420cd3d54)
	/usr/local/go/src/runtime/sema.go:47 +0x30
sync.(*RWMutex).RLock(0xc420cd3d48)
	/usr/local/go/src/sync/rwmutex.go:43 +0x95
github.com/NebulousLabs/demotemutex.(*DemoteMutex).RLock(0xc420cd3d40)
	/home/luke/go/src/github.com/NebulousLabs/demotemutex/demotemutex.go:42 +0x3f
github.com/NebulousLabs/Sia/modules/consensus.(*ConsensusSet).LockedTryTransactionSet(0xc420cd3b80, 0xc420503140, 0x0, 0x0)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/consensus/validtransaction.go:383 +0xcf
github.com/NebulousLabs/Sia/modules/transactionpool.(*TransactionPool).AcceptTransactionSet(0xc420b74750, 0xc420141800, 0x3, 0x4, 0xc420079d00, 0x0)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/transactionpool/accept.go:322 +0x179
github.com/NebulousLabs/Sia/modules/host.(*Host).addStorageObligation(0xc420c02c00, 0x0, 0x0, 0x0, 0x0, 0xc420079d40, 0x2, 0x7, 0x0, 0xc420502150, ...)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/host/storageobligations.go:374 +0x1213
github.com/NebulousLabs/Sia/modules/host.(*Host).managedFinalizeContract.func2(0xc420c02c00, 0xc420b88288, 0xc420b88a30, 0xc54be0, 0xc421024000, 0x0, 0x0)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/host/negotiate.go:259 +0xc9
github.com/NebulousLabs/Sia/modules/host.(*Host).managedFinalizeContract(0xc420c02c00, 0xc54be0, 0xc421024000, 0xb9173f0dc5969142, 0x1be62c21c028e7d5, 0x94b77c5345a4f4e0, 0xc46f8900d781085c, 0xc4200c1b80, 0x1, 0x1, ...)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/host/negotiate.go:275 +0xc2f
github.com/NebulousLabs/Sia/modules/host.(*Host).managedRPCFormContract(0xc420c02c00, 0xc53920, 0xc4200908a0, 0x0, 0x0)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/host/negotiateformcontract.go:174 +0x169d
github.com/NebulousLabs/Sia/modules/host.(*Host).threadedHandleConn(0xc420c02c00, 0xc53920, 0xc4200908a0)
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/host/network.go:154 +0x982
created by github.com/NebulousLabs/Sia/modules/host.(*Host).threadedListen
	/home/luke/go/src/github.com/NebulousLabs/Sia/modules/host/network.go:197 +0xcb
```
