### PR TITLE
Add bash completion command.

### DIFF
--- a/siac/bashcomplcmd.go
+++ b/siac/bashcomplcmd.go
@@ -1,0 +1,25 @@
+package main
+
+import "github.com/spf13/cobra"
+
+var (
+	bashcomplCmd = &cobra.Command{
+		Use:   "bash-completion [path]",
+		Short: "Creates bash completion file.",
+		Long: "Creates a bash completion file at the specified " +
+			"location.\n\n" +
+
+			"Note: Bash completions will only work with the " +
+			"prefix with which the script is created (e.g. " +
+			"`./siac` or `siac`).\n\n" +
+
+			"Once created, the file has to be moved to the bash " +
+			"completion script folder - usually " +
+			"`/etc/bash_completion.d/`.",
+		Run: wrap(bashcomplcmd),
+	}
+)
+
+func bashcomplcmd(path string) {
+	rootCmd.GenBashCompletionFile(path)
+}

--- a/siac/main.go
+++ b/siac/main.go
@@ -16,16 +16,19 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
-// flags
 var (
+	// Flags.
 	addr              string // override default API address
 	initPassword      bool   // supply a custom password when creating a wallet
 	hostVerbose       bool   // display additional host info
 	renterShowHistory bool   // Show download history in addition to download queue.
 	renterListVerbose bool   // Show additional info about uploaded files.
+
+	// Globals.
+	rootCmd *cobra.Command // Root command cobra object, used by bash completion cmd.
 )
 
-// exit codes
+// Exit codes.
 // inspired by sysexits.h
 const (
 	exitCodeGeneral = 1  // Not in sysexits.h, but is standard practice.
@@ -227,6 +230,8 @@ func main() {
 		Run:   wrap(consensuscmd),
 	}
 
+	rootCmd = root
+
 	// create command tree
 	root.AddCommand(versionCmd)
 	root.AddCommand(stopCmd)
@@ -271,6 +276,8 @@ func main() {
 	gatewayCmd.AddCommand(gatewayConnectCmd, gatewayDisconnectCmd, gatewayAddressCmd, gatewayListCmd)
 
 	root.AddCommand(consensusCmd)
+
+	root.AddCommand(bashcomplCmd)
 
 	// parse flags
 	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")


### PR DESCRIPTION
Adds a command allowing the creation of a bash completion script, as well as instructions on how to use it. Closes #1613.

The command syntax is:
```bash
siac bash-completion [path]
```

This command creates a file which needs to be copied to the bash completion folder (e.g. `/etc/bash_completion.d/`)