### PR TITLE
remove deprecated RelayBlock RPC

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -21,17 +21,8 @@ var (
 
 // managedBroadcastBlock will broadcast a block to the consensus set's peers.
 func (cs *ConsensusSet) managedBroadcastBlock(b types.Block) {
-	// COMPATv0.5.1 - broadcast the block to all peers <= v0.5.1 and block header to all peers > v0.5.1.
-	var relayBlockPeers, relayHeaderPeers []modules.Peer
-	for _, p := range cs.gateway.Peers() {
-		if build.VersionCmp(p.Version, "0.5.1") <= 0 {
-			relayBlockPeers = append(relayBlockPeers, p)
-		} else {
-			relayHeaderPeers = append(relayHeaderPeers, p)
-		}
-	}
-	go cs.gateway.Broadcast("RelayBlock", b, relayBlockPeers)
-	go cs.gateway.Broadcast("RelayHeader", b.Header(), relayHeaderPeers)
+	// broadcast the block header to all peers
+	go cs.gateway.Broadcast("RelayHeader", b.Header(), cs.gateway.Peers())
 }
 
 // validateHeaderAndBlock does some early, low computation verification on the

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -1002,9 +1002,6 @@ func TestAcceptBlockBroadcasts(t *testing.T) {
 	}
 	select {
 	case <-mg.broadcastCalled:
-		// Broadcast is called twice, once to broadcast blocks to peers <= v0.5.1
-		// and once to broadcast block headers to peers > v0.5.1.
-		<-mg.broadcastCalled
 	case <-time.After(10 * time.Millisecond):
 		t.Error("expected AcceptBlock to broadcast a valid block")
 	}

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -165,13 +165,11 @@ func New(gateway modules.Gateway, bootstrap bool, persistDir string) (*Consensus
 
 		// Register RPCs
 		gateway.RegisterRPC("SendBlocks", cs.rpcSendBlocks)
-		gateway.RegisterRPC("RelayBlock", cs.rpcRelayBlock) // COMPATv0.5.1
 		gateway.RegisterRPC("RelayHeader", cs.threadedRPCRelayHeader)
 		gateway.RegisterRPC("SendBlk", cs.rpcSendBlk)
 		gateway.RegisterConnectCall("SendBlocks", cs.threadedReceiveBlocks)
 		cs.tg.OnStop(func() {
 			cs.gateway.UnregisterRPC("SendBlocks")
-			cs.gateway.UnregisterRPC("RelayBlock")
 			cs.gateway.UnregisterRPC("RelayHeader")
 			cs.gateway.UnregisterRPC("SendBlk")
 			cs.gateway.UnregisterConnectCall("SendBlocks")

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -255,27 +255,27 @@ func TestSendBlocksBroadcastsOnce(t *testing.T) {
 		},
 		{
 			blocksToMine:          1,
-			expectedNumBroadcasts: 2,
+			expectedNumBroadcasts: 1,
 			synced:                true,
 		},
 		{
 			blocksToMine:          2,
-			expectedNumBroadcasts: 2,
+			expectedNumBroadcasts: 1,
 			synced:                true,
 		},
 		{
 			blocksToMine:          int(MaxCatchUpBlocks),
-			expectedNumBroadcasts: 2,
+			expectedNumBroadcasts: 1,
 			synced:                true,
 		},
 		{
 			blocksToMine:          2 * int(MaxCatchUpBlocks),
-			expectedNumBroadcasts: 2,
+			expectedNumBroadcasts: 1,
 			synced:                true,
 		},
 		{
 			blocksToMine:          2*int(MaxCatchUpBlocks) + 1,
-			expectedNumBroadcasts: 2,
+			expectedNumBroadcasts: 1,
 			synced:                true,
 		},
 	}
@@ -1161,18 +1161,13 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	cst1.cs.gateway.Broadcast("RelayHeader", validBlock.Header(), cst1.cs.gateway.Peers())
 	select {
 	case <-mg.broadcastCalled:
-		// Broadcast is called twice, once to broadcast blocks to peers <= v0.5.1
-		// and once to broadcast block headers to peers > v0.5.1.
-		<-mg.broadcastCalled
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("RelayHeader didn't broadcast a valid block header")
 	}
 }
 
 // TestIntegrationRelaySynchronize tests that blocks are relayed as they are
-// accepted and that peers stay synchronized. This test is header/block
-// broadcast agnostic. When build.Version <= 0.5.1 block relaying will be
-// tested. When build.Version > 0.5.1 header relaying will be tested.
+// accepted and that peers stay synchronized.
 func TestIntegrationRelaySynchronize(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()


### PR DESCRIPTION
Remove deprecated RelayBlock RPC as mentioned/requested by @DavidVorick in PR #1630.