### PR TITLE
Hostdb scanner

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -79,12 +79,21 @@ type FileInfo struct {
 // aggregates the host's external settings and metrics with its public key.
 type HostDBEntry struct {
 	HostExternalSettings
-	PublicKey types.SiaPublicKey `json:"publickey"`
-	// ScanHistory is the set of scans performed on the host. It should always
-	// be ordered according to the scan's Timestamp, oldest to newest.
-	ScanHistory HostDBScans `json:"scanhistory"`
+
 	// FirstSeen is the last block height at which this host was announced.
 	FirstSeen types.BlockHeight `json:"firstseen"`
+
+	// Measurements that have been taken on the host. The most recent
+	// measurements are kept in full detail, historic ones are compressed into
+	// the historic values.
+	HistoricDowntime time.Duration `json:"historicdowntime"`
+	HistoricUptime time.Duration `json:"historicuptime"`
+	ScanHistory HostDBScans `json:"scanhistory"`
+
+	// The public key of the host, stored separately to minimize risk of certain
+	// MitM based vulnerabilities.
+	PublicKey types.SiaPublicKey `json:"publickey"`
+
 }
 
 // HostDBScan represents a single scan event.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -87,13 +87,12 @@ type HostDBEntry struct {
 	// measurements are kept in full detail, historic ones are compressed into
 	// the historic values.
 	HistoricDowntime time.Duration `json:"historicdowntime"`
-	HistoricUptime time.Duration `json:"historicuptime"`
-	ScanHistory HostDBScans `json:"scanhistory"`
+	HistoricUptime   time.Duration `json:"historicuptime"`
+	ScanHistory      HostDBScans   `json:"scanhistory"`
 
 	// The public key of the host, stored separately to minimize risk of certain
 	// MitM based vulnerabilities.
 	PublicKey types.SiaPublicKey `json:"publickey"`
-
 }
 
 // HostDBScan represents a single scan event.

--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -39,7 +39,7 @@ var (
 	// hostCheckupQuantity specifies the number of hosts that get scanned every
 	// time there is a regular scanning operation.
 	hostCheckupQuantity = build.Select(build.Var{
-		Standard: int(250),
+		Standard: int(200),
 		Dev:      int(6),
 		Testing:  int(5),
 	}).(int)

--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -11,9 +11,17 @@ const (
 	// cannot successfully get a random number.
 	defaultScanSleep = 1*time.Hour + 37*time.Minute
 
+	// maxHostDowntime specifies the maximum amount of time that a host is
+	// allowed to be offline while still being in the hostdb.
+	maxHostDowntime = 30 * 24 * time.Hour
+
 	// maxScanSleep is the maximum amount of time that the hostdb will sleep
 	// between performing scans of the hosts.
 	maxScanSleep = 4 * time.Hour
+
+	// minScans specifies the number of scans that a host should have before the
+	// scans start getting compressed.
+	minScans = 20
 
 	// minScanSleep is the minimum amount of time that the hostdb will sleep
 	// between performing scans of the hosts.

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -4,9 +4,6 @@
 // set of hosts it has found and updates who is online.
 package hostdb
 
-// TODO: Scan history should be truncated. Further, if a host hasn't been around
-// in long enough, they should just be removed (1 month).
-
 import (
 	"errors"
 	"fmt"

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -4,17 +4,8 @@
 // set of hosts it has found and updates who is online.
 package hostdb
 
-// TODO: Not sure what happens with hosts that fail their first scan. Is it
-// possible for them to get scored inappropriately? If they start behind, can
-// they scan back into the set of good hosts?
-
-// TODO: Scan history should be truncated.
-
-// TODO: Investigate why hosts that seem to be online can fail scans, and figure
-// out a more robust way to not miss hosts.
-
-// TODO: Refine the method by which the hostdb selects which hosts to scan
-// during its regular scanning period.
+// TODO: Scan history should be truncated. Further, if a host hasn't been around
+// in long enough, they should just be removed (1 month).
 
 import (
 	"errors"

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -3,7 +3,6 @@ package hostdb
 import (
 	"math"
 	"math/big"
-	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -256,8 +255,8 @@ func (hdb *HostDB) uptimeAdjustments(entry modules.HostDBEntry) float64 {
 
 	// Compute the total measured uptime and total measured downtime for this
 	// host.
-	var uptime time.Duration
-	var downtime time.Duration
+	downtime := entry.HistoricDowntime
+	uptime := entry.HistoricUptime
 	recentTime := entry.ScanHistory[0].Timestamp
 	recentSuccess := entry.ScanHistory[0].Success
 	for _, scan := range entry.ScanHistory[1:] {

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -226,8 +226,8 @@ func hostdbviewcmd(pubkey string) {
 	// host.
 	uptimeRatio := float64(0)
 	if len(info.Entry.ScanHistory) > 1 {
-		var uptime time.Duration
-		var downtime time.Duration
+		downtime := info.Entry.HistoricDowntime
+		uptime := info.Entry.HistoricUptime
 		recentTime := info.Entry.ScanHistory[0].Timestamp
 		recentSuccess := info.Entry.ScanHistory[0].Success
 		for _, scan := range info.Entry.ScanHistory[1:] {


### PR DESCRIPTION
This does 3 things:

1. Makes sure that when the hosts get scanned which are both online and offline
2. compresses the scan histories, so only the most recent 30 days of scans are kept. this I think will amount to between 20kb and 50kb per host, so still a pretty significant footprint. But at least somewhat bounded.
3. toss out hosts that have been offline for more than a month so that they aren't cluttering the json files and slowing everything down.