### PR TITLE
unsubscribe renter modules from consensus set on shutdown

### DIFF
--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -18,7 +18,8 @@ type newStub struct{}
 func (newStub) ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error {
 	return nil
 }
-func (newStub) Synced() bool { return true }
+func (newStub) Synced() bool                               { return true }
+func (newStub) Unsubscribe(modules.ConsensusSetSubscriber) { return }
 
 // wallet stubs
 func (newStub) NextAddress() (uc types.UnlockConditions, err error) { return }

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -13,6 +13,7 @@ type (
 	consensusSet interface {
 		ConsensusSetSubscribe(modules.ConsensusSetSubscriber, modules.ConsensusChangeID) error
 		Synced() bool
+		Unsubscribe(modules.ConsensusSetSubscriber)
 	}
 	// in order to restrict the modules.TransactionBuilder interface, we must
 	// provide a shim to bridge the gap between modules.Wallet and

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -165,6 +165,7 @@ func addPubKeys(cs consensusSet, contracts map[string]modules.RenterContract) ma
 		c.HostPublicKey = pubkeys[c.NetAddress]
 		contracts[id] = c
 	}
+	cs.Unsubscribe(&pubkeys)
 	return contracts
 }
 

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -147,6 +147,8 @@ func (cs blockCS) ConsensusSetSubscribe(s modules.ConsensusSetSubscriber, _ modu
 
 func (blockCS) Synced() bool { return true }
 
+func (blockCS) Unsubscribe(modules.ConsensusSetSubscriber) { return }
+
 // TestPubKeyScanner tests that the pubkeyScanner type correctly identifies
 // public keys in the blockchain.
 func TestPubKeyScanner(t *testing.T) {

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -155,6 +155,9 @@ func newHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir string, de
 	if err != nil {
 		return nil, errors.New("hostdb subscription failed: " + err.Error())
 	}
+	hdb.tg.OnStop(func() {
+		cs.Unsubscribe(hdb)
+	})
 
 	// Spin up the host scanning processes.
 	if build.Release == "standard" {


### PR DESCRIPTION
If the build fails it's likely b/c the other PR needs to be merged first.