### PR TITLE
Add contract details command

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -89,12 +89,33 @@ type (
 
 	// RenterContract represents a contract formed by the renter.
 	RenterContract struct {
-		EndHeight       types.BlockHeight    `json:"endheight"`
-		ID              types.FileContractID `json:"id"`
-		LastTransaction types.Transaction    `json:"lasttransaction"`
-		NetAddress      modules.NetAddress   `json:"netaddress"`
-		RenterFunds     types.Currency       `json:"renterfunds"`
-		Size            uint64               `json:"size"`
+		// Amount of contract funds that have been spent on downloads.
+		DownloadSpending types.Currency `json:"downloadspending"`
+		// Block height that the file contract ends on.
+		EndHeight types.BlockHeight `json:"endheight"`
+		// Fees paid in order to form the file contract.
+		Fees types.Currency `json:"fees"`
+		// Public key of the host the contract was formed with.
+		HostPublicKey types.SiaPublicKey `json:"hostpublickey"`
+		// ID of the file contract.
+		ID types.FileContractID `json:"id"`
+		// A signed transaction containing the most recent contract revision.
+		LastTransaction types.Transaction `json:"lasttransaction"`
+		// Address of the host the file contract was formed with.
+		NetAddress modules.NetAddress `json:"netaddress"`
+		// Remaining funds left for the renter to spend on uploads & downloads.
+		RenterFunds types.Currency `json:"renterfunds"`
+		// Size of the file contract, which is typically equal to the number of
+		// bytes that have been uploaded to the host.
+		Size uint64 `json:"size"`
+		// Block height that the file contract began on.
+		StartHeight types.BlockHeight `json:"startheight"`
+		// Amount of contract funds that have been spent on storage.
+		StorageSpending types.Currency `json:"StorageSpending"`
+		// Total cost to the wallet of forming the file contract.
+		TotalCost types.Currency `json:"totalcost"`
+		// Amount of contract funds that have been spent on uploads.
+		UploadSpending types.Currency `json:"uploadspending"`
 	}
 
 	// RenterContracts contains the renter's contracts.
@@ -232,12 +253,19 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 	contracts := []RenterContract{}
 	for _, c := range api.renter.Contracts() {
 		contracts = append(contracts, RenterContract{
-			EndHeight:       c.EndHeight(),
-			ID:              c.ID,
-			NetAddress:      c.NetAddress,
-			LastTransaction: c.LastRevisionTxn,
-			RenterFunds:     c.RenterFunds(),
-			Size:            c.LastRevision.NewFileSize,
+			DownloadSpending: c.DownloadSpending,
+			EndHeight:        c.EndHeight(),
+			Fees:             c.TxnFee.Add(c.SiafundFee).Add(c.ContractFee),
+			HostPublicKey:    c.HostPublicKey,
+			ID:               c.ID,
+			LastTransaction:  c.LastRevisionTxn,
+			NetAddress:       c.NetAddress,
+			RenterFunds:      c.RenterFunds(),
+			Size:             c.LastRevision.NewFileSize,
+			StartHeight:      c.StartHeight,
+			StorageSpending:  c.StorageSpending,
+			TotalCost:        c.TotalCost,
+			UploadSpending:   c.UploadSpending,
 		})
 	}
 	WriteJSON(w, RenterContracts{

--- a/doc/API.md
+++ b/doc/API.md
@@ -737,12 +737,49 @@ returns active contracts. Expired contracts are not included.
 {
   "contracts": [
     {
-      "endheight":       50000, // block height
-      "id":              "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-      "lasttransaction": {}, // types.Transaction
-      "netaddress":      "12.34.56.78:9",
-      "renterfunds":     "1234", // hastings
-      "size":            8192    // bytes
+      // Amount of contract funds that have been spent on downloads.
+      "downloadspending": "1234", // hastings
+
+      // Block height that the file contract ends on.
+      "endheight": 50000, // block height
+
+      // Fees paid in order to form the file contract.
+      "fees": "1234", // hastings
+
+      // Public key of the host the contract was formed with.
+      "hostpublickey": {
+        "algorithm": "ed25519",
+        "key": "RW50cm9weSBpc24ndCB3aGF0IGl0IHVzZWQgdG8gYmU="
+      },
+
+      // ID of the file contract.
+      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
+      // A signed transaction containing the most recent contract revision.
+      "lasttransaction": {},
+
+      // Address of the host the file contract was formed with.
+      "netaddress": "12.34.56.78:9",
+
+      // Remaining funds left for the renter to spend on uploads & downloads.
+      "renterfunds": "1234", // hastings
+
+      // Size of the file contract, which is typically equal to the number of
+      // bytes that have been uploaded to the host.
+      "size": 8192, // bytes
+
+      // Block height that the file contract began on.
+      "startheight": 50000, // block height
+
+      // Amount of contract funds that have been spent on storage.
+      "storagespending": "1234", // hastings
+
+      // Total cost to the wallet of forming the file contract.
+      // This includes both the fees and the funds allocated in the contract.
+      "totalcost": "1234", // hastings
+
+      // Amount of contract funds that have been spent on uploads.
+      "uploadspending": "1234" // hastings
     }
   ]
 }

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -188,7 +188,7 @@ func (mrs *MerkleRootSet) UnmarshalJSON(b []byte) error {
 }
 
 // A RenterContract contains all the metadata necessary to revise or renew a
-// file contract.
+// file contract. See `api.RenterContract` for field information.
 type RenterContract struct {
 	FileContract    types.FileContract         `json:"filecontract"`
 	HostPublicKey   types.SiaPublicKey         `json:"hostpublickey"`

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -94,6 +94,14 @@ func (c *Contractor) load() error {
 		if contract.StartHeight == 0 {
 			contract.StartHeight = c.currentPeriod + 1
 		}
+		// COMPATv1.1.2
+		// Old versions calculated the TotalCost field incorrectly, omitting
+		// the transaction fee. Recompute the TotalCost from scratch using the
+		// original allocated funds and fees.
+		if len(contract.FileContract.ValidProofOutputs) > 0 {
+			contract.TotalCost = contract.FileContract.ValidProofOutputs[0].Value.
+				Add(contract.TxnFee).Add(contract.SiafundFee).Add(contract.ContractFee)
+		}
 		c.contracts[contract.ID] = contract
 	}
 

--- a/siac/main.go
+++ b/siac/main.go
@@ -267,6 +267,9 @@ func main() {
 		renterContractsCmd, renterFilesListCmd, renterFilesRenameCmd,
 		renterFilesUploadCmd, renterUploadsCmd, renterExportCmd,
 		renterPricesCmd)
+
+	renterContractsCmd.AddCommand(renterContractsViewCmd)
+
 	renterCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")
 	renterDownloadsCmd.Flags().BoolVarP(&renterShowHistory, "history", "H", false, "Show download history in addition to the download queue")
 	renterFilesListCmd.Flags().BoolVarP(&renterListVerbose, "verbose", "v", false, "Show additional file info such as redundancy")

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -62,6 +62,13 @@ have a reasonable number (>30) of hosts in your hostdb.`,
 		Run:   wrap(rentercontractscmd),
 	}
 
+	renterContractsViewCmd = &cobra.Command{
+		Use:   "view [contract-id]",
+		Short: "View details of the specified contract",
+		Long:  "View all details available of the specified contract.",
+		Run:   wrap(rentercontractsviewcmd),
+	}
+
 	renterFilesDeleteCmd = &cobra.Command{
 		Use:     "delete [path]",
 		Aliases: []string{"rm"},
@@ -292,6 +299,48 @@ func rentercontractscmd() {
 			c.ID)
 	}
 	w.Flush()
+}
+
+// rentercontractsviewcmd is the handler for the command `siac renter contracts <id>`.
+// It lists details of a specific contract.
+func rentercontractsviewcmd(cid string) {
+	var rc api.RenterContracts
+	err := getAPI("/renter/contracts", &rc)
+	if err != nil {
+		die("Could not get contract details: ", err)
+	}
+
+	for _, rc := range rc.Contracts {
+		if rc.ID.String() == cid {
+			fmt.Printf(`
+Contract %v
+Host: %v (Public Key: %v)
+
+Start Height: %v
+End Height:   %v
+
+Total cost:        %v (Fees: %v)
+Funds Allocated:   %v
+Upload Spending:   %v
+Storage Spending:  %v
+Download Spending: %v
+Remaining Funds:   %v
+
+File Size: %v
+`, rc.ID, rc.NetAddress, rc.HostPublicKey, rc.StartHeight, rc.EndHeight,
+				currencyUnits(rc.TotalCost),
+				currencyUnits(rc.Fees),
+				currencyUnits(rc.TotalCost.Sub(rc.Fees)),
+				currencyUnits(rc.UploadSpending),
+				currencyUnits(rc.StorageSpending),
+				currencyUnits(rc.DownloadSpending),
+				currencyUnits(rc.RenterFunds),
+				filesizeUnits(int64(rc.Size)))
+			return
+		}
+	}
+
+	fmt.Println("Contract not found")
 }
 
 // renterfilesdeletecmd is the handler for the command `siac renter delete [path]`.


### PR DESCRIPTION
Adds an endpoint for contract details, and a `siac` command to view details of a contract. Adresses #1620.

The endpoint is at:
`GET /renter/contract/*contract-id`. It returns a json-serialized `modules.RenterContract` object.

The siac command is:
`siac renter contracts view <contract-id>`

The output is currently:
```
OVERVIEW
========
End height:             107385
Host:                   x.x.x.x:9982
ID:                     xxxxxxxxxx7c56f90b7cc0a8ef31c27792bd2bb8cc4d5c468ae5426bec5

FILE CONTRACT
=============
File Size:              0 B

SPENDING
========
Renter funds:           2.329 SC
Upload Spending:        7.565 mS
```


This is a work in progress - let me know what else should be included. See [here](https://github.com/NebulousLabs/Sia/blob/master/modules/renter.go#L192) which information can be printed.