### PR TITLE
establish clean + quick shutdown for conns in the consensus set

### DIFF
--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -227,6 +227,14 @@ func (cs *ConsensusSet) threadedReceiveBlocks(conn modules.PeerConn) error {
 	if err != nil {
 		return err
 	}
+	finishedChan := make(chan struct{})
+	go func() {
+		select {
+		case <-cs.tg.StopChan():
+		case <-finishedChan:
+		}
+		conn.Close()
+	}()
 	err = cs.tg.Add()
 	if err != nil {
 		return err
@@ -245,6 +253,15 @@ func (cs *ConsensusSet) rpcSendBlocks(conn modules.PeerConn) error {
 	if err != nil {
 		return err
 	}
+	finishedChan := make(chan struct{})
+	defer close(finishedChan)
+	go func() {
+		select {
+		case <-cs.tg.StopChan():
+		case <-finishedChan:
+		}
+		conn.Close()
+	}()
 	err = cs.tg.Add()
 	if err != nil {
 		return err
@@ -353,6 +370,15 @@ func (cs *ConsensusSet) rpcRelayBlock(conn modules.PeerConn) error {
 	if err != nil {
 		return err
 	}
+	finishedChan := make(chan struct{})
+	defer close(finishedChan)
+	go func() {
+		select {
+		case <-cs.tg.StopChan():
+		case <-finishedChan:
+		}
+		conn.Close()
+	}()
 	err = cs.tg.Add()
 	if err != nil {
 		return err
@@ -392,6 +418,15 @@ func (cs *ConsensusSet) threadedRPCRelayHeader(conn modules.PeerConn) error {
 	if err != nil {
 		return err
 	}
+	finishedChan := make(chan struct{})
+	defer close(finishedChan)
+	go func() {
+		select {
+		case <-cs.tg.StopChan():
+		case <-finishedChan:
+		}
+		conn.Close()
+	}()
 	err = cs.tg.Add()
 	if err != nil {
 		return err
@@ -469,6 +504,15 @@ func (cs *ConsensusSet) rpcSendBlk(conn modules.PeerConn) error {
 	if err != nil {
 		return err
 	}
+	finishedChan := make(chan struct{})
+	defer close(finishedChan)
+	go func() {
+		select {
+		case <-cs.tg.StopChan():
+		case <-finishedChan:
+		}
+		conn.Close()
+	}()
 	err = cs.tg.Add()
 	if err != nil {
 		return err

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -663,6 +663,13 @@ var (
 	errFailingWriter = errors.New("failing writer")
 )
 
+// Close returns 'nil', and does nothing behind the scenes. This is because the
+// testing reuses pipes, but the consensus code now correctly closes conns after
+// handling them.
+func (pc mockPeerConn) Close() error {
+	return nil
+}
+
 // RPCAddr implements this method of the modules.PeerConn interface.
 func (pc mockPeerConn) RPCAddr() modules.NetAddress {
 	return "mockPeerConn dialback addr"


### PR DESCRIPTION
Combine this with the tpool PR and we should have Sia to a place where it can shut down in 10 seconds every time.