### PR TITLE
change host announce mechanics

### DIFF
--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -115,7 +115,8 @@ func (h *Host) Announce() error {
 }
 
 // AnnounceAddress submits a host announcement to the blockchain to announce a
-// specific address.
+// specific address. If there is no error, the host's address will be updated
+// to the supplied address.
 func (h *Host) AnnounceAddress(addr modules.NetAddress) error {
 	err := h.tg.Add()
 	if err != nil {
@@ -132,16 +133,16 @@ func (h *Host) AnnounceAddress(addr modules.NetAddress) error {
 		return errors.New("announcement requested with local net address")
 	}
 
-	// Address is valid, update the host's internal net address to match the
-	// specified addr.
-	h.mu.Lock()
-	h.settings.NetAddress = addr
-	h.mu.Unlock()
-
 	// Attempt the actual announcement.
 	err = h.managedAnnounce(addr)
 	if err != nil {
 		return build.ExtendErr("unable to perform manual host announcement", err)
 	}
+
+	// Address is valid, update the host's internal net address to match the
+	// specified addr.
+	h.mu.Lock()
+	h.settings.NetAddress = addr
+	h.mu.Unlock()
 	return nil
 }


### PR DESCRIPTION
Host will check addresses are valid before attempting to make an announce call.
Hosts will also update the internal address to match the announcement that they
are making.

I think that we have gone back and forth on this before, but it's pretty clear
that users expect their most recent announcement to be the one that they keep.
Also, it does not make sense to be announcing a netaddress that you do not plan
to use as your permanent address, as the hostdb only remembers the most recent
address that has crossed the blockchain.