### PR TITLE
Upgrade Travis to Go 1.8 and use t.Name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 
 go:
-  - 1.6
+  - 1.8
 
 install:
   - make dependencies

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -11,7 +11,7 @@ func TestApiClient(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestApiClient")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestAuthenticatedApiClient(t *testing.T) {
 	}
 	t.Parallel()
 	testpass := "testPassword"
-	st, err := createAuthenticatedServerTester("TestAuthenticatedApiClient", testpass)
+	st, err := createAuthenticatedServerTester(t.Name(), testpass)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -14,7 +14,7 @@ func TestIntegrationConsensusGET(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestIntegrationConsensusGET")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestConsensusValidateTransactionSet(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestConsensusValidateTransactionSet")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/ecosystem_test.go
+++ b/api/ecosystem_test.go
@@ -268,31 +268,31 @@ func TestHostPoorConnectivity(t *testing.T) {
 
 	// Create the various nodes that will be forming the simulated ecosystem of
 	// this test.
-	stLeader, err := createServerTester("TestHostPoorConnectivity - Leader")
+	stLeader, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost1, err := blankServerTester("TestHostPoorConnectivity - Host 1")
+	stHost1, err := blankServerTester(t.Name() + " - Host 1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost2, err := blankServerTester("TestHostPoorConnectivity - Host 2")
+	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost3, err := blankServerTester("TestHostPoorConnectivity - Host 3")
+	stHost3, err := blankServerTester(t.Name() + " - Host 3")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost4, err := blankServerTester("TestHostPoorConnectivity - Host 4")
+	stHost4, err := blankServerTester(t.Name() + " - Host 4")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stRenter1, err := blankServerTester("TestHostPoorConnectivity - Renter 1")
+	stRenter1, err := blankServerTester(t.Name() + " - Renter 1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stRenter2, err := blankServerTester("TestHostPoorConnectivity - Renter 2")
+	stRenter2, err := blankServerTester(t.Name() + " - Renter 2")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/explorer_test.go
+++ b/api/explorer_test.go
@@ -12,7 +12,7 @@ func TestIntegrationExplorerGET(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestIntegrationExplorerGET")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestIntegrationExplorerBlockGET(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestIntegrationExplorerBlockGET")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestIntegrationExplorerHashGet(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestIntegrationExplorerHashGET")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -14,7 +14,7 @@ func TestGatewayStatus(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestGatewayStatus")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,13 +34,13 @@ func TestGatewayPeerConnect(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestGatewayPeerConnect1")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
 
-	peer, err := gateway.New("localhost:0", false, build.TempDir("api", "TestGatewayPeerConnect2", "gateway"))
+	peer, err := gateway.New("localhost:0", false, build.TempDir("api", t.Name(), "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,13 +66,13 @@ func TestGatewayPeerDisconnect(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestGatewayPeerDisconnect1")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
 
-	peer, err := gateway.New("localhost:0", false, build.TempDir("api", "TestGatewayPeerDisconnect2", "gateway"))
+	peer, err := gateway.New("localhost:0", false, build.TempDir("api", t.Name()+"2", "gateway"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -49,7 +49,7 @@ func TestStorageHandler(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestStorageHandler")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestAddFolderNoPath(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestAddFolderNoPath")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestAddFolderNoSize(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestAddFolderNoSize")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestAddSameFolderTwice(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestAddSameFolderTwice")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestResizeEmptyStorageFolder(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestResizeEmptyStorageFolder")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestResizeNonemptyStorageFolder(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestResizeNonemptyStorageFolder")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +394,7 @@ func TestResizeNonexistentFolder(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestResizeNonexistentFolder")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func TestResizeFolderNoPath(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestResizeFolderNoPath")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +440,7 @@ func TestRemoveEmptyStorageFolder(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRemoveEmptyStorageFolder")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +466,7 @@ func TestRemoveStorageFolderError(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRemoveStorageFolderErr")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -501,7 +501,7 @@ func TestRemoveStorageFolderForced(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRemoveStorageFolderForced")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -572,7 +572,7 @@ func TestDeleteSector(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestDeleteSector")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +640,7 @@ func TestDeleteNonexistentSector(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestDeleteNonexistentSector")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -27,7 +27,7 @@ func TestHostDBHostsActiveHandler(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestHostDBHostsActiveHandler")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func TestHostDBHostsAllHandler(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestHostDBHostsAllHandler")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func TestHostDBHostsHandler(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestHostDBHostsHandler")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,11 +318,11 @@ func TestHostDBScanOnlineOffline(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBScanOnlineOffline")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost, err := blankServerTester("TestHostDBScanOnlineAndOffline-Host")
+	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,11 +418,11 @@ func TestHostDBAndRenterDownloadDynamicIPs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBAndRenterDownloadDynamicIPs")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost, err := blankServerTester("TestHostDBAndRenterDownloadDynamicIPs-Host")
+	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -636,11 +636,11 @@ func TestHostDBAndRenterUploadDynamicIPs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBAndRenterUploadDynamicIPs")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost, err := blankServerTester("TestHostDBAndRenterUploadDynamicIPs-Host")
+	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -885,11 +885,11 @@ func TestHostDBAndRenterFormDynamicIPs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBAndRenterFormDynamicIPs")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost, err := blankServerTester("TestHostDBAndRenterFormDynamicIPs-Host")
+	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1089,11 +1089,11 @@ func TestHostDBAndRenterRenewDynamicIPs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBAndRenterRenewDynamicIPs")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost, err := blankServerTester("TestHostDBAndRenterRenewDynamicIPs-Host")
+	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/miner_test.go
+++ b/api/miner_test.go
@@ -15,7 +15,7 @@ func TestMinerGET(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestMinerGET")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestMinerStartStop(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestMinerStartStop")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestMinerHeader(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestMinerHeader")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -38,7 +38,7 @@ func TestRenterDownloadError(t *testing.T) {
 	}
 	t.Parallel()
 
-	st, err := createServerTester("TestRenterDownloadError")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestRenterDownloadError(t *testing.T) {
 	}
 
 	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", "TestRenterDownloadError", "test.dat")
+	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
 	err = createRandFile(path, 1e4)
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestRenterAsyncDownloadError(t *testing.T) {
 	}
 	t.Parallel()
 
-	st, err := createServerTester("TestRenterAsyncDownloadError")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestRenterAsyncDownloadError(t *testing.T) {
 	}
 
 	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", "TestRenterAsyncDownloadError", "test.dat")
+	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
 	err = createRandFile(path, 1e4)
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestRenterAsyncDownload(t *testing.T) {
 	}
 	t.Parallel()
 
-	st, err := createServerTester("TestRenterAsyncDownload")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestRenterAsyncDownload(t *testing.T) {
 	}
 
 	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", "TestRenterAsyncDownload", "test.dat")
+	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
 	err = createRandFile(path, 1e4)
 	if err != nil {
 		t.Fatal(err)
@@ -291,7 +291,7 @@ func TestRenterPaths(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterPaths")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestRenterPaths(t *testing.T) {
 	}
 
 	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", "TestRenterPaths", "test.dat")
+	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
 	err = createRandFile(path, 1024)
 	if err != nil {
 		t.Fatal(err)
@@ -336,7 +336,7 @@ func TestRenterConflicts(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterConflicts")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +349,7 @@ func TestRenterConflicts(t *testing.T) {
 	}
 
 	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", "TestRenterConflicts", "test.dat")
+	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
 	err = createRandFile(path, 1024)
 	if err != nil {
 		t.Fatal(err)
@@ -397,7 +397,7 @@ func TestRenterHandlerContracts(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterHandlerContracts")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +461,7 @@ func TestRenterHandlerGetAndPost(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterHandlerGetAndPost")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +558,7 @@ func TestRenterLoadNonexistent(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterLoadNonexistent")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -616,7 +616,7 @@ func TestRenterHandlerRename(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterHandlerRename")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -714,7 +714,7 @@ func TestRenterHandlerDelete(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterHandlerDelete")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -779,7 +779,7 @@ func TestRenterRelativePathErrorUpload(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterRelativePathErrorUpload")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -840,7 +840,7 @@ func TestRenterRelativePathErrorDownload(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestRenterRelativePathErrorDownload")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -920,7 +920,7 @@ func TestRenterPricesHandler(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBHostsAllHandler")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -937,11 +937,11 @@ func TestRenterPricesHandler(t *testing.T) {
 	}
 
 	// Create several more hosts all using the default settings.
-	stHost1, err := blankServerTester("TestRenterPricesHandler - Host 1")
+	stHost1, err := blankServerTester(t.Name() + " - Host 1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost2, err := blankServerTester("TestRenterPricesHandler - Host 2")
+	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -992,7 +992,7 @@ func TestRenterPricesHandlerCheap(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBHostsAllHandlerCheap")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1009,11 +1009,11 @@ func TestRenterPricesHandlerCheap(t *testing.T) {
 	}
 
 	// Create several more hosts all using the default settings.
-	stHost1, err := blankServerTester("TestRenterPricesHandlerCheap - Host 1")
+	stHost1, err := blankServerTester(t.Name() + " - Host 1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost2, err := blankServerTester("TestRenterPricesHandlerCheap - Host 2")
+	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1093,7 +1093,7 @@ func TestRenterPricesHandlerIgnorePricey(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBHostsAllHandlerIgnorePricey")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1110,23 +1110,23 @@ func TestRenterPricesHandlerIgnorePricey(t *testing.T) {
 	}
 
 	// Create several more hosts all using the default settings.
-	stHost1, err := blankServerTester("TestRenterPricesHandlerIgnorePricey - Host 1")
+	stHost1, err := blankServerTester(t.Name() + " - Host 1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost2, err := blankServerTester("TestRenterPricesHandlerIgnorePricey - Host 2")
+	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost3, err := blankServerTester("TestRenterPricesHandlerIgnorePricey - Host 3")
+	stHost3, err := blankServerTester(t.Name() + " - Host 3")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost4, err := blankServerTester("TestRenterPricesHandlerIgnorePricey - Host 4")
+	stHost4, err := blankServerTester(t.Name() + " - Host 4")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost5, err := blankServerTester("TestRenterPricesHandlerIgnorePricey - Host 5")
+	stHost5, err := blankServerTester(t.Name() + " - Host 5")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1193,7 @@ func TestRenterPricesHandlerPricey(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostDBHostsAllHandlerPricey")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1210,11 +1210,11 @@ func TestRenterPricesHandlerPricey(t *testing.T) {
 	}
 
 	// Create several more hosts all using the default settings.
-	stHost1, err := blankServerTester("TestRenterPricesHandlerPricey - Host 1")
+	stHost1, err := blankServerTester(t.Name() + " - Host 1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	stHost2, err := blankServerTester("TestRenterPricesHandlerPricey - Host 2")
+	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -24,7 +24,7 @@ func TestHostAndRentVanilla(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestHostAndRentVanilla")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,17 +163,17 @@ func TestHostAndRentMultiHost(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestHostAndRentMultiHost-Host1andRenter")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	stH1, err := blankServerTester("TestHostAndRentMultiHost - Host 2")
+	stH1, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer stH1.server.Close()
-	stH2, err := blankServerTester("TestHostAndRentMultiHost - Host 3")
+	stH2, err := blankServerTester(t.Name() + " - Host 3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,22 +278,22 @@ func TestHostAndRentManyFiles(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestHostAndRentManyFiles-Host1andRenter")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st.server.Close()
-	stH1, err := blankServerTester("TestHostAndRentManyFiles - Host 2")
+	stH1, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer stH1.server.Close()
-	stH2, err := blankServerTester("TestHostAndRentManyFiles - Host 3")
+	stH2, err := blankServerTester(t.Name() + " - Host 3")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer stH2.server.Close()
-	stH3, err := blankServerTester("TestHostAndRentManyFiles - Host 4")
+	stH3, err := blankServerTester(t.Name() + " - Host 4")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestRenterUploadDownload(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestRenterUploadDownload")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +613,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestRenterCancelAllowance")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -693,7 +693,7 @@ func TestRenterParallelDelete(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestRenterParallelDelete")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -802,7 +802,7 @@ func TestRenterRenew(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestRenterRenew")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -918,7 +918,7 @@ func TestRenterAllowance(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	st, err := createServerTester("TestRenterAllowance")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1025,7 +1025,7 @@ func TestHostAndRentReload(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestHostAndRentReload")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -879,7 +879,8 @@ func TestRenterRenew(t *testing.T) {
 	contractID := rc.Contracts[0].ID
 
 	// Mine enough blocks to enter the renewal window.
-	for i := 0; i < testPeriod; i++ {
+	testWindow := testPeriod / 2
+	for i := 0; i < testWindow+1; i++ {
 		st.miner.AddBlock()
 	}
 	// Wait for the contract to be renewed.

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -12,7 +12,7 @@ func TestExplorerPreset(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createExplorerServerTester("TestExplorerPreset")
+	st, err := createExplorerServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestReloading(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestReloading")
+	st, err := createServerTester(t.Name())
 
 	height := st.server.api.cs.Height()
 	if err != nil {
@@ -69,7 +69,7 @@ func TestAuthentication(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createAuthenticatedServerTester("TestAuthentication", "password")
+	st, err := createAuthenticatedServerTester(t.Name(), "password")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -24,7 +24,7 @@ func TestWalletGETEncrypted(t *testing.T) {
 	}
 	t.Parallel()
 	// Check a wallet that has never been encrypted.
-	testdir := build.TempDir("api", "TestWalletGETEncrypted")
+	testdir := build.TempDir("api", t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal("Failed to create gateway:", err)
@@ -90,7 +90,7 @@ func TestWalletBlankEncrypt(t *testing.T) {
 	}
 	t.Parallel()
 	// Create a server object without encrypting or unlocking the wallet.
-	testdir := build.TempDir("api", "TestWalletBlankEncrypt")
+	testdir := build.TempDir("api", t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +154,7 @@ func TestWalletGETSiacoins(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestWalletGETSiacoins")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestWalletTransactionGETid(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestWalletTransactionGETid")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +300,7 @@ func TestWalletRelativePathErrorBackup(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestWalletRelativePathErrorBackup")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -348,7 +348,7 @@ func TestWalletRelativePathError033x(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestWalletRelativePathError033x")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +417,7 @@ func TestWalletRelativePathErrorSiag(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	st, err := createServerTester("TestWalletRelativePathErrorSiag")
+	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/build/testing_test.go
+++ b/build/testing_test.go
@@ -13,7 +13,7 @@ import (
 func TestCopyDir(t *testing.T) {
 	// Create some nested folders to copy.
 	os.MkdirAll(TempDir("build"), 0700)
-	root := TempDir("build", "TestCopyDir")
+	root := TempDir("build", t.Name())
 	os.MkdirAll(root, 0700)
 
 	data := make([][]byte, 2)

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -346,7 +346,7 @@ func TestUnmarshalAll(t *testing.T) {
 func TestReadWriteFile(t *testing.T) {
 	// standard
 	os.MkdirAll(build.TempDir("encoding"), 0777)
-	path := build.TempDir("encoding", "TestReadWriteFile")
+	path := build.TempDir("encoding", t.Name())
 	err := WriteFile(path, testStructs[3])
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/accept_bench_test.go
+++ b/modules/consensus/accept_bench_test.go
@@ -15,7 +15,7 @@ import (
 //
 // i7-4770, 1d60d69: 1.356 ms / op
 func BenchmarkAcceptEmptyBlocks(b *testing.B) {
-	cst, err := createConsensusSetTester("BenchmarkEmptyBlocks")
+	cst, err := createConsensusSetTester(b.Name())
 	if err != nil {
 		b.Fatal("Error creating tester: " + err.Error())
 	}
@@ -77,7 +77,7 @@ func BenchmarkAcceptEmptyBlocks(b *testing.B) {
 //
 // i7-4770, 1d60d69: 3.579 ms / op
 func BenchmarkAcceptSmallBlocks(b *testing.B) {
-	cst, err := createConsensusSetTester("BenchmarkAcceptSmallBlocks")
+	cst, err := createConsensusSetTester(b.Name())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/modules/consensus/accept_reorg_test.go
+++ b/modules/consensus/accept_reorg_test.go
@@ -164,7 +164,7 @@ func TestIntegrationSimpleReorg(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	rs := createReorgSets("TestIntegrationSimpleReorg")
+	rs := createReorgSets(t.Name())
 	defer rs.Close()
 
 	// Give a simple block to cstMain.
@@ -182,7 +182,7 @@ func TestIntegrationSiacoinReorg(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	rs := createReorgSets("TestIntegrationSiacoinReorg")
+	rs := createReorgSets(t.Name())
 	defer rs.Close()
 
 	// Give a siacoin block to cstMain.
@@ -200,7 +200,7 @@ func TestIntegrationValidStorageProofReorg(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	rs := createReorgSets("TestIntegrationValidStorageProofReorg")
+	rs := createReorgSets(t.Name())
 	defer rs.Close()
 
 	// Give a series of blocks containing a file contract and a valid storage
@@ -219,7 +219,7 @@ func TestIntegrationMissedStorageProofReorg(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	rs := createReorgSets("TestIntegrationMissedStorageProofReorg")
+	rs := createReorgSets(t.Name())
 	defer rs.Close()
 
 	// Give a series of blocks containing a file contract and a valid storage
@@ -238,7 +238,7 @@ func TestIntegrationFileContractRevisionReorg(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	rs := createReorgSets("TestIntegrationFileContractRevisionReorg")
+	rs := createReorgSets(t.Name())
 	defer rs.Close()
 
 	// Give a series of blocks containing a file contract and a valid storage
@@ -257,7 +257,7 @@ func TestIntegrationComplexReorg(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	rs := createReorgSets("TestIntegrationComplexReorg")
+	rs := createReorgSets(t.Name())
 	defer rs.Close()
 
 	// Give a wide variety of block types to cstMain.
@@ -286,7 +286,7 @@ func TestBuriedBadFork(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestBuriedBadFork")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -493,7 +493,7 @@ func TestIntegrationDoSBlockHandling(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestIntegrationDoSBlockHandling")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -538,7 +538,7 @@ func TestBlockKnownHandling(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestBlockKnownHandling")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -602,7 +602,7 @@ func TestOrphanHandling(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestOrphanHandling")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -628,7 +628,7 @@ func TestMissedTarget(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestMissedTarget")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -658,7 +658,7 @@ func TestMinerPayoutHandling(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestMinerPayoutHandling")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -686,7 +686,7 @@ func TestEarlyTimestampHandling(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestEarlyTimestampHandling")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -716,7 +716,7 @@ func TestFutureTimestampHandling(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestFutureTimestampHandling")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -756,7 +756,7 @@ func TestExtremeFutureTimestampHandling(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestExtremeFutureTimestampHandling")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,7 +782,7 @@ func TestBuriedBadTransaction(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestBuriedBadTransaction")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -833,7 +833,7 @@ func TestInconsistentCheck(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestInconsistentCheck")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -864,7 +864,7 @@ func TestTaxHardfork(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestTaxHardfork")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -983,7 +983,7 @@ func TestAcceptBlockBroadcasts(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := blankConsensusSetTester("TestAcceptBlockBroadcasts")
+	cst, err := blankConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/accept_txntypes_test.go
+++ b/modules/consensus/accept_txntypes_test.go
@@ -90,7 +90,7 @@ func TestIntegrationSimpleBlock(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestIntegrationSimpleBlock")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestIntegrationSpendSiacoinsBlock(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestSpendSiacoinsBlock")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +291,7 @@ func TestIntegrationValidStorageProofBlocks(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestIntegrationValidStorageProofBlocks")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +396,7 @@ func TestIntegrationMissedStorageProofBlocks(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestIntegrationMissedStorageProofBlocks")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +558,7 @@ func TestIntegrationFileContractRevision(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestIntegrationFileContractRevision")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -652,7 +652,7 @@ func (cst *consensusSetTester) TestIntegrationSpendSiafunds(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestIntegtrationSpendSiafunds")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1201,7 +1201,7 @@ func TestPaymentChannelBlocks(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestPaymentChannelBlocks")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/applytransaction_test.go
+++ b/modules/consensus/applytransaction_test.go
@@ -17,7 +17,7 @@ func TestApplySiacoinInputs(t *testing.T) {
 
 	// Create a consensus set and get it to 3 siacoin outputs. The consensus
 	// set starts with 2 siacoin outputs, mining a block will add another.
-	cst, err := createConsensusSetTester("TestApplySiacoinInputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestMisuseApplySiacoinInputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestMisuseApplySiacoinInputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestApplySiacoinOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplySiacoinOutputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestMisuseApplySiacoinOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestMisuseApplySiacoinOutputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestApplyFileContracts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyFileContracts")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +286,7 @@ func TestMisuseApplyFileContracts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestMisuseApplyFileContracts")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestApplyFileContractRevisions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyFileContractRevisions")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +420,7 @@ func TestMisuseApplyFileContractRevisions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestMisuseApplyFileContractRevisions")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +448,7 @@ func TestApplyStorageProofs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyStorageProofs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -570,7 +570,7 @@ func TestNonexistentStorageProof(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestNonexistentStorageProof")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -599,7 +599,7 @@ func TestDuplicateStorageProof(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestDuplicateStorageProof")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -646,7 +646,7 @@ func TestApplySiafundInputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplySiafundInputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +696,7 @@ func TestMisuseApplySiafundInputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplySiacoinInput")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -738,7 +738,7 @@ func TestApplySiafundOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplySiafundOutputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -806,7 +806,7 @@ func TestMisuseApplySiafundOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestMisuseApplySiafundOutputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/changelog_test.go
+++ b/modules/consensus/changelog_test.go
@@ -17,7 +17,7 @@ func TestIntegrationChangeLog(t *testing.T) {
 	t.Parallel()
 	// Get a blank consensus set tester so that the mocked subscriber can join
 	// immediately after genesis.
-	cst, err := blankConsensusSetTester("TestIntegrationChangeLog")
+	cst, err := blankConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/consensusset_bench_test.go
+++ b/modules/consensus/consensusset_bench_test.go
@@ -13,7 +13,7 @@ import (
 // i7-4770, 1d60d69: 22.883 ms / op
 func BenchmarkCreateServerTester(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		cst, err := createConsensusSetTester("BenchmarkCreateServerTester - " + strconv.Itoa(i))
+		cst, err := createConsensusSetTester(b.Name() + strconv.Itoa(i))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -177,7 +177,7 @@ func TestNilInputs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	testdir := build.TempDir(modules.ConsensusDir, "TestNilInputs")
+	testdir := build.TempDir(modules.ConsensusDir, t.Name())
 	_, err := New(nil, false, testdir)
 	if err != errNilGateway {
 		t.Fatal(err)
@@ -190,7 +190,7 @@ func TestDatabaseClosing(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	testdir := build.TempDir(modules.ConsensusDir, "TestClosing")
+	testdir := build.TempDir(modules.ConsensusDir, t.Name())
 
 	// Create the gateway.
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))

--- a/modules/consensus/diffs_test.go
+++ b/modules/consensus/diffs_test.go
@@ -16,7 +16,7 @@ func TestCommitDelayedSiacoinOutputDiffBadMaturity(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestCommitDelayedSiacoinOutputDiffBadMaturity")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestCommitNodeDiffs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestCommitNodeDiffs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestCommitSiacoinOutputDiff(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestCommitSiacoinOutputDiff")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestCommitFileContractDiff(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestCommitFileContractDiff")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestCommitSiafundOutputDiff(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestCommitSiafundOutputDiff")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestCommitDelayedSiacoinOutputDiff(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	cst, err := createConsensusSetTester("TestCommitDelayedSiacoinOutputDiff")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestCommitSiafundPoolDiff(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestCommitSiafundPoolDiff")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -568,7 +568,7 @@ func TestDeleteObsoleteDelayedOutputMapsSanity(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestDeleteObsoleteDelayedOutputMapsSanity")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -630,7 +630,7 @@ func TestGenerateAndApplyDiffSanity(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestGenerateAndApplyDiffSanity")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/fork_test.go
+++ b/modules/consensus/fork_test.go
@@ -13,7 +13,7 @@ func TestBacktrackToCurrentPath(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestBacktrackToCurrentPath")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestRevertToNode(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestRevertToNode")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/maintenance_test.go
+++ b/modules/consensus/maintenance_test.go
@@ -16,7 +16,7 @@ func TestApplyMinerPayouts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyMinerPayouts")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestApplyMaturedSiacoinOutputs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyMaturedSiacoinOutputs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestApplyMissedStorageProof(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyMissedStorageProof")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +242,7 @@ func TestApplyFileContractMaintenance(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestApplyMissedStorageProof")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/persist_test.go
+++ b/modules/consensus/persist_test.go
@@ -16,7 +16,7 @@ func TestSaveLoad(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestSaveLoad")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,11 +27,11 @@ func TestSaveLoad(t *testing.T) {
 
 	// Reassigning this will lose subscribers and such, but we
 	// just want to call load and get a hash
-	g, err := gateway.New("localhost:0", false, build.TempDir(modules.ConsensusDir, "TestSaveLoad", modules.GatewayDir))
+	g, err := gateway.New("localhost:0", false, build.TempDir(modules.ConsensusDir, t.Name(), modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
-	d := filepath.Join(build.SiaTestingDir, modules.ConsensusDir, "TestSaveLoad", modules.ConsensusDir)
+	d := filepath.Join(build.SiaTestingDir, modules.ConsensusDir, t.Name(), modules.ConsensusDir)
 	cst.cs, err = New(g, false, d)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/processedblock_test.go
+++ b/modules/consensus/processedblock_test.go
@@ -23,7 +23,7 @@ func TestIntegrationMinimumValidChildTimestamp(t *testing.T) {
 	t.Parallel()
 
 	// Create a custom consensus set to control the blocks.
-	testdir := build.TempDir(modules.ConsensusDir, "TestIntegrationMinimumValidChildTimestamp")
+	testdir := build.TempDir(modules.ConsensusDir, t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
@@ -168,7 +168,7 @@ func TestChildDepth(t *testing.T) {
 // TestTargetAdjustmentBase probes the targetAdjustmentBase method of the block
 // node type.
 func TestTargetAdjustmentBase(t *testing.T) {
-	cst, err := createConsensusSetTester("TestTargetAdjustmentBase")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestClampTargetAdjustment(t *testing.T) {
 
 // TestSetChildTarget probes the setChildTarget method of the block node type.
 func TestSetChildTarget(t *testing.T) {
-	cst, err := createConsensusSetTester("TestSetChildTarget")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestSetChildTarget(t *testing.T) {
 
 // TestNewChild probes the newChild method of the block node type.
 func TestNewChild(t *testing.T) {
-	cst, err := createConsensusSetTester("TestNewChild")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/subscribe_test.go
+++ b/modules/consensus/subscribe_test.go
@@ -41,7 +41,7 @@ func TestInvalidConsensusChangeSubscription(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestInvalidConsensusChangeSubscription")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestInvalidToValidSubscription(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestInvalidToValidSubscription")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestUnsubscribe(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestUnsubscribe")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -27,7 +27,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 	// Create 8 remote peers.
 	remoteCSTs := make([]*consensusSetTester, 8)
 	for i := range remoteCSTs {
-		cst, err := blankConsensusSetTester(fmt.Sprintf("TestSimpleInitialBlockchainDownload - %v", i))
+		cst, err := blankConsensusSetTester(t.Name() + strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -35,7 +35,7 @@ func TestSimpleInitialBlockchainDownload(t *testing.T) {
 		remoteCSTs[i] = cst
 	}
 	// Create the "local" peer.
-	localCST, err := blankConsensusSetTester("TestSimpleInitialBlockchainDownload - local")
+	localCST, err := blankConsensusSetTester(t.Name() + "- local")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestInitialBlockchainDownloadDisconnects(t *testing.T) {
 		t.SkipNow()
 	}
 
-	testdir := build.TempDir(modules.ConsensusDir, "TestInitialBlockchainDownloadDisconnects")
+	testdir := build.TempDir(modules.ConsensusDir, t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, "local", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
@@ -286,7 +286,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testdir := build.TempDir(modules.ConsensusDir, "TestInitialBlockchainDownloadDoneRules")
+	testdir := build.TempDir(modules.ConsensusDir, t.Name())
 
 	// Create a gateway that can be forced to return errors when its RPC method
 	// is called, then create a consensus set using that gateway.
@@ -330,7 +330,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	func() {
 		inboundCSTs := make([]*consensusSetTester, 8)
 		for i := 0; i < len(inboundCSTs); i++ {
-			inboundCST, err := blankConsensusSetTester(filepath.Join("TestInitialBlockchainDownloadDoneRules", fmt.Sprintf("remote - inbound %v", i)))
+			inboundCST, err := blankConsensusSetTester(filepath.Join(t.Name(), " - inbound "+strconv.Itoa(i)))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -463,11 +463,11 @@ func TestGenesisBlockSync(t *testing.T) {
 
 	// Create two consensus sets that have zero blocks each (except for the
 	// genesis block).
-	cst1, err := blankConsensusSetTester("TestGenesisBlockSync1")
+	cst1, err := blankConsensusSetTester(t.Name() + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	cst2, err := blankConsensusSetTester("TestGenesisBlockSync2")
+	cst2, err := blankConsensusSetTester(t.Name() + "2")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -27,12 +27,12 @@ func TestSynchronize(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst1, err := createConsensusSetTester("TestSynchronize1")
+	cst1, err := createConsensusSetTester(t.Name() + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cst1.Close()
-	cst2, err := createConsensusSetTester("TestSynchronize2")
+	cst2, err := createConsensusSetTester(t.Name() + "2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestBlockHistory(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cst, err := createConsensusSetTester("TestBlockHistory")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,12 +208,12 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 	}
 
 	// Setup consensus sets.
-	cst1, err := blankConsensusSetTester("TestSendBlocksBroadcastsOnce1")
+	cst1, err := blankConsensusSetTester(t.Name() + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cst1.Close()
-	cst2, err := blankConsensusSetTester("TestSendBlocksBroadcastsOnce2")
+	cst2, err := blankConsensusSetTester(t.Name() + "2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,12 +436,12 @@ func TestIntegrationRPCSendBlocks(t *testing.T) {
 
 	for i, tt := range tests {
 		// Create the "remote" peer.
-		remoteCST, err := blankConsensusSetTester(filepath.Join("TestIntegrationRPCSendBlocks - remote", strconv.Itoa(i)))
+		remoteCST, err := blankConsensusSetTester(filepath.Join(t.Name()+" - remote", strconv.Itoa(i)))
 		if err != nil {
 			t.Fatal(err)
 		}
 		// Create the "local" peer.
-		localCST, err := blankConsensusSetTester(filepath.Join("TestIntegrationRPCSendBlocks - local", strconv.Itoa(i)))
+		localCST, err := blankConsensusSetTester(filepath.Join(t.Name()+" - local", strconv.Itoa(i)))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -536,7 +536,7 @@ func TestRPCSendBlockSendsOnlyNecessaryBlocks(t *testing.T) {
 	}
 
 	// Create the "remote" peer.
-	cst, err := blankConsensusSetTester("TestRPCSendBlockSendsOnlyNecessaryBlocks - remote")
+	cst, err := blankConsensusSetTester(t.Name() + "- remote")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -546,7 +546,7 @@ func TestRPCSendBlockSendsOnlyNecessaryBlocks(t *testing.T) {
 	// We create this peer manually (not using blankConsensusSetTester) so that we
 	// can connect it to the remote peer before calling consensus.New so as to
 	// prevent SendBlocks from triggering on Connect.
-	testdir := build.TempDir(modules.ConsensusDir, "TestRPCSendBlockSendsOnlyNecessaryBlocks - local")
+	testdir := build.TempDir(modules.ConsensusDir, t.Name()+" - local")
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
@@ -686,7 +686,7 @@ func TestSendBlk(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := blankConsensusSetTester("TestSendBlk")
+	cst, err := blankConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -777,7 +777,7 @@ func TestThreadedReceiveBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := blankConsensusSetTester("TestThreadedReceiveBlock")
+	cst, err := blankConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -898,12 +898,12 @@ func TestIntegrationSendBlkRPC(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst1, err := blankConsensusSetTester("TestIntegrationSendBlkRPC1")
+	cst1, err := blankConsensusSetTester(t.Name() + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cst1.Close()
-	cst2, err := blankConsensusSetTester("TestIntegrationSendBlkRPC2")
+	cst2, err := blankConsensusSetTester(t.Name() + "2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -997,7 +997,7 @@ func TestRelayHeader(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := blankConsensusSetTester("TestRelayHeader")
+	cst, err := blankConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1104,12 +1104,12 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 		t.SkipNow()
 	}
 	// Setup consensus sets.
-	cst1, err := blankConsensusSetTester("TestIntegrationBroadcastRelayHeader1")
+	cst1, err := blankConsensusSetTester(t.Name() + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cst1.Close()
-	cst2, err := blankConsensusSetTester("TestIntegrationBroadcastRelayHeader2")
+	cst2, err := blankConsensusSetTester(t.Name() + "2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1165,17 +1165,17 @@ func TestIntegrationRelaySynchronize(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst1, err := blankConsensusSetTester("TestRelaySynchronize1")
+	cst1, err := blankConsensusSetTester(t.Name() + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cst1.Close()
-	cst2, err := blankConsensusSetTester("TestRelaySynchronize2")
+	cst2, err := blankConsensusSetTester(t.Name() + "2")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cst2.Close()
-	cst3, err := blankConsensusSetTester("TestRelaySynchronize3")
+	cst3, err := blankConsensusSetTester(t.Name() + "3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1361,7 +1361,7 @@ func TestThreadedReceiveBlocksStalls(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cst, err := blankConsensusSetTester("TestThreadedReceiveBlocksStalls")
+	cst, err := blankConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1480,12 +1480,12 @@ func TestIntegrationSendBlocksStalls(t *testing.T) {
 		t.SkipNow()
 	}
 
-	cstLocal, err := blankConsensusSetTester("TestThreadedReceiveBlocksTimesout - local")
+	cstLocal, err := blankConsensusSetTester(t.Name() + "- local")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cstLocal.Close()
-	cstRemote, err := blankConsensusSetTester("TestThreadedReceiveBlocksTimesout - remote")
+	cstRemote, err := blankConsensusSetTester(t.Name() + "- remote")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/consensus/validtransaction_test.go
+++ b/modules/consensus/validtransaction_test.go
@@ -17,7 +17,7 @@ func TestTryValidTransactionSet(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestTryValidTransactionSet")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestTryInvalidTransactionSet(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestTryInvalidTransactionSet")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestStorageProofBoundaries(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestStorageProofBoundaries")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestEmptyStorageProof(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestEmptyStorageProof")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestValidSiacoins(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestValidSiacoins")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +398,7 @@ func TestStorageProofSegment(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestStorageProofSegment")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -428,7 +428,7 @@ func TestValidStorageProofs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestValidStorageProofs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +553,7 @@ func TestPreForkValidStorageProofs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestPreForkValidStorageProofs")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -610,7 +610,7 @@ func TestValidFileContractRevisions(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	cst, err := createConsensusSetTester("TestValidFileContractRevisions")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -748,7 +748,7 @@ func TestValidSiafunds(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestValidSiafunds")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -798,7 +798,7 @@ func TestValidTransaction(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	cst, err := createConsensusSetTester("TestValidTransaction")
+	cst, err := createConsensusSetTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/explorer/explorer_test.go
+++ b/modules/explorer/explorer_test.go
@@ -164,7 +164,7 @@ func TestNilExplorerDependencies(t *testing.T) {
 // genesis block, the result has the correct height.
 func TestExplorerGenesisHeight(t *testing.T) {
 	// Create the dependencies.
-	testdir := build.TempDir(modules.HostDir, "TestExplorerGenesisHeight")
+	testdir := build.TempDir(modules.HostDir, t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)

--- a/modules/explorer/info_test.go
+++ b/modules/explorer/info_test.go
@@ -12,7 +12,7 @@ func TestImmediateBlockFacts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	et, err := createExplorerTester("TestImmediateBlockFacts")
+	et, err := createExplorerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	et, err := createExplorerTester("TestBlock")
+	et, err := createExplorerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestBlockFacts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	et, err := createExplorerTester("TestBlockFacts")
+	et, err := createExplorerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/explorer/update_test.go
+++ b/modules/explorer/update_test.go
@@ -24,7 +24,7 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 		t.Skip()
 	}
 
-	et, err := createExplorerTester("TestIntegrationExporerFileContractMetrics")
+	et, err := createExplorerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gateway/nodes_test.go
+++ b/modules/gateway/nodes_test.go
@@ -20,7 +20,7 @@ func TestAddNode(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestAddNode", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	g.mu.Lock()
@@ -50,7 +50,7 @@ func TestRemoveNode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	g := newTestingGateway("TestRemoveNode", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 	t.Parallel()
 
@@ -74,7 +74,7 @@ func TestRandomNode(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestRandomNode", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	// Test with 0 nodes.
@@ -152,9 +152,9 @@ func TestShareNodes(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestShareNodes1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestShareNodes2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	// add a node to g2
@@ -228,11 +228,11 @@ func TestNodesAreSharedOnConnect(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestNodesAreSharedOnConnect1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestNodesAreSharedOnConnect2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
-	g3 := newTestingGateway("TestNodesAreSharedOnConnect3", t)
+	g3 := newNamedTestingGateway(t, "3")
 	defer g3.Close()
 
 	// connect g2 to g1
@@ -273,8 +273,7 @@ func TestPruneNodeThreshold(t *testing.T) {
 	// Create and connect pruneNodeListLen gateways.
 	var gs []*Gateway
 	for i := 0; i < pruneNodeListLen; i++ {
-		gname := "TestPruneNodeThreshold" + strconv.Itoa(i)
-		gs = append(gs, newTestingGateway(gname, t))
+		gs = append(gs, newNamedTestingGateway(t, strconv.Itoa(i)))
 
 		// Connect this gateway to the previous gateway.
 		if i != 0 {
@@ -361,8 +360,7 @@ func TestHealthyNodeListPruning(t *testing.T) {
 	// Create and connect healthyNodeListLen*2 gateways.
 	var gs []*Gateway
 	for i := 0; i < healthyNodeListLen*2; i++ {
-		gname := "TestHealthyNodeListPruning" + strconv.Itoa(i)
-		gs = append(gs, newTestingGateway(gname, t))
+		gs = append(gs, newNamedTestingGateway(t, strconv.Itoa(i)))
 
 		// Connect this gateway to the previous gateway.
 		if i != 0 {

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -33,7 +33,7 @@ func TestAddPeer(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestAddPeer", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	g.mu.Lock()
@@ -56,7 +56,7 @@ func TestRandomOutboundPeer(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestRandomInboundPeer", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -88,7 +88,7 @@ func TestListen(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestListen", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	// compliant connect with old version
@@ -204,7 +204,7 @@ func TestConnect(t *testing.T) {
 	}
 	t.Parallel()
 	// create bootstrap peer
-	bootstrap := newTestingGateway("TestConnect1", t)
+	bootstrap := newNamedTestingGateway(t, "1")
 	defer bootstrap.Close()
 
 	// give it a node
@@ -213,7 +213,7 @@ func TestConnect(t *testing.T) {
 	bootstrap.mu.Unlock()
 
 	// create peer who will connect to bootstrap
-	g := newTestingGateway("TestConnect2", t)
+	g := newNamedTestingGateway(t, "2")
 	defer g.Close()
 
 	// first simulate a "bad" connect, where bootstrap won't share its nodes
@@ -357,10 +357,10 @@ func TestConnectRejectsInvalidAddrs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestConnectRejectsInvalidAddrs", t)
+	g := newNamedTestingGateway(t, "1")
 	defer g.Close()
 
-	g2 := newTestingGateway("TestConnectRejectsInvalidAddrs2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	_, g2Port, err := net.SplitHostPort(string(g2.Address()))
@@ -412,7 +412,7 @@ func TestConnectRejectsVersions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	g := newTestingGateway("TestConnectRejectsVersions", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 	// Setup a listener that mocks Gateway.acceptConn, but sends the
 	// version sent over mockVersionChan instead of build.Version.
@@ -543,7 +543,7 @@ func TestAcceptConnRejectsVersions(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestAcceptConnRejectsVersions", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	tests := []struct {
@@ -656,7 +656,7 @@ func TestDisconnect(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestDisconnect", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	if err := g.Disconnect("bar.com:123"); err == nil {
@@ -699,11 +699,11 @@ func TestPeerManager(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestPeerManager1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
 
 	// create a valid node to connect to
-	g2 := newTestingGateway("TestPeerManager2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	// g1's node list should only contain g2
@@ -737,8 +737,7 @@ func TestOverloadedBootstrap(t *testing.T) {
 	// first node.
 	var gs []*Gateway
 	for i := 0; i < fullyConnectedThreshold*2; i++ {
-		gname := "TestOverloadedBootstrap" + strconv.Itoa(i)
-		gs = append(gs, newTestingGateway(gname, t))
+		gs = append(gs, newNamedTestingGateway(t, strconv.Itoa(i)))
 		// Connect this gateway to the first gateway.
 		if i == 0 {
 			continue

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -9,7 +9,7 @@ func TestLoad(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestLoad", t)
+	g := newTestingGateway(t)
 
 	g.mu.Lock()
 	g.addNode(dummyNode)

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -41,7 +41,7 @@ func TestRegisterRPC(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestRegisterRPC", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	g.RegisterRPC("Foo", func(conn modules.PeerConn) error { return nil })
@@ -60,9 +60,9 @@ func TestUnregisterRPC(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestUnregisterRPC1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestUnregisterRPC2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	err := g2.Connect(g1.Address())
@@ -106,7 +106,7 @@ func TestRegisterConnectCall(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g := newTestingGateway("TestRegisterConnectCall", t)
+	g := newTestingGateway(t)
 	defer g.Close()
 
 	// Register an on-connect call.
@@ -126,9 +126,9 @@ func TestUnregisterConnectCallPanics(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestUnregisterConnectCall1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestUnregisterConnectCall2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	rpcChan := make(chan struct{})
@@ -176,14 +176,14 @@ func TestRPC(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestRPC1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
 
 	if err := g1.RPC("foo.com:123", "", nil); err == nil {
 		t.Fatal("RPC on unconnected peer succeeded")
 	}
 
-	g2 := newTestingGateway("TestRPC2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	err := g1.Connect(g2.Address())
@@ -252,9 +252,9 @@ func TestThreadedHandleConn(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestThreadedHandleConn1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestThreadedHandleConn2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	err := g1.Connect(g2.Address())
@@ -316,11 +316,11 @@ func TestBroadcast(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestBroadcast1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestBroadcast2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
-	g3 := newTestingGateway("TestBroadcast3", t)
+	g3 := newNamedTestingGateway(t, "3")
 	defer g3.Close()
 
 	err := g1.Connect(g2.Address())
@@ -440,9 +440,9 @@ func TestOutboundAndInboundRPCs(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestRPC1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestRPC2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	rpcChanG1 := make(chan struct{})
@@ -489,9 +489,9 @@ func TestCallingRPCFromRPC(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	g1 := newTestingGateway("TestCallingRPCFromRPC1", t)
+	g1 := newNamedTestingGateway(t, "1")
 	defer g1.Close()
-	g2 := newTestingGateway("TestCallingRPCFromRPC2", t)
+	g2 := newNamedTestingGateway(t, "2")
 	defer g2.Close()
 
 	errChan := make(chan error)

--- a/modules/miner/blockmanager_test.go
+++ b/modules/miner/blockmanager_test.go
@@ -31,7 +31,7 @@ func TestIntegrationHeaderForWork(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegreationHeaderForWork")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestIntegrationHeaderForWorkUpdates(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationHeaderForWorkUpdates")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestIntegrationManyHeaders(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationManyHeaders")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestIntegrationHeaderBlockOverflow(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationHeaderBlockOverflow")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +176,7 @@ func TestIntegrationHeaderRequestOverflow(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationHeaderRequestOverflow")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -101,7 +101,7 @@ func TestIntegrationMiner(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestMiner")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestIntegrationNilMinerDependencies(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationNilMinerDependencies")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestIntegrationBlocksMined(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationBlocksMined")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +239,7 @@ func TestIntegrationAutoRescan(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationAutoRescan")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +286,7 @@ func TestIntegrationStartupRescan(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	mt, err := createMinerTester("TestIntegrationStartupRescan")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +323,7 @@ func TestIntegrationStartupRescan(t *testing.T) {
 // TestMinerCloseDeadlock checks that the miner can cleanly close even if the
 // CPU miner is running.
 func TestMinerCloseDeadlock(t *testing.T) {
-	mt, err := createMinerTester("TestMinerCloseDeadlock")
+	mt, err := createMinerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/miner/update_test.go
+++ b/modules/miner/update_test.go
@@ -14,15 +14,15 @@ func TestIntegrationBlockHeightReorg(t *testing.T) {
 	}
 
 	// Create 3 miner testers that will be used to cause each other to reorg.
-	mt1, err := createMinerTester("TestIntegrationBlockHeightReorg - 1")
+	mt1, err := createMinerTester(t.Name() + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	mt2, err := createMinerTester("TestIntegrationBlockHeightReorg - 2")
+	mt2, err := createMinerTester(t.Name() + "2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	mt3, err := createMinerTester("TestIntegrationBlockHeightReorg - 3")
+	mt3, err := createMinerTester(t.Name() + "3")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -40,7 +40,7 @@ func TestNew(t *testing.T) {
 	// Using a stub implementation of the dependencies is fine, as long as its
 	// non-nil.
 	var stub newStub
-	dir := build.TempDir("contractor", "TestNew")
+	dir := build.TempDir("contractor", t.Name())
 
 	// Sane values.
 	_, err := New(stub, stub, stub, stub, dir)
@@ -115,7 +115,7 @@ func TestContract(t *testing.T) {
 // TestContracts tests the Contracts method.
 func TestContracts(t *testing.T) {
 	var stub newStub
-	dir := build.TempDir("contractor", "TestContracts")
+	dir := build.TempDir("contractor", t.Name())
 	c, err := New(stub, stub, stub, stub, dir)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
@@ -193,7 +193,7 @@ func TestIntegrationSetAllowance(t *testing.T) {
 		t.SkipNow()
 	}
 	// create testing trio
-	_, c, m, err := newTestingTrio("TestIntegrationSetAllowance")
+	_, c, m, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -182,7 +182,7 @@ func TestIntegrationFormContract(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	h, c, _, err := newTestingTrio("TestIntegrationFormContract")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestIntegrationReviseContract(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationReviseContract")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestIntegrationUploadDownload(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationUploadDownload")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +323,7 @@ func TestIntegrationDelete(t *testing.T) {
 	t.Skip("deletion is deprecated")
 
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationDelete")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestIntegrationInsertDelete(t *testing.T) {
 	t.Skip("deletion is deprecated")
 
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationInsertDelete")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,7 +446,7 @@ func TestIntegrationModify(t *testing.T) {
 	t.Skip("modification is deprecated")
 
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationModify")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationRenew")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -642,7 +642,7 @@ func TestIntegrationResync(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationResync")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -781,7 +781,7 @@ func TestIntegrationDownloaderCaching(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationDownloaderCaching")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -875,7 +875,7 @@ func TestIntegrationEditorCaching(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationEditorCaching")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -968,7 +968,7 @@ func TestIntegrationCachedRenew(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	h, c, _, err := newTestingTrio("TestIntegrationCachedRenew")
+	h, c, _, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/negotiate_test.go
+++ b/modules/renter/contractor/negotiate_test.go
@@ -110,7 +110,7 @@ func TestNegotiateContract(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	ct, err := newContractorTester("TestNegotiateContract")
+	ct, err := newContractorTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestReviseContract(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	ct, err := newContractorTester("TestReviseContract")
+	ct, err := newContractorTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -90,8 +90,8 @@ func TestSaveLoad(t *testing.T) {
 	}
 
 	// use stdPersist instead of mock
-	c.persist = newPersist(build.TempDir("contractor", "TestSaveLoad"))
-	os.MkdirAll(build.TempDir("contractor", "TestSaveLoad"), 0700)
+	c.persist = newPersist(build.TempDir("contractor", t.Name()))
+	os.MkdirAll(build.TempDir("contractor", t.Name()), 0700)
 
 	// save, clear, and reload
 	err = c.save()

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -57,7 +57,7 @@ func TestIntegrationAutoRenew(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	_, c, m, err := newTestingTrio("TestIntegrationAutoRenew")
+	_, c, m, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestIntegrationRenewInvalidate(t *testing.T) {
 	}
 	t.Parallel()
 	// create testing trio
-	_, c, m, err := newTestingTrio("TestIntegrationRenewInvalidate")
+	_, c, m, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -38,7 +38,7 @@ func TestIntegrationReplaceOffline(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	h, c, m, err := newTestingTrio("TestIntegrationReplaceOffline")
+	h, c, m, err := newTestingTrio(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestIntegrationReplaceOffline(t *testing.T) {
 	c.hdb = offlineHostDB{c.hdb, h.PublicKey()}
 
 	// create another host
-	dir := build.TempDir("contractor", "TestIntegrationReplaceOffline", "Host2")
+	dir := build.TempDir("contractor", t.Name(), "Host2")
 	h2, err := newTestingHost(dir, c.cs.(modules.ConsensusSet), c.tpool.(modules.TransactionPool))
 	if err != nil {
 		t.Fatal(err)

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -185,7 +185,7 @@ func TestRenterDeleteFile(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	rt, err := newRenterTester("TestRenterDeleteFile")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestRenterFileList(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	rt, err := newRenterTester("TestRenterFileList")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +296,7 @@ func TestRenterFileList(t *testing.T) {
 
 // TestRenterRenameFile probes the rename method of the renter.
 func TestRenterRenameFile(t *testing.T) {
-	rt, err := newRenterTester("TestRenterRenameFile")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -131,7 +131,7 @@ func TestNew(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testDir := build.TempDir("HostDB", "TestNew")
+	testDir := build.TempDir("HostDB", t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testDir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
@@ -183,7 +183,7 @@ func TestRandomHosts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	hdbt, err := newHDBTesterDeps("TestRandomHosts", disableScanLoopDeps{})
+	hdbt, err := newHDBTesterDeps(t.Name(), disableScanLoopDeps{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestRemoveNonexistingHostFromHostTree(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	hdbt, err := newHDBTester("TestRemoveNonexistingHostFromHostTree")
+	hdbt, err := newHDBTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -30,7 +30,7 @@ func TestSaveLoad(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	hdbt, err := newHDBTester("TestSaveLoad")
+	hdbt, err := newHDBTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestRescan(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	_, err := newHDBTester("TestRescan")
+	_, err := newHDBTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/persist_test.go
+++ b/modules/renter/persist_test.go
@@ -74,7 +74,7 @@ func TestFileShareLoad(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	rt, err := newRenterTester("TestRenterShareLoad")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestFileShareLoad(t *testing.T) {
 	rt.renter.mu.Unlock(id)
 
 	// Share .sia file to disk.
-	path := filepath.Join(build.SiaTestingDir, "renter", "TestRenterShareLoad", "test.sia")
+	path := filepath.Join(build.SiaTestingDir, "renter", t.Name(), "test.sia")
 	err = rt.renter.ShareFiles([]string{savedFile.name}, path)
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestFileShareLoad(t *testing.T) {
 	// Share and load multiple files.
 	savedFile2 := newTestingFile()
 	rt.renter.files[savedFile2.name] = savedFile2
-	path = filepath.Join(build.SiaTestingDir, "renter", "TestRenterShareLoad", "test2.sia")
+	path = filepath.Join(build.SiaTestingDir, "renter", t.Name(), "test2.sia")
 	err = rt.renter.ShareFiles([]string{savedFile.name, savedFile2.name}, path)
 	if err != nil {
 		t.Fatal(err)
@@ -144,7 +144,7 @@ func TestFileShareLoadASCII(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	rt, err := newRenterTester("TestRenterShareLoadASCII")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestRenterSaveLoad(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	rt, err := newRenterTester("TestRenterSaveLoad")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestRenterPaths(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	rt, err := newRenterTester("TestRenterPaths")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestSiafileCompatibility(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	rt, err := newRenterTester("TestSiafileCompatibility")
+	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter_test.go
+++ b/modules/renter_test.go
@@ -43,7 +43,7 @@ func TestMerkleRootSetCompatibility(t *testing.T) {
 		}
 
 		// Save and load, check that they are the same.
-		dir := build.TempDir("modules", "TestMerkleRootSetCompatibility")
+		dir := build.TempDir("modules", t.Name())
 		err := os.MkdirAll(dir, 0700)
 		if err != nil {
 			t.Fatal(err)

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -12,7 +12,7 @@ import (
 // of the transaction pool.
 func TestIntegrationAcceptTransactionSet(t *testing.T) {
 	// Create a transaction pool tester.
-	tpt, err := createTpoolTester("TestIntegrationAcceptTransactionSet")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestIntegrationConflictingTransactionSets(t *testing.T) {
 		t.SkipNow()
 	}
 	// Create a transaction pool tester.
-	tpt, err := createTpoolTester("TestIntegrationConflictingTransactionSets")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestIntegrationCheckMinerFees(t *testing.T) {
 		t.SkipNow()
 	}
 	// Create a transaction pool tester.
-	tpt, err := createTpoolTester("TestIntegrationCheckMinerFees")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestIntegrationTransactionSuperset(t *testing.T) {
 		t.SkipNow()
 	}
 	// Create a transaction pool tester.
-	tpt, err := createTpoolTester("TestTransactionSuperset")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestIntegrationTransactionSubset(t *testing.T) {
 		t.SkipNow()
 	}
 	// Create a transaction pool tester.
-	tpt, err := createTpoolTester("TestTransactionSubset")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestIntegrationTransactionChild(t *testing.T) {
 		t.SkipNow()
 	}
 	// Create a transaction pool tester.
-	tpt, err := createTpoolTester("TestTransactionChild")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestIntegrationNilAccept(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	tpt, err := createTpoolTester("TestTransactionChild")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +340,7 @@ func TestAcceptFCAndConflictingRevision(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	tpt, err := createTpoolTester("TestAcceptFCAndConflictingRevision")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +396,7 @@ func TestPartialConfirmation(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	tpt, err := createTpoolTester("TestPartialConfirmation")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +473,7 @@ func TestPartialConfirmationWeave(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	tpt, err := createTpoolTester("TestPartialConfirmation")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/transactionpool/persist_test.go
+++ b/modules/transactionpool/persist_test.go
@@ -19,7 +19,7 @@ func TestRescan(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tpt, err := createTpoolTester("TestRescan")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/transactionpool/standard_test.go
+++ b/modules/transactionpool/standard_test.go
@@ -15,7 +15,7 @@ func TestIntegrationLargeTransactions(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tpt, err := createTpoolTester("TestIntegrationLargeTransaction")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/transactionpool/subscribe_test.go
+++ b/modules/transactionpool/subscribe_test.go
@@ -1,9 +1,10 @@
 package transactionpool
 
 import (
+	"testing"
+
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
-	"testing"
 )
 
 // mockSubscriber receives transactions from the transaction pool it is
@@ -28,7 +29,7 @@ func TestSubscription(t *testing.T) {
 		t.Skip()
 	}
 
-	tpt, err := createTpoolTester("TestUnsubscribe")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -111,7 +111,7 @@ func (tpt *tpoolTester) Close() error {
 // TestIntegrationNewNilInputs tries to trigger a panic with nil inputs.
 func TestIntegrationNewNilInputs(t *testing.T) {
 	// Create a gateway and consensus set.
-	testdir := build.TempDir(modules.TransactionPoolDir, "TestNewNilInputs")
+	testdir := build.TempDir(modules.TransactionPoolDir, t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -15,7 +15,7 @@ func TestArbDataOnly(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	tpt, err := createTpoolTester("TestArbDataOnly")
+	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/defrag_test.go
+++ b/modules/wallet/defrag_test.go
@@ -14,7 +14,7 @@ func TestDefragWallet(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestDefragWallet")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestDefragWalletDust(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestDefragWalletDust")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestDefragOutputExhaustion(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestDefragOutputExhaustion")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -91,7 +91,7 @@ func TestIntegrationPreEncryption(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createBlankWalletTester("TestIntegrationPreEncryption")
+	wt, err := createBlankWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestIntegrationUserSuppliedEncryption(t *testing.T) {
 
 	// Create and wallet and user-specified key, then encrypt the wallet and
 	// run post-encryption tests on it.
-	wt, err := createBlankWalletTester("TestIntegrationUserSuppliedEncryption")
+	wt, err := createBlankWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestIntegrationBlankEncryption(t *testing.T) {
 	}
 
 	// Create the wallet.
-	wt, err := createBlankWalletTester("TestIntegrationBlankEncryption")
+	wt, err := createBlankWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestLock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestLock")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -12,7 +12,7 @@ func TestSendSiacoins(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestSendSiacoins")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestIntegrationSendOverUnder(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestIntegrationSpendOverUnder")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestIntegrationSpendHalfHalf(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestIntegrationSpendHalfHalf")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestIntegrationSpendUnconfirmed(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestIntegrationSpendUnconfirmed")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -18,7 +18,7 @@ func TestPrimarySeed(t *testing.T) {
 	}
 	t.Parallel()
 	// Start with a blank wallet tester.
-	wt, err := createBlankWalletTester("TestPrimarySeed")
+	wt, err := createBlankWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestLoadSeed(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestLoadSeed")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestLoadSeed(t *testing.T) {
 		t.Error("AllSeeds returned the wrong seed")
 	}
 
-	dir := filepath.Join(build.TempDir(modules.WalletDir, "TestLoadSeed - 0"), modules.WalletDir)
+	dir := filepath.Join(build.TempDir(modules.WalletDir, t.Name()+"1"), modules.WalletDir)
 	w, err := New(wt.cs, wt.tpool, dir)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -37,7 +37,7 @@ func TestViewAdded(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestViewAdded")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestDoubleSignError(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestDoubleSignError")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestConcurrentBuilders(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestConcurrentBuilders")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestConcurrentBuildersSingleOutput")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +371,7 @@ func TestParallelBuilders(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestParallelBuilders")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/transactions_test.go
+++ b/modules/wallet/transactions_test.go
@@ -12,7 +12,7 @@ func TestIntegrationTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestIntegrationTransactions")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestIntegrationAddressTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestTransactionHistory")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/unseeded_test.go
+++ b/modules/wallet/unseeded_test.go
@@ -13,7 +13,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestIntegrationLoad1of1Siag")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestIntegrationLoad2of3Siag")
+	wt, err := createWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -146,7 +146,7 @@ func (wt *walletTester) closeWt() {
 
 // TestNilInputs tries starting the wallet using nil inputs.
 func TestNilInputs(t *testing.T) {
-	testdir := build.TempDir(modules.WalletDir, "TestNilInputs")
+	testdir := build.TempDir(modules.WalletDir, t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +178,7 @@ func TestNilInputs(t *testing.T) {
 // TestAllAddresses checks that AllAddresses returns all of the wallet's
 // addresses in sorted order.
 func TestAllAddresses(t *testing.T) {
-	wt, err := createBlankWalletTester("TestAllAddresses")
+	wt, err := createBlankWalletTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestCloseWallet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	testdir := build.TempDir(modules.WalletDir, "TestCloseWallet")
+	testdir := build.TempDir(modules.WalletDir, t.Name())
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)

--- a/persist/boltdb_test.go
+++ b/persist/boltdb_test.go
@@ -86,7 +86,7 @@ func TestOpenDatabase(t *testing.T) {
 	}
 	// Create a folder for the database file. If a folder by that name exists
 	// already, it will be replaced by an empty folder.
-	testDir := build.TempDir(persistDir, "TestOpenNewDatabase")
+	testDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -212,7 +212,7 @@ func TestErrPermissionOpenDatabase(t *testing.T) {
 		dbVersion  = "0.0.0"
 		dbFilename = "Fake Filename"
 	)
-	testDir := build.TempDir(persistDir, "TestErrPermissionOpenDatabase")
+	testDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -248,7 +248,7 @@ func TestErrTxNotWritable(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testDir := build.TempDir(persistDir, "TestErrTxNotWritable")
+	testDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -287,7 +287,7 @@ func TestErrDatabaseNotOpen(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testDir := build.TempDir(persistDir, "TestErrDatabaseNotOpen")
+	testDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -323,7 +323,7 @@ func TestErrCheckMetadata(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testDir := build.TempDir(persistDir, "TestErrCheckMetadata")
+	testDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -382,7 +382,7 @@ func TestErrIntegratedCheckMetadata(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testDir := build.TempDir(persistDir, "TestErrIntegratedCheckMetadata")
+	testDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)

--- a/persist/json_test.go
+++ b/persist/json_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestSaveLoad checks that saving and loading data behaves as expected.
 func TestSaveLoad(t *testing.T) {
-	var meta = Metadata{"TestSaveLoad", "0.1"}
+	var meta = Metadata{t.Name(), "0.1"}
 	var saveData int = 3
 	buf := new(bytes.Buffer)
 
@@ -32,11 +32,11 @@ func TestSaveLoad(t *testing.T) {
 	}
 
 	// load with bad metadata
-	err = Load(Metadata{"BadTestSaveLoad", "0.1"}, &loadData, bytes.NewReader(data))
+	err = Load(Metadata{t.Name() + "Bad", "0.1"}, &loadData, bytes.NewReader(data))
 	if err != ErrBadHeader {
 		t.Fatal("expected ErrBadHeader, got", err)
 	}
-	err = Load(Metadata{"TestSaveLoad", "-1"}, &loadData, bytes.NewReader(data))
+	err = Load(Metadata{t.Name(), "-1"}, &loadData, bytes.NewReader(data))
 	if err != ErrBadVersion {
 		t.Fatal("expected ErrBadVersion, got", err)
 	}
@@ -62,11 +62,11 @@ func TestSaveLoad(t *testing.T) {
 // TestSaveLoadFile tests that saving and loading a file without fsync properly
 // stores and fetches data.
 func TestSaveLoadFile(t *testing.T) {
-	var meta = Metadata{"TestSaveLoadFile", "0.1"}
+	var meta = Metadata{t.Name(), "0.1"}
 	var saveData int = 3
 
 	os.MkdirAll(build.TempDir("persist"), 0777)
-	filename := build.TempDir("persist", "TestSaveLoadFile")
+	filename := build.TempDir("persist", t.Name())
 	err := SaveFile(meta, saveData, filename)
 	if err != nil {
 		t.Fatal(err)
@@ -85,11 +85,11 @@ func TestSaveLoadFile(t *testing.T) {
 // TestSaveLoadFileSync test that saving and loading a file with fsync properly
 // stores and fetches data.
 func TestSaveLoadFileSync(t *testing.T) {
-	var meta = Metadata{"TestSaveLoadFileFsync", "0.1"}
+	var meta = Metadata{t.Name(), "0.1"}
 	var saveData int = 3
 
 	os.MkdirAll(build.TempDir("persist"), 0777)
-	filename := build.TempDir("persist", "TestSaveLoadFile")
+	filename := build.TempDir("persist", t.Name())
 	err := SaveFileSync(meta, saveData, filename)
 	if err != nil {
 		t.Fatal(err)

--- a/persist/log_test.go
+++ b/persist/log_test.go
@@ -14,7 +14,7 @@ import (
 // designed.
 func TestLogger(t *testing.T) {
 	// Create a folder for the log file.
-	testdir := build.TempDir(persistDir, "TestLogger")
+	testdir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testdir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestLogger(t *testing.T) {
 // TestLoggerCritical prints a critical message from the logger.
 func TestLoggerCritical(t *testing.T) {
 	// Create a folder for the log file.
-	testdir := build.TempDir(persistDir, "TestLoggerCritical")
+	testdir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(testdir, 0700)
 	if err != nil {
 		t.Fatal(err)

--- a/persist/persist_test.go
+++ b/persist/persist_test.go
@@ -14,7 +14,7 @@ import (
 // TestIntegrationRandomSuffix checks that the random suffix creator creates
 // valid files.
 func TestIntegrationRandomSuffix(t *testing.T) {
-	tmpDir := build.TempDir(persistDir, "TestIntegrationRandomSuffix")
+	tmpDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(tmpDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -33,7 +33,7 @@ func TestIntegrationRandomSuffix(t *testing.T) {
 // TestAbsolutePathSafeFile tests creating and committing safe files with
 // absolute paths.
 func TestAbsolutePathSafeFile(t *testing.T) {
-	tmpDir := build.TempDir(persistDir, "TestAbsolutePathSafeFile")
+	tmpDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(tmpDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +80,7 @@ func TestAbsolutePathSafeFile(t *testing.T) {
 // and committing a safe file doesn't affect the safe file's final path. The
 // relative path tested is relative to the working directory.
 func TestRelativePathSafeFile(t *testing.T) {
-	tmpDir := build.TempDir(persistDir, "TestRelativePathSafeFile")
+	tmpDir := build.TempDir(persistDir, t.Name())
 	err := os.MkdirAll(tmpDir, 0700)
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +114,7 @@ func TestRelativePathSafeFile(t *testing.T) {
 	}
 
 	// Change directories and commit.
-	tmpChdir := build.TempDir(persistDir, "TestRelativePathSafeFileTmpChdir")
+	tmpChdir := build.TempDir(persistDir, t.Name()+"2")
 	err = os.MkdirAll(tmpChdir, 0700)
 	if err != nil {
 		t.Fatal(err)

--- a/sync/threadgroup_test.go
+++ b/sync/threadgroup_test.go
@@ -329,7 +329,7 @@ func TestThreadGroupSiaExample(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	testDir := build.TempDir("sync", "TestThreadGroupSiaExample")
+	testDir := build.TempDir("sync", t.Name())
 	err := os.MkdirAll(testDir, 0700)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
As of Go 1.8, `testing.T` and `testing.B` have a `Name` method. Previously we have cut-and-paste the name of the test into strings, but this is error prone and has caused NDFs in the past. Going forward, we should use `t.Name()` in all new tests.
I updated all existing tests except for those in the host package. I will add those as well if @DavidVorick does not think the changes will conflict too badly with the new storage manager code.