### PR TITLE
Rpc deadlines

### DIFF
--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"errors"
-	"net"
 	"sync"
 	"time"
 
@@ -127,12 +126,6 @@ func (cs *ConsensusSet) managedReceiveBlocks(conn modules.PeerConn) (returnErr e
 	// SendBlocks will timeout. This is by design so that IBD switches peers to
 	// prevent any one peer from stalling IBD.
 	err := conn.SetDeadline(time.Now().Add(sendBlocksTimeout))
-	// Ignore errors returned by SetDeadline if the conn is a pipe in testing.
-	// Pipes do not support Set{,Read,Write}Deadline and should only be used in
-	// testing.
-	if opErr, ok := err.(*net.OpError); ok && opErr.Op == "set" && opErr.Net == "pipe" && build.Release == "testing" {
-		err = nil
-	}
 	if err != nil {
 		return err
 	}
@@ -231,12 +224,6 @@ func (cs *ConsensusSet) managedReceiveBlocks(conn modules.PeerConn) (returnErr e
 // threadedReceiveBlocks is the calling end of the SendBlocks RPC.
 func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 	err := conn.SetDeadline(time.Now().Add(sendBlocksTimeout))
-	// Ignore errors returned by SetDeadline if the conn is a pipe in testing.
-	// Pipes do not support Set{,Read,Write}Deadline and should only be used in
-	// testing.
-	if opErr, ok := err.(*net.OpError); ok && opErr.Op == "set" && opErr.Net == "pipe" && build.Release == "testing" {
-		err = nil
-	}
 	if err != nil {
 		return err
 	}
@@ -402,12 +389,6 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 // threadedRPCRelayHeader is an RPC that accepts a block header from a peer.
 func (cs *ConsensusSet) threadedRPCRelayHeader(conn modules.PeerConn) error {
 	err := conn.SetDeadline(time.Now().Add(relayHeaderTimeout))
-	// Ignore errors returned by SetDeadline if the conn is a pipe in testing.
-	// Pipes do not support Set{,Read,Write}Deadline and should only be used in
-	// testing.
-	if opErr, ok := err.(*net.OpError); ok && opErr.Op == "set" && opErr.Net == "pipe" && build.Release == "testing" {
-		err = nil
-	}
 	if err != nil {
 		return err
 	}
@@ -485,12 +466,6 @@ func (cs *ConsensusSet) threadedRPCRelayHeader(conn modules.PeerConn) error {
 // rpcSendBlk is an RPC that sends the requested block to the requesting peer.
 func (cs *ConsensusSet) rpcSendBlk(conn modules.PeerConn) error {
 	err := conn.SetDeadline(time.Now().Add(sendBlkTimeout))
-	// Ignore errors returned by SetDeadline if the conn is a pipe in testing.
-	// Pipes do not support Set{,Read,Write}Deadline and should only be used in
-	// testing.
-	if opErr, ok := err.(*net.OpError); ok && opErr.Op == "set" && opErr.Net == "pipe" && build.Release == "testing" {
-		err = nil
-	}
 	if err != nil {
 		return err
 	}

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -668,6 +668,11 @@ func (pc mockPeerConn) RPCAddr() modules.NetAddress {
 	return "mockPeerConn dialback addr"
 }
 
+// SetDeadline returns 'nil', and does nothing behind the scenes.
+func (pc mockPeerConn) SetDeadline(time.Time) error {
+	return nil
+}
+
 // Read is a mock implementation of modules.PeerConn.Read that always returns
 // an error.
 func (mockPeerConnFailingReader) Read([]byte) (int, error) {

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -181,4 +181,12 @@ var (
 		Dev:      20 * time.Second,
 		Testing:  500 * time.Millisecond,
 	}).(time.Duration)
+
+	// rpcStdDeadline defines the standard deadline that should be used for all
+	// incoming RPC calls.
+	rpcStdDeadline = build.Select(build.Var{
+		Standard: 10 * time.Minute,
+		Dev:      5 * time.Minute,
+		Testing:  90 * time.Second,
+	}).(time.Duration)
 )

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -162,7 +162,16 @@ func (g *Gateway) threadedListenPeer(p *peer) {
 			break
 		}
 
-		// it is the handler's responsibility to close the connection
+		// Set a standard deadline on the conn. The handler may set a new
+		// deadline, this is fine.
+		err = conn.SetDeadline(time.Now().Add(rpcStdDeadline))
+		if err != nil {
+			g.log.Printf("Peer connection (%v) deadline could not be set: %v\n", p.NetAddress, err)
+			continue
+		}
+
+		// The handler is responsible for closing the connection, though a
+		// default deadline has been set.
 		go g.threadedHandleConn(conn)
 	}
 	// Signal that the goroutine can shutdown.


### PR DESCRIPTION
Add deadlines to RPCs that don't have them.

We should probably have a safety deadline in the gateway just to be sure, that will automatically put a 20 minute deadline on every conn or something like that.

I'm guessing that this PR will fix the 'too many open sockets' problems that we are seeing, as well as some of the absurd amounts of goroutines we are seeing, as well as help clean up some of the memory usage.