### PR TITLE
Testing around dynamic ip addresses

### DIFF
--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -848,25 +848,23 @@ func TestHostDBAndRenterRenewDynamicIPs(t *testing.T) {
 
 	// Close and re-open the host. This should reset the host's address, as the
 	// host should now be on a new port.
-	/*
-		err = stHost.server.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		stHost, err = assembleServerTester(stHost.walletKey, stHost.dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		sts[1] = stHost
-		err = fullyConnectNodes(sts)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = stHost.announceHost()
-		if err != nil {
-			t.Fatal(err)
-		}
-	*/
+	err = stHost.server.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stHost, err = assembleServerTester(stHost.walletKey, stHost.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sts[1] = stHost
+	err = fullyConnectNodes(sts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stHost.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Pull the host's net address and pubkey from the hostdb.
 	err = retry(50, time.Millisecond*100, func() error {
 		// Get the hostdb internals.
@@ -894,6 +892,7 @@ func TestHostDBAndRenterRenewDynamicIPs(t *testing.T) {
 
 	// Mine enough blocks that multiple renew cylces happen. After the renewing
 	// happens, the file should still be downloadable.
+	println("mining blocks")
 	for i := 0; i < testPeriodInt*2; i++ {
 		_, err = st.miner.AddBlock()
 		if err != nil {

--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"net/url"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestHostDBHostsActiveHandler checks the behavior of the call to
@@ -216,5 +221,155 @@ func TestHostDBHostsHandler(t *testing.T) {
 	}
 	if hh.ScoreBreakdown.VersionAdjustment == 1 {
 		t.Error("One value in host score breakdown")
+	}
+}
+
+// TestHostDBAndRenterDynamicIPs checks that the hostdb and the renter are
+// successfully able to follow a host that has changed IP addresses and then
+// re-announced.
+func TestHostDBAndRenterDynamicIPs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestHostDBAndRenterDynamicIPs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stHost, err := blankServerTester("TestHostDBAndRenterDynamicIPs-Host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sts := []*serverTester{st, stHost}
+	err = fullyConnectNodes(sts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = fundAllNodes(sts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Announce the host.
+	err = stHost.acceptContracts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stHost.setHostStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stHost.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pull the host's net address and pubkey from the hostdb.
+	var ah HostdbActiveGET
+	if err = st.getAPI("/hostdb/active", &ah); err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatalf("expected 1 host, got %v", len(ah.Hosts))
+	}
+	addr := ah.Hosts[0].NetAddress
+	pks := ah.Hosts[0].PublicKeyString
+
+	// Upload a file to the host.
+	allowanceValues := url.Values{}
+	testFunds := "10000000000000000000000000000" // 10k SC
+	testPeriod := "10"
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create a file.
+	path := filepath.Join(st.dir, "test.dat")
+	err = createRandFile(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Upload the file to the renter.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	err = st.stdPostAPI("/renter/upload/test", uploadValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only one piece will be uploaded (10% at current redundancy).
+	var rf RenterFiles
+	for i := 0; i < 200 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
+		st.getAPI("/renter/files", &rf)
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10 {
+		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
+	}
+
+	// Try downloading the file.
+	downpath := filepath.Join(st.dir, "testdown.dat")
+	err = st.stdGetAPI("/renter/download/test?destination=" + downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the download has the right contents.
+	orig, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	download, err := ioutil.ReadFile(downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(orig, download) != 0 {
+		t.Fatal("data mismatch when downloading a file")
+	}
+
+	// Close and re-open the host. This should reset the host's address, as the
+	// host should now be on a new port.
+	err = stHost.server.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stHost, err = assembleServerTester(stHost.walletKey, stHost.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sts[1] = stHost
+	err = fullyConnectNodes(sts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stHost.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pull the host's net address and pubkey from the hostdb.
+	if err = st.getAPI("/hostdb/active", &ah); err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatalf("expected 1 host, got %v", len(ah.Hosts))
+	}
+	if ah.Hosts[0].PublicKeyString != pks {
+		t.Error("public key appears to have changed for host")
+	}
+	if ah.Hosts[0].NetAddress == addr {
+		t.Log("NetAddress did not change for the new host")
+	}
+
+	// Try downloading the file.
+	err = st.stdGetAPI("/renter/download/test?destination=" + downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the download has the right contents.
+	download, err = ioutil.ReadFile(downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(orig, download) != 0 {
+		t.Fatal("data mismatch when downloading a file")
 	}
 }

--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -533,3 +533,139 @@ func TestHostDBAndRenterUploadDynamicIPs(t *testing.T) {
 		t.Fatal("data mismatch when downloading a file")
 	}
 }
+
+// TestHostDBAndRenterFormDynamicIPs checks that the hostdb and the renter are
+// successfully able to follow a host that has changed IP addresses and then
+// re-announced.
+func TestHostDBAndRenterFormDynamicIPs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	st, err := createServerTester("TestHostDBAndRenterFormDynamicIPs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stHost, err := blankServerTester("TestHostDBAndRenterFormDynamicIPs-Host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sts := []*serverTester{st, stHost}
+	err = fullyConnectNodes(sts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = fundAllNodes(sts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Announce the host.
+	err = stHost.acceptContracts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stHost.setHostStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stHost.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pull the host's net address and pubkey from the hostdb.
+	var ah HostdbActiveGET
+	if err = st.getAPI("/hostdb/active", &ah); err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatalf("expected 1 host, got %v", len(ah.Hosts))
+	}
+	addr := ah.Hosts[0].NetAddress
+	pks := ah.Hosts[0].PublicKeyString
+
+	// Close and re-open the host. This should reset the host's address, as the
+	// host should now be on a new port.
+	err = stHost.server.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stHost, err = assembleServerTester(stHost.walletKey, stHost.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sts[1] = stHost
+	err = fullyConnectNodes(sts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stHost.announceHost()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pull the host's net address and pubkey from the hostdb.
+	if err = st.getAPI("/hostdb/active", &ah); err != nil {
+		t.Fatal(err)
+	}
+	if len(ah.Hosts) != 1 {
+		t.Fatalf("expected 1 host, got %v", len(ah.Hosts))
+	}
+	if ah.Hosts[0].PublicKeyString != pks {
+		t.Error("public key appears to have changed for host")
+	}
+	if ah.Hosts[0].NetAddress == addr {
+		t.Log("NetAddress did not change for the new host")
+	}
+
+	// Upload a file to the host.
+	allowanceValues := url.Values{}
+	testFunds := "10000000000000000000000000000" // 10k SC
+	testPeriod := "10"
+	allowanceValues.Set("funds", testFunds)
+	allowanceValues.Set("period", testPeriod)
+	err = st.stdPostAPI("/renter", allowanceValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create a file.
+	path := filepath.Join(st.dir, "test.dat")
+	err = createRandFile(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Upload the file to the renter.
+	uploadValues := url.Values{}
+	uploadValues.Set("source", path)
+	err = st.stdPostAPI("/renter/upload/test", uploadValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only one piece will be uploaded (10% at current redundancy).
+	var rf RenterFiles
+	for i := 0; i < 200 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
+		st.getAPI("/renter/files", &rf)
+		time.Sleep(100 * time.Millisecond)
+	}
+	if len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10 {
+		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
+	}
+
+	// Try downloading the file.
+	downpath := filepath.Join(st.dir, "testdown.dat")
+	err = st.stdGetAPI("/renter/download/test?destination=" + downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the download has the right contents.
+	orig, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	download, err := ioutil.ReadFile(downpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(orig, download) != 0 {
+		t.Fatal("data mismatch when downloading a file")
+	}
+}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -521,7 +521,7 @@ func (st *serverTester) announceHost() error {
 	acceptingContractsValues.Set("acceptingcontracts", "true")
 	err := st.stdPostAPI("/host", acceptingContractsValues)
 	if err != nil {
-		return err
+		return build.ExtendErr("couldn't make an api call to the host:", err)
 	}
 
 	announceValues := url.Values{}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -448,11 +448,6 @@ func createExplorerServerTester(name string) (*serverTester, error) {
 	return st, nil
 }
 
-// non2xx returns true for non-success HTTP status codes.
-func non2xx(code int) bool {
-	return code < 200 || code > 299
-}
-
 // decodeError returns the api.Error from a API response. This method should
 // only be called if the response's status code is non-2xx. The error returned
 // may not be of type api.Error in the event of an error unmarshalling the
@@ -464,6 +459,25 @@ func decodeError(resp *http.Response) error {
 		return err
 	}
 	return apiErr
+}
+
+// non2xx returns true for non-success HTTP status codes.
+func non2xx(code int) bool {
+	return code < 200 || code > 299
+}
+
+// retry will retry a function multiple times until it returns 'nil'. It will
+// sleep the specified duration between tries. If success is not achieved in the
+// specified number of attempts, the final error is returned.
+func retry(tries int, durationBetweenAttempts time.Duration, fn func() error) (err error) {
+	for i := 0; i < tries-1; i++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(durationBetweenAttempts)
+	}
+	return fn()
 }
 
 // reloadedServerTester creates a server tester where all of the persistent

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -167,6 +167,13 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 		}
 	}
 
+	// Update the contract to the most recent net address for the host.
+	host, exists := c.hdb.Host(contract.HostPublicKey)
+	if !exists {
+		return nil, errors.New("unable to find the contract's host in the host database")
+	}
+	contract.NetAddress = host.NetAddress
+
 	// create downloader
 	d, err := proto.NewDownloader(host, contract)
 	if proto.IsRevisionMismatch(err) {

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -136,6 +136,8 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 	} else if host.DownloadBandwidthPrice.Cmp(maxDownloadPrice) > 0 {
 		return nil, errTooExpensive
 	}
+	// Update the contract to the most recent net address for the host.
+	contract.NetAddress = host.NetAddress
 
 	// acquire revising lock
 	c.mu.Lock()
@@ -166,13 +168,6 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 			c.log.Critical("Cached revision does not exist for contract.")
 		}
 	}
-
-	// Update the contract to the most recent net address for the host.
-	host, exists := c.hdb.Host(contract.HostPublicKey)
-	if !exists {
-		return nil, errors.New("unable to find the contract's host in the host database")
-	}
-	contract.NetAddress = host.NetAddress
 
 	// create downloader
 	d, err := proto.NewDownloader(host, contract)

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -231,6 +231,13 @@ func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 		}
 	}
 
+	// Make sure that we have the most recent net address for this host.
+	host, exists := c.hdb.Host(contract.HostPublicKey)
+	if !exists {
+		return nil, errors.New("unable to find the host in the hostdb")
+	}
+	contract.NetAddress = host.NetAddress
+
 	// create editor
 	e, err := proto.NewEditor(host, contract, height)
 	if proto.IsRevisionMismatch(err) {

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -200,6 +200,7 @@ func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 			host.Collateral = maxUploadCollateral
 		}
 	}
+	contract.NetAddress = host.NetAddress
 
 	// acquire revising lock
 	c.mu.Lock()
@@ -230,13 +231,6 @@ func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 			c.log.Critical("Cached revision does not exist for contract.")
 		}
 	}
-
-	// Make sure that we have the most recent net address for this host.
-	host, exists := c.hdb.Host(contract.HostPublicKey)
-	if !exists {
-		return nil, errors.New("unable to find the host in the hostdb")
-	}
-	contract.NetAddress = host.NetAddress
 
 	// create editor
 	e, err := proto.NewEditor(host, contract, height)

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -14,13 +14,10 @@ import (
 // It returns the new contract. This is a blocking call that performs network
 // I/O.
 func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors uint64, newEndHeight types.BlockHeight) (modules.RenterContract, error) {
-	println("performing renew")
 	host, ok := c.hdb.Host(contract.HostPublicKey)
 	if !ok {
-		println("a")
 		return modules.RenterContract{}, errors.New("no record of that host")
 	} else if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
-		println("b")
 		return modules.RenterContract{}, errTooExpensive
 	}
 	// cap host.MaxCollateral
@@ -34,7 +31,6 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 	// get an address to use for negotiation
 	uc, err := c.wallet.NextAddress()
 	if err != nil {
-		println("c")
 		return modules.RenterContract{}, err
 	}
 
@@ -62,7 +58,6 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 		if !ok {
 			// nothing we can do; return original error
 			c.log.Printf("wanted to recover contract %v with host %v, but no revision was cached", contract.ID, contract.NetAddress)
-			println("d")
 			return modules.RenterContract{}, err
 		}
 		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
@@ -73,11 +68,9 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 	}
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet
-		println("e")
 		return modules.RenterContract{}, err
 	}
 
-	println("renew successful")
 	return newContract, nil
 }
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -14,10 +14,13 @@ import (
 // It returns the new contract. This is a blocking call that performs network
 // I/O.
 func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors uint64, newEndHeight types.BlockHeight) (modules.RenterContract, error) {
+	println("performing renew")
 	host, ok := c.hdb.Host(contract.HostPublicKey)
 	if !ok {
+		println("a")
 		return modules.RenterContract{}, errors.New("no record of that host")
 	} else if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
+		println("b")
 		return modules.RenterContract{}, errTooExpensive
 	}
 	// cap host.MaxCollateral
@@ -31,6 +34,7 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 	// get an address to use for negotiation
 	uc, err := c.wallet.NextAddress()
 	if err != nil {
+		println("c")
 		return modules.RenterContract{}, err
 	}
 
@@ -58,6 +62,7 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 		if !ok {
 			// nothing we can do; return original error
 			c.log.Printf("wanted to recover contract %v with host %v, but no revision was cached", contract.ID, contract.NetAddress)
+			println("d")
 			return modules.RenterContract{}, err
 		}
 		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
@@ -68,9 +73,11 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 	}
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet
+		println("e")
 		return modules.RenterContract{}, err
 	}
 
+	println("renew successful")
 	return newContract, nil
 }
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -24,6 +24,9 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 	if host.MaxCollateral.Cmp(maxCollateral) > 0 {
 		host.MaxCollateral = maxCollateral
 	}
+	// Set the net address of the contract to the most recent net address for
+	// the host.
+	contract.NetAddress = host.NetAddress
 
 	// get an address to use for negotiation
 	uc, err := c.wallet.NextAddress()
@@ -42,9 +45,8 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 	}
 	c.mu.RUnlock()
 
-	txnBuilder := c.wallet.StartTransaction()
-
 	// execute negotiation protocol
+	txnBuilder := c.wallet.StartTransaction()
 	newContract, err := proto.Renew(contract, params, txnBuilder, c.tpool)
 	if proto.IsRevisionMismatch(err) {
 		// return unused outputs to wallet

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -30,8 +30,6 @@ type hdbTester struct {
 
 // bareHostDB returns a HostDB with its fields initialized, but without any
 // dependencies or scanning threads. It is only intended for use in unit tests.
-//
-// TODO: purge
 func bareHostDB() *HostDB {
 	hdb := &HostDB{
 		log: persist.NewLogger(ioutil.Discard),

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -25,10 +25,6 @@ func (quitAfterLoadDeps) disrupt(s string) bool {
 }
 
 // TestSaveLoad tests that the hostdb can save and load itself.
-//
-// TODO: By extending the hdbTester and adding some helper functions, we can
-// eliminate the necessary disruption by adding real hosts + blocks instead of
-// fake ones.
 func TestSaveLoad(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()


### PR DESCRIPTION
I did some testing to make sure the renter+host+contractor are all following dynamic IPs correctly. The contractor was not, but I fixed that with some very small code changes. One of the tests I wrote I could not get to pass, even when I was keeping the IP static. @lukechampine could you look at the test I wrote with t.Skip() and see if there's any obvious reason that the file is not downloadable at the end of the test?

With the exception of that final test (exploring that renew functions correctly with dynamic IPs), I think it's safe to establish that the renter can now follow around hosts with dynamic ip addresses. This should dramatically increase the reliability on our network, I believe that we were shedding a dozen or more hosts (out of 42) due to this, and now we won't be losing them.