### PR TITLE
Faster Wallet IBD/rescan

### DIFF
--- a/modules/wallet/database_test.go
+++ b/modules/wallet/database_test.go
@@ -48,31 +48,25 @@ func TestDBHistoricHelpers(t *testing.T) {
 
 	id := types.OutputID{1, 2, 3}
 	c := types.NewCurrency64(7)
-	wt.wallet.db.Update(func(tx *bolt.Tx) error {
-		return dbPutHistoricOutput(tx, id, c)
-	})
-	wt.wallet.db.View(func(tx *bolt.Tx) error {
-		c2, err := dbGetHistoricOutput(tx, id)
-		if err != nil {
-			t.Fatal(err)
-		} else if c2.Cmp(c) != 0 {
-			t.Fatal(c, c2)
-		}
-		return nil
-	})
+	wt.wallet.mu.Lock()
+	dbPutHistoricOutput(wt.wallet.dbTx, id, c)
+	c2, err := dbGetHistoricOutput(wt.wallet.dbTx, id)
+	if err != nil {
+		t.Fatal(err)
+	} else if c2.Cmp(c) != 0 {
+		t.Fatal(c, c2)
+	}
+	wt.wallet.mu.Unlock()
 
 	soid := types.SiafundOutputID{1, 2, 3}
 	c = types.NewCurrency64(7)
-	wt.wallet.db.Update(func(tx *bolt.Tx) error {
-		return dbPutHistoricClaimStart(tx, soid, c)
-	})
-	wt.wallet.db.View(func(tx *bolt.Tx) error {
-		c2, err := dbGetHistoricClaimStart(tx, soid)
-		if err != nil {
-			t.Fatal(err)
-		} else if c2.Cmp(c) != 0 {
-			t.Fatal(c, c2)
-		}
-		return nil
-	})
+	wt.wallet.mu.Lock()
+	defer wt.wallet.mu.Unlock()
+	dbPutHistoricClaimStart(wt.wallet.dbTx, soid, c)
+	c2, err = dbGetHistoricClaimStart(wt.wallet.dbTx, soid)
+	if err != nil {
+		t.Fatal(err)
+	} else if c2.Cmp(c) != 0 {
+		t.Fatal(c, c2)
+	}
 }

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -125,16 +125,8 @@ func (w *Wallet) threadedDefragWallet() {
 
 	// Check that a defrag makes sense.
 	w.mu.Lock()
-	// Can't defrag if the wallet is locked.
 	if !w.unlocked {
-		w.mu.Unlock()
-		return
-	}
-	// No need to defrag if the number of outputs is below the defrag limit.
-	// NOTE: some outputs may be invalid (e.g. dust), but it's still more
-	// efficient to count them naively as a first pass.
-	totalOutputs := w.dbTx.Bucket(bucketSiacoinOutputs).Stats().KeyN
-	if totalOutputs < defragThreshold {
+		// Can't defrag if the wallet is locked.
 		w.mu.Unlock()
 		return
 	}

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/types"
-	"github.com/NebulousLabs/bolt"
 )
 
 var (
@@ -15,106 +14,102 @@ var (
 
 // createDefragTransaction creates a transaction that spends multiple existing
 // wallet outputs into a single new address.
-func (w *Wallet) createDefragTransaction() (txnSet []types.Transaction, err error) {
-	err = w.db.Update(func(tx *bolt.Tx) error {
-		consensusHeight, err := dbGetConsensusHeight(tx)
-		if err != nil {
-			return err
-		}
+func (w *Wallet) createDefragTransaction() ([]types.Transaction, error) {
+	consensusHeight, err := dbGetConsensusHeight(w.dbTx)
+	if err != nil {
+		return nil, err
+	}
 
-		// Collect a value-sorted set of siacoin outputs.
-		var so sortedOutputs
-		err = dbForEachSiacoinOutput(tx, func(scoid types.SiacoinOutputID, sco types.SiacoinOutput) {
-			if w.checkOutput(tx, consensusHeight, scoid, sco) == nil {
-				so.ids = append(so.ids, scoid)
-				so.outputs = append(so.outputs, sco)
-			}
-		})
-		if err != nil {
-			return err
+	// Collect a value-sorted set of siacoin outputs.
+	var so sortedOutputs
+	err = dbForEachSiacoinOutput(w.dbTx, func(scoid types.SiacoinOutputID, sco types.SiacoinOutput) {
+		if w.checkOutput(w.dbTx, consensusHeight, scoid, sco) == nil {
+			so.ids = append(so.ids, scoid)
+			so.outputs = append(so.outputs, sco)
 		}
-		sort.Sort(sort.Reverse(so))
-
-		// Only defrag if there are enough outputs to merit defragging.
-		if len(so.ids) <= defragThreshold {
-			return errDefragNotNeeded
-		}
-
-		// Skip over the 'defragStartIndex' largest outputs, so that the user can
-		// still reasonably use their wallet while the defrag is happening.
-		var amount types.Currency
-		var parentTxn types.Transaction
-		var spentScoids []types.SiacoinOutputID
-		for i := defragStartIndex; i < defragStartIndex+defragBatchSize; i++ {
-			scoid := so.ids[i]
-			sco := so.outputs[i]
-
-			// Add a siacoin input for this output.
-			outputUnlockConditions := w.keys[sco.UnlockHash].UnlockConditions
-			sci := types.SiacoinInput{
-				ParentID:         scoid,
-				UnlockConditions: outputUnlockConditions,
-			}
-			parentTxn.SiacoinInputs = append(parentTxn.SiacoinInputs, sci)
-			spentScoids = append(spentScoids, scoid)
-
-			// Add the output to the total fund
-			amount = amount.Add(sco.Value)
-		}
-
-		// Create and add the output that will be used to fund the defrag
-		// transaction.
-		parentUnlockConditions, err := w.nextPrimarySeedAddress(tx)
-		if err != nil {
-			return err
-		}
-		exactOutput := types.SiacoinOutput{
-			Value:      amount,
-			UnlockHash: parentUnlockConditions.UnlockHash(),
-		}
-		parentTxn.SiacoinOutputs = append(parentTxn.SiacoinOutputs, exactOutput)
-
-		// Sign all of the inputs to the parent transaction.
-		for _, sci := range parentTxn.SiacoinInputs {
-			addSignatures(&parentTxn, types.FullCoveredFields, sci.UnlockConditions, crypto.Hash(sci.ParentID), w.keys[sci.UnlockConditions.UnlockHash()])
-		}
-
-		// Create the defrag transaction.
-		fee := defragFee()
-		refundAddr, err := w.nextPrimarySeedAddress(tx)
-		if err != nil {
-			return err
-		}
-		txn := types.Transaction{
-			SiacoinInputs: []types.SiacoinInput{{
-				ParentID:         parentTxn.SiacoinOutputID(0),
-				UnlockConditions: parentUnlockConditions,
-			}},
-			SiacoinOutputs: []types.SiacoinOutput{{
-				Value:      amount.Sub(fee),
-				UnlockHash: refundAddr.UnlockHash(),
-			}},
-			MinerFees: []types.Currency{fee},
-		}
-		addSignatures(&txn, types.FullCoveredFields, parentUnlockConditions, crypto.Hash(parentTxn.SiacoinOutputID(0)), w.keys[parentUnlockConditions.UnlockHash()])
-
-		// Mark all outputs that were spent as spent.
-		for _, scoid := range spentScoids {
-			if err := dbPutSpentOutput(tx, types.OutputID(scoid), consensusHeight); err != nil {
-				return err
-			}
-		}
-		// Mark the parent output as spent. Must be done after the transaction is
-		// finished because otherwise the txid and output id will change.
-		if err := dbPutSpentOutput(tx, types.OutputID(parentTxn.SiacoinOutputID(0)), consensusHeight); err != nil {
-			return err
-		}
-
-		// Construct the final transaction set
-		txnSet = []types.Transaction{parentTxn, txn}
-		return nil
 	})
-	return
+	if err != nil {
+		return nil, err
+	}
+	sort.Sort(sort.Reverse(so))
+
+	// Only defrag if there are enough outputs to merit defragging.
+	if len(so.ids) <= defragThreshold {
+		return nil, errDefragNotNeeded
+	}
+
+	// Skip over the 'defragStartIndex' largest outputs, so that the user can
+	// still reasonably use their wallet while the defrag is happening.
+	var amount types.Currency
+	var parentTxn types.Transaction
+	var spentScoids []types.SiacoinOutputID
+	for i := defragStartIndex; i < defragStartIndex+defragBatchSize; i++ {
+		scoid := so.ids[i]
+		sco := so.outputs[i]
+
+		// Add a siacoin input for this output.
+		outputUnlockConditions := w.keys[sco.UnlockHash].UnlockConditions
+		sci := types.SiacoinInput{
+			ParentID:         scoid,
+			UnlockConditions: outputUnlockConditions,
+		}
+		parentTxn.SiacoinInputs = append(parentTxn.SiacoinInputs, sci)
+		spentScoids = append(spentScoids, scoid)
+
+		// Add the output to the total fund
+		amount = amount.Add(sco.Value)
+	}
+
+	// Create and add the output that will be used to fund the defrag
+	// transaction.
+	parentUnlockConditions, err := w.nextPrimarySeedAddress(w.dbTx)
+	if err != nil {
+		return nil, err
+	}
+	exactOutput := types.SiacoinOutput{
+		Value:      amount,
+		UnlockHash: parentUnlockConditions.UnlockHash(),
+	}
+	parentTxn.SiacoinOutputs = append(parentTxn.SiacoinOutputs, exactOutput)
+
+	// Sign all of the inputs to the parent transaction.
+	for _, sci := range parentTxn.SiacoinInputs {
+		addSignatures(&parentTxn, types.FullCoveredFields, sci.UnlockConditions, crypto.Hash(sci.ParentID), w.keys[sci.UnlockConditions.UnlockHash()])
+	}
+
+	// Create the defrag transaction.
+	fee := defragFee()
+	refundAddr, err := w.nextPrimarySeedAddress(w.dbTx)
+	if err != nil {
+		return nil, err
+	}
+	txn := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{{
+			ParentID:         parentTxn.SiacoinOutputID(0),
+			UnlockConditions: parentUnlockConditions,
+		}},
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Value:      amount.Sub(fee),
+			UnlockHash: refundAddr.UnlockHash(),
+		}},
+		MinerFees: []types.Currency{fee},
+	}
+	addSignatures(&txn, types.FullCoveredFields, parentUnlockConditions, crypto.Hash(parentTxn.SiacoinOutputID(0)), w.keys[parentUnlockConditions.UnlockHash()])
+
+	// Mark all outputs that were spent as spent.
+	for _, scoid := range spentScoids {
+		if err = dbPutSpentOutput(w.dbTx, types.OutputID(scoid), consensusHeight); err != nil {
+			return nil, err
+		}
+	}
+	// Mark the parent output as spent. Must be done after the transaction is
+	// finished because otherwise the txid and output id will change.
+	if err = dbPutSpentOutput(w.dbTx, types.OutputID(parentTxn.SiacoinOutputID(0)), consensusHeight); err != nil {
+		return nil, err
+	}
+
+	// Construct the final transaction set
+	return []types.Transaction{parentTxn, txn}, nil
 }
 
 // threadedDefragWallet computes the sum of the 15 largest outputs in the wallet and
@@ -129,27 +124,22 @@ func (w *Wallet) threadedDefragWallet() {
 	defer w.tg.Done()
 
 	// Check that a defrag makes sense.
-	w.mu.RLock()
+	w.mu.Lock()
 	// Can't defrag if the wallet is locked.
 	if !w.unlocked {
-		w.mu.RUnlock()
+		w.mu.Unlock()
 		return
 	}
 	// No need to defrag if the number of outputs is below the defrag limit.
 	// NOTE: some outputs may be invalid (e.g. dust), but it's still more
 	// efficient to count them naively as a first pass.
-	var totalOutputs int
-	w.db.View(func(tx *bolt.Tx) error {
-		totalOutputs = tx.Bucket(bucketSiacoinOutputs).Stats().KeyN
-		return nil
-	})
-	w.mu.RUnlock()
+	totalOutputs := w.dbTx.Bucket(bucketSiacoinOutputs).Stats().KeyN
 	if totalOutputs < defragThreshold {
+		w.mu.Unlock()
 		return
 	}
 
 	// Create the defrag transaction.
-	w.mu.Lock()
 	txnSet, err := w.createDefragTransaction()
 	w.mu.Unlock()
 	if err == errDefragNotNeeded {

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -112,10 +112,8 @@ func (w *Wallet) initPersist() error {
 
 // createBackup copies the wallet database to dst.
 func (w *Wallet) createBackup(dst io.Writer) error {
-	return w.db.View(func(tx *bolt.Tx) error {
-		_, err := tx.WriteTo(dst)
-		return err
-	})
+	_, err := w.dbTx.WriteTo(dst)
+	return err
 }
 
 // CreateBackup creates a backup file at the desired filepath.

--- a/modules/wallet/scan_test.go
+++ b/modules/wallet/scan_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/types"
-	"github.com/NebulousLabs/bolt"
 	"github.com/NebulousLabs/fastrand"
 )
 
@@ -33,9 +32,9 @@ func TestScanLargeIndex(t *testing.T) {
 	}
 
 	// set the wallet's seed progress to a high number and then mine some coins.
-	err = wt.wallet.db.Update(func(tx *bolt.Tx) error {
-		return dbPutPrimarySeedProgress(tx, numInitialKeys+1)
-	})
+	wt.wallet.mu.Lock()
+	dbPutPrimarySeedProgress(wt.wallet.dbTx, numInitialKeys+1)
+	wt.wallet.mu.Unlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,9 +92,9 @@ func TestScanLoop(t *testing.T) {
 	// scanner to loop exactly three times.
 	indices := []uint64{500, 2500, 8000, 100000}
 	for _, index := range indices {
-		err = wt.wallet.db.Update(func(tx *bolt.Tx) error {
-			return dbPutPrimarySeedProgress(tx, index)
-		})
+		wt.wallet.mu.Lock()
+		dbPutPrimarySeedProgress(wt.wallet.dbTx, index)
+		wt.wallet.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -10,19 +10,14 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/types"
-
-	"github.com/NebulousLabs/bolt"
 )
 
 // resetChangeID clears the wallet's ConsensusChangeID. When Unlock is called,
 // the wallet will rescan from the genesis block.
 func resetChangeID(w *Wallet) {
-	err := w.db.Update(func(tx *bolt.Tx) error {
-		return dbPutConsensusChangeID(tx, modules.ConsensusChangeBeginning)
-	})
-	if err != nil {
-		panic(err)
-	}
+	w.mu.Lock()
+	dbPutConsensusChangeID(w.dbTx, modules.ConsensusChangeBeginning)
+	w.mu.Unlock()
 }
 
 // TestPrimarySeed checks that the correct seed is returned when calling

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -120,134 +120,132 @@ func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
 	tb.wallet.mu.Lock()
 	defer tb.wallet.mu.Unlock()
 
-	return tb.wallet.db.Update(func(tx *bolt.Tx) error {
-		consensusHeight, err := dbGetConsensusHeight(tx)
-		if err != nil {
-			return err
-		}
+	consensusHeight, err := dbGetConsensusHeight(tb.wallet.dbTx)
+	if err != nil {
+		return err
+	}
 
-		// Collect a value-sorted set of siacoin outputs.
-		var so sortedOutputs
-		err = dbForEachSiacoinOutput(tx, func(scoid types.SiacoinOutputID, sco types.SiacoinOutput) {
-			so.ids = append(so.ids, scoid)
-			so.outputs = append(so.outputs, sco)
-		})
-		if err != nil {
-			return err
-		}
-		// Add all of the unconfirmed outputs as well.
-		for _, upt := range tb.wallet.unconfirmedProcessedTransactions {
-			for i, sco := range upt.Transaction.SiacoinOutputs {
-				// Determine if the output belongs to the wallet.
-				_, exists := tb.wallet.keys[sco.UnlockHash]
-				if !exists {
-					continue
-				}
-				so.ids = append(so.ids, upt.Transaction.SiacoinOutputID(uint64(i)))
-				so.outputs = append(so.outputs, sco)
-			}
-		}
-		sort.Sort(sort.Reverse(so))
-
-		// Create and fund a parent transaction that will add the correct amount of
-		// siacoins to the transaction.
-		var fund types.Currency
-		// potentialFund tracks the balance of the wallet including outputs that
-		// have been spent in other unconfirmed transactions recently. This is to
-		// provide the user with a more useful error message in the event that they
-		// are overspending.
-		var potentialFund types.Currency
-		parentTxn := types.Transaction{}
-		var spentScoids []types.SiacoinOutputID
-		for i := range so.ids {
-			scoid := so.ids[i]
-			sco := so.outputs[i]
-			// Check that the output can be spent.
-			if err := tb.wallet.checkOutput(tx, consensusHeight, scoid, sco); err != nil {
-				if err == errSpendHeightTooHigh {
-					potentialFund = potentialFund.Add(sco.Value)
-				}
+	// Collect a value-sorted set of siacoin outputs.
+	var so sortedOutputs
+	err = dbForEachSiacoinOutput(tb.wallet.dbTx, func(scoid types.SiacoinOutputID, sco types.SiacoinOutput) {
+		so.ids = append(so.ids, scoid)
+		so.outputs = append(so.outputs, sco)
+	})
+	if err != nil {
+		return err
+	}
+	// Add all of the unconfirmed outputs as well.
+	for _, upt := range tb.wallet.unconfirmedProcessedTransactions {
+		for i, sco := range upt.Transaction.SiacoinOutputs {
+			// Determine if the output belongs to the wallet.
+			_, exists := tb.wallet.keys[sco.UnlockHash]
+			if !exists {
 				continue
 			}
+			so.ids = append(so.ids, upt.Transaction.SiacoinOutputID(uint64(i)))
+			so.outputs = append(so.outputs, sco)
+		}
+	}
+	sort.Sort(sort.Reverse(so))
 
-			// Add a siacoin input for this output.
-			sci := types.SiacoinInput{
-				ParentID:         scoid,
-				UnlockConditions: tb.wallet.keys[sco.UnlockHash].UnlockConditions,
+	// Create and fund a parent transaction that will add the correct amount of
+	// siacoins to the transaction.
+	var fund types.Currency
+	// potentialFund tracks the balance of the wallet including outputs that
+	// have been spent in other unconfirmed transactions recently. This is to
+	// provide the user with a more useful error message in the event that they
+	// are overspending.
+	var potentialFund types.Currency
+	parentTxn := types.Transaction{}
+	var spentScoids []types.SiacoinOutputID
+	for i := range so.ids {
+		scoid := so.ids[i]
+		sco := so.outputs[i]
+		// Check that the output can be spent.
+		if err := tb.wallet.checkOutput(tb.wallet.dbTx, consensusHeight, scoid, sco); err != nil {
+			if err == errSpendHeightTooHigh {
+				potentialFund = potentialFund.Add(sco.Value)
 			}
-			parentTxn.SiacoinInputs = append(parentTxn.SiacoinInputs, sci)
-			spentScoids = append(spentScoids, scoid)
-
-			// Add the output to the total fund
-			fund = fund.Add(sco.Value)
-			potentialFund = potentialFund.Add(sco.Value)
-			if fund.Cmp(amount) >= 0 {
-				break
-			}
-		}
-		if potentialFund.Cmp(amount) >= 0 && fund.Cmp(amount) < 0 {
-			return modules.ErrIncompleteTransactions
-		}
-		if fund.Cmp(amount) < 0 {
-			return modules.ErrLowBalance
+			continue
 		}
 
-		// Create and add the output that will be used to fund the standard
-		// transaction.
-		parentUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tx)
+		// Add a siacoin input for this output.
+		sci := types.SiacoinInput{
+			ParentID:         scoid,
+			UnlockConditions: tb.wallet.keys[sco.UnlockHash].UnlockConditions,
+		}
+		parentTxn.SiacoinInputs = append(parentTxn.SiacoinInputs, sci)
+		spentScoids = append(spentScoids, scoid)
+
+		// Add the output to the total fund
+		fund = fund.Add(sco.Value)
+		potentialFund = potentialFund.Add(sco.Value)
+		if fund.Cmp(amount) >= 0 {
+			break
+		}
+	}
+	if potentialFund.Cmp(amount) >= 0 && fund.Cmp(amount) < 0 {
+		return modules.ErrIncompleteTransactions
+	}
+	if fund.Cmp(amount) < 0 {
+		return modules.ErrLowBalance
+	}
+
+	// Create and add the output that will be used to fund the standard
+	// transaction.
+	parentUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tb.wallet.dbTx)
+	if err != nil {
+		return err
+	}
+
+	exactOutput := types.SiacoinOutput{
+		Value:      amount,
+		UnlockHash: parentUnlockConditions.UnlockHash(),
+	}
+	parentTxn.SiacoinOutputs = append(parentTxn.SiacoinOutputs, exactOutput)
+
+	// Create a refund output if needed.
+	if !amount.Equals(fund) {
+		refundUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tb.wallet.dbTx)
 		if err != nil {
 			return err
 		}
-
-		exactOutput := types.SiacoinOutput{
-			Value:      amount,
-			UnlockHash: parentUnlockConditions.UnlockHash(),
+		refundOutput := types.SiacoinOutput{
+			Value:      fund.Sub(amount),
+			UnlockHash: refundUnlockConditions.UnlockHash(),
 		}
-		parentTxn.SiacoinOutputs = append(parentTxn.SiacoinOutputs, exactOutput)
+		parentTxn.SiacoinOutputs = append(parentTxn.SiacoinOutputs, refundOutput)
+	}
 
-		// Create a refund output if needed.
-		if !amount.Equals(fund) {
-			refundUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tx)
-			if err != nil {
-				return err
-			}
-			refundOutput := types.SiacoinOutput{
-				Value:      fund.Sub(amount),
-				UnlockHash: refundUnlockConditions.UnlockHash(),
-			}
-			parentTxn.SiacoinOutputs = append(parentTxn.SiacoinOutputs, refundOutput)
-		}
+	// Sign all of the inputs to the parent trancstion.
+	for _, sci := range parentTxn.SiacoinInputs {
+		addSignatures(&parentTxn, types.FullCoveredFields, sci.UnlockConditions, crypto.Hash(sci.ParentID), tb.wallet.keys[sci.UnlockConditions.UnlockHash()])
+	}
+	// Mark the parent output as spent. Must be done after the transaction is
+	// finished because otherwise the txid and output id will change.
+	err = dbPutSpentOutput(tb.wallet.dbTx, types.OutputID(parentTxn.SiacoinOutputID(0)), consensusHeight)
+	if err != nil {
+		return err
+	}
 
-		// Sign all of the inputs to the parent trancstion.
-		for _, sci := range parentTxn.SiacoinInputs {
-			addSignatures(&parentTxn, types.FullCoveredFields, sci.UnlockConditions, crypto.Hash(sci.ParentID), tb.wallet.keys[sci.UnlockConditions.UnlockHash()])
-		}
-		// Mark the parent output as spent. Must be done after the transaction is
-		// finished because otherwise the txid and output id will change.
-		err = dbPutSpentOutput(tx, types.OutputID(parentTxn.SiacoinOutputID(0)), consensusHeight)
+	// Add the exact output.
+	newInput := types.SiacoinInput{
+		ParentID:         parentTxn.SiacoinOutputID(0),
+		UnlockConditions: parentUnlockConditions,
+	}
+	tb.newParents = append(tb.newParents, len(tb.parents))
+	tb.parents = append(tb.parents, parentTxn)
+	tb.siacoinInputs = append(tb.siacoinInputs, len(tb.transaction.SiacoinInputs))
+	tb.transaction.SiacoinInputs = append(tb.transaction.SiacoinInputs, newInput)
+
+	// Mark all outputs that were spent as spent.
+	for _, scoid := range spentScoids {
+		err = dbPutSpentOutput(tb.wallet.dbTx, types.OutputID(scoid), consensusHeight)
 		if err != nil {
 			return err
 		}
-
-		// Add the exact output.
-		newInput := types.SiacoinInput{
-			ParentID:         parentTxn.SiacoinOutputID(0),
-			UnlockConditions: parentUnlockConditions,
-		}
-		tb.newParents = append(tb.newParents, len(tb.parents))
-		tb.parents = append(tb.parents, parentTxn)
-		tb.siacoinInputs = append(tb.siacoinInputs, len(tb.transaction.SiacoinInputs))
-		tb.transaction.SiacoinInputs = append(tb.transaction.SiacoinInputs, newInput)
-
-		// Mark all outputs that were spent as spent.
-		for _, scoid := range spentScoids {
-			err = dbPutSpentOutput(tx, types.OutputID(scoid), consensusHeight)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+	}
+	return nil
 }
 
 // FundSiafunds will add a siafund input of exactly 'amount' to the
@@ -258,129 +256,127 @@ func (tb *transactionBuilder) FundSiafunds(amount types.Currency) error {
 	tb.wallet.mu.Lock()
 	defer tb.wallet.mu.Unlock()
 
-	return tb.wallet.db.Update(func(tx *bolt.Tx) error {
-		consensusHeight, err := dbGetConsensusHeight(tx)
-		if err != nil {
+	consensusHeight, err := dbGetConsensusHeight(tb.wallet.dbTx)
+	if err != nil {
+		return err
+	}
+
+	// Create and fund a parent transaction that will add the correct amount of
+	// siafunds to the transaction.
+	var fund types.Currency
+	var potentialFund types.Currency
+	parentTxn := types.Transaction{}
+	var spentSfoids []types.SiafundOutputID
+	c := tb.wallet.dbTx.Bucket(bucketSiafundOutputs).Cursor()
+	for idBytes, sfoBytes := c.First(); idBytes != nil; idBytes, sfoBytes = c.Next() {
+		var sfoid types.SiafundOutputID
+		var sfo types.SiafundOutput
+		if err := encoding.Unmarshal(idBytes, &sfoid); err != nil {
+			return err
+		} else if err := encoding.Unmarshal(sfoBytes, &sfo); err != nil {
 			return err
 		}
 
-		// Create and fund a parent transaction that will add the correct amount of
-		// siafunds to the transaction.
-		var fund types.Currency
-		var potentialFund types.Currency
-		parentTxn := types.Transaction{}
-		var spentSfoids []types.SiafundOutputID
-		c := tx.Bucket(bucketSiafundOutputs).Cursor()
-		for idBytes, sfoBytes := c.First(); idBytes != nil; idBytes, sfoBytes = c.Next() {
-			var sfoid types.SiafundOutputID
-			var sfo types.SiafundOutput
-			if err := encoding.Unmarshal(idBytes, &sfoid); err != nil {
-				return err
-			} else if err := encoding.Unmarshal(sfoBytes, &sfo); err != nil {
-				return err
-			}
-
-			// Check that this output has not recently been spent by the wallet.
-			spendHeight, err := dbGetSpentOutput(tx, types.OutputID(sfoid))
-			if err != nil {
-				// mimic map behavior: no entry means zero value
-				spendHeight = 0
-			}
-			// Prevent an underflow error.
-			allowedHeight := consensusHeight - RespendTimeout
-			if consensusHeight < RespendTimeout {
-				allowedHeight = 0
-			}
-			if spendHeight > allowedHeight {
-				potentialFund = potentialFund.Add(sfo.Value)
-				continue
-			}
-			outputUnlockConditions := tb.wallet.keys[sfo.UnlockHash].UnlockConditions
-			if consensusHeight < outputUnlockConditions.Timelock {
-				continue
-			}
-
-			// Add a siafund input for this output.
-			parentClaimUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tx)
-			if err != nil {
-				return err
-			}
-			sfi := types.SiafundInput{
-				ParentID:         sfoid,
-				UnlockConditions: outputUnlockConditions,
-				ClaimUnlockHash:  parentClaimUnlockConditions.UnlockHash(),
-			}
-			parentTxn.SiafundInputs = append(parentTxn.SiafundInputs, sfi)
-			spentSfoids = append(spentSfoids, sfoid)
-
-			// Add the output to the total fund
-			fund = fund.Add(sfo.Value)
+		// Check that this output has not recently been spent by the wallet.
+		spendHeight, err := dbGetSpentOutput(tb.wallet.dbTx, types.OutputID(sfoid))
+		if err != nil {
+			// mimic map behavior: no entry means zero value
+			spendHeight = 0
+		}
+		// Prevent an underflow error.
+		allowedHeight := consensusHeight - RespendTimeout
+		if consensusHeight < RespendTimeout {
+			allowedHeight = 0
+		}
+		if spendHeight > allowedHeight {
 			potentialFund = potentialFund.Add(sfo.Value)
-			if fund.Cmp(amount) >= 0 {
-				break
-			}
+			continue
 		}
-		if potentialFund.Cmp(amount) >= 0 && fund.Cmp(amount) < 0 {
-			return modules.ErrIncompleteTransactions
-		}
-		if fund.Cmp(amount) < 0 {
-			return modules.ErrLowBalance
+		outputUnlockConditions := tb.wallet.keys[sfo.UnlockHash].UnlockConditions
+		if consensusHeight < outputUnlockConditions.Timelock {
+			continue
 		}
 
-		// Create and add the output that will be used to fund the standard
-		// transaction.
-		parentUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tx)
+		// Add a siafund input for this output.
+		parentClaimUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tb.wallet.dbTx)
 		if err != nil {
 			return err
 		}
-		exactOutput := types.SiafundOutput{
-			Value:      amount,
-			UnlockHash: parentUnlockConditions.UnlockHash(),
+		sfi := types.SiafundInput{
+			ParentID:         sfoid,
+			UnlockConditions: outputUnlockConditions,
+			ClaimUnlockHash:  parentClaimUnlockConditions.UnlockHash(),
 		}
-		parentTxn.SiafundOutputs = append(parentTxn.SiafundOutputs, exactOutput)
+		parentTxn.SiafundInputs = append(parentTxn.SiafundInputs, sfi)
+		spentSfoids = append(spentSfoids, sfoid)
 
-		// Create a refund output if needed.
-		if !amount.Equals(fund) {
-			refundUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tx)
-			if err != nil {
-				return err
-			}
-			refundOutput := types.SiafundOutput{
-				Value:      fund.Sub(amount),
-				UnlockHash: refundUnlockConditions.UnlockHash(),
-			}
-			parentTxn.SiafundOutputs = append(parentTxn.SiafundOutputs, refundOutput)
+		// Add the output to the total fund
+		fund = fund.Add(sfo.Value)
+		potentialFund = potentialFund.Add(sfo.Value)
+		if fund.Cmp(amount) >= 0 {
+			break
 		}
+	}
+	if potentialFund.Cmp(amount) >= 0 && fund.Cmp(amount) < 0 {
+		return modules.ErrIncompleteTransactions
+	}
+	if fund.Cmp(amount) < 0 {
+		return modules.ErrLowBalance
+	}
 
-		// Sign all of the inputs to the parent trancstion.
-		for _, sfi := range parentTxn.SiafundInputs {
-			addSignatures(&parentTxn, types.FullCoveredFields, sfi.UnlockConditions, crypto.Hash(sfi.ParentID), tb.wallet.keys[sfi.UnlockConditions.UnlockHash()])
-		}
+	// Create and add the output that will be used to fund the standard
+	// transaction.
+	parentUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tb.wallet.dbTx)
+	if err != nil {
+		return err
+	}
+	exactOutput := types.SiafundOutput{
+		Value:      amount,
+		UnlockHash: parentUnlockConditions.UnlockHash(),
+	}
+	parentTxn.SiafundOutputs = append(parentTxn.SiafundOutputs, exactOutput)
 
-		// Add the exact output.
-		claimUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tx)
+	// Create a refund output if needed.
+	if !amount.Equals(fund) {
+		refundUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tb.wallet.dbTx)
 		if err != nil {
 			return err
 		}
-		newInput := types.SiafundInput{
-			ParentID:         parentTxn.SiafundOutputID(0),
-			UnlockConditions: parentUnlockConditions,
-			ClaimUnlockHash:  claimUnlockConditions.UnlockHash(),
+		refundOutput := types.SiafundOutput{
+			Value:      fund.Sub(amount),
+			UnlockHash: refundUnlockConditions.UnlockHash(),
 		}
-		tb.newParents = append(tb.newParents, len(tb.parents))
-		tb.parents = append(tb.parents, parentTxn)
-		tb.siafundInputs = append(tb.siafundInputs, len(tb.transaction.SiafundInputs))
-		tb.transaction.SiafundInputs = append(tb.transaction.SiafundInputs, newInput)
+		parentTxn.SiafundOutputs = append(parentTxn.SiafundOutputs, refundOutput)
+	}
 
-		// Mark all outputs that were spent as spent.
-		for _, sfoid := range spentSfoids {
-			err = dbPutSpentOutput(tx, types.OutputID(sfoid), consensusHeight)
-			if err != nil {
-				return err
-			}
+	// Sign all of the inputs to the parent trancstion.
+	for _, sfi := range parentTxn.SiafundInputs {
+		addSignatures(&parentTxn, types.FullCoveredFields, sfi.UnlockConditions, crypto.Hash(sfi.ParentID), tb.wallet.keys[sfi.UnlockConditions.UnlockHash()])
+	}
+
+	// Add the exact output.
+	claimUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tb.wallet.dbTx)
+	if err != nil {
+		return err
+	}
+	newInput := types.SiafundInput{
+		ParentID:         parentTxn.SiafundOutputID(0),
+		UnlockConditions: parentUnlockConditions,
+		ClaimUnlockHash:  claimUnlockConditions.UnlockHash(),
+	}
+	tb.newParents = append(tb.newParents, len(tb.parents))
+	tb.parents = append(tb.parents, parentTxn)
+	tb.siafundInputs = append(tb.siafundInputs, len(tb.transaction.SiafundInputs))
+	tb.transaction.SiafundInputs = append(tb.transaction.SiafundInputs, newInput)
+
+	// Mark all outputs that were spent as spent.
+	for _, sfoid := range spentSfoids {
+		err = dbPutSpentOutput(tb.wallet.dbTx, types.OutputID(sfoid), consensusHeight)
+		if err != nil {
+			return err
 		}
-		return nil
-	})
+	}
+	return nil
 }
 
 // AddParents adds a set of parents to the transaction.
@@ -472,15 +468,12 @@ func (tb *transactionBuilder) Drop() {
 
 	// Iterate through all parents and the transaction itself and restore all
 	// outputs to the list of available outputs.
-	tb.wallet.db.Update(func(tx *bolt.Tx) error {
-		txns := append(tb.parents, tb.transaction)
-		for _, txn := range txns {
-			for _, sci := range txn.SiacoinInputs {
-				dbDeleteSpentOutput(tx, types.OutputID(sci.ParentID))
-			}
+	txns := append(tb.parents, tb.transaction)
+	for _, txn := range txns {
+		for _, sci := range txn.SiacoinInputs {
+			dbDeleteSpentOutput(tb.wallet.dbTx, types.OutputID(sci.ParentID))
 		}
-		return nil
-	})
+	}
 
 	tb.parents = nil
 	tb.signed = false

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -222,7 +222,7 @@ func walletinitseedcmd() {
 		}
 		qs += fmt.Sprintf("&encryptionpassword=%s", password)
 	}
-	err = post("/wallet/init", qs)
+	err = post("/wallet/initseed", qs)
 	if err != nil {
 		die("Could not initialize wallet from seed:", err)
 	}


### PR DESCRIPTION
The wallet now interacts with the database via a single global bolt.Tx, which is committed every 2 minutes or when durability is required (e.g. before reporting the balance). In testing on my SSD, this sped up a full rescan about 5x. This sort of speedup is important because some of the new wallet functionality (e.g. `InitSeed` and `SweepSeed`) requires rescanning.

A further step to take here would be to remove the references to `w.dbTx` in a bunch of places and instead make it implicit. The only reason I decided against this was that it makes it very difficult to work with any sort of bolt.Tx that isn't `w.dbTx`.