### PR TITLE
Continued hostdb improvements

### DIFF
--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -14,7 +14,11 @@ const (
 	maxSettingsLen = 4e3
 
 	hostRequestTimeout = 60 * time.Second
-	hostScanDeadline   = 60 * time.Second
+	hostScanDeadline   = 240 * time.Second
+
+	// saveFrequency defines how frequently the hostdb will save to disk. Hostdb
+	// will also save immediately prior to shutdown.
+	saveFrequency = 2 * time.Minute
 )
 
 var (
@@ -29,7 +33,7 @@ var (
 	// scanningThreads is the number of threads that will be probing hosts for
 	// their settings and checking for reliability.
 	scanningThreads = build.Select(build.Var{
-		Standard: int(25),
+		Standard: int(40),
 		Dev:      int(4),
 		Testing:  int(3),
 	}).(int)

--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -7,14 +7,28 @@ import (
 )
 
 const (
+	// defaultScanSleep is the amount of time that the hostdb will sleep if it
+	// cannot successfully get a random number.
 	defaultScanSleep = 1*time.Hour + 37*time.Minute
+
+	// maxScanSleep is the maximum amount of time that the hostdb will sleep
+	// between performing scans of the hosts.
 	maxScanSleep     = 4 * time.Hour
+
+	// minScanSleep is the minimum amount of time that the hostdb will sleep
+	// between performing scans of the hosts.
 	minScanSleep     = 1*time.Hour + 20*time.Minute
 
-	maxSettingsLen = 4e3
+	// maxSettingsLen indicates how long in bytes the host settings field is
+	// allowed to be before being ignored as a DoS attempt.
+	maxSettingsLen = 10e3
 
-	hostRequestTimeout = 60 * time.Second
-	hostScanDeadline   = 240 * time.Second
+	// hostRequestTimeout indicates how long a host has to respond to a dial.
+	hostRequestTimeout = 2 * time.Minute
+
+	// hostScanDeadline indicates how long a host has to complete an entire
+	// scan.
+	hostScanDeadline   = 4 * time.Minute
 
 	// saveFrequency defines how frequently the hostdb will save to disk. Hostdb
 	// will also save immediately prior to shutdown.

--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -13,11 +13,11 @@ const (
 
 	// maxScanSleep is the maximum amount of time that the hostdb will sleep
 	// between performing scans of the hosts.
-	maxScanSleep     = 4 * time.Hour
+	maxScanSleep = 4 * time.Hour
 
 	// minScanSleep is the minimum amount of time that the hostdb will sleep
 	// between performing scans of the hosts.
-	minScanSleep     = 1*time.Hour + 20*time.Minute
+	minScanSleep = 1*time.Hour + 20*time.Minute
 
 	// maxSettingsLen indicates how long in bytes the host settings field is
 	// allowed to be before being ignored as a DoS attempt.
@@ -28,7 +28,7 @@ const (
 
 	// hostScanDeadline indicates how long a host has to complete an entire
 	// scan.
-	hostScanDeadline   = 4 * time.Minute
+	hostScanDeadline = 4 * time.Minute
 
 	// saveFrequency defines how frequently the hostdb will save to disk. Hostdb
 	// will also save immediately prior to shutdown.

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -62,8 +62,10 @@ type HostDB struct {
 
 	// the scanPool is a set of hosts that need to be scanned. There are a
 	// handful of goroutines constantly waiting on the channel for hosts to
-	// scan.
+	// scan. The scan map is used to prevent duplicates from entering the scan
+	// pool.
 	scanList []modules.HostDBEntry
+	scanMap  map[string]struct{}
 	scanPool chan modules.HostDBEntry
 	scanWait bool
 	online   bool
@@ -96,6 +98,7 @@ func newHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir string, de
 		gateway:    g,
 		persistDir: persistDir,
 
+		scanMap:  make(map[string]struct{}),
 		scanPool: make(chan modules.HostDBEntry, scanPoolSize),
 	}
 

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -13,6 +13,9 @@ package hostdb
 // TODO: Investigate why hosts that seem to be online can fail scans, and figure
 // out a more robust way to not miss hosts.
 
+// TODO: Refine the method by which the hostdb selects which hosts to scan
+// during its regular scanning period.
+
 import (
 	"errors"
 	"fmt"

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -5,15 +5,13 @@
 package hostdb
 
 // TODO: Not sure what happens with hosts that fail their first scan. Is it
-// possible for them to get scored inappropriately?
+// possible for them to get scored inappropriately? If they start behind, can
+// they scan back into the set of good hosts?
 
-// TODO: Do not add a host pk to the scan pool if a host with that pk is
-// already in the scan pool.
+// TODO: Scan history should be truncated.
 
-// TODO: Scan history should be truncated, perhaps to the past year.
-
-// TODO: Write tests to see that a host which is initally scanned as offline
-// can eventually fight their way back through the ranks.
+// TODO: Investigate why hosts that seem to be online can fail scans, and figure
+// out a more robust way to not miss hosts.
 
 import (
 	"errors"
@@ -28,13 +26,6 @@ import (
 	"github.com/NebulousLabs/Sia/persist"
 	siasync "github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
-)
-
-const (
-	// scanPoolSize sets the buffer size of the channel that holds hosts which
-	// need to be scanned. A thread pool pulls from the scan pool to query
-	// hosts that are due for an update.
-	scanPoolSize = 1000
 )
 
 var (
@@ -99,7 +90,7 @@ func newHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir string, de
 		persistDir: persistDir,
 
 		scanMap:  make(map[string]struct{}),
-		scanPool: make(chan modules.HostDBEntry, scanPoolSize),
+		scanPool: make(chan modules.HostDBEntry),
 	}
 
 	// Create the persist directory if it does not yet exist.

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -36,7 +36,7 @@ func bareHostDB() *HostDB {
 	hdb := &HostDB{
 		log: persist.NewLogger(ioutil.Discard),
 
-		scanPool: make(chan modules.HostDBEntry, scanPoolSize),
+		scanPool: make(chan modules.HostDBEntry),
 	}
 	hdb.hostTree = hosttree.New(hdb.calculateHostWeight)
 	return hdb

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -234,9 +234,9 @@ func (hdb *HostDB) lifetimeAdjustments(entry modules.HostDBEntry) float64 {
 // uptimeAdjustments penalizes the host for having poor uptime, and for being
 // offline.
 //
-// CAUTION: The function 'managedUpdateEntry' will manually fill out two scans
-// for a new host to give the host some initial uptime or downtime. Modification
-// of this function needs to be made paying attention to the structure of that
+// CAUTION: The function 'updateEntry' will manually fill out two scans for a
+// new host to give the host some initial uptime or downtime. Modification of
+// this function needs to be made paying attention to the structure of that
 // function.
 func (hdb *HostDB) uptimeAdjustments(entry modules.HostDBEntry) float64 {
 	// Special case: if we have scanned the host twice or fewer, don't perform

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -13,7 +13,7 @@ import (
 var (
 	// Because most weights would otherwise be fractional, we set the base
 	// weight to be very large.
-	baseWeight = types.NewCurrency(new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil))
+	baseWeight = types.NewCurrency(new(big.Int).Exp(big.NewInt(10), big.NewInt(80), nil))
 
 	// tbMonth is the number of bytes in a terabyte times the number of blocks
 	// in a month.
@@ -21,9 +21,6 @@ var (
 
 	// collateralExponentiation is the number of times that the collateral is
 	// multiplied into the price.
-	//
-	// NOTE: Changing this value downwards needs that the baseWeight will need
-	// to be increased.
 	collateralExponentiation = 1
 
 	// priceDiveNormalization reduces the raw value of the price so that not so
@@ -47,10 +44,7 @@ var (
 
 	// priceExponentiation is the number of times that the weight is divided by
 	// the price.
-	//
-	// NOTE: Changing this value upwards means that the baseWeight will need to
-	// be increased.
-	priceExponentiation = 4
+	priceExponentiation = 5
 
 	// requiredStorage indicates the amount of storage that the host must be
 	// offering in order to be considered a valuable/worthwhile host.

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -2,6 +2,7 @@ package hostdb
 
 import (
 	"path/filepath"
+	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
@@ -34,11 +35,6 @@ func (hdb *HostDB) persistData() (data hdbPersist) {
 	data.BlockHeight = hdb.blockHeight
 	data.LastChange = hdb.lastChange
 	return data
-}
-
-// save saves the hostdb persistence data to disk.
-func (hdb *HostDB) save() error {
-	return hdb.deps.saveFile(persistMetadata, hdb.persistData(), filepath.Join(hdb.persistDir, persistFilename))
 }
 
 // saveSync saves the hostdb persistence data to disk and then syncs to disk.
@@ -74,4 +70,28 @@ func (hdb *HostDB) load() error {
 	hdb.blockHeight = data.BlockHeight
 	hdb.lastChange = data.LastChange
 	return nil
+}
+
+// threadedSaveLoop saves the hostdb to disk every 2 minutes, also saving when
+// given the shutdown signal.
+func (hdb *HostDB) threadedSaveLoop(shutChan chan struct{}) {
+	for {
+		select {
+		case <-shutChan:
+			hdb.mu.Lock()
+			err := hdb.saveSync()
+			hdb.mu.Unlock()
+			if err != nil {
+				hdb.log.Println("Difficulties saving the hostdb:", err)
+			}
+			return
+		case <-time.After(saveFrequency):
+			hdb.mu.Lock()
+			err := hdb.saveSync()
+			hdb.mu.Unlock()
+			if err != nil {
+				hdb.log.Println("Difficulties saving the hostdb:", err)
+			}
+		}
+	}
 }

--- a/modules/renter/hostdb/persist.go
+++ b/modules/renter/hostdb/persist.go
@@ -74,16 +74,10 @@ func (hdb *HostDB) load() error {
 
 // threadedSaveLoop saves the hostdb to disk every 2 minutes, also saving when
 // given the shutdown signal.
-func (hdb *HostDB) threadedSaveLoop(shutChan chan struct{}) {
+func (hdb *HostDB) threadedSaveLoop() {
 	for {
 		select {
-		case <-shutChan:
-			hdb.mu.Lock()
-			err := hdb.saveSync()
-			hdb.mu.Unlock()
-			if err != nil {
-				hdb.log.Println("Difficulties saving the hostdb:", err)
-			}
+		case <-hdb.tg.StopChan():
 			return
 		case <-time.After(saveFrequency):
 			hdb.mu.Lock()

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -54,7 +54,7 @@ func TestSaveLoad(t *testing.T) {
 	hdbt.hdb.mu.Lock()
 	hdbt.hdb.lastChange = modules.ConsensusChangeID{1, 2, 3}
 	stashedLC := hdbt.hdb.lastChange
-	err = hdbt.hdb.save()
+	err = hdbt.hdb.saveSync()
 	hdbt.hdb.mu.Unlock()
 	if err != nil {
 		t.Fatal(err)

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -117,8 +117,6 @@ func (hdb *HostDB) managedUpdateEntry(entry modules.HostDBEntry, netErr error) {
 			hdb.log.Println("ERROR: unable to modify entry which is thought to exist:", err)
 		}
 	}
-
-	hdb.save()
 }
 
 // managedScanHost will connect to a host and grab the settings, verifying

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -35,7 +35,7 @@ func (hdb *HostDB) queueScan(entry modules.HostDBEntry) {
 
 	// Sanity check - the length of the scan pool and the length of the scan map
 	// should be within 'scanningThreads' of eachother.
-	if build.DEBUG && len(hdb.scanMap) > len(hdb.scanList) {
+	if build.DEBUG && len(hdb.scanMap) > len(hdb.scanList)+scanningThreads {
 		hdb.log.Critical("The hostdb scan map has seemingly grown too large:", len(hdb.scanMap), len(hdb.scanList), scanningThreads)
 	}
 
@@ -62,7 +62,6 @@ func (hdb *HostDB) queueScan(entry modules.HostDBEntry) {
 			// Get the next host, shrink the scan list.
 			entry := hdb.scanList[0]
 			hdb.scanList = hdb.scanList[1:]
-			delete(hdb.scanMap, entry.PublicKey.String())
 			scansRemaining := len(hdb.scanList)
 			hdb.mu.Unlock()
 
@@ -185,6 +184,7 @@ func (hdb *HostDB) managedScanHost(entry modules.HostDBEntry) {
 	// Update the host tree to have a new entry, including the new error. Then
 	// delete the entry from the scan map as the scan has been successful.
 	hdb.mu.Lock()
+	delete(hdb.scanMap, entry.PublicKey.String())
 	hdb.updateEntry(entry, err)
 	hdb.mu.Unlock()
 }

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -121,7 +121,7 @@ func (hdb *HostDB) updateEntry(entry modules.HostDBEntry, netErr error) {
 		}
 	} else {
 		if newEntry.ScanHistory[len(newEntry.ScanHistory)-1].Success && netErr != nil {
-			hdb.log.Printf("Host %v is being downgraded from an online host to an offline host: %v\n", newEntry.PublicKey.String(), netErr)
+			hdb.log.Debugf("Host %v is being downgraded from an online host to an offline host: %v\n", newEntry.PublicKey.String(), netErr)
 		}
 		newEntry.ScanHistory = append(newEntry.ScanHistory, modules.HostDBScan{Timestamp: time.Now(), Success: netErr == nil})
 	}

--- a/modules/renter/hostdb/update.go
+++ b/modules/renter/hostdb/update.go
@@ -94,8 +94,4 @@ func (hdb *HostDB) ProcessConsensusChange(cc modules.ConsensusChange) {
 	}
 
 	hdb.lastChange = cc.ID
-	err := hdb.save()
-	if err != nil {
-		hdb.log.Println("Error saving hostdb:", err)
-	}
 }

--- a/modules/renter/hostdb/update.go
+++ b/modules/renter/hostdb/update.go
@@ -42,7 +42,15 @@ func (hdb *HostDB) insertBlockchainHost(host modules.HostDBEntry) {
 	// shutdown occurs before a scan can be performed.
 	oldEntry, exists := hdb.hostTree.Select(host.PublicKey)
 	if exists {
+		// Replace the netaddress with the most recently announced netaddress.
+		// Also replace the FirstSeen value with the current block height if
+		// the first seen value has been set to zero (no hosts actually have a
+		// first seen height of zero, but due to rescans hosts can end up with
+		// a zero-value FirstSeen field.
 		oldEntry.NetAddress = host.NetAddress
+		if oldEntry.FirstSeen == 0 {
+			oldEntry.FirstSeen = hdb.blockHeight
+		}
 		err := hdb.hostTree.Modify(oldEntry)
 		if err != nil {
 			hdb.log.Println("ERROR: unable to modify host entry of host tree after a blockchain scan:", err)


### PR DESCRIPTION
This is a very big upgrade for the hostdb in terms of fuctionality.

1. Upgrade time has been reduced from 10k-50k seconds to 100-1k seconds. Definitely a big deal.
2. When scanning a bunch of hosts from the blockchain, duplicates are ignored.
3. The hostdb more gracefully handles ip address changes than before. My hostdb is now finding 87 ipv4 hosts, and there are at least 4 known ipv6 hosts, meaning that the total number of discoverable hosts has been increased to at least 91, which is substantially higher than any number previously available.
4. The logging is slightly better.

There's no automated testing for this yet, but I've been doing manual testing all night, and I'm very pleased with the results.