### PR TITLE
add validateSiapath to validate renter siapaths on upload

### DIFF
--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -49,7 +49,7 @@ var (
 // ../ is disallowed to prevent directory traversal,
 // and paths must not begin with / or be empty.
 func validateSiapath(siapath string) error {
-	if strings.HasPrefix(siapath, "/") {
+	if strings.HasPrefix(siapath, "/") || strings.HasPrefix(siapath, "./") {
 		return errors.New("nicknames cannot begin with /")
 	}
 

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -61,6 +61,10 @@ func validateSiapath(siapath string) error {
 		return errors.New("directory traversal is not allowed")
 	}
 
+	if strings.Contains(siapath, "./") {
+		return errors.New("siapath contains invalid characters")
+	}
+
 	return nil
 }
 

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -16,7 +16,7 @@ func TestRenterSiapathValidate(t *testing.T) {
 		{"valid/siapath/../with/directory/traversal", false},
 		{"validpath/test", true},
 		{"..validpath/..test", true},
-		{"./valid/path", true},
+		{"./invalid/path", false},
 		{"test/path", true},
 		{"/leading/slash", false},
 		{"", false},

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -19,6 +19,7 @@ func TestRenterSiapathValidate(t *testing.T) {
 		{"./invalid/path", false},
 		{"test/path", true},
 		{"/leading/slash", false},
+		{"foo/./bar", false},
 		{"", false},
 	}
 	for _, pathtest := range pathtests {

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -1,0 +1,33 @@
+package renter
+
+import (
+	"testing"
+)
+
+// TestRenterSiapathValidate verifies that the validateSiapath function correctly validates SiaPaths.
+func TestRenterSiapathValidate(t *testing.T) {
+	var pathtests = []struct {
+		in    string
+		valid bool
+	}{
+		{"valid/siapath", true},
+		{"../../../directory/traversal", false},
+		{"testpath", true},
+		{"valid/siapath/../with/directory/traversal", false},
+		{"validpath/test", true},
+		{"..validpath/..test", true},
+		{"./valid/path", true},
+		{"test/path", true},
+		{"/leading/slash", false},
+		{"", false},
+	}
+	for _, pathtest := range pathtests {
+		err := validateSiapath(pathtest.in)
+		if err != nil && pathtest.valid {
+			t.Fatal("validateSiapath failed on valid path: ", pathtest.in)
+		}
+		if err == nil && !pathtest.valid {
+			t.Fatal("validateSiapath succeeded on invalid path: ", pathtest.in)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes an issue where by specifying a siapath with `../`, users could write .sia files outside of their renter directory anywhere on their filesystem. I also moved the existing validation to the `validateSiapath` function and added testing around it.