### PR TITLE
Compat code for new wallet

### DIFF
--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -1093,6 +1093,11 @@ func TestHostAndRentReload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Mine a block so that the wallet reclaims refund outputs
+	_, err = st.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Set an allowance for the renter, allowing a contract to be formed.
 	allowanceValues := url.Values{}

--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -28,8 +28,6 @@ var (
 	// chronological order. Only transactions relevant to the wallet are
 	// stored. The key of this bucket is an autoincrementing integer.
 	bucketProcessedTransactions = []byte("bucketProcessedTransactions")
-	// bucketSeedFiles stores the (encrypted) auxiliary seeds of the wallet.
-	bucketSeedFiles = []byte("bucketSeedFiles")
 	// bucketSiacoinOutputs maps a SiacoinOutputID to its SiacoinOutput. Only
 	// outputs that the wallet controls are stored. The wallet uses these
 	// outputs to fund transactions.
@@ -38,10 +36,6 @@ var (
 	// outputs that the wallet controls are stored. The wallet uses these
 	// outputs to fund transactions.
 	bucketSiafundOutputs = []byte("bucketSiafundOutputs")
-	// bucketSpendableKeyFiles stores the (encrypted) spendableKeys of the
-	// wallet that were not generated via seed. In practice, this means keys
-	// that were imported from a 0.3.3.x wallet or from a siag file.
-	bucketSpendableKeyFiles = []byte("bucketSpendableKeyFiles")
 	// bucketSpentOutputs maps an OutputID to the height at which it was
 	// spent. Only outputs spent by the wallet are stored. The wallet tracks
 	// these outputs so that it can reuse them if they are not confirmed on
@@ -55,10 +49,8 @@ var (
 		bucketHistoricClaimStarts,
 		bucketHistoricOutputs,
 		bucketProcessedTransactions,
-		bucketSeedFiles,
 		bucketSiacoinOutputs,
 		bucketSiafundOutputs,
-		bucketSpendableKeyFiles,
 		bucketSpentOutputs,
 		bucketWallet,
 	}
@@ -70,6 +62,8 @@ var (
 	keyPrimarySeedProgress    = []byte("keyPrimarySeedProgress")
 	keyConsensusChange        = []byte("keyConsensusChange")
 	keyConsensusHeight        = []byte("keyConsensusHeight")
+	keySpendableKeyFiles      = []byte("keySpendableKeyFiles")
+	keyAuxiliarySeedFiles     = []byte("keyAuxiliarySeedFiles")
 )
 
 // dbPut is a helper function for storing a marshalled key/value pair.

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -141,29 +141,13 @@ func (w *Wallet) managedUnlock(masterKey crypto.TwofishKey) error {
 		}
 
 		// auxiliarySeedFiles
-		err = tx.Bucket(bucketSeedFiles).ForEach(func(_, sfBytes []byte) error {
-			var sf seedFile
-			err := encoding.Unmarshal(sfBytes, &sf)
-			if err != nil {
-				return err
-			}
-			auxiliarySeedFiles = append(auxiliarySeedFiles, sf)
-			return nil
-		})
+		err = encoding.Unmarshal(tx.Bucket(bucketWallet).Get(keyAuxiliarySeedFiles), &auxiliarySeedFiles)
 		if err != nil {
 			return err
 		}
 
 		// unseededKeyFiles
-		err = tx.Bucket(bucketSpendableKeyFiles).ForEach(func(_, ukfBytes []byte) error {
-			var ukf spendableKeyFile
-			err := encoding.Unmarshal(ukfBytes, &ukf)
-			if err != nil {
-				return err
-			}
-			unseededKeyFiles = append(unseededKeyFiles, ukf)
-			return nil
-		})
+		err = encoding.Unmarshal(tx.Bucket(bucketWallet).Get(keySpendableKeyFiles), &unseededKeyFiles)
 		if err != nil {
 			return err
 		}

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -167,9 +167,10 @@ func (w *Wallet) convertPersist(dbFilename, compatFilename string) error {
 		tx.Bucket(bucketWallet).Put(keyUID, data.UID[:])
 		tx.Bucket(bucketWallet).Put(keyEncryptionVerification, data.EncryptionVerification)
 		tx.Bucket(bucketWallet).Put(keyPrimarySeedFile, encoding.Marshal(data.PrimarySeedFile))
-		dbPutPrimarySeedProgress(tx, data.PrimarySeedProgress)
 		tx.Bucket(bucketWallet).Put(keyAuxiliarySeedFiles, encoding.Marshal(data.AuxiliarySeedFiles))
 		tx.Bucket(bucketWallet).Put(keySpendableKeyFiles, encoding.Marshal(data.UnseededKeys))
+		// old wallets had a "preload depth" of 25
+		dbPutPrimarySeedProgress(tx, data.PrimarySeedProgress+25)
 
 		// set consensus height and CCID to zero so that a full rescan is
 		// triggered

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
 
@@ -15,8 +16,9 @@ import (
 )
 
 const (
-	logFile = modules.WalletDir + ".log"
-	dbFile  = modules.WalletDir + ".db"
+	logFile    = modules.WalletDir + ".log"
+	dbFile     = modules.WalletDir + ".db"
+	compatFile = modules.WalletDir + ".json"
 )
 
 var (
@@ -84,7 +86,17 @@ func (w *Wallet) initPersist() error {
 	}
 
 	// Open the database.
-	err = w.openDB(filepath.Join(w.persistDir, dbFile))
+	dbFilename := filepath.Join(w.persistDir, dbFile)
+	compatFilename := filepath.Join(w.persistDir, compatFile)
+	_, dbErr := os.Stat(dbFilename)
+	_, compatErr := os.Stat(compatFilename)
+	if dbErr != nil && compatErr == nil {
+		// database does not exist, but old persist does; convert it
+		err = w.convertPersist(dbFilename, compatFilename)
+	} else {
+		// either database exists or neither exists; open/create the database
+		err = w.openDB(filepath.Join(w.persistDir, dbFile))
+	}
 	if err != nil {
 		return err
 	}
@@ -115,6 +127,58 @@ func (w *Wallet) CreateBackup(backupFilepath string) error {
 	}
 	defer f.Close()
 	return w.createBackup(f)
+}
+
+type compatPersist struct {
+	UID                    uniqueID
+	EncryptionVerification crypto.Ciphertext
+	PrimarySeedFile        seedFile
+	PrimarySeedProgress    uint64
+	AuxiliarySeedFiles     []seedFile
+	UnseededKeys           []spendableKeyFile
+}
+
+var compatMeta = persist.Metadata{
+	Header:  "Wallet Settings",
+	Version: "0.4.0",
+}
+
+// convertPersist converts an old wallet.json file to a wallet.db database.
+func (w *Wallet) convertPersist(dbFilename, compatFilename string) error {
+	var data compatPersist
+	err := persist.LoadFile(compatMeta, &data, compatFilename)
+	if err != nil {
+		return err
+	}
+
+	w.db, err = persist.OpenDatabase(dbMetadata, dbFilename)
+	if err != nil {
+		return err
+	}
+	// initialize the database
+	err = w.db.Update(func(tx *bolt.Tx) error {
+		for _, b := range dbBuckets {
+			_, err := tx.CreateBucket(b)
+			if err != nil {
+				return fmt.Errorf("could not create bucket %v: %v", string(b), err)
+			}
+		}
+		// set UID, verification, seeds, and seed progress
+		tx.Bucket(bucketWallet).Put(keyUID, data.UID[:])
+		tx.Bucket(bucketWallet).Put(keyEncryptionVerification, data.EncryptionVerification)
+		tx.Bucket(bucketWallet).Put(keyPrimarySeedFile, encoding.Marshal(data.PrimarySeedFile))
+		dbPutPrimarySeedProgress(tx, data.PrimarySeedProgress)
+		tx.Bucket(bucketWallet).Put(keyAuxiliarySeedFiles, encoding.Marshal(data.AuxiliarySeedFiles))
+		tx.Bucket(bucketWallet).Put(keySpendableKeyFiles, encoding.Marshal(data.UnseededKeys))
+
+		// set consensus height and CCID to zero so that a full rescan is
+		// triggered
+		dbPutConsensusHeight(tx, 0)
+		dbPutConsensusChangeID(tx, modules.ConsensusChangeBeginning)
+		return nil
+	})
+	w.encrypted = true
+	return err
 }
 
 /*

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -58,10 +58,18 @@ func (w *Wallet) openDB(filename string) (err error) {
 			}
 			tx.Bucket(bucketWallet).Put(keyUID, uid)
 		}
-		// if the consensus height is nil, set it to zero
-		if tx.Bucket(bucketWallet).Get(keyConsensusHeight) == nil {
-			dbPutConsensusHeight(tx, 0)
+		// if fields in bucketWallet are nil, set them to zero to prevent unmarshal errors
+		wb := tx.Bucket(bucketWallet)
+		if wb.Get(keyConsensusHeight) == nil {
+			wb.Put(keyConsensusHeight, encoding.Marshal(uint64(0)))
 		}
+		if wb.Get(keyAuxiliarySeedFiles) == nil {
+			wb.Put(keyAuxiliarySeedFiles, encoding.Marshal([]seedFile{}))
+		}
+		if wb.Get(keySpendableKeyFiles) == nil {
+			wb.Put(keySpendableKeyFiles, encoding.Marshal([]spendableKeyFile{}))
+		}
+
 		// check whether wallet is encrypted
 		w.encrypted = tx.Bucket(bucketWallet).Get(keyEncryptionVerification) != nil
 		return nil

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -140,7 +140,12 @@ func (w *Wallet) loadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error 
 		}
 
 		// add the seedFile
-		return tx.Bucket(bucketSeedFiles).Put(sf.UID[:], encoding.Marshal(sf))
+		var current []seedFile
+		err = encoding.Unmarshal(tx.Bucket(bucketWallet).Get(keyAuxiliarySeedFiles), &current)
+		if err != nil {
+			return err
+		}
+		return tx.Bucket(bucketWallet).Put(keyAuxiliarySeedFiles, encoding.Marshal(append(current, sf)))
 	})
 	if err != nil {
 		return err

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -102,17 +102,10 @@ func (w *Wallet) checkOutput(tx *bolt.Tx, currentHeight types.BlockHeight, id ty
 	}
 	// Check that this output has not recently been spent by the wallet.
 	spendHeight, err := dbGetSpentOutput(tx, types.OutputID(id))
-	if err != nil {
-		// mimic map behavior: no entry means zero value
-		spendHeight = 0
-	}
-	// Prevent an underflow error.
-	allowedHeight := currentHeight - RespendTimeout
-	if currentHeight < RespendTimeout {
-		allowedHeight = 0
-	}
-	if spendHeight > allowedHeight {
-		return errSpendHeightTooHigh
+	if err == nil {
+		if spendHeight+RespendTimeout > currentHeight {
+			return errSpendHeightTooHigh
+		}
 	}
 	outputUnlockConditions := w.keys[output.UnlockHash].UnlockConditions
 	if currentHeight < outputUnlockConditions.Timelock {

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -111,7 +111,12 @@ func (w *Wallet) loadSpendableKey(masterKey crypto.TwofishKey, sk spendableKey) 
 		if err != nil {
 			return err
 		}
-		return tx.Bucket(bucketSpendableKeyFiles).Put(skf.UID[:], encoding.Marshal(skf))
+		var current []spendableKeyFile
+		err = encoding.Unmarshal(tx.Bucket(bucketWallet).Get(keySpendableKeyFiles), &current)
+		if err != nil {
+			return err
+		}
+		return tx.Bucket(bucketWallet).Put(keySpendableKeyFiles, encoding.Marshal(append(current, skf)))
 	})
 
 	// w.keys[sk.UnlockConditions.UnlockHash()] = sk -> aids with duplicate


### PR DESCRIPTION
This PR adds upgrade code for migrating from the old wallet.json to the new wallet.db.

Not visible in this PR is the merge commit (66bcadf5) I made to update the wallet branch to the latest master. So far I have not been able to get the branch to pass the `TestRentAndHostReload` api test. I would appreciate some help in tracking down why exactly the test fails. The error message is:
```
renterhost_test.go:1172: wallet has coins spent in incomplete transactions - not enough remaining coins
```
I suspected defragging was the cause, but disabling defragging does not fix the problem.