### PR TITLE
require write lock for dbTx

### DIFF
--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -108,8 +108,8 @@ func (w *Wallet) managedUnlock(masterKey crypto.TwofishKey) error {
 	var auxiliarySeedFiles []seedFile
 	var unseededKeyFiles []spendableKeyFile
 	err := func() error {
-		w.mu.RLock()
-		defer w.mu.RUnlock()
+		w.mu.Lock()
+		defer w.mu.Unlock()
 
 		// verify masterKey
 		err := checkMasterKey(w.dbTx, masterKey)
@@ -240,9 +240,9 @@ func (w *Wallet) rescanMessage(done chan struct{}) {
 	}
 
 	for {
-		w.mu.RLock()
+		w.mu.Lock()
 		height, _ := dbGetConsensusHeight(w.dbTx)
-		w.mu.RUnlock()
+		w.mu.Unlock()
 		print("\rWallet: scanned to height ", height, "...")
 
 		select {

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -79,7 +79,8 @@ type Wallet struct {
 
 	// The wallet's database tracks its seeds, keys, outputs, and
 	// transactions. A global db transaction is maintained in memory to avoid
-	// excessive disk writes.
+	// excessive disk writes. Any operations involving dbTx must hold an
+	// exclusive lock.
 	db   *persist.BoltDatabase
 	dbTx *bolt.Tx
 


### PR DESCRIPTION
Turns out even operations like `tx.Bucket` can result in writes to the `bolt.Tx` object, so a write-lock is now required whenever `dbTx` is touched.