### PR TITLE
persist inbound info together with node address

### DIFF
--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -74,13 +74,6 @@ import (
 // peers of the same IP address, it should favor kicking peers of the same ip
 // address range.
 //
-// TODO: Currently the gateway does not save a list of its outbound
-// connections. When it restarts, it will have a full nodelist (which may be
-// primarily attacker nodes) and it will be connecting primarily to nodes in
-// the nodelist. Instead, it should start by trying to connect to peers that
-// have previously been outbound peers, as it is less likely that those have
-// been manipulated.
-//
 // TODO: When peers connect to eachother, and when they add nodes to the node
 // list, there is no verification that the peers are running on the same Sia
 // network, something that will be problematic if we set up a large testnet.
@@ -179,7 +172,7 @@ type Gateway struct {
 	// and would block any threads.Flush() calls. So a second threadgroup is
 	// added which handles clean-shutdown for the peers, without blocking
 	// threads.Flush() calls.
-	nodes  map[modules.NetAddress]struct{}
+	nodes  map[modules.NetAddress]*node
 	peers  map[modules.NetAddress]*peer
 	peerTG siasync.ThreadGroup
 
@@ -232,7 +225,7 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 		initRPCs: make(map[string]modules.RPCFunc),
 
 		peers: make(map[modules.NetAddress]*peer),
-		nodes: make(map[modules.NetAddress]struct{}),
+		nodes: make(map[modules.NetAddress]*node),
 
 		persistDir: persistDir,
 	}
@@ -278,8 +271,9 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 
 	// Add the bootstrap peers to the node list.
 	if bootstrap {
+		const inbound = true
 		for _, addr := range modules.BootstrapPeers {
-			err := g.addNode(addr)
+			err := g.addNode(addr, inbound)
 			if err != nil && err != errNodeExists {
 				g.log.Printf("WARN: failed to add the bootstrap node '%v': %v", addr, err)
 			}

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -207,9 +207,11 @@ func TestConnect(t *testing.T) {
 	bootstrap := newNamedTestingGateway(t, "1")
 	defer bootstrap.Close()
 
+	const inbound = false
+
 	// give it a node
 	bootstrap.mu.Lock()
-	bootstrap.addNode(dummyNode)
+	bootstrap.addNode(dummyNode, inbound)
 	bootstrap.mu.Unlock()
 
 	// create peer who will connect to bootstrap
@@ -708,8 +710,8 @@ func TestPeerManager(t *testing.T) {
 
 	// g1's node list should only contain g2
 	g1.mu.Lock()
-	g1.nodes = map[modules.NetAddress]struct{}{}
-	g1.nodes[g2.Address()] = struct{}{}
+	g1.nodes = make(map[modules.NetAddress]*node)
+	g1.nodes[g2.Address()] = &node{Inbound: false}
 	g1.mu.Unlock()
 
 	// when peerManager wakes up, it should connect to g2.

--- a/modules/gateway/peersmanager.go
+++ b/modules/gateway/peersmanager.go
@@ -32,6 +32,12 @@ func (g *Gateway) managedPeerManagerConnect(addr modules.NetAddress) {
 			p.Inbound = false
 			g.log.Debugf("[PMC] [SUCCESS] [%v] existing peer has been converted to outbound peer", addr)
 		}
+		n, exists := g.nodes[addr]
+		if exists {
+			n.Inbound = false
+		} else {
+			g.nodes[addr] = &node{Inbound: false}
+		}
 		g.mu.Unlock()
 	} else if err != nil {
 		g.log.Debugf("[PMC] [ERROR] [%v] WARN: removing peer because automatic connect failed: %v\n", addr, err)

--- a/modules/gateway/persist_test.go
+++ b/modules/gateway/persist_test.go
@@ -12,7 +12,8 @@ func TestLoad(t *testing.T) {
 	g := newTestingGateway(t)
 
 	g.mu.Lock()
-	g.addNode(dummyNode)
+	g.addNode("111.111.111.111:1111", false)
+	g.addNode("222.222.222.222:2222", true)
 	g.save()
 	g.mu.Unlock()
 	g.Close()
@@ -21,7 +22,10 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := g2.nodes[dummyNode]; !ok {
+	if _, ok := g2.nodes["111.111.111.111:1111"]; !ok {
+		t.Fatal("gateway did not load old peer list:", g2.nodes)
+	}
+	if _, ok := g2.nodes["222.222.222.222:2222"]; !ok {
 		t.Fatal("gateway did not load old peer list:", g2.nodes)
 	}
 }

--- a/modules/gateway/rpc_test.go
+++ b/modules/gateway/rpc_test.go
@@ -472,8 +472,8 @@ func TestOutboundAndInboundRPCs(t *testing.T) {
 	// Call the "recv" RPC on g1. We don't know g1's address as g2 sees it, so we
 	// get it from the first address in g2's peer list.
 	var addr modules.NetAddress
-	for p_addr := range g2.peers {
-		addr = p_addr
+	for pAddr := range g2.peers {
+		addr = pAddr
 		break
 	}
 	err = g2.RPC(addr, "recv", func(conn modules.PeerConn) error { return nil })


### PR DESCRIPTION
I'm not sure if my execution is perfect here, but the idea is there. Feedback needed I think. The goal is to store the inbound information along with the NetAddress, rather then just the NetAddress.

First I thought a small change could be done, where I'm just serializing the current outbound peers. However the problem is that all peers are disconnected before we serialize, thus that is not possible. Than I noticed that while we do store the nodes, we were storing them as empty structs, so why not store some extra information along with it?

This approach does mean that the update is a bit more invasive than intended, but should still be safe for merging once we agree on all modifications.

I also bumped the gateway persist version, as the format changed a bit. I do support the previous version, so that this node information is not lost after the upgrade.