### PR TITLE
Change command naming of `siac renter export contracts`

### DIFF
--- a/siac/export.go
+++ b/siac/export.go
@@ -16,13 +16,14 @@ var (
 		Use:   "export",
 		Short: "export renter data to various formats",
 		Long:  "Export renter data in various formats.",
-		// Run field not provided; export requires a subcommand
+		// Run field not provided; export requires a subcommand.
 	}
 
 	renterExportContractsCmd = &cobra.Command{
-		Use:   "contracts [destination]",
-		Short: "export the renter's contracts",
-		Long:  "Export the renter's current contract set in JSON format to the specified file.",
+		Use:   "rankings-data [destination]",
+		Short: "export the renter's contracts for import to `https://rankings.sia.tech/`",
+		Long:  "Export the renter's current contract set in JSON format to the specified " +
+			"file. Intended for upload to `https://rankings.sia.tech/`.",
 		Run:   wrap(renterexportcontractscmd),
 	}
 )

--- a/siac/export.go
+++ b/siac/export.go
@@ -20,7 +20,7 @@ var (
 	}
 
 	renterExportContractsCmd = &cobra.Command{
-		Use:   "rankings-data [destination]",
+		Use:   "contract-txns [destination]",
 		Short: "export the renter's contracts for import to `https://rankings.sia.tech/`",
 		Long: "Export the renter's current contract set in JSON format to the specified " +
 			"file. Intended for upload to `https://rankings.sia.tech/`.",

--- a/siac/export.go
+++ b/siac/export.go
@@ -19,18 +19,18 @@ var (
 		// Run field not provided; export requires a subcommand.
 	}
 
-	renterExportContractsCmd = &cobra.Command{
+	renterExportContractTxnsCmd = &cobra.Command{
 		Use:   "contract-txns [destination]",
 		Short: "export the renter's contracts for import to `https://rankings.sia.tech/`",
 		Long: "Export the renter's current contract set in JSON format to the specified " +
 			"file. Intended for upload to `https://rankings.sia.tech/`.",
-		Run: wrap(renterexportcontractscmd),
+		Run: wrap(renterexportcontracttxnscmd),
 	}
 )
 
-// renterexportcontractscmd is the handler for the command `siac renter export contracts`.
+// renterexportcontracttxnscmd is the handler for the command `siac renter export contract-txns`.
 // Exports the current contract set to JSON.
-func renterexportcontractscmd(destination string) {
+func renterexportcontracttxnscmd(destination string) {
 	var cs api.RenterContracts
 	err := getAPI("/renter/contracts", &cs)
 	if err != nil {

--- a/siac/export.go
+++ b/siac/export.go
@@ -22,9 +22,9 @@ var (
 	renterExportContractsCmd = &cobra.Command{
 		Use:   "rankings-data [destination]",
 		Short: "export the renter's contracts for import to `https://rankings.sia.tech/`",
-		Long:  "Export the renter's current contract set in JSON format to the specified " +
+		Long: "Export the renter's current contract set in JSON format to the specified " +
 			"file. Intended for upload to `https://rankings.sia.tech/`.",
-		Run:   wrap(renterexportcontractscmd),
+		Run: wrap(renterexportcontractscmd),
 	}
 )
 

--- a/siac/main.go
+++ b/siac/main.go
@@ -265,7 +265,7 @@ func main() {
 	renterCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
 	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
 	renterFilesListCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
-	renterExportCmd.AddCommand(renterExportContractsCmd)
+	renterExportCmd.AddCommand(renterExportContractTxnsCmd)
 
 	root.AddCommand(gatewayCmd)
 	gatewayCmd.AddCommand(gatewayConnectCmd, gatewayDisconnectCmd, gatewayAddressCmd, gatewayListCmd)


### PR DESCRIPTION
New name: `siac renter export rankings-data` and expand the help messages. Change made to clarify that `renter export contracts` is intended to be used to upload contract details to [https://rankings.sia.tech/](https://rankings.sia.tech/). 