### PR TITLE
Contractor journal

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -28,8 +28,8 @@ var (
 // as a safeguard against desynchronizing with the host.
 // TODO: save a diff of the Merkle roots instead of all of them.
 type cachedRevision struct {
-	Revision    types.FileContractRevision
-	MerkleRoots modules.MerkleRootSet
+	Revision    types.FileContractRevision `json:"revision"`
+	MerkleRoots modules.MerkleRootSet      `json:"merkleroots"`
 }
 
 // A Contractor negotiates, revises, renews, and provides access to file

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -124,6 +124,12 @@ func (c *Contractor) ResolveID(id types.FileContractID) types.FileContractID {
 	return id
 }
 
+// Close closes the Contractor.
+func (c *Contractor) Close() error {
+	c.log.Close()
+	return c.persist.Close()
+}
+
 // New returns a new Contractor.
 func New(cs consensusSet, wallet walletShim, tpool transactionPool, hdb hostDB, persistDir string) (*Contractor, error) {
 	// Check for nil inputs.

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -114,7 +114,7 @@ func TestContract(t *testing.T) {
 // TestContracts tests the Contracts method.
 func TestContracts(t *testing.T) {
 	var stub newStub
-	dir := build.TempDir("contractor", "TestNew")
+	dir := build.TempDir("contractor", "TestContracts")
 	c, err := New(stub, stub, stub, stub, dir)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -1,10 +1,7 @@
 package contractor
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -72,13 +69,6 @@ func TestNew(t *testing.T) {
 	_, err = New(stub, stub, stub, stub, "")
 	if !os.IsNotExist(err) {
 		t.Fatalf("expected invalid directory, got %v", err)
-	}
-
-	// Corrupted persist file.
-	ioutil.WriteFile(filepath.Join(dir, "contractor.json"), []byte{1, 2, 3}, 0666)
-	_, err = New(stub, stub, stub, stub, dir)
-	if _, ok := err.(*json.SyntaxError); !ok {
-		t.Fatalf("expected invalid json, got %v", err)
 	}
 }
 

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -68,9 +68,8 @@ type walletBridge struct {
 func (ws *walletBridge) NextAddress() (types.UnlockConditions, error) { return ws.w.NextAddress() }
 func (ws *walletBridge) StartTransaction() transactionBuilder         { return ws.w.StartTransaction() }
 
-// stdPersist implements the persister interface via jj.OpenJournal and
-// jj.CheckPoint. The filename required by these functions is internal to
-// stdPersist.
+// stdPersist implements the persister interface via the journal type. The
+// filename required by these functions is internal to stdPersist.
 type stdPersist struct {
 	journal  *journal
 	filename string

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -78,10 +78,8 @@ type stdPersist struct {
 func (p *stdPersist) save(data contractorPersist) error {
 	if p.journal == nil {
 		var err error
-		p.journal, err = newJournal(p.filename)
-		if err != nil {
-			return err
-		}
+		p.journal, err = newJournal(p.filename, data)
+		return err
 	}
 	return p.journal.checkpoint(data)
 }
@@ -95,7 +93,11 @@ func (p *stdPersist) load(data *contractorPersist) error {
 	p.journal, err = openJournal(p.filename, data)
 	if err != nil {
 		// try loading old persist
-		return loadv110persist(filepath.Dir(p.filename), data)
+		err = loadv110persist(filepath.Dir(p.filename), data)
+		if err != nil {
+			return err
+		}
+		p.journal, err = newJournal(p.filename, *data)
 	}
 	return err
 }

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -55,6 +55,7 @@ type (
 		save(contractorPersist) error
 		update(...journalUpdate) error
 		load(*contractorPersist) error
+		Close() error
 	}
 )
 
@@ -98,6 +99,10 @@ func (p *stdPersist) load(data *contractorPersist) error {
 		return loadv110persist(filepath.Dir(p.filename), data)
 	}
 	return err
+}
+
+func (p stdPersist) Close() error {
+	return p.journal.Close()
 }
 
 func newPersist(dir string) *stdPersist {

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -82,14 +82,8 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 	hd.contractor.contracts[contract.ID] = contract
 	cpath := fmt.Sprintf("contracts.%s", contract.ID.String())
 	hd.contractor.persist.update(
-		cpath+".lastrevision.newrevisionnumber", contract.LastRevision.NewRevisionNumber,
-		cpath+".lastrevision.newvalidproofoutputs", contract.LastRevision.NewValidProofOutputs,
-		cpath+".lastrevision.newmissedproofoutputs", contract.LastRevision.NewMissedProofOutputs,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newrevisionnumber", contract.LastRevisionTxn.FileContractRevisions[0].NewRevisionNumber,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newvalidproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewValidProofOutputs,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newmissedproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewMissedProofOutputs,
-		cpath+".lastrevisiontxn.transactionsignatures.0.signature", contract.LastRevisionTxn.TransactionSignatures[0].Signature,
-		cpath+".lastrevisiontxn.transactionsignatures.1.signature", contract.LastRevisionTxn.TransactionSignatures[1].Signature,
+		cpath+".lastrevision", contract.LastRevision,
+		cpath+".lastrevisiontxn", contract.LastRevisionTxn,
 		cpath+".downloadspending", contract.DownloadSpending,
 	)
 	hd.contractor.mu.Unlock()

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -202,7 +202,7 @@ func (c *Contractor) Downloader(id types.FileContractID) (_ Downloader, err erro
 	}
 	// supply a SaveFn that saves the revision to the contractor's persist
 	// (the existing revision will be overwritten when SaveFn is called)
-	d.SaveFn = c.saveRevision(contract.ID)
+	d.SaveFn = c.saveDownloadRevision(contract.ID)
 
 	// cache downloader
 	hd := &hostDownloader{

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -2,6 +2,7 @@ package contractor
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -79,7 +80,18 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 
 	hd.contractor.mu.Lock()
 	hd.contractor.contracts[contract.ID] = contract
-	hd.contractor.saveSync()
+	cpath := fmt.Sprintf("contracts.%s", contract.ID.String())
+	hd.contractor.persist.update(
+		cpath+".lastrevision.newrevisionnumber", contract.LastRevision.NewRevisionNumber,
+		cpath+".lastrevision.newvalidproofoutputs", contract.LastRevision.NewValidProofOutputs,
+		cpath+".lastrevision.newmissedproofoutputs", contract.LastRevision.NewMissedProofOutputs,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newrevisionnumber", contract.LastRevisionTxn.FileContractRevisions[0].NewRevisionNumber,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newvalidproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewValidProofOutputs,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newmissedproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewMissedProofOutputs,
+		cpath+".lastrevisiontxn.transactionsignatures.0.signature", contract.LastRevisionTxn.TransactionSignatures[0].Signature,
+		cpath+".lastrevisiontxn.transactionsignatures.1.signature", contract.LastRevisionTxn.TransactionSignatures[1].Signature,
+		cpath+".downloadspending", contract.DownloadSpending,
+	)
 	hd.contractor.mu.Unlock()
 
 	return sector, nil

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -2,7 +2,6 @@ package contractor
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -80,12 +79,10 @@ func (hd *hostDownloader) Sector(root crypto.Hash) ([]byte, error) {
 
 	hd.contractor.mu.Lock()
 	hd.contractor.contracts[contract.ID] = contract
-	cpath := fmt.Sprintf("contracts.%s", contract.ID.String())
-	hd.contractor.persist.update(
-		cpath+".lastrevision", contract.LastRevision,
-		cpath+".lastrevisiontxn", contract.LastRevisionTxn,
-		cpath+".downloadspending", contract.DownloadSpending,
-	)
+	hd.contractor.persist.update(updateDownloadRevision{
+		NewRevisionTxn:      contract.LastRevisionTxn,
+		NewDownloadSpending: contract.DownloadSpending,
+	})
 	hd.contractor.mu.Unlock()
 
 	return sector, nil

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -116,18 +116,8 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	he.contractor.contracts[contract.ID] = contract
 	cpath := fmt.Sprintf("contracts.%s", contract.ID.String())
 	he.contractor.persist.update(
-		cpath+".lastrevision.newrevisionnumber", contract.LastRevision.NewRevisionNumber,
-		cpath+".lastrevision.newfilesize", contract.LastRevision.NewFileSize,
-		cpath+".lastrevision.newfilemerkleroot", contract.LastRevision.NewFileMerkleRoot,
-		cpath+".lastrevision.newvalidproofoutputs", contract.LastRevision.NewValidProofOutputs,
-		cpath+".lastrevision.newmissedproofoutputs", contract.LastRevision.NewMissedProofOutputs,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newrevisionnumber", contract.LastRevisionTxn.FileContractRevisions[0].NewRevisionNumber,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newfilesize", contract.LastRevision.NewFileSize,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newfilemerkleroot", contract.LastRevision.NewFileMerkleRoot,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newvalidproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewValidProofOutputs,
-		cpath+".lastrevisiontxn.filecontractrevisions.0.newmissedproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewMissedProofOutputs,
-		cpath+".lastrevisiontxn.transactionsignatures.0.signature", contract.LastRevisionTxn.TransactionSignatures[0].Signature,
-		cpath+".lastrevisiontxn.transactionsignatures.1.signature", contract.LastRevisionTxn.TransactionSignatures[1].Signature,
+		cpath+".lastrevision", contract.LastRevision,
+		cpath+".lastrevisiontxn", contract.LastRevisionTxn,
 		cpath+".merkleroots."+fmt.Sprint(len(contract.MerkleRoots)-1), sectorRoot,
 		cpath+".uploadspending", contract.UploadSpending,
 		cpath+".storagespending", contract.StorageSpending,

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -2,6 +2,7 @@ package contractor
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -113,7 +114,24 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	}
 	he.contractor.mu.Lock()
 	he.contractor.contracts[contract.ID] = contract
-	he.contractor.saveSync()
+	cpath := fmt.Sprintf("contracts.%s", contract.ID.String())
+	he.contractor.persist.update(
+		cpath+".lastrevision.newrevisionnumber", contract.LastRevision.NewRevisionNumber,
+		cpath+".lastrevision.newfilesize", contract.LastRevision.NewFileSize,
+		cpath+".lastrevision.newfilemerkleroot", contract.LastRevision.NewFileMerkleRoot,
+		cpath+".lastrevision.newvalidproofoutputs", contract.LastRevision.NewValidProofOutputs,
+		cpath+".lastrevision.newmissedproofoutputs", contract.LastRevision.NewMissedProofOutputs,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newrevisionnumber", contract.LastRevisionTxn.FileContractRevisions[0].NewRevisionNumber,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newfilesize", contract.LastRevision.NewFileSize,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newfilemerkleroot", contract.LastRevision.NewFileMerkleRoot,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newvalidproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewValidProofOutputs,
+		cpath+".lastrevisiontxn.filecontractrevisions.0.newmissedproofoutputs", contract.LastRevisionTxn.FileContractRevisions[0].NewMissedProofOutputs,
+		cpath+".lastrevisiontxn.transactionsignatures.0.signature", contract.LastRevisionTxn.TransactionSignatures[0].Signature,
+		cpath+".lastrevisiontxn.transactionsignatures.1.signature", contract.LastRevisionTxn.TransactionSignatures[1].Signature,
+		cpath+".merkleroots."+fmt.Sprint(len(contract.MerkleRoots)-1), sectorRoot,
+		cpath+".uploadspending", contract.UploadSpending,
+		cpath+".storagespending", contract.StorageSpending,
+	)
 	he.contractor.mu.Unlock()
 	he.contract = contract
 

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -2,7 +2,6 @@ package contractor
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -114,14 +113,12 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	}
 	he.contractor.mu.Lock()
 	he.contractor.contracts[contract.ID] = contract
-	cpath := fmt.Sprintf("contracts.%s", contract.ID.String())
-	he.contractor.persist.update(
-		cpath+".lastrevision", contract.LastRevision,
-		cpath+".lastrevisiontxn", contract.LastRevisionTxn,
-		cpath+".merkleroots."+fmt.Sprint(len(contract.MerkleRoots)-1), sectorRoot,
-		cpath+".uploadspending", contract.UploadSpending,
-		cpath+".storagespending", contract.StorageSpending,
-	)
+	he.contractor.persist.update(updateUploadRevision{
+		NewRevisionTxn:     contract.LastRevisionTxn,
+		NewSectorRoot:      sectorRoot,
+		NewUploadSpending:  contract.UploadSpending,
+		NewStorageSpending: contract.StorageSpending,
+	})
 	he.contractor.mu.Unlock()
 	he.contract = contract
 

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -116,6 +116,7 @@ func (he *hostEditor) Upload(data []byte) (crypto.Hash, error) {
 	he.contractor.persist.update(updateUploadRevision{
 		NewRevisionTxn:     contract.LastRevisionTxn,
 		NewSectorRoot:      sectorRoot,
+		NewSectorIndex:     len(contract.MerkleRoots) - 1,
 		NewUploadSpending:  contract.UploadSpending,
 		NewStorageSpending: contract.StorageSpending,
 	})

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -272,7 +272,7 @@ func (c *Contractor) Editor(id types.FileContractID) (_ Editor, err error) {
 	}
 	// supply a SaveFn that saves the revision to the contractor's persist
 	// (the existing revision will be overwritten when SaveFn is called)
-	e.SaveFn = c.saveRevision(contract.ID)
+	e.SaveFn = c.saveUploadRevision(contract.ID)
 
 	// cache editor
 	he := &hostEditor{

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/proto"
 	"github.com/NebulousLabs/Sia/types"
@@ -113,7 +114,8 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, numSectors uin
 
 	contractValue := contract.RenterFunds()
 	c.log.Printf("Formed contract with %v for %v SC", host.NetAddress, contractValue.Div(types.SiacoinPrecision))
-
+	contract.MerkleRoots = []crypto.Hash{}
+	c.cachedRevisions[contract.ID] = cachedRevision{contract.LastRevision, contract.MerkleRoots}
 	return contract, nil
 }
 

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
-	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/proto"
 	"github.com/NebulousLabs/Sia/types"
@@ -114,8 +113,6 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, numSectors uin
 
 	contractValue := contract.RenterFunds()
 	c.log.Printf("Formed contract with %v for %v SC", host.NetAddress, contractValue.Div(types.SiacoinPrecision))
-	contract.MerkleRoots = []crypto.Hash{}
-	c.cachedRevisions[contract.ID] = cachedRevision{contract.LastRevision, contract.MerkleRoots}
 	return contract, nil
 }
 

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -317,10 +317,8 @@ func TestIntegrationUploadDownload(t *testing.T) {
 // TestIntegrationDelete tests that the contractor can delete a sector from a
 // contract previously formed with a host.
 func TestIntegrationDelete(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	t.Parallel()
+	t.Skip("deletion is deprecated")
+
 	// create testing trio
 	h, c, _, err := newTestingTrio("TestIntegrationDelete")
 	if err != nil {
@@ -382,10 +380,8 @@ func TestIntegrationDelete(t *testing.T) {
 // TestIntegrationInsertDelete tests that the contractor can insert and delete
 // a sector during the same revision.
 func TestIntegrationInsertDelete(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	t.Parallel()
+	t.Skip("deletion is deprecated")
+
 	// create testing trio
 	h, c, _, err := newTestingTrio("TestIntegrationInsertDelete")
 	if err != nil {

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -187,6 +187,7 @@ func TestIntegrationFormContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -214,6 +215,7 @@ func TestIntegrationReviseContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -262,6 +264,7 @@ func TestIntegrationUploadDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -325,6 +328,7 @@ func TestIntegrationDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -388,6 +392,7 @@ func TestIntegrationInsertDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -448,6 +453,7 @@ func TestIntegrationModify(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -515,6 +521,7 @@ func TestIntegrationRenew(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -642,6 +649,7 @@ func TestIntegrationResync(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -780,6 +788,7 @@ func TestIntegrationDownloaderCaching(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -873,6 +882,7 @@ func TestIntegrationEditorCaching(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())
@@ -965,6 +975,7 @@ func TestIntegrationCachedRenew(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer h.Close()
+	defer c.Close()
 
 	// get the host's entry from the db
 	hostEntry, ok := c.hdb.Host(h.PublicKey())

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -443,10 +443,8 @@ func TestIntegrationInsertDelete(t *testing.T) {
 // TestIntegrationModify tests that the contractor can modify a previously-
 // uploaded sector.
 func TestIntegrationModify(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	t.Parallel()
+	t.Skip("modification is deprecated")
+
 	// create testing trio
 	h, c, _, err := newTestingTrio("TestIntegrationModify")
 	if err != nil {

--- a/modules/renter/contractor/journal.go
+++ b/modules/renter/contractor/journal.go
@@ -1,0 +1,485 @@
+package contractor
+
+// The contractor achieves efficient persistence using a JSON transaction
+// journal. It enables efficient ACID transactions on JSON objects.
+//
+// Each journal represents a single JSON object. The object is serialized as
+// an "initial object" followed by a series of update sets, one per line. Each
+// update specifies a field and a modification. See the journalUpdate type for
+// a full specification.
+//
+// During operation, the object is first loaded by reading the file and
+// applying each update to the initial object. It is subsequently modified by
+// appending update sets to the file, one per line. At any time, a
+// "checkpoint" may be created, which clears the journal and starts over with
+// a new initial object. This allows for compaction of the journal file.
+//
+// In the event of power failure or other serious disruption, the most recent
+// update set may be only partially written. Partially written update sets are
+// simply ignored when reading the journal. Individual updates may also be
+// ignored if they are malformed, though other updates in the set may be
+// applied. See the journalUpdate docstring for an explanation of malformed updates.
+
+// TODO:
+// - handle case sensitivity
+// - handle null vs. empty array
+//    - if index is 0, just do a wholesale replace with [val]
+// - handle inserting new keys into object
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// A journal is a log of updates to a JSON object.
+type journal struct {
+	f        *os.File
+	filename string
+}
+
+// update applies the updates atomically to j. It syncs the underlying file
+// before returning.
+func (j *journal) update(us []journalUpdate) error {
+	buf := make([]byte, 0, 1024) // reasonable guess; avoids GC if we're lucky
+	buf = append(buf, '[')
+	for i, u := range us {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		buf = append(buf, `{"p":"`...)
+		buf = append(buf, u.Path...)
+		buf = append(buf, `","v":`...)
+		buf = append(buf, *u.Value...)
+		buf = append(buf, '}')
+	}
+	buf = append(buf, ']', '\n')
+	if _, err := j.f.Write(buf); err != nil {
+		return err
+	}
+	return j.f.Sync()
+}
+
+// Checkpoint refreshes the journal with a new initial object. It syncs the
+// underlying file before returning.
+func (j *journal) checkpoint(obj interface{}) error {
+	// write to a new temp file
+	//
+	// TODO: a separate file may not be necessary. We could use an update with
+	// path "" instead, and then overwrite the beginning of the file and
+	// truncate. If the overwrite fails, we still have the full rewrite update
+	// left at the end. Just need to be careful not to overflow into the
+	// update if the new object is large.
+	tmp, err := os.Create(j.filename + "_tmp")
+	if err != nil {
+		return err
+	}
+	if err := json.NewEncoder(tmp).Encode(obj); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+
+	// atomically replace the old file with the new one
+	if err := j.f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(j.filename+"_tmp", j.filename); err != nil {
+		return err
+	}
+
+	j.f = tmp
+	return nil
+}
+
+// Close closes the underlying file.
+func (j *journal) Close() error {
+	return j.f.Close()
+}
+
+// openJournal opens the supplied journal and decodes the reconstructed object
+// into obj. If the journal does not exist, it will be created and obj will be
+// used as the initial object.
+func openJournal(filename string, obj interface{}) (*journal, error) {
+	// open file handle, creating the file if it does not exist
+	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, err
+	}
+	// if file was newly created, use obj as the initial object.
+	if stat, err := f.Stat(); err != nil {
+		return nil, err
+	} else if stat.Size() == 0 {
+		j := &journal{
+			f:        f,
+			filename: filename,
+		}
+		if err := j.checkpoint(obj); err != nil {
+			return nil, err
+		}
+		return j, nil
+	}
+
+	// decode the initial object
+	var initObj json.RawMessage
+	dec := json.NewDecoder(f)
+	if err = dec.Decode(&initObj); err != nil {
+		return nil, err
+	}
+	// decode each set of updates
+	for {
+		var set []journalUpdate
+		if err = dec.Decode(&set); err == io.EOF || err == io.ErrUnexpectedEOF {
+			// unexpected EOF means the last update was corrupted
+			break
+		} else if _, ok := err.(*json.SyntaxError); ok {
+			// skip malformed update sets
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		for _, u := range set {
+			initObj = u.apply(initObj)
+		}
+	}
+	// decode the final object into obj
+	if err = json.Unmarshal(initObj, obj); err != nil {
+		return nil, err
+	}
+
+	return &journal{
+		f:        f,
+		filename: filename,
+	}, nil
+}
+
+// A journalUpdate is a modification of a path in a JSON object. A "path" in this
+// context means an object or array element. Syntactically, a path is a set of
+// accessors joined by the '.' character. An accessor is either an object key
+// or an array index. For example, given this object:
+//
+//    {
+//        "foo": {
+//            "bars": [
+//                {"baz":3}
+//            ]
+//        }
+//    }
+//
+// The following path accesses the value "3":
+//
+//    foo.bars.0.baz
+//
+// The path is accompanied by a new object. Thus, to increment the value "3"
+// in the above object, we would use the following journalUpdate:
+//
+//    {
+//        "p": "foo.bars.0.baz",
+//        "v": 4
+//    }
+//
+// All permutations of the journalUpdate object are legal. However, malformed updates
+// are ignored during application. A journalUpdate is considered malformed in three
+// circumstances:
+//
+// - Its Path references an element that does not exist at application time.
+//   This includes out-of-bounds array indices.
+// - Its Path contains invalid characters (e.g. "). See the JSON spec.
+// - Value contains invalid JSON or is empty.
+//
+// Other special cases are handled as follows:
+//
+// - If Path is "", the entire object is replaced.
+// - If an object contains duplicate keys, the first key encountered is used.
+//
+// Finally, to enable efficient array updates, the length of the array (at
+// application time) may be used as a special array index.  When this index is
+// the last accessor in Path, Value will be appended to the end of the array.
+// If the index is not the last accessor, the journalUpdate is considered malformed
+// (and thus is ignored).
+type journalUpdate struct {
+	// Path is an arbitrarily-nested JSON element, such as foo.bars.1.baz
+	Path string `json:"p"`
+	// Value contains the new value of Path.
+	// TODO: remove pointer once Go 1.8 is released.
+	Value *json.RawMessage `json:"v"`
+}
+
+// apply applies u to obj, returning the new JSON, which may share underlying
+// memory with obj or u.Value. If u is malformed, obj is returned unaltered.
+// See the journalUpdate docstring for an explanation of malformed journalUpdates. If obj is
+// not valid JSON, the result is undefined.
+func (u journalUpdate) apply(obj json.RawMessage) json.RawMessage {
+	if len(*u.Value) == 0 {
+		// u is malformed
+		return obj
+	}
+	return rewritePath(obj, u.Path, *u.Value)
+}
+
+// newJournalUpdate constructs an update using the provided path and val. If val
+// cannot be marshaled, newJournalUpdate panics. If val implements the json.Marshaler
+// interface, it is called directly. Note that this bypasses validation of the
+// produced JSON, which may result in a malformed journalUpdate.
+func newJournalUpdate(path string, val interface{}) journalUpdate {
+	var data []byte
+	var err error
+	if m, ok := val.(json.Marshaler); ok {
+		// bypass validation
+		data, err = m.MarshalJSON()
+	} else {
+		data, err = json.Marshal(val)
+	}
+	if err != nil {
+		panic(err)
+	}
+	rm := json.RawMessage(data)
+	return journalUpdate{
+		Path:  path,
+		Value: &rm,
+	}
+}
+
+// rewritePath replaces the value at path in json with val. The returned slice
+// may share underlying memory with json. If path is malformed, the original
+// json is returned.
+func rewritePath(json []byte, path string, val []byte) []byte {
+	if path == "" {
+		return val
+	}
+
+	var lastAcc string
+	var i int
+	for j := 0; lastAcc == ""; j++ {
+		// determine next accessor by seeking to .
+		dotIndex := strings.IndexByte(path[j:], '.')
+		if dotIndex == -1 {
+			// not found; this is the last accessor
+			dotIndex = len(path[j:])
+			lastAcc = path[j:]
+		}
+		acc := path[j : j+dotIndex]
+		j += dotIndex
+
+		// seek to accessor
+		accIndex := locateAccessor(json[i:], acc)
+		if accIndex == -1 {
+			// not found; return unmodified
+			return json
+		} else if json[accIndex] == ']' && lastAcc == "" {
+			// only the last accessor may use the "append" index
+			return json
+		}
+		i += accIndex
+	}
+
+	// replace old value
+	newJSON := make([]byte, 0, len(json)+len(val)) // reasonable guess
+	newJSON = append(newJSON, json[:i]...)
+	if json[i] == ']' {
+		// we are appending. If the array is not empty, insert an extra ,
+		if lastAcc != "0" {
+			newJSON = append(newJSON, ',')
+		}
+	}
+	newJSON = append(newJSON, val...)
+	newJSON = append(newJSON, consumeValue(json[i:])...)
+
+	return newJSON
+}
+
+// locateAccessor returns the offset of acc in json.
+func locateAccessor(json []byte, acc string) int {
+	origLen := len(json)
+	json = consumeWhitespace(json)
+	if len(json) == 0 || len(json) < len(acc) {
+		return -1
+	}
+
+	// acc must refer to either an object key or an array index. So if we
+	// don't see a { or [, the path is invalid.
+	switch json[0] {
+	default:
+		return -1
+
+	case '{': // object
+		json = consumeSeparator(json) // consume {
+		// iterate through keys, searching for acc
+		for json[0] != '}' {
+			var key []byte
+			key, json = parseString(json)
+			json = consumeWhitespace(json)
+			json = consumeSeparator(json) // consume :
+			if bytes.Equal(key, []byte(acc)) {
+				// acc found
+				return origLen - len(json)
+			}
+			json = consumeValue(json)
+			json = consumeWhitespace(json)
+			if json[0] == ',' {
+				json = consumeSeparator(json) // consume ,
+			}
+		}
+		// acc not found
+		return -1
+
+	case '[': // array
+		// is accessor possibly an array index?
+		n, err := strconv.Atoi(acc)
+		if err != nil || n < 0 {
+			// invalid index
+			return -1
+		}
+		json = consumeSeparator(json) // consume [
+		// consume n keys, stopping early if we hit the end of the array
+		var arrayLen int
+		for n > arrayLen && json[0] != ']' {
+			json = consumeValue(json)
+			arrayLen++
+			json = consumeWhitespace(json)
+			if json[0] == ',' {
+				json = consumeSeparator(json) // consume ,
+			}
+		}
+		if n > arrayLen {
+			// Note that n == arrayLen is allowed. In this case, an append
+			// operation is desired; we return the offset of the closing ].
+			return -1
+		}
+		return origLen - len(json)
+	}
+}
+
+func parseString(json []byte) ([]byte, []byte) {
+	after := consumeString(json)
+	strLen := len(json) - len(after) - 2
+	return json[1 : 1+strLen], after
+}
+
+func consumeWhitespace(json []byte) []byte {
+	for i := range json {
+		if c := json[i]; c > ' ' || (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+			return json[i:]
+		}
+	}
+	return json[len(json):]
+}
+
+func consumeSeparator(json []byte) []byte {
+	json = json[1:] // consume one of [ { } ] : ,
+	return consumeWhitespace(json)
+}
+
+func consumeValue(json []byte) []byte {
+	// determine value type
+	switch json[0] {
+	case '{': // object
+		return consumeObject(json)
+	case '[': // array
+		return consumeArray(json)
+	case '"': // string
+		return consumeString(json)
+	case 't', 'n': // true or null
+		return json[4:]
+	case 'f': // false
+		return json[5:]
+	default: // number
+		return consumeNumber(json)
+	}
+}
+
+func consumeObject(json []byte) []byte {
+	json = json[1:] // consume {
+	// seek to next {, }, or ". Each time we encounter a {, increment n. Each
+	// time encounter a }, decrement n. Exit when n == 0. If we encounter ",
+	// consume the string.
+	n := 1
+	for n > 0 {
+		json = json[bytes.IndexAny(json, `{}"`):]
+		switch json[0] {
+		case '{':
+			n++
+			json = json[1:] // consume {
+		case '}':
+			n--
+			json = json[1:] // consume }
+		case '"':
+			json = consumeString(json)
+		}
+	}
+	return json
+}
+
+func consumeArray(json []byte) []byte {
+	json = json[1:] // consume [
+	// seek to next [, ], or ". Each time we encounter a [, increment n. Each
+	// time encounter a ], decrement n. Exit when n == 0. If we encounter ",
+	// consume the string.
+	n := 1
+	for n > 0 {
+		json = json[bytes.IndexAny(json, `[]"`):]
+		switch json[0] {
+		case '[':
+			n++
+			json = json[1:] // consume [
+		case ']':
+			n--
+			json = json[1:] // consume ]
+		case '"':
+			json = consumeString(json)
+		}
+	}
+	return json
+}
+
+func consumeString(json []byte) []byte {
+	i := 1 // consume "
+	// seek forward until we find a " without a preceeding \
+	i += bytes.IndexByte(json[i:], '"')
+	for json[i-1] == '\\' {
+		i++
+		i += bytes.IndexByte(json[i:], '"')
+	}
+	return json[i+1:] // consume "
+}
+
+func consumeNumber(json []byte) []byte {
+	if json[0] == '-' {
+		json = json[1:]
+	}
+	// leading digits
+	for '0' <= json[0] && json[0] <= '9' {
+		json = json[1:]
+		if len(json) == 0 {
+			return json
+		}
+	}
+	// decimal digits
+	if json[0] == '.' {
+		json = json[1:]
+		for '0' <= json[0] && json[0] <= '9' {
+			json = json[1:]
+			if len(json) == 0 {
+				return json
+			}
+		}
+	}
+	// exponent
+	if json[0] == 'e' || json[0] == 'E' {
+		json = json[1:]
+		if json[0] == '+' || json[0] == '-' {
+			json = json[1:]
+		}
+		for '0' <= json[0] && json[0] <= '9' {
+			json = json[1:]
+			if len(json) == 0 {
+				return json
+			}
+		}
+	}
+	return json
+}

--- a/modules/renter/contractor/journal.go
+++ b/modules/renter/contractor/journal.go
@@ -130,9 +130,8 @@ func (j *journal) Close() error {
 	return j.f.Close()
 }
 
-// newJournal creates a new journal, using an empty contractorPersist as the
-// initial object.
-func newJournal(filename string) (*journal, error) {
+// newJournal creates a new journal, using data as the initial object.
+func newJournal(filename string, data contractorPersist) (*journal, error) {
 	f, err := os.Create(filename)
 	if err != nil {
 		return nil, err
@@ -142,13 +141,8 @@ func newJournal(filename string) (*journal, error) {
 	if err := enc.Encode(journalMeta); err != nil {
 		return nil, err
 	}
-	// write empty contractorPersist
-	initObj := contractorPersist{
-		CachedRevisions: map[string]cachedRevision{},
-		Contracts:       map[string]modules.RenterContract{},
-		RenewedIDs:      map[string]string{},
-	}
-	if err := enc.Encode(initObj); err != nil {
+	// write initial object
+	if err := enc.Encode(data); err != nil {
 		return nil, err
 	}
 	if err := f.Sync(); err != nil {

--- a/modules/renter/contractor/journal.go
+++ b/modules/renter/contractor/journal.go
@@ -3,10 +3,10 @@ package contractor
 // The contractor achieves efficient persistence using a JSON transaction
 // journal. It enables efficient ACID transactions on JSON objects.
 //
-// Each journal represents a single JSON object. The object is serialized as
-// an "initial object" followed by a series of update sets, one per line. Each
-// update specifies a field and a modification. See the journalUpdate type for
-// a full specification.
+// The journal represents a single JSON object, containing all of the
+// contractor's persisted data. The object is serialized as an "initial
+// object" followed by a series of update sets, one per line. Each update
+// specifies a modification.
 //
 // During operation, the object is first loaded by reading the file and
 // applying each update to the initial object. It is subsequently modified by
@@ -16,23 +16,18 @@ package contractor
 //
 // In the event of power failure or other serious disruption, the most recent
 // update set may be only partially written. Partially written update sets are
-// simply ignored when reading the journal. Individual updates may also be
-// ignored if they are malformed, though other updates in the set may be
-// applied. See the journalUpdate docstring for an explanation of malformed updates.
-
-// TODO:
-// - handle case sensitivity
-// - handle null vs. empty array
-//    - if index is 0, just do a wholesale replace with [val]
-// - handle inserting new keys into object
+// simply ignored when reading the journal.
 
 import (
-	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
-	"strconv"
-	"strings"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // A journal is a log of updates to a JSON object.
@@ -41,23 +36,10 @@ type journal struct {
 	filename string
 }
 
-// update applies the updates atomically to j. It syncs the underlying file
+// update applies the updateSet atomically to j. It syncs the underlying file
 // before returning.
-func (j *journal) update(us []journalUpdate) error {
-	buf := make([]byte, 0, 1024) // reasonable guess; avoids GC if we're lucky
-	buf = append(buf, '[')
-	for i, u := range us {
-		if i > 0 {
-			buf = append(buf, ',')
-		}
-		buf = append(buf, `{"p":"`...)
-		buf = append(buf, u.Path...)
-		buf = append(buf, `","v":`...)
-		buf = append(buf, *u.Value...)
-		buf = append(buf, '}')
-	}
-	buf = append(buf, ']', '\n')
-	if _, err := j.f.Write(buf); err != nil {
+func (j *journal) update(us updateSet) error {
+	if err := json.NewEncoder(j.f).Encode(us); err != nil {
 		return err
 	}
 	return j.f.Sync()
@@ -65,19 +47,13 @@ func (j *journal) update(us []journalUpdate) error {
 
 // Checkpoint refreshes the journal with a new initial object. It syncs the
 // underlying file before returning.
-func (j *journal) checkpoint(obj interface{}) error {
+func (j *journal) checkpoint(data contractorPersist) error {
 	// write to a new temp file
-	//
-	// TODO: a separate file may not be necessary. We could use an update with
-	// path "" instead, and then overwrite the beginning of the file and
-	// truncate. If the overwrite fails, we still have the full rewrite update
-	// left at the end. Just need to be careful not to overflow into the
-	// update if the new object is large.
 	tmp, err := os.Create(j.filename + "_tmp")
 	if err != nil {
 		return err
 	}
-	if err := json.NewEncoder(tmp).Encode(obj); err != nil {
+	if err := json.NewEncoder(tmp).Encode(data); err != nil {
 		return err
 	}
 	if err := tmp.Sync(); err != nil {
@@ -105,41 +81,52 @@ func (j *journal) Close() error {
 	return j.f.Close()
 }
 
-// openJournal opens the supplied journal and decodes the reconstructed object
-// into obj. If the journal does not exist, it will be created and obj will be
-// used as the initial object.
-func openJournal(filename string, obj interface{}) (*journal, error) {
-	// open file handle, creating the file if it does not exist
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
+// newJournal creates a new journal, using an empty contractorPersist as the
+// initial object.
+func newJournal(filename string) (*journal, error) {
+	f, err := os.Create(filename)
 	if err != nil {
 		return nil, err
 	}
-	// if file was newly created, use obj as the initial object.
-	if stat, err := f.Stat(); err != nil {
+	var initObj contractorPersist
+	if err := json.NewEncoder(f).Encode(initObj); err != nil {
 		return nil, err
-	} else if stat.Size() == 0 {
-		j := &journal{
-			f:        f,
-			filename: filename,
-		}
-		if err := json.NewEncoder(f).Encode(obj); err != nil {
-			return nil, err
-		}
-		if err := f.Sync(); err != nil {
-			return nil, err
-		}
-		return j, nil
+	}
+	if err := f.Sync(); err != nil {
+		return nil, err
+	}
+	return &journal{f: f, filename: filename}, nil
+}
+
+// openJournal opens the supplied journal and decodes the reconstructed
+// contractorPersist into data.
+func openJournal(filename string, data *contractorPersist) (*journal, error) {
+	// open file handle for reading and writing
+	f, err := os.OpenFile(filename, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
 	}
 
 	// decode the initial object
-	var initObj json.RawMessage
 	dec := json.NewDecoder(f)
-	if err = dec.Decode(&initObj); err != nil {
+	if err = dec.Decode(data); err != nil {
 		return nil, err
 	}
-	// decode each set of updates
+
+	// make sure all maps are properly initialized
+	if data.CachedRevisions == nil {
+		data.CachedRevisions = map[string]cachedRevision{}
+	}
+	if data.Contracts == nil {
+		data.Contracts = map[string]modules.RenterContract{}
+	}
+	if data.RenewedIDs == nil {
+		data.RenewedIDs = map[string]string{}
+	}
+
+	// decode each set of updates and apply them to data
 	for {
-		var set []journalUpdate
+		var set updateSet
 		if err = dec.Decode(&set); err == io.EOF || err == io.ErrUnexpectedEOF {
 			// unexpected EOF means the last update was corrupted
 			break
@@ -150,12 +137,8 @@ func openJournal(filename string, obj interface{}) (*journal, error) {
 			return nil, err
 		}
 		for _, u := range set {
-			initObj = u.apply(initObj)
+			u.apply(data)
 		}
-	}
-	// decode the final object into obj
-	if err = json.Unmarshal(initObj, obj); err != nil {
-		return nil, err
 	}
 
 	return &journal{
@@ -164,329 +147,147 @@ func openJournal(filename string, obj interface{}) (*journal, error) {
 	}, nil
 }
 
-// A journalUpdate is a modification of a path in a JSON object. A "path" in this
-// context means an object or array element. Syntactically, a path is a set of
-// accessors joined by the '.' character. An accessor is either an object key
-// or an array index. For example, given this object:
-//
-//    {
-//        "foo": {
-//            "bars": [
-//                {"baz":3}
-//            ]
-//        }
-//    }
-//
-// The following path accesses the value "3":
-//
-//    foo.bars.0.baz
-//
-// The path is accompanied by a new object. Thus, to increment the value "3"
-// in the above object, we would use the following journalUpdate:
-//
-//    {
-//        "p": "foo.bars.0.baz",
-//        "v": 4
-//    }
-//
-// All permutations of the journalUpdate object are legal. However, malformed updates
-// are ignored during application. A journalUpdate is considered malformed in three
-// circumstances:
-//
-// - Its Path references an element that does not exist at application time.
-//   This includes out-of-bounds array indices.
-// - Its Path contains invalid characters (e.g. "). See the JSON spec.
-// - Value contains invalid JSON or is empty.
-//
-// Other special cases are handled as follows:
-//
-// - If Path is "", the entire object is replaced.
-// - If an object contains duplicate keys, the first key encountered is used.
-//
-// Finally, to enable efficient array updates, the length of the array (at
-// application time) may be used as a special array index.  When this index is
-// the last accessor in Path, Value will be appended to the end of the array.
-// If the index is not the last accessor, the journalUpdate is considered malformed
-// (and thus is ignored).
-type journalUpdate struct {
-	// Path is an arbitrarily-nested JSON element, such as foo.bars.1.baz
-	Path string `json:"p"`
-	// Value contains the new value of Path.
-	// TODO: remove pointer once Go 1.8 is released.
-	Value *json.RawMessage `json:"v"`
+type journalUpdate interface {
+	apply(*contractorPersist)
 }
 
-// apply applies u to obj, returning the new JSON, which may share underlying
-// memory with obj or u.Value. If u is malformed, obj is returned unaltered.
-// See the journalUpdate docstring for an explanation of malformed journalUpdates. If obj is
-// not valid JSON, the result is undefined.
-func (u journalUpdate) apply(obj json.RawMessage) json.RawMessage {
-	if len(*u.Value) == 0 {
-		// u is malformed
-		return obj
-	}
-	return rewritePath(obj, u.Path, *u.Value)
+type marshaledUpdate struct {
+	Type string  `json:"t"`
+	Data rawJSON `json:"d"`
 }
 
-// newJournalUpdate constructs an update using the provided path and val. If val
-// cannot be marshaled, newJournalUpdate panics. If val implements the json.Marshaler
-// interface, it is called directly. Note that this bypasses validation of the
-// produced JSON, which may result in a malformed journalUpdate.
-func newJournalUpdate(path string, val interface{}) journalUpdate {
-	var data []byte
-	var err error
-	if m, ok := val.(json.Marshaler); ok {
-		// bypass validation
-		data, err = m.MarshalJSON()
-	} else {
-		data, err = json.Marshal(val)
+// TODO: replace with json.RawMessage after upgrading to Go 1.8
+type rawJSON []byte
+
+// MarshalJSON returns r as the JSON encoding of r.
+func (r rawJSON) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return []byte("null"), nil
 	}
-	if err != nil {
-		panic(err)
-	}
-	rm := json.RawMessage(data)
-	return journalUpdate{
-		Path:  path,
-		Value: &rm,
-	}
+	return r, nil
 }
 
-// rewritePath replaces the value at path in json with val. The returned slice
-// may share underlying memory with json. If path is malformed, the original
-// json is returned.
-func rewritePath(json []byte, path string, val []byte) []byte {
-	if path == "" {
-		return val
+// UnmarshalJSON sets *r to a copy of data.
+func (r *rawJSON) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return errors.New("rawJSON: UnmarshalJSON on nil pointer")
 	}
-
-	var lastAcc string
-	var i int
-	for j := 0; lastAcc == ""; j++ {
-		// determine next accessor by seeking to .
-		dotIndex := strings.IndexByte(path[j:], '.')
-		if dotIndex == -1 {
-			// not found; this is the last accessor
-			dotIndex = len(path[j:])
-			lastAcc = path[j:]
-		}
-		acc := path[j : j+dotIndex]
-		j += dotIndex
-
-		// seek to accessor
-		accIndex := locateAccessor(json[i:], acc)
-		if accIndex == -1 {
-			// not found; return unmodified
-			return json
-		} else if json[accIndex] == ']' && lastAcc == "" {
-			// only the last accessor may use the "append" index
-			return json
-		}
-		i += accIndex
-	}
-
-	// replace old value
-	newJSON := make([]byte, 0, len(json)+len(val)) // reasonable guess
-	newJSON = append(newJSON, json[:i]...)
-	if json[i] == ']' {
-		// we are appending. If the array is not empty, insert an extra ,
-		if lastAcc != "0" {
-			newJSON = append(newJSON, ',')
-		}
-	}
-	newJSON = append(newJSON, val...)
-	newJSON = append(newJSON, consumeValue(json[i:])...)
-
-	return newJSON
+	*r = append((*r)[0:0], data...)
+	return nil
 }
 
-// locateAccessor returns the offset of acc in json.
-func locateAccessor(json []byte, acc string) int {
-	origLen := len(json)
-	json = consumeWhitespace(json)
-	if len(json) == 0 || len(json) < len(acc) {
-		return -1
+type updateSet []journalUpdate
+
+func (set updateSet) MarshalJSON() ([]byte, error) {
+	marshaledSet := make([]marshaledUpdate, len(set))
+	for i, u := range set {
+		data, err := json.Marshal(u)
+		if err != nil {
+			build.Critical("failed to marshal known type:", err)
+		}
+		marshaledSet[i].Data = data
+		switch u.(type) {
+		case updateUploadRevision:
+			marshaledSet[i].Type = "uploadRevision"
+		case updateDownloadRevision:
+			marshaledSet[i].Type = "downloadRevision"
+		case updateCachedUploadRevision:
+			marshaledSet[i].Type = "cachedUploadRevision"
+		case updateCachedDownloadRevision:
+			marshaledSet[i].Type = "cachedDownloadRevision"
+		}
 	}
-
-	// acc must refer to either an object key or an array index. So if we
-	// don't see a { or [, the path is invalid.
-	switch json[0] {
-	default:
-		return -1
-
-	case '{': // object
-		json = consumeSeparator(json) // consume {
-		// iterate through keys, searching for acc
-		for json[0] != '}' {
-			var key []byte
-			key, json = parseString(json)
-			json = consumeWhitespace(json)
-			json = consumeSeparator(json) // consume :
-			if bytes.Equal(key, []byte(acc)) {
-				// acc found
-				return origLen - len(json)
-			}
-			json = consumeValue(json)
-			json = consumeWhitespace(json)
-			if json[0] == ',' {
-				json = consumeSeparator(json) // consume ,
-			}
-		}
-		// acc not found
-		return -1
-
-	case '[': // array
-		// is accessor possibly an array index?
-		n, err := strconv.Atoi(acc)
-		if err != nil || n < 0 {
-			// invalid index
-			return -1
-		}
-		json = consumeSeparator(json) // consume [
-		// consume n keys, stopping early if we hit the end of the array
-		var arrayLen int
-		for n > arrayLen && json[0] != ']' {
-			json = consumeValue(json)
-			arrayLen++
-			json = consumeWhitespace(json)
-			if json[0] == ',' {
-				json = consumeSeparator(json) // consume ,
-			}
-		}
-		if n > arrayLen {
-			// Note that n == arrayLen is allowed. In this case, an append
-			// operation is desired; we return the offset of the closing ].
-			return -1
-		}
-		return origLen - len(json)
-	}
+	return json.Marshal(marshaledSet)
 }
 
-func parseString(json []byte) ([]byte, []byte) {
-	after := consumeString(json)
-	strLen := len(json) - len(after) - 2
-	return json[1 : 1+strLen], after
-}
-
-func consumeWhitespace(json []byte) []byte {
-	for i := range json {
-		if c := json[i]; c > ' ' || (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
-			return json[i:]
+func (set *updateSet) UnmarshalJSON(b []byte) error {
+	var marshaledSet []marshaledUpdate
+	if err := json.Unmarshal(b, &marshaledSet); err != nil {
+		return err
+	}
+	for _, u := range marshaledSet {
+		var err error
+		switch u.Type {
+		case "uploadRevision":
+			var ur updateUploadRevision
+			err = json.Unmarshal(u.Data, &ur)
+			*set = append(*set, ur)
+		case "downloadRevision":
+			var dr updateDownloadRevision
+			err = json.Unmarshal(u.Data, &dr)
+			*set = append(*set, dr)
+		case "cachedUploadRevision":
+			var cur updateCachedUploadRevision
+			err = json.Unmarshal(u.Data, &cur)
+			*set = append(*set, cur)
+		case "cachedDownloadRevision":
+			var cdr updateCachedDownloadRevision
+			err = json.Unmarshal(u.Data, &cdr)
+			*set = append(*set, cdr)
+		}
+		if err != nil {
+			return err
 		}
 	}
-	return json[len(json):]
+	return nil
 }
 
-func consumeSeparator(json []byte) []byte {
-	json = json[1:] // consume one of [ { } ] : ,
-	return consumeWhitespace(json)
+type updateUploadRevision struct {
+	NewRevisionTxn     types.Transaction `json:"newrevisiontxn"`
+	NewSectorRoot      crypto.Hash       `json:"newsectorroot"`
+	NewUploadSpending  types.Currency    `json:"newuploadspending"`
+	NewStorageSpending types.Currency    `json:"newstoragespending"`
 }
 
-func consumeValue(json []byte) []byte {
-	// determine value type
-	switch json[0] {
-	case '{': // object
-		return consumeObject(json)
-	case '[': // array
-		return consumeArray(json)
-	case '"': // string
-		return consumeString(json)
-	case 't', 'n': // true or null
-		return json[4:]
-	case 'f': // false
-		return json[5:]
-	default: // number
-		return consumeNumber(json)
+func (u updateUploadRevision) apply(data *contractorPersist) {
+	if len(u.NewRevisionTxn.FileContractRevisions) == 0 {
+		return // shouldn't happen
 	}
+	rev := u.NewRevisionTxn.FileContractRevisions[0]
+	c := data.Contracts[rev.ParentID.String()]
+	c.LastRevisionTxn = u.NewRevisionTxn
+	c.LastRevision = rev
+	c.MerkleRoots = append(c.MerkleRoots, u.NewSectorRoot) // TODO: make this idempotent
+	c.UploadSpending = u.NewUploadSpending
+	c.StorageSpending = u.NewStorageSpending
+	data.Contracts[rev.ParentID.String()] = c
 }
 
-func consumeObject(json []byte) []byte {
-	json = json[1:] // consume {
-	// seek to next {, }, or ". Each time we encounter a {, increment n. Each
-	// time encounter a }, decrement n. Exit when n == 0. If we encounter ",
-	// consume the string.
-	n := 1
-	for n > 0 {
-		json = json[bytes.IndexAny(json, `{}"`):]
-		switch json[0] {
-		case '{':
-			n++
-			json = json[1:] // consume {
-		case '}':
-			n--
-			json = json[1:] // consume }
-		case '"':
-			json = consumeString(json)
-		}
-	}
-	return json
+type updateDownloadRevision struct {
+	NewRevisionTxn      types.Transaction `json:"newrevisiontxn"`
+	NewDownloadSpending types.Currency    `json:"newdownloadspending"`
 }
 
-func consumeArray(json []byte) []byte {
-	json = json[1:] // consume [
-	// seek to next [, ], or ". Each time we encounter a [, increment n. Each
-	// time encounter a ], decrement n. Exit when n == 0. If we encounter ",
-	// consume the string.
-	n := 1
-	for n > 0 {
-		json = json[bytes.IndexAny(json, `[]"`):]
-		switch json[0] {
-		case '[':
-			n++
-			json = json[1:] // consume [
-		case ']':
-			n--
-			json = json[1:] // consume ]
-		case '"':
-			json = consumeString(json)
-		}
+func (u updateDownloadRevision) apply(data *contractorPersist) {
+	if len(u.NewRevisionTxn.FileContractRevisions) == 0 {
+		return // shouldn't happen
 	}
-	return json
+	rev := u.NewRevisionTxn.FileContractRevisions[0]
+	c := data.Contracts[rev.ParentID.String()]
+	c.LastRevisionTxn = u.NewRevisionTxn
+	c.LastRevision = rev
+	c.DownloadSpending = u.NewDownloadSpending
+	data.Contracts[rev.ParentID.String()] = c
 }
 
-func consumeString(json []byte) []byte {
-	i := 1 // consume "
-	// seek forward until we find a " without a preceeding \
-	i += bytes.IndexByte(json[i:], '"')
-	for json[i-1] == '\\' {
-		i++
-		i += bytes.IndexByte(json[i:], '"')
-	}
-	return json[i+1:] // consume "
+type updateCachedUploadRevision struct {
+	Revision   types.FileContractRevision `json:"revision"`
+	SectorRoot crypto.Hash                `json:"sectorroot"`
 }
 
-func consumeNumber(json []byte) []byte {
-	if json[0] == '-' {
-		json = json[1:]
-	}
-	// leading digits
-	for '0' <= json[0] && json[0] <= '9' {
-		json = json[1:]
-		if len(json) == 0 {
-			return json
-		}
-	}
-	// decimal digits
-	if json[0] == '.' {
-		json = json[1:]
-		for '0' <= json[0] && json[0] <= '9' {
-			json = json[1:]
-			if len(json) == 0 {
-				return json
-			}
-		}
-	}
-	// exponent
-	if json[0] == 'e' || json[0] == 'E' {
-		json = json[1:]
-		if json[0] == '+' || json[0] == '-' {
-			json = json[1:]
-		}
-		for '0' <= json[0] && json[0] <= '9' {
-			json = json[1:]
-			if len(json) == 0 {
-				return json
-			}
-		}
-	}
-	return json
+func (u updateCachedUploadRevision) apply(data *contractorPersist) {
+	c := data.CachedRevisions[u.Revision.ParentID.String()]
+	c.Revision = u.Revision
+	c.MerkleRoots = append(c.MerkleRoots, u.SectorRoot) // TODO: make this idempotent
+	data.CachedRevisions[u.Revision.ParentID.String()] = c
+}
+
+type updateCachedDownloadRevision struct {
+	Revision types.FileContractRevision `json:"revision"`
+}
+
+func (u updateCachedDownloadRevision) apply(data *contractorPersist) {
+	c := data.CachedRevisions[u.Revision.ParentID.String()]
+	c.Revision = u.Revision
+	data.CachedRevisions[u.Revision.ParentID.String()] = c
 }

--- a/modules/renter/contractor/journal_test.go
+++ b/modules/renter/contractor/journal_test.go
@@ -3,8 +3,10 @@ package contractor
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -139,6 +141,207 @@ func TestJournalBadChecksum(t *testing.T) {
 	// the last update set should have been discarded
 	if _, ok := data.CachedRevisions[crypto.Hash{}.String()]; !ok {
 		t.Fatal("log was not applied correctly:", data)
+	}
+}
+
+// TestJournalLoadCompat tests that the contractor can convert the previous
+// persist file to a journal.
+func TestJournalLoadCompat(t *testing.T) {
+	// create old persist file
+	dir := build.TempDir("contractor", "TestJournalLoadCompat")
+	os.MkdirAll(dir, 0700)
+	err := ioutil.WriteFile(filepath.Join(dir, "contractor.json"), []byte(`"Contractor Persistence"
+"0.5.2"
+{
+	"Allowance": {
+		"funds": "5000000000000000000000000000",
+		"hosts": 42,
+		"period": 12960,
+		"renewwindow": 6480
+	},
+	"BlockHeight": 92885,
+	"CachedRevisions": [
+		{
+			"Revision": {
+				"parentid": "85a32f6ca706298407668718703b005ab1a558694eab69a2cc33e1bc0d3fb38f",
+				"unlockconditions": {
+					"publickeys": [
+						{"algorithm": "ed25519", "key": "sU1bxlHat5zgjlAqI7UfVPGKFQp3FpcPzGWa6K9ARfk="},
+						{"algorithm": "ed25519", "key": "pFrpZJEoH8dF+wQMLwZ6f8N2ghYzXjSCkotoJ0vgAjo="}
+					],
+					"signaturesrequired": 2
+				},
+				"newrevisionnumber": 205,
+				"newfilesize": 792723456,
+				"newfilemerkleroot": "1a6c3bae8f95b168188fcd86461e4b8830a0af5f895b401856e144e6ac833d4d",
+				"newwindowstart": 101748,
+				"newwindowend": 101892,
+				"newvalidproofoutputs": [
+					{"value": "912571784802684347584", "unlockhash": "f23541eb5c5de647b56c708e1b4972d0770e802f562c521a5f3e6613bb890999fd6a72c3c4cd" },
+					{"value": "54974203903776165095014400", "unlockhash": "e9d49e22328ba38ecc4969cb21f777915ff9828a79438aa408a668434c557d0c119d7d02e798" }
+				],
+				"newmissedproofoutputs": [
+					{"value": "912571784802684347584", "unlockhash": "f23541eb5c5de647b56c708e1b4972d0770e802f562c521a5f3e6613bb890999fd6a72c3c4cd"},
+					{"value": "53776524850119119131978612", "unlockhash": "e9d49e22328ba38ecc4969cb21f777915ff9828a79438aa408a668434c557d0c119d7d02e798"},
+					{"value": "1197679053657045963035788", "unlockhash": "000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"}
+				],
+				"newunlockhash": "3aa8c31a63d67d0671d924df556a6214057c9fa611fa5607b1bf5d1ec3e861b0cc78fc4e3914"
+			},
+			"MerkleRoots": [
+				"d3c27e3e361f7ff8fbb7aedcb8b24b0613d7e413fc9d7edd8ebbbf9911134487",
+				"5bc124f5dcadee196611252eec599096b5146642b6785cac3c0625ce472d863a",
+				"ff3bf7ccbc092ce4b851b76587fa3e9decff3f8421d49d6e72069d6cfc46f382"
+			]
+		}
+	],
+	"Contracts": [
+		{
+			"filecontract": {
+				"filesize": 0,
+				"filemerkleroot": "0000000000000000000000000000000000000000000000000000000000000000",
+				"windowstart": 101748,
+				"windowend": 101892,
+				"payout": "1601052162572897650533988302",
+				"validproofoutputs": [
+					{"value": "1258611128232554642163168302", "unlockhash": "9a712eceba9f0523522ff9f5687ef6a54e5299d27c632044cd20f207e809fcb306f8373fe12b"},
+					{"value": "280000000000000000000000000", "unlockhash": "f879ab09edd4b3650aed02ce6226d4f6a197409d42be84c310a5e86657879a85d9575dc51a0d"}
+				],
+				"missedproofoutputs": [
+					{"value": "1258611128232554642163168302", "unlockhash": "9a712eceba9f0523522ff9f5687ef6a54e5299d27c632044cd20f207e809fcb306f8373fe12b"},
+					{"value": "280000000000000000000000000", "unlockhash": "f879ab09edd4b3650aed02ce6226d4f6a197409d42be84c310a5e86657879a85d9575dc51a0d"},
+					{"value": "0", "unlockhash": "000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"}
+				],
+				"unlockhash": "4440e7ad4a744a1745797f9180b08aeeb1aa42c3c12729ed063f6ef4897f2cf7599a9efe4059",
+				"revisionnumber": 0
+			},
+			"id": "87893a702b4af71151a853229f7dd4071929b24b4bf1c39bafec551daeaf11de",
+			"lastrevision": {
+				"parentid": "87893a702b4af71151a853229f7dd4071929b24b4bf1c39bafec551daeaf11de",
+				"unlockconditions": {
+					"timelock": 0,
+					"publickeys": [
+						{"algorithm": "ed25519", "key": "ux0dwMoOTt2Q+VlmSy3G59nIn5kwWPrZMUKFphJgIGM="},
+						{"algorithm": "ed25519", "key": "5rgAREJJuMrmHfS3vWV0TN2Y8cHZf8UU2CM8BBFX5q4="}
+					],
+					"signaturesrequired": 2
+				},
+				"newrevisionnumber": 117,
+				"newfilesize": 465567744,
+				"newfilemerkleroot": "449af205a10e645324c9016062e843856538122e4044e18b6e93aaab960cd8e6",
+				"newwindowstart": 101748,
+				"newwindowend": 101892,
+				"newvalidproofoutputs": [
+					{"value": "1232516258766241909102140813", "unlockhash": "9a712eceba9f0523522ff9f5687ef6a54e5299d27c632044cd20f207e809fcb306f8373fe12b"},
+					{"value": "306094869466312733061027489", "unlockhash": "f879ab09edd4b3650aed02ce6226d4f6a197409d42be84c310a5e86657879a85d9575dc51a0d"}
+				],
+				"newmissedproofoutputs": [
+					{"value": "1232516258766241909102140813", "unlockhash": "9a712eceba9f0523522ff9f5687ef6a54e5299d27c632044cd20f207e809fcb306f8373fe12b"},
+					{"value": "278593489793967488506695049", "unlockhash": "f879ab09edd4b3650aed02ce6226d4f6a197409d42be84c310a5e86657879a85d9575dc51a0d"},
+					{"value": "27501379672345244554332440", "unlockhash": "000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"}
+				],
+				"newunlockhash": "4440e7ad4a744a1745797f9180b08aeeb1aa42c3c12729ed063f6ef4897f2cf7599a9efe4059"
+			},
+			"lastrevisiontxn": {
+				"filecontractrevisions": [
+					{
+						"parentid": "87893a702b4af71151a853229f7dd4071929b24b4bf1c39bafec551daeaf11de",
+						"unlockconditions": {
+							"timelock": 0,
+							"publickeys": [
+								{"algorithm": "ed25519", "key": "ux0dwMoOTt2Q+VlmSy3G59nIn5kwWPrZMUKFphJgIGM="},
+								{"algorithm": "ed25519", "key": "5rgAREJJuMrmHfS3vWV0TN2Y8cHZf8UU2CM8BBFX5q4="}
+							],
+							"signaturesrequired": 2
+						},
+						"newrevisionnumber": 117,
+						"newfilesize": 465567744,
+						"newfilemerkleroot": "449af205a10e645324c9016062e843856538122e4044e18b6e93aaab960cd8e6",
+						"newwindowstart": 101748,
+						"newwindowend": 101892,
+						"newvalidproofoutputs": [
+							{"value": "1232516258766241909102140813", "unlockhash": "9a712eceba9f0523522ff9f5687ef6a54e5299d27c632044cd20f207e809fcb306f8373fe12b"},
+							{"value": "306094869466312733061027489", "unlockhash": "f879ab09edd4b3650aed02ce6226d4f6a197409d42be84c310a5e86657879a85d9575dc51a0d"}
+						],
+						"newmissedproofoutputs": [
+							{"value": "1232516258766241909102140813", "unlockhash": "9a712eceba9f0523522ff9f5687ef6a54e5299d27c632044cd20f207e809fcb306f8373fe12b"},
+							{"value": "278593489793967488506695049", "unlockhash": "f879ab09edd4b3650aed02ce6226d4f6a197409d42be84c310a5e86657879a85d9575dc51a0d"},
+							{"value": "27501379672345244554332440", "unlockhash": "000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"}
+						],
+						"newunlockhash": "4440e7ad4a744a1745797f9180b08aeeb1aa42c3c12729ed063f6ef4897f2cf7599a9efe4059"
+					}
+				],
+				"transactionsignatures": [
+					{
+						"parentid": "87893a702b4af71151a853229f7dd4071929b24b4bf1c39bafec551daeaf11de",
+						"publickeyindex": 0,
+						"coveredfields": {
+							"wholetransaction": false,
+							"filecontractrevisions": [0]
+						},
+						"signature": "zs1T+NO5sFR6jVgilYXxJx33gPhd4Y7KRjpsKAG4EFZ7cthgBidXIDkTbOknk8P9Al7bDj1Dq6PMt+Mgvb+tBg=="
+					},
+					{
+						"parentid": "87893a702b4af71151a853229f7dd4071929b24b4bf1c39bafec551daeaf11de",
+						"publickeyindex": 1,
+						"timelock": 0,
+						"coveredfields": {
+							"wholetransaction": false,
+							"filecontractrevisions": [0]
+						},
+						"signature": "5jxxxqSaKF/KXNT8oWHiesiHl6l+GHH+zDCSxe3UsQJS+LyB+NY6k+AoQ+7l8ysA5rt/MXt08Gh+iFc95StJCQ=="
+					}
+				]
+			},
+			"merkleroots": [
+				"5d8c2b8ecb23b0cbbb842f236bca90f0f9a684c0d49e5008fa356a3c75d83764",
+				"35e9e31000bdfc6adf1eddbe13d2e584bc274f803f03b23bbf1ac3b3334b7335",
+				"9f6b52ff2b68da078648f073e119d030a69137020792bb6ba601590aead4ab76",
+				"c327be1fc31360c40f6ed5cd729354f20c820f31970a1093cadd914ab55bfed9",
+				"749df474d6ff4c306f8ca8695af352e3596724a286171f495097599b6d6bda61"
+			],
+			"netaddress": "88.196.244.208:5982",
+			"secretkey": [0,0,0,0,0],
+			"startheight": 88793,
+			"downloadspending": "83886080000000000000000",
+			"storagespending": "25189293437743169757705777",
+			"uploadspending": "462296186880000000819500",
+			"totalcost": "1351052162572897650533988302",
+			"contractfee": "30000000000000000000000000",
+			"txnfee": "10240000000000000000000000",
+			"siafundfee": "62441034340343008370820000"
+		}
+	],
+	"CurrentPeriod": 88788,
+	"LastChange": [194,19,235,129,22,141,244,238,202,1,240,253,223,37,173,182,252,119,197,154,77,226,137,98,242,231,164,201,34,102,96,194],
+	"OldContracts": null,
+	"RenewedIDs": {}
+}
+`), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// load will fail to load journal, fall back to loading contractor.json,
+	// and save data as a new journal
+	p := newPersist(dir)
+	var data contractorPersist
+	err = p.load(&data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	// second load should find the journal
+	var data2 contractorPersist
+	p = newPersist(dir)
+	err = p.load(&data2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	if !reflect.DeepEqual(data, data2) {
+		t.Fatal("data mismatch after loading old persist:", data, data2)
 	}
 }
 

--- a/modules/renter/contractor/journal_test.go
+++ b/modules/renter/contractor/journal_test.go
@@ -1,11 +1,14 @@
 package contractor
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 func tempFile(t interface {
@@ -23,8 +26,8 @@ func tempFile(t interface {
 
 func tempJournal(t interface {
 	Fatal(...interface{})
-}, obj interface{}, name string) (*journal, func()) {
-	j, err := openJournal(filepath.Join(build.TempDir("contractor", name)), obj)
+}, name string) (*journal, func()) {
+	j, err := newJournal(filepath.Join(build.TempDir("contractor", name)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,21 +38,11 @@ func tempJournal(t interface {
 }
 
 func TestJournal(t *testing.T) {
-	type bar struct {
-		Z int `json:"z"`
-	}
-	type foo struct {
-		X int   `json:"x"`
-		Y []bar `json:"y"`
-	}
-
-	j, cleanup := tempJournal(t, foo{Y: []bar{}}, "TestJournal")
+	j, cleanup := tempJournal(t, "TestJournal")
 	defer cleanup()
 
 	us := []journalUpdate{
-		newJournalUpdate("x", 7),
-		newJournalUpdate("y.0", bar{}),
-		newJournalUpdate("y.0.z", 3),
+		updateCachedDownloadRevision{Revision: types.FileContractRevision{}},
 	}
 	if err := j.update(us); err != nil {
 		t.Fatal(err)
@@ -58,44 +51,38 @@ func TestJournal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var f foo
-	j2, err := openJournal(j.filename, &f)
+	var data contractorPersist
+	j2, err := openJournal(j.filename, &data)
 	if err != nil {
 		t.Fatal(err)
 	}
 	j2.Close()
-	if f.X != 7 || len(f.Y) != 1 || f.Y[0].Z != 3 {
-		t.Fatal("openJournal applied updates incorrectly:", f)
+	if len(data.CachedRevisions) != 1 {
+		t.Fatal("openJournal applied updates incorrectly:", data)
 	}
 }
 
 func TestJournalCheckpoint(t *testing.T) {
-	type bar struct {
-		Z int `json:"z"`
-	}
-	type foo struct {
-		X int   `json:"x"`
-		Y []bar `json:"y"`
-	}
-
-	j, cleanup := tempJournal(t, foo{Y: []bar{}}, "TestJournalCheckpoint")
+	j, cleanup := tempJournal(t, "TestJournalCheckpoint")
 	defer cleanup()
 
-	if err := j.checkpoint(bar{3}); err != nil {
+	var data contractorPersist
+	data.BlockHeight = 777
+	if err := j.checkpoint(data); err != nil {
 		t.Fatal(err)
 	}
 	if err := j.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	var b bar
-	j2, err := openJournal(j.filename, &b)
+	data.BlockHeight = 0
+	j2, err := openJournal(j.filename, &data)
 	if err != nil {
 		t.Fatal(err)
 	}
 	j2.Close()
-	if b.Z != 3 {
-		t.Fatal("checkpoint failed:", b.Z)
+	if data.BlockHeight != 777 {
+		t.Fatal("checkpoint failed:", data)
 	}
 }
 
@@ -104,444 +91,23 @@ func TestJournalMalformed(t *testing.T) {
 	defer cleanup()
 
 	// write a partially-malformed log
-	f.WriteString(`{"foo": 3}
-[{"p": "foo", "v": 4}]
-[{"p": "foo", "v": 5}`)
+	f.WriteString(`{"cachedrevisions":{}}
+[{"t":"cachedDownloadRevision","d":{"revision":{"parentid":"1000000000000000000000000000000000000000000000000000000000000000"}}}]
+[{"t":"cachedDownloadRevision","d":{"revision":{"parentid":"2000000000000000000000000000000000000000000000000000000000000000"
+`)
 	f.Close()
 
-	// load log into foo
-	var foo struct {
-		Foo int `json:"foo"`
-	}
-	j, err := openJournal(f.Name(), &foo)
+	// load log
+	var data contractorPersist
+	j, err := openJournal(f.Name(), &data)
 	if err != nil {
 		t.Fatal(err)
 	}
 	j.Close()
 
 	// the last update set should have been discarded
-	if foo.Foo != 4 {
-		t.Fatal("log was not applied correctly:", foo.Foo)
-	}
-}
-
-func TestRewritePath(t *testing.T) {
-	tests := []struct {
-		json string
-		path string
-		val  string
-		exp  string
-	}{
-		{``, ``, ``, ``},
-		{`"foo"`, ``, ``, ``},
-		{``, `foo`, ``, ``},
-		{``, ``, `"foo"`, `"foo"`},
-		{`"foo"`, ``, `"bar"`, `"bar"`},
-		// object
-		{`{"foo":"bar"}`, `bar`, `"baz"`, `{"foo":"bar"}`},
-		{`{"foo":"bar"}`, `foo`, `"baz"`, `{"foo":"baz"}`},
-		{`{"foo":"bar", "bar":"baz"}`, `bar`, `"quux"`, `{"foo":"bar", "bar":"quux"}`},
-		{`{"foo": {"bar": "baz"}}`, `foo.bar`, `"quux"`, `{"foo": {"bar": "quux"}}`},
-		// array
-		{`[]`, `foo`, `"bar"`, `[]`},
-		{`[1]`, `0`, `"bar"`, `["bar"]`},
-		{`[1, 2]`, `0`, `"bar"`, `["bar", 2]`},
-		{`[1, 2]`, `1`, `"bar"`, `[1, "bar"]`},
-		{`[]`, `0`, `"bar"`, `["bar"]`},
-		{`[1]`, `1`, `"bar"`, `[1,"bar"]`},
-		{`["foo", "bar"]`, `2`, `"baz"`, `["foo", "bar","baz"]`},
-		{`[[1,2], [3,4]]`, `1.0`, `"baz"`, `[[1,2], ["baz",4]]`},
-		{`[[1,2], [3,4]]`, `1.2`, `"baz"`, `[[1,2], [3,4,"baz"]]`},
-		{`[[1,2], [3,4]]`, `2.0`, `"baz"`, `[[1,2], [3,4]]`},
-		{`[[1,2], [3,4]]`, `2`, `"baz"`, `[[1,2], [3,4],"baz"]`},
-		// array in object
-		{`{"foo": [1,2]}`, `foo.0`, `"bar"`, `{"foo": ["bar",2]}`},
-		{`{"foo": [1,2]}`, `foo.2`, `"bar"`, `{"foo": [1,2,"bar"]}`},
-		{`{"foo": [1,2]}`, `bar.2`, `"bar"`, `{"foo": [1,2]}`},
-		// object in array
-		{`[{"foo": "bar"}]`, `0.foo`, `"baz"`, `[{"foo": "baz"}]`},
-		{`[{}, {"foo": "bar"}]`, `1.foo`, `"baz"`, `[{}, {"foo": "baz"}]`},
-		{`[{"foo": "bar"}]`, `1.foo`, `"baz"`, `[{"foo": "bar"}]`},
-		// monster
-		{`{"foo": [{}, {"bar": [{"baz":""}]}}]`, `foo.1.bar.0.baz`, `"quux"`, `{"foo": [{}, {"bar": [{"baz":"quux"}]}}]`},
-	}
-	for _, test := range tests {
-		if res := rewritePath([]byte(test.json), test.path, []byte(test.val)); string(res) != test.exp {
-			t.Errorf("rewritePath('%s', %q, '%s'): expected '%s', got '%s'", test.json, test.path, test.val, test.exp, res)
-		}
-	}
-}
-
-func TestLocateAccessor(t *testing.T) {
-	tests := []struct {
-		json string
-		acc  string
-		loc  int
-	}{
-		// object
-		{`{}`, `foo`, -1},
-		{`{"foo":0}`, `foo`, 7},
-		{`{"foo":0}`, `bar`, -1},
-		{`{"foo":0}3`, `foo`, 7},
-		{`{"foo":0} 3`, `foo`, 7},
-		{`{"foo":0,"bar":7}`, `bar`, len(`{"foo":0,"bar":`)},
-		{`{"foo":0 , "bar":7}`, `bar`, len(`{"foo":0 , "bar":`)},
-		{`{"foo":0,"bar":7}3`, `bar`, len(`{"foo":0,"bar":`)},
-		{`{"foo":0,"bar":7} 3`, `bar`, len(`{"foo":0,"bar":`)},
-		// array
-		{`[1,2,3]`, `0`, 1},
-		{`[1,2,3]`, `1`, 3},
-		{`[1,2,3]`, `2`, 5},
-		{`[1,2,3]`, `3`, 6}, // special case
-		{`[1,2,3]`, `4`, -1},
-		{`[1,2,3]`, `foo`, -1},
-		{`[]`, `0`, 1},
-		{`[]`, `1`, -1},
-		// string
-		{`"foo"`, `foo`, -1},
-		{`"{\"foo\": 3}"`, `foo`, -1},
-		// number
-		{`3`, `foo`, -1},
-		{`3`, `3`, -1},
-	}
-	for _, test := range tests {
-		if loc := locateAccessor([]byte(test.json), test.acc); loc != test.loc {
-			t.Errorf("locateAccessor('%s', %q): expected %v, got %v", test.json, test.acc, test.loc, loc)
-		}
-	}
-}
-
-func TestParseString(t *testing.T) {
-	tests := []struct {
-		json string
-		str  string
-		rest string
-	}{
-		{`""`, ``, ``},
-		{`"foo"`, `foo`, ``},
-		{`"foo":"bar"`, `foo`, `:"bar"`},
-		{`"foo" : "bar"`, `foo`, ` : "bar"`},
-		{`"foo\"bar"`, `foo\"bar`, ``},
-		{`"foo\"bar":"baz"`, `foo\"bar`, `:"baz"`},
-		{`"foo\\\"bar":"baz"`, `foo\\\"bar`, `:"baz"`},
-	}
-	for _, test := range tests {
-		if str, rest := parseString([]byte(test.json)); string(str) != test.str || string(rest) != test.rest {
-			t.Errorf("parseString('%s'): expected (%q, '%s'), got (%q, '%s')", test.json, test.str, test.rest, str, rest)
-		}
-	}
-}
-
-func TestConsumeWhitespace(t *testing.T) {
-	tests := []struct {
-		json string
-		rest string
-	}{
-		{" ", ``},
-		{" 3", `3`},
-		{"\t", ``},
-		{"\t3", `3`},
-		{"\n", ``},
-		{"\n3", `3`},
-		{"\r", ``},
-		{"\r3", `3`},
-		{" \t\n\r", ``},
-		{" \t\n\r3", `3`},
-	}
-	for _, test := range tests {
-		if rest := consumeWhitespace([]byte(test.json)); string(rest) != test.rest {
-			t.Errorf("consumeWhitespace('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
-		}
-	}
-}
-
-func TestConsumeSeparator(t *testing.T) {
-	tests := []struct {
-		json string
-		rest string
-	}{
-		{"[", ``},
-		{"[ \r\n\t", ``},
-		{"[3", `3`},
-		{"[ \r\n\t3", `3`},
-		{"{", ``},
-		{"{ \r\n\t", ``},
-		{"{3", `3`},
-		{"{ \r\n\t3", `3`},
-		{"}", ``},
-		{"} \r\n\t", ``},
-		{"}3", `3`},
-		{"} \r\n\t3", `3`},
-		{"]", ``},
-		{"] \r\n\t", ``},
-		{"]3", `3`},
-		{"] \r\n\t3", `3`},
-		{":", ``},
-		{": \r\n\t", ``},
-		{":3", `3`},
-		{": \r\n\t3", `3`},
-		{",", ``},
-		{", \r\n\t", ``},
-		{",3", `3`},
-		{", \r\n\t3", `3`},
-	}
-	for _, test := range tests {
-		if rest := consumeSeparator([]byte(test.json)); string(rest) != test.rest {
-			t.Errorf("consumeSeparator('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
-		}
-	}
-}
-
-func TestConsumeValue(t *testing.T) {
-	tests := []struct {
-		json string
-		rest string
-	}{
-		// object
-		{`{}`, ``},
-		{`{}3`, `3`},
-		{`{} 3`, ` 3`},
-		{`{"foo":0}`, ``},
-		{`{"foo":0}3`, `3`},
-		{`{"foo":0} 3`, ` 3`},
-		{`{"foo":0,"bar":7}`, ``},
-		{`{"foo":0,"bar":7}3`, `3`},
-		{`{"foo":0,"bar":7} 3`, ` 3`},
-		{`{"foo":0 , "bar":7}`, ``},
-		{`{"foo":0 , "bar":7}3`, `3`},
-		{`{"foo":0 , "bar":7} 3`, ` 3`},
-		{`{"":""}`, ``},
-		{`{"":""}3`, `3`},
-		{`{"":""} 3`, ` 3`},
-		{`{"}":"}"}`, ``},
-		{`{"}":"}"}3`, `3`},
-		{`{"}":"}"} 3`, ` 3`},
-		{`{"":{}}`, ``},
-		{`{"":{}}3`, `3`},
-		{`{"":{}} 3`, ` 3`},
-		{`{"}":["}{"]}`, ``},
-		{`{"}":["}{"]}3`, `3`},
-		{`{"}":["}{"]} 3`, ` 3`},
-		{`{"":{"":{"":{}}}}`, ``},
-		{`{"":{"":{"":{}}}}3`, `3`},
-		{`{"":{"":{"":{}}}} 3`, ` 3`},
-		// array
-		{`[]`, ``},
-		{`[]3`, `3`},
-		{`[] 3`, ` 3`},
-		{`[0]`, ``},
-		{`[0]3`, `3`},
-		{`[0] 3`, ` 3`},
-		{`[0,1]`, ``},
-		{`[0,1]3`, `3`},
-		{`[0,1] 3`, ` 3`},
-		{`[0 , 1]`, ``},
-		{`[0 , 1]3`, `3`},
-		{`[0 , 1] 3`, ` 3`},
-		{`["", ""]`, ``},
-		{`["", ""]3`, `3`},
-		{`["", ""] 3`, ` 3`},
-		{`[[], []]`, ``},
-		{`[[], []]3`, `3`},
-		{`[[], []] 3`, ` 3`},
-		{`["[", "]"]`, ``},
-		{`["[", "]"]3`, `3`},
-		{`["[", "]"] 3`, ` 3`},
-		{`[["]", "]"], [{"foo":[]}]]`, ``},
-		{`[["]", "]"], [{"foo":[]}]]3`, `3`},
-		{`[["]", "]"], [{"foo":[]}]] 3`, ` 3`},
-		// string
-		{`""`, ``},
-		{`"foo"`, ``},
-		{`"foo":"bar"`, `:"bar"`},
-		{`"foo" : "bar"`, ` : "bar"`},
-		{`"foo\"bar"`, ``},
-		{`"foo\"bar":"baz"`, `:"baz"`},
-		// true, false, null
-		{`true`, ``},
-		{`false`, ``},
-		{`null`, ``},
-		{`true3`, `3`},
-		{`false3`, `3`},
-		{`null3`, `3`},
-		{`true 3`, ` 3`},
-		{`false 3`, ` 3`},
-		{`null 3`, ` 3`},
-		// number
-		{`-0`, ``},
-		{`-0 true`, ` true`},
-		{`0`, ``},
-		{`0 true`, ` true`},
-		{`0.0`, ``},
-		{`0.0 true`, ` true`},
-		{`1.0`, ``},
-		{`1.0 true`, ` true`},
-		{`10`, ``},
-		{`10 true`, ` true`},
-		{`10.1`, ``},
-		{`10.1 true`, ` true`},
-		{`1e7`, ``},
-		{`1e7 true`, ` true`},
-		{`1e+7`, ``},
-		{`1e+7 true`, ` true`},
-		{`1e-7`, ``},
-		{`1e-7 true`, ` true`},
-		{`1.0e7`, ``},
-		{`1.0e7 true`, ` true`},
-		{`1.0e+7`, ``},
-		{`1.0e+7 true`, ` true`},
-		{`1.0e-7`, ``},
-		{`1.0e-7 true`, ` true`},
-		{`10.1e7`, ``},
-		{`10.1e7 true`, ` true`},
-		{`10.1e+7`, ``},
-		{`10.1e+7 true`, ` true`},
-		{`10.1e-7`, ``},
-		{`10.1e-7 true`, ` true`},
-	}
-	for _, test := range tests {
-		if rest := consumeValue([]byte(test.json)); string(rest) != test.rest {
-			t.Errorf("consumeValue('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
-		}
-	}
-}
-
-func TestConsumeObject(t *testing.T) {
-	tests := []struct {
-		json string
-		rest string
-	}{
-		{`{}`, ``},
-		{`{}3`, `3`},
-		{`{} 3`, ` 3`},
-		{`{"foo":0}`, ``},
-		{`{"foo":0}3`, `3`},
-		{`{"foo":0} 3`, ` 3`},
-		{`{"foo":0,"bar":7}`, ``},
-		{`{"foo":0,"bar":7}3`, `3`},
-		{`{"foo":0,"bar":7} 3`, ` 3`},
-		{`{"foo":0 , "bar":7}`, ``},
-		{`{"foo":0 , "bar":7}3`, `3`},
-		{`{"foo":0 , "bar":7} 3`, ` 3`},
-		{`{"":""}`, ``},
-		{`{"":""}3`, `3`},
-		{`{"":""} 3`, ` 3`},
-		{`{"}":"}"}`, ``},
-		{`{"}":"}"}3`, `3`},
-		{`{"}":"}"} 3`, ` 3`},
-		{`{"":{}}`, ``},
-		{`{"":{}}3`, `3`},
-		{`{"":{}} 3`, ` 3`},
-		{`{"}":["}{"]}`, ``},
-		{`{"}":["}{"]}3`, `3`},
-		{`{"}":["}{"]} 3`, ` 3`},
-		{`{"":{"":{"":{}}}}`, ``},
-		{`{"":{"":{"":{}}}}3`, `3`},
-		{`{"":{"":{"":{}}}} 3`, ` 3`},
-	}
-	for _, test := range tests {
-		if rest := consumeObject([]byte(test.json)); string(rest) != test.rest {
-			t.Errorf("consumeObject('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
-		}
-	}
-}
-
-func TestConsumeArray(t *testing.T) {
-	tests := []struct {
-		json string
-		rest string
-	}{
-		{`[]`, ``},
-		{`[]3`, `3`},
-		{`[] 3`, ` 3`},
-		{`[0]`, ``},
-		{`[0]3`, `3`},
-		{`[0] 3`, ` 3`},
-		{`[0,1]`, ``},
-		{`[0,1]3`, `3`},
-		{`[0,1] 3`, ` 3`},
-		{`[0 , 1]`, ``},
-		{`[0 , 1]3`, `3`},
-		{`[0 , 1] 3`, ` 3`},
-		{`["", ""]`, ``},
-		{`["", ""]3`, `3`},
-		{`["", ""] 3`, ` 3`},
-		{`[[], []]`, ``},
-		{`[[], []]3`, `3`},
-		{`[[], []] 3`, ` 3`},
-		{`["[", "]"]`, ``},
-		{`["[", "]"]3`, `3`},
-		{`["[", "]"] 3`, ` 3`},
-		{`[["]", "]"], [{"foo":[]}]]`, ``},
-		{`[["]", "]"], [{"foo":[]}]]3`, `3`},
-		{`[["]", "]"], [{"foo":[]}]] 3`, ` 3`},
-	}
-	for _, test := range tests {
-		if rest := consumeArray([]byte(test.json)); string(rest) != test.rest {
-			t.Errorf("consumeArray('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
-		}
-	}
-}
-
-func TestConsumeString(t *testing.T) {
-	tests := []struct {
-		json string
-		rest string
-	}{
-		{`""`, ``},
-		{`"foo"`, ``},
-		{`"foo":"bar"`, `:"bar"`},
-		{`"foo" : "bar"`, ` : "bar"`},
-		{`"foo\"bar"`, ``},
-		{`"foo\"bar":"baz"`, `:"baz"`},
-	}
-	for _, test := range tests {
-		if rest := consumeString([]byte(test.json)); string(rest) != test.rest {
-			t.Errorf("consumeString('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
-		}
-	}
-}
-
-func TestConsumeNumber(t *testing.T) {
-	tests := []struct {
-		json string
-		rest string
-	}{
-		{`-0`, ``},
-		{`-0 true`, ` true`},
-		{`0`, ``},
-		{`0 true`, ` true`},
-		{`0.0`, ``},
-		{`0.0 true`, ` true`},
-		{`1.0`, ``},
-		{`1.0 true`, ` true`},
-		{`10`, ``},
-		{`10 true`, ` true`},
-		{`10.1`, ``},
-		{`10.1 true`, ` true`},
-		{`1e7`, ``},
-		{`1e7 true`, ` true`},
-		{`1e+7`, ``},
-		{`1e+7 true`, ` true`},
-		{`1e-7`, ``},
-		{`1e-7 true`, ` true`},
-		{`1.0e7`, ``},
-		{`1.0e7 true`, ` true`},
-		{`1.0e+7`, ``},
-		{`1.0e+7 true`, ` true`},
-		{`1.0e-7`, ``},
-		{`1.0e-7 true`, ` true`},
-		{`10.1e7`, ``},
-		{`10.1e7 true`, ` true`},
-		{`10.1e+7`, ``},
-		{`10.1e+7 true`, ` true`},
-		{`10.1e-7`, ``},
-		{`10.1e-7 true`, ` true`},
-	}
-	for _, test := range tests {
-		if rest := consumeNumber([]byte(test.json)); string(rest) != test.rest {
-			t.Errorf("consumeNumber('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
-		}
+	if _, ok := data.CachedRevisions["1000000000000000000000000000000000000000000000000000000000000000"]; !ok {
+		t.Fatal("log was not applied correctly:", data)
 	}
 }
 
@@ -550,22 +116,34 @@ func BenchmarkUpdateJournal(b *testing.B) {
 	defer cleanup()
 
 	j := &journal{f: f}
-	us := []journalUpdate{
-		newJournalUpdate("foo.bar", struct{ X, Y int }{3, 4}),
-		newJournalUpdate("foo.bar", nil),
+	us := updateSet{
+		updateCachedUploadRevision{
+			Revision: types.FileContractRevision{
+				NewValidProofOutputs:  []types.SiacoinOutput{{}, {}},
+				NewMissedProofOutputs: []types.SiacoinOutput{{}, {}},
+				UnlockConditions:      types.UnlockConditions{PublicKeys: []types.SiaPublicKey{{}, {}}},
+			},
+		},
+		updateUploadRevision{
+			NewRevisionTxn: types.Transaction{
+				FileContractRevisions: []types.FileContractRevision{{
+					NewValidProofOutputs:  []types.SiacoinOutput{{}, {}},
+					NewMissedProofOutputs: []types.SiacoinOutput{{}, {}},
+					UnlockConditions:      types.UnlockConditions{PublicKeys: []types.SiaPublicKey{{}, {}}},
+				}},
+				TransactionSignatures: []types.TransactionSignature{{}, {}},
+			},
+			NewUploadSpending:  types.SiacoinPrecision,
+			NewStorageSpending: types.SiacoinPrecision,
+		},
 	}
-
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(us)
+	b.SetBytes(int64(buf.Len()))
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := j.update(us); err != nil {
 			b.Fatal(err)
 		}
-	}
-}
-
-func BenchmarkApply(b *testing.B) {
-	u := newJournalUpdate("foo.bar.baz", "")
-	json := []byte(`{"foo": {"bar": {"baz": "quux"}}}`)
-	for i := 0; i < b.N; i++ {
-		u.apply(json)
 	}
 }

--- a/modules/renter/contractor/journal_test.go
+++ b/modules/renter/contractor/journal_test.go
@@ -28,7 +28,7 @@ func tempFile(t interface {
 func tempJournal(t interface {
 	Fatal(...interface{})
 }, name string) (*journal, func()) {
-	j, err := newJournal(filepath.Join(build.TempDir("contractor", name)))
+	j, err := newJournal(filepath.Join(build.TempDir("contractor", name)), contractorPersist{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/journal_test.go
+++ b/modules/renter/contractor/journal_test.go
@@ -1,0 +1,544 @@
+package contractor
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func tempFile(t interface {
+	Fatal(...interface{})
+}, name string) (*os.File, func()) {
+	f, err := ioutil.TempFile("", name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f, func() {
+		f.Close()
+		os.RemoveAll(f.Name())
+	}
+}
+
+func tempJournal(t interface {
+	Fatal(...interface{})
+}, obj interface{}, name string) (*journal, func()) {
+	f, err := ioutil.TempFile("", name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	j, err := openJournal(f.Name(), obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return j, func() {
+		j.Close()
+		os.RemoveAll(f.Name())
+	}
+}
+
+func TestJournal(t *testing.T) {
+	type bar struct {
+		Z int `json:"z"`
+	}
+	type foo struct {
+		X int   `json:"x"`
+		Y []bar `json:"y"`
+	}
+
+	j, cleanup := tempJournal(t, foo{Y: []bar{}}, "TestJournal")
+	defer cleanup()
+
+	us := []journalUpdate{
+		newJournalUpdate("x", 7),
+		newJournalUpdate("y.0", bar{}),
+		newJournalUpdate("y.0.z", 3),
+	}
+	if err := j.update(us); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var f foo
+	j2, err := openJournal(j.filename, &f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j2.Close()
+	if f.X != 7 || len(f.Y) != 1 || f.Y[0].Z != 3 {
+		t.Fatal("openJournal applied updates incorrectly:", f)
+	}
+}
+
+func TestJournalMalformed(t *testing.T) {
+	f, cleanup := tempFile(t, "TestJournalMalformed")
+	defer cleanup()
+
+	// write a partially-malformed log
+	f.WriteString(`{"foo": 3}
+[{"p": "foo", "v": 4}]
+[{"p": "foo", "v": 5}`)
+	f.Close()
+
+	// load log into foo
+	var foo struct {
+		Foo int `json:"foo"`
+	}
+	j, err := openJournal(f.Name(), &foo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j.Close()
+
+	// the last update set should have been discarded
+	if foo.Foo != 4 {
+		t.Fatal("log was not applied correctly:", foo.Foo)
+	}
+}
+
+func TestRewritePath(t *testing.T) {
+	tests := []struct {
+		json string
+		path string
+		val  string
+		exp  string
+	}{
+		{``, ``, ``, ``},
+		{`"foo"`, ``, ``, ``},
+		{``, `foo`, ``, ``},
+		{``, ``, `"foo"`, `"foo"`},
+		{`"foo"`, ``, `"bar"`, `"bar"`},
+		// object
+		{`{"foo":"bar"}`, `bar`, `"baz"`, `{"foo":"bar"}`},
+		{`{"foo":"bar"}`, `foo`, `"baz"`, `{"foo":"baz"}`},
+		{`{"foo":"bar", "bar":"baz"}`, `bar`, `"quux"`, `{"foo":"bar", "bar":"quux"}`},
+		{`{"foo": {"bar": "baz"}}`, `foo.bar`, `"quux"`, `{"foo": {"bar": "quux"}}`},
+		// array
+		{`[]`, `foo`, `"bar"`, `[]`},
+		{`[1]`, `0`, `"bar"`, `["bar"]`},
+		{`[1, 2]`, `0`, `"bar"`, `["bar", 2]`},
+		{`[1, 2]`, `1`, `"bar"`, `[1, "bar"]`},
+		{`[]`, `0`, `"bar"`, `["bar"]`},
+		{`[1]`, `1`, `"bar"`, `[1,"bar"]`},
+		{`["foo", "bar"]`, `2`, `"baz"`, `["foo", "bar","baz"]`},
+		{`[[1,2], [3,4]]`, `1.0`, `"baz"`, `[[1,2], ["baz",4]]`},
+		{`[[1,2], [3,4]]`, `1.2`, `"baz"`, `[[1,2], [3,4,"baz"]]`},
+		{`[[1,2], [3,4]]`, `2.0`, `"baz"`, `[[1,2], [3,4]]`},
+		{`[[1,2], [3,4]]`, `2`, `"baz"`, `[[1,2], [3,4],"baz"]`},
+		// array in object
+		{`{"foo": [1,2]}`, `foo.0`, `"bar"`, `{"foo": ["bar",2]}`},
+		{`{"foo": [1,2]}`, `foo.2`, `"bar"`, `{"foo": [1,2,"bar"]}`},
+		{`{"foo": [1,2]}`, `bar.2`, `"bar"`, `{"foo": [1,2]}`},
+		// object in array
+		{`[{"foo": "bar"}]`, `0.foo`, `"baz"`, `[{"foo": "baz"}]`},
+		{`[{}, {"foo": "bar"}]`, `1.foo`, `"baz"`, `[{}, {"foo": "baz"}]`},
+		{`[{"foo": "bar"}]`, `1.foo`, `"baz"`, `[{"foo": "bar"}]`},
+		// monster
+		{`{"foo": [{}, {"bar": [{"baz":""}]}}]`, `foo.1.bar.0.baz`, `"quux"`, `{"foo": [{}, {"bar": [{"baz":"quux"}]}}]`},
+	}
+	for _, test := range tests {
+		if res := rewritePath([]byte(test.json), test.path, []byte(test.val)); string(res) != test.exp {
+			t.Errorf("rewritePath('%s', %q, '%s'): expected '%s', got '%s'", test.json, test.path, test.val, test.exp, res)
+		}
+	}
+}
+
+func TestLocateAccessor(t *testing.T) {
+	tests := []struct {
+		json string
+		acc  string
+		loc  int
+	}{
+		// object
+		{`{}`, `foo`, -1},
+		{`{"foo":0}`, `foo`, 7},
+		{`{"foo":0}`, `bar`, -1},
+		{`{"foo":0}3`, `foo`, 7},
+		{`{"foo":0} 3`, `foo`, 7},
+		{`{"foo":0,"bar":7}`, `bar`, len(`{"foo":0,"bar":`)},
+		{`{"foo":0 , "bar":7}`, `bar`, len(`{"foo":0 , "bar":`)},
+		{`{"foo":0,"bar":7}3`, `bar`, len(`{"foo":0,"bar":`)},
+		{`{"foo":0,"bar":7} 3`, `bar`, len(`{"foo":0,"bar":`)},
+		// array
+		{`[1,2,3]`, `0`, 1},
+		{`[1,2,3]`, `1`, 3},
+		{`[1,2,3]`, `2`, 5},
+		{`[1,2,3]`, `3`, 6}, // special case
+		{`[1,2,3]`, `4`, -1},
+		{`[1,2,3]`, `foo`, -1},
+		{`[]`, `0`, 1},
+		{`[]`, `1`, -1},
+		// string
+		{`"foo"`, `foo`, -1},
+		{`"{\"foo\": 3}"`, `foo`, -1},
+		// number
+		{`3`, `foo`, -1},
+		{`3`, `3`, -1},
+	}
+	for _, test := range tests {
+		if loc := locateAccessor([]byte(test.json), test.acc); loc != test.loc {
+			t.Errorf("locateAccessor('%s', %q): expected %v, got %v", test.json, test.acc, test.loc, loc)
+		}
+	}
+}
+
+func TestParseString(t *testing.T) {
+	tests := []struct {
+		json string
+		str  string
+		rest string
+	}{
+		{`""`, ``, ``},
+		{`"foo"`, `foo`, ``},
+		{`"foo":"bar"`, `foo`, `:"bar"`},
+		{`"foo" : "bar"`, `foo`, ` : "bar"`},
+		{`"foo\"bar"`, `foo\"bar`, ``},
+		{`"foo\"bar":"baz"`, `foo\"bar`, `:"baz"`},
+		{`"foo\\\"bar":"baz"`, `foo\\\"bar`, `:"baz"`},
+	}
+	for _, test := range tests {
+		if str, rest := parseString([]byte(test.json)); string(str) != test.str || string(rest) != test.rest {
+			t.Errorf("parseString('%s'): expected (%q, '%s'), got (%q, '%s')", test.json, test.str, test.rest, str, rest)
+		}
+	}
+}
+
+func TestConsumeWhitespace(t *testing.T) {
+	tests := []struct {
+		json string
+		rest string
+	}{
+		{" ", ``},
+		{" 3", `3`},
+		{"\t", ``},
+		{"\t3", `3`},
+		{"\n", ``},
+		{"\n3", `3`},
+		{"\r", ``},
+		{"\r3", `3`},
+		{" \t\n\r", ``},
+		{" \t\n\r3", `3`},
+	}
+	for _, test := range tests {
+		if rest := consumeWhitespace([]byte(test.json)); string(rest) != test.rest {
+			t.Errorf("consumeWhitespace('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
+		}
+	}
+}
+
+func TestConsumeSeparator(t *testing.T) {
+	tests := []struct {
+		json string
+		rest string
+	}{
+		{"[", ``},
+		{"[ \r\n\t", ``},
+		{"[3", `3`},
+		{"[ \r\n\t3", `3`},
+		{"{", ``},
+		{"{ \r\n\t", ``},
+		{"{3", `3`},
+		{"{ \r\n\t3", `3`},
+		{"}", ``},
+		{"} \r\n\t", ``},
+		{"}3", `3`},
+		{"} \r\n\t3", `3`},
+		{"]", ``},
+		{"] \r\n\t", ``},
+		{"]3", `3`},
+		{"] \r\n\t3", `3`},
+		{":", ``},
+		{": \r\n\t", ``},
+		{":3", `3`},
+		{": \r\n\t3", `3`},
+		{",", ``},
+		{", \r\n\t", ``},
+		{",3", `3`},
+		{", \r\n\t3", `3`},
+	}
+	for _, test := range tests {
+		if rest := consumeSeparator([]byte(test.json)); string(rest) != test.rest {
+			t.Errorf("consumeSeparator('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
+		}
+	}
+}
+
+func TestConsumeValue(t *testing.T) {
+	tests := []struct {
+		json string
+		rest string
+	}{
+		// object
+		{`{}`, ``},
+		{`{}3`, `3`},
+		{`{} 3`, ` 3`},
+		{`{"foo":0}`, ``},
+		{`{"foo":0}3`, `3`},
+		{`{"foo":0} 3`, ` 3`},
+		{`{"foo":0,"bar":7}`, ``},
+		{`{"foo":0,"bar":7}3`, `3`},
+		{`{"foo":0,"bar":7} 3`, ` 3`},
+		{`{"foo":0 , "bar":7}`, ``},
+		{`{"foo":0 , "bar":7}3`, `3`},
+		{`{"foo":0 , "bar":7} 3`, ` 3`},
+		{`{"":""}`, ``},
+		{`{"":""}3`, `3`},
+		{`{"":""} 3`, ` 3`},
+		{`{"}":"}"}`, ``},
+		{`{"}":"}"}3`, `3`},
+		{`{"}":"}"} 3`, ` 3`},
+		{`{"":{}}`, ``},
+		{`{"":{}}3`, `3`},
+		{`{"":{}} 3`, ` 3`},
+		{`{"}":["}{"]}`, ``},
+		{`{"}":["}{"]}3`, `3`},
+		{`{"}":["}{"]} 3`, ` 3`},
+		{`{"":{"":{"":{}}}}`, ``},
+		{`{"":{"":{"":{}}}}3`, `3`},
+		{`{"":{"":{"":{}}}} 3`, ` 3`},
+		// array
+		{`[]`, ``},
+		{`[]3`, `3`},
+		{`[] 3`, ` 3`},
+		{`[0]`, ``},
+		{`[0]3`, `3`},
+		{`[0] 3`, ` 3`},
+		{`[0,1]`, ``},
+		{`[0,1]3`, `3`},
+		{`[0,1] 3`, ` 3`},
+		{`[0 , 1]`, ``},
+		{`[0 , 1]3`, `3`},
+		{`[0 , 1] 3`, ` 3`},
+		{`["", ""]`, ``},
+		{`["", ""]3`, `3`},
+		{`["", ""] 3`, ` 3`},
+		{`[[], []]`, ``},
+		{`[[], []]3`, `3`},
+		{`[[], []] 3`, ` 3`},
+		{`["[", "]"]`, ``},
+		{`["[", "]"]3`, `3`},
+		{`["[", "]"] 3`, ` 3`},
+		{`[["]", "]"], [{"foo":[]}]]`, ``},
+		{`[["]", "]"], [{"foo":[]}]]3`, `3`},
+		{`[["]", "]"], [{"foo":[]}]] 3`, ` 3`},
+		// string
+		{`""`, ``},
+		{`"foo"`, ``},
+		{`"foo":"bar"`, `:"bar"`},
+		{`"foo" : "bar"`, ` : "bar"`},
+		{`"foo\"bar"`, ``},
+		{`"foo\"bar":"baz"`, `:"baz"`},
+		// true, false, null
+		{`true`, ``},
+		{`false`, ``},
+		{`null`, ``},
+		{`true3`, `3`},
+		{`false3`, `3`},
+		{`null3`, `3`},
+		{`true 3`, ` 3`},
+		{`false 3`, ` 3`},
+		{`null 3`, ` 3`},
+		// number
+		{`-0`, ``},
+		{`-0 true`, ` true`},
+		{`0`, ``},
+		{`0 true`, ` true`},
+		{`0.0`, ``},
+		{`0.0 true`, ` true`},
+		{`1.0`, ``},
+		{`1.0 true`, ` true`},
+		{`10`, ``},
+		{`10 true`, ` true`},
+		{`10.1`, ``},
+		{`10.1 true`, ` true`},
+		{`1e7`, ``},
+		{`1e7 true`, ` true`},
+		{`1e+7`, ``},
+		{`1e+7 true`, ` true`},
+		{`1e-7`, ``},
+		{`1e-7 true`, ` true`},
+		{`1.0e7`, ``},
+		{`1.0e7 true`, ` true`},
+		{`1.0e+7`, ``},
+		{`1.0e+7 true`, ` true`},
+		{`1.0e-7`, ``},
+		{`1.0e-7 true`, ` true`},
+		{`10.1e7`, ``},
+		{`10.1e7 true`, ` true`},
+		{`10.1e+7`, ``},
+		{`10.1e+7 true`, ` true`},
+		{`10.1e-7`, ``},
+		{`10.1e-7 true`, ` true`},
+	}
+	for _, test := range tests {
+		if rest := consumeValue([]byte(test.json)); string(rest) != test.rest {
+			t.Errorf("consumeValue('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
+		}
+	}
+}
+
+func TestConsumeObject(t *testing.T) {
+	tests := []struct {
+		json string
+		rest string
+	}{
+		{`{}`, ``},
+		{`{}3`, `3`},
+		{`{} 3`, ` 3`},
+		{`{"foo":0}`, ``},
+		{`{"foo":0}3`, `3`},
+		{`{"foo":0} 3`, ` 3`},
+		{`{"foo":0,"bar":7}`, ``},
+		{`{"foo":0,"bar":7}3`, `3`},
+		{`{"foo":0,"bar":7} 3`, ` 3`},
+		{`{"foo":0 , "bar":7}`, ``},
+		{`{"foo":0 , "bar":7}3`, `3`},
+		{`{"foo":0 , "bar":7} 3`, ` 3`},
+		{`{"":""}`, ``},
+		{`{"":""}3`, `3`},
+		{`{"":""} 3`, ` 3`},
+		{`{"}":"}"}`, ``},
+		{`{"}":"}"}3`, `3`},
+		{`{"}":"}"} 3`, ` 3`},
+		{`{"":{}}`, ``},
+		{`{"":{}}3`, `3`},
+		{`{"":{}} 3`, ` 3`},
+		{`{"}":["}{"]}`, ``},
+		{`{"}":["}{"]}3`, `3`},
+		{`{"}":["}{"]} 3`, ` 3`},
+		{`{"":{"":{"":{}}}}`, ``},
+		{`{"":{"":{"":{}}}}3`, `3`},
+		{`{"":{"":{"":{}}}} 3`, ` 3`},
+	}
+	for _, test := range tests {
+		if rest := consumeObject([]byte(test.json)); string(rest) != test.rest {
+			t.Errorf("consumeObject('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
+		}
+	}
+}
+
+func TestConsumeArray(t *testing.T) {
+	tests := []struct {
+		json string
+		rest string
+	}{
+		{`[]`, ``},
+		{`[]3`, `3`},
+		{`[] 3`, ` 3`},
+		{`[0]`, ``},
+		{`[0]3`, `3`},
+		{`[0] 3`, ` 3`},
+		{`[0,1]`, ``},
+		{`[0,1]3`, `3`},
+		{`[0,1] 3`, ` 3`},
+		{`[0 , 1]`, ``},
+		{`[0 , 1]3`, `3`},
+		{`[0 , 1] 3`, ` 3`},
+		{`["", ""]`, ``},
+		{`["", ""]3`, `3`},
+		{`["", ""] 3`, ` 3`},
+		{`[[], []]`, ``},
+		{`[[], []]3`, `3`},
+		{`[[], []] 3`, ` 3`},
+		{`["[", "]"]`, ``},
+		{`["[", "]"]3`, `3`},
+		{`["[", "]"] 3`, ` 3`},
+		{`[["]", "]"], [{"foo":[]}]]`, ``},
+		{`[["]", "]"], [{"foo":[]}]]3`, `3`},
+		{`[["]", "]"], [{"foo":[]}]] 3`, ` 3`},
+	}
+	for _, test := range tests {
+		if rest := consumeArray([]byte(test.json)); string(rest) != test.rest {
+			t.Errorf("consumeArray('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
+		}
+	}
+}
+
+func TestConsumeString(t *testing.T) {
+	tests := []struct {
+		json string
+		rest string
+	}{
+		{`""`, ``},
+		{`"foo"`, ``},
+		{`"foo":"bar"`, `:"bar"`},
+		{`"foo" : "bar"`, ` : "bar"`},
+		{`"foo\"bar"`, ``},
+		{`"foo\"bar":"baz"`, `:"baz"`},
+	}
+	for _, test := range tests {
+		if rest := consumeString([]byte(test.json)); string(rest) != test.rest {
+			t.Errorf("consumeString('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
+		}
+	}
+}
+
+func TestConsumeNumber(t *testing.T) {
+	tests := []struct {
+		json string
+		rest string
+	}{
+		{`-0`, ``},
+		{`-0 true`, ` true`},
+		{`0`, ``},
+		{`0 true`, ` true`},
+		{`0.0`, ``},
+		{`0.0 true`, ` true`},
+		{`1.0`, ``},
+		{`1.0 true`, ` true`},
+		{`10`, ``},
+		{`10 true`, ` true`},
+		{`10.1`, ``},
+		{`10.1 true`, ` true`},
+		{`1e7`, ``},
+		{`1e7 true`, ` true`},
+		{`1e+7`, ``},
+		{`1e+7 true`, ` true`},
+		{`1e-7`, ``},
+		{`1e-7 true`, ` true`},
+		{`1.0e7`, ``},
+		{`1.0e7 true`, ` true`},
+		{`1.0e+7`, ``},
+		{`1.0e+7 true`, ` true`},
+		{`1.0e-7`, ``},
+		{`1.0e-7 true`, ` true`},
+		{`10.1e7`, ``},
+		{`10.1e7 true`, ` true`},
+		{`10.1e+7`, ``},
+		{`10.1e+7 true`, ` true`},
+		{`10.1e-7`, ``},
+		{`10.1e-7 true`, ` true`},
+	}
+	for _, test := range tests {
+		if rest := consumeNumber([]byte(test.json)); string(rest) != test.rest {
+			t.Errorf("consumeNumber('%s'): expected '%s', got '%s'", test.json, test.rest, rest)
+		}
+	}
+}
+
+func BenchmarkUpdateJournal(b *testing.B) {
+	f, cleanup := tempFile(b, "BenchmarkUpdateJournal")
+	defer cleanup()
+
+	j := &journal{f: f}
+	us := []journalUpdate{
+		newJournalUpdate("foo.bar", struct{ X, Y int }{3, 4}),
+		newJournalUpdate("foo.bar", nil),
+	}
+
+	for i := 0; i < b.N; i++ {
+		if err := j.update(us); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkApply(b *testing.B) {
+	u := newJournalUpdate("foo.bar.baz", "")
+	json := []byte(`{"foo": {"bar": {"baz": "quux"}}}`)
+	for i := 0; i < b.N; i++ {
+		u.apply(json)
+	}
+}

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -1,7 +1,6 @@
 package contractor
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/crypto"
@@ -129,12 +128,11 @@ func (c *Contractor) saveUploadRevision(id types.FileContractID) func(types.File
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		c.cachedRevisions[id] = cachedRevision{rev, newRoots}
-		path := "cachedRevisions." + id.String()
-		return c.persist.update(
-			path+".revision", rev,
+		return c.persist.update(updateCachedUploadRevision{
+			Revision: rev,
 			// only the last root is new
-			path+".merkleroots."+fmt.Sprint(len(newRoots)-1), newRoots[len(newRoots)-1],
-		)
+			SectorRoot: newRoots[len(newRoots)-1],
+		})
 	}
 }
 
@@ -146,7 +144,9 @@ func (c *Contractor) saveDownloadRevision(id types.FileContractID) func(types.Fi
 		defer c.mu.Unlock()
 		c.cachedRevisions[id] = cachedRevision{rev, newRoots}
 		// roots have not changed
-		return c.persist.update("cachedRevisions."+id.String()+".revision", rev)
+		return c.persist.update(updateCachedDownloadRevision{
+			Revision: rev,
+		})
 	}
 }
 
@@ -258,5 +258,6 @@ func loadv110persist(dir string, data *contractorPersist) error {
 		OldContracts:    oldPersist.OldContracts,
 		RenewedIDs:      oldPersist.RenewedIDs,
 	}
+
 	return nil
 }

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -40,6 +40,7 @@ func (c *Contractor) persistData() contractorPersist {
 		data.Contracts[contract.ID.String()] = contract
 	}
 	for _, contract := range c.oldContracts {
+		contract.MerkleRoots = []crypto.Hash{} // prevent roots from being saved to disk twice
 		data.OldContracts = append(data.OldContracts, contract)
 	}
 	for oldID, newID := range c.renewedIDs {

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -140,11 +140,13 @@ func (c *Contractor) saveUploadRevision(id types.FileContractID) func(types.File
 // saveDownloadRevision returns a function that saves an upload revision. It
 // is used by the Downloader type to prevent desynchronizing with the host.
 func (c *Contractor) saveDownloadRevision(id types.FileContractID) func(types.FileContractRevision, []crypto.Hash) error {
-	return func(rev types.FileContractRevision, newRoots []crypto.Hash) error {
+	return func(rev types.FileContractRevision, _ []crypto.Hash) error {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		c.cachedRevisions[id] = cachedRevision{rev, newRoots}
 		// roots have not changed
+		cr := c.cachedRevisions[id]
+		cr.Revision = rev
+		c.cachedRevisions[id] = cr
 		return c.persist.update(updateCachedDownloadRevision{
 			Revision: rev,
 		})

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -131,7 +131,8 @@ func (c *Contractor) saveUploadRevision(id types.FileContractID) func(types.File
 		return c.persist.update(updateCachedUploadRevision{
 			Revision: rev,
 			// only the last root is new
-			SectorRoot: newRoots[len(newRoots)-1],
+			SectorRoot:  newRoots[len(newRoots)-1],
+			SectorIndex: len(newRoots) - 1,
 		})
 	}
 }

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -15,9 +15,9 @@ import (
 // memPersist implements the persister interface in-memory.
 type memPersist contractorPersist
 
-func (m *memPersist) save(data contractorPersist) error     { *m = memPersist(data); return nil }
-func (m *memPersist) saveSync(data contractorPersist) error { *m = memPersist(data); return nil }
-func (m memPersist) load(data *contractorPersist) error     { *data = contractorPersist(m); return nil }
+func (m *memPersist) save(data contractorPersist) error { *m = memPersist(data); return nil }
+func (m *memPersist) update(...interface{}) error       { return nil }
+func (m memPersist) load(data *contractorPersist) error { *data = contractorPersist(m); return nil }
 
 // TestSaveLoad tests that the contractor can save and load itself.
 func TestSaveLoad(t *testing.T) {

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -16,7 +16,7 @@ import (
 type memPersist contractorPersist
 
 func (m *memPersist) save(data contractorPersist) error { *m = memPersist(data); return nil }
-func (m *memPersist) update(...interface{}) error       { return nil }
+func (m *memPersist) update(...journalUpdate) error     { return nil }
 func (m memPersist) load(data *contractorPersist) error { *data = contractorPersist(m); return nil }
 
 // TestSaveLoad tests that the contractor can save and load itself.

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -18,6 +18,7 @@ type memPersist contractorPersist
 func (m *memPersist) save(data contractorPersist) error { *m = memPersist(data); return nil }
 func (m *memPersist) update(...journalUpdate) error     { return nil }
 func (m memPersist) load(data *contractorPersist) error { *data = contractorPersist(m); return nil }
+func (m memPersist) Close() error                       { return nil }
 
 // TestSaveLoad tests that the contractor can save and load itself.
 func TestSaveLoad(t *testing.T) {

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -180,6 +180,9 @@ func (c *Contractor) managedRenewContracts() error {
 		c.contracts[contract.ID] = contract
 		// add a mapping from old->new contract
 		c.renewedIDs[oldID] = contract.ID
+		// move the cachedRevision entry to the new ID
+		c.cachedRevisions[contract.ID] = c.cachedRevisions[oldID]
+		delete(c.cachedRevisions, oldID)
 	}
 	err = c.saveSync()
 	c.mu.Unlock()

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -71,8 +71,6 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 		return modules.RenterContract{}, err
 	}
 
-	c.cachedRevisions[newContract.ID] = cachedRevision{newContract.LastRevision, newContract.MerkleRoots}
-
 	return newContract, nil
 }
 

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -71,6 +71,8 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 		return modules.RenterContract{}, err
 	}
 
+	c.cachedRevisions[newContract.ID] = cachedRevision{newContract.LastRevision, newContract.MerkleRoots}
+
 	return newContract, nil
 }
 

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -148,7 +148,7 @@ func TestIsOffline(t *testing.T) {
 		// construct a contractor with a hostdb containing the scans
 		c := &Contractor{
 			contracts: map[types.FileContractID]modules.RenterContract{
-				types.FileContractID{1}: {HostPublicKey: types.SiaPublicKey{Key: []byte("foo")}},
+				{1}: {HostPublicKey: types.SiaPublicKey{Key: []byte("foo")}},
 			},
 			hdb: mapHostDB{
 				hosts: map[string]modules.HostDBEntry{

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -151,7 +151,7 @@ func newHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir string, de
 	}
 
 	// Spin up the host scanning processes.
-	if build.Release != "testing" {
+	if build.Release == "standard" {
 		go hdb.threadedOnlineCheck()
 	} else {
 		// During testing, the hostdb is just always assumed to be online, since

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -92,8 +92,8 @@ func (hdb *HostDB) queueScan(entry modules.HostDBEntry) {
 // with the host weight functions. Adjustment of the host weight functions need
 // to keep this function in mind, and vice-versa.
 func (hdb *HostDB) updateEntry(entry modules.HostDBEntry, netErr error) {
-	// If the host is not online, toss out this update.
-	if !hdb.online {
+	// If the scan failed because we don't have Internet access, toss out this update.
+	if netErr != nil && !hdb.online {
 		return
 	}
 

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -12,6 +12,12 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+var hostPriceLeeway = build.Select(build.Var{
+	Dev:      0.05,
+	Standard: 0.002,
+	Testing:  0.002,
+}).(float64)
+
 var (
 	// sectorHeight is the height of a Merkle tree that covers a single
 	// sector. It is log2(modules.SectorSize / crypto.SegmentSize)
@@ -115,9 +121,9 @@ func (he *Editor) Upload(data []byte) (modules.RenterContract, crypto.Hash, erro
 	// price and collateral by 0.2%. This is only applied to hosts above
 	// v1.0.1; older hosts use stricter math.
 	if build.VersionCmp(he.host.Version, "1.0.1") > 0 {
-		sectorStoragePrice = sectorStoragePrice.MulFloat(1.002)
-		sectorBandwidthPrice = sectorBandwidthPrice.MulFloat(1.002)
-		sectorCollateral = sectorCollateral.MulFloat(0.998)
+		sectorStoragePrice = sectorStoragePrice.MulFloat(1 + hostPriceLeeway)
+		sectorBandwidthPrice = sectorBandwidthPrice.MulFloat(1 + hostPriceLeeway)
+		sectorCollateral = sectorCollateral.MulFloat(1 - hostPriceLeeway)
 	}
 
 	sectorPrice := sectorStoragePrice.Add(sectorBandwidthPrice)

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -80,6 +80,9 @@ type hostContractor interface {
 	// Allowance returns the current allowance
 	Allowance() modules.Allowance
 
+	// Close closes the hostContractor.
+	Close() error
+
 	// Contract returns the latest contract formed with the specified host.
 	Contract(modules.NetAddress) (modules.RenterContract, bool)
 
@@ -220,7 +223,8 @@ func newRenter(cs modules.ConsensusSet, tpool modules.TransactionPool, hdb hostD
 // Close closes the Renter and its dependencies
 func (r *Renter) Close() error {
 	r.tg.Stop()
-	return r.hostDB.Close()
+	r.hostDB.Close()
+	return r.hostContractor.Close()
 }
 
 // PriceEstimation estimates the cost in siacoins of performing various storage


### PR DESCRIPTION
My biggest PR in a while.

Recently it became clear that the contractor was not scaling well when storing lots of data. This was because it re-marshaled its entire persist data on every save -- and we save every time we revise a contract. Our tests showed that this amounted to about 35MB of data being encoded and written to disk (with fsync).

To address this, I wrote a json-based transaction journal. The journal records updates to the contracts instead of rewriting the whole contract. These updates are applied to the original object at regular intervals. The primary goal is to reduce latency when uploading/downloading, so for now, only those actions take advantage of the journal.

Things got a little ugly because the contractor persist object changed: it now uses string-keyed maps instead of slices in a few places.

Left to do:
- fix bugs in journal (see TODOs in journal.go)
- add metadata to journal format
- test extensively on antfarm before even attempting with real contracts