### PR TITLE
fix historic output handling in wallet

### DIFF
--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"encoding/binary"
+	"errors"
 	"reflect"
 	"time"
 
@@ -65,6 +66,8 @@ var (
 	keyConsensusHeight        = []byte("keyConsensusHeight")
 	keySpendableKeyFiles      = []byte("keySpendableKeyFiles")
 	keyAuxiliarySeedFiles     = []byte("keyAuxiliarySeedFiles")
+
+	errNoKey = errors.New("key does not exist")
 )
 
 // threadedDBUpdate commits the active database transaction and starts a new
@@ -111,7 +114,11 @@ func dbPut(b *bolt.Bucket, key, val interface{}) error {
 // dbGet is a helper function for retrieving a marshalled key/value pair. val
 // must be a pointer.
 func dbGet(b *bolt.Bucket, key, val interface{}) error {
-	return encoding.Unmarshal(b.Get(encoding.Marshal(key)), val)
+	valBytes := b.Get(encoding.Marshal(key))
+	if valBytes == nil {
+		return errNoKey
+	}
+	return encoding.Unmarshal(valBytes, val)
 }
 
 // dbDelete is a helper function for deleting a marshalled key/value pair.

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -21,6 +21,15 @@ func (w *Wallet) isWalletAddress(uh types.UnlockHash) bool {
 // outputs as understood by the wallet.
 func (w *Wallet) updateConfirmedSet(tx *bolt.Tx, cc modules.ConsensusChange) error {
 	for _, diff := range cc.SiacoinOutputDiffs {
+		// Add to historic outputs.
+		// NOTE: it's never necessary to delete from the historic output set.
+		if diff.Direction == modules.DiffApply {
+			err := dbPutHistoricOutput(tx, types.OutputID(diff.ID), diff.SiacoinOutput.Value)
+			if err != nil {
+				w.log.Severe("Could not update historic output:", err)
+			}
+		}
+
 		// Verify that the diff is relevant to the wallet.
 		if !w.isWalletAddress(diff.SiacoinOutput.UnlockHash) {
 			continue
@@ -33,10 +42,19 @@ func (w *Wallet) updateConfirmedSet(tx *bolt.Tx, cc modules.ConsensusChange) err
 			err = dbDeleteSiacoinOutput(tx, diff.ID)
 		}
 		if err != nil {
-			return err
+			w.log.Severe("Could not update siacoin output:", err)
 		}
 	}
 	for _, diff := range cc.SiafundOutputDiffs {
+		// Add to historic claim starts.
+		// NOTE: it's never necessary to delete from the historic claim start set.
+		if diff.Direction == modules.DiffApply {
+			err := dbPutHistoricClaimStart(tx, diff.ID, diff.SiafundOutput.ClaimStart)
+			if err != nil {
+				w.log.Severe("Could not update historic claim start:", err)
+			}
+		}
+
 		// Verify that the diff is relevant to the wallet.
 		if !w.isWalletAddress(diff.SiafundOutput.UnlockHash) {
 			continue
@@ -49,7 +67,7 @@ func (w *Wallet) updateConfirmedSet(tx *bolt.Tx, cc modules.ConsensusChange) err
 			err = dbDeleteSiafundOutput(tx, diff.ID)
 		}
 		if err != nil {
-			return err
+			w.log.Severe("Could not update siafund output:", err)
 		}
 	}
 	for _, diff := range cc.SiafundPoolDiffs {
@@ -77,7 +95,7 @@ func (w *Wallet) revertHistory(tx *bolt.Tx, reverted []types.Block) error {
 			}
 			if txid == pt.TransactionID {
 				if err := dbDeleteLastProcessedTransaction(tx); err != nil {
-					return err
+					w.log.Severe("Could not revert transaction:", err)
 				}
 			}
 		}
@@ -86,9 +104,9 @@ func (w *Wallet) revertHistory(tx *bolt.Tx, reverted []types.Block) error {
 		for _, mp := range block.MinerPayouts {
 			if w.isWalletAddress(mp.UnlockHash) {
 				if err := dbDeleteLastProcessedTransaction(tx); err != nil {
-					return err
+					w.log.Severe("Could not revert transaction:", err)
 				}
-				break
+				break // there will only ever be one miner transaction
 			}
 		}
 
@@ -125,12 +143,8 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, applied []types.Block) error {
 		}
 
 		relevant := false
-		for i, mp := range block.MinerPayouts {
+		for _, mp := range block.MinerPayouts {
 			relevant = relevant || w.isWalletAddress(mp.UnlockHash)
-			err := dbPutHistoricOutput(tx, types.OutputID(block.MinerPayoutID(uint64(i))), mp.Value)
-			if err != nil {
-				return fmt.Errorf("could not put historic output: %v", err)
-			}
 		}
 		if relevant {
 			// Apply the miner payout transaction if applicable.
@@ -160,28 +174,14 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, applied []types.Block) error {
 			for _, sci := range txn.SiacoinInputs {
 				relevant = relevant || w.isWalletAddress(sci.UnlockConditions.UnlockHash())
 			}
-			for i, sco := range txn.SiacoinOutputs {
+			for _, sco := range txn.SiacoinOutputs {
 				relevant = relevant || w.isWalletAddress(sco.UnlockHash)
-				err := dbPutHistoricOutput(tx, types.OutputID(txn.SiacoinOutputID(uint64(i))), sco.Value)
-				if err != nil {
-					return fmt.Errorf("could not put historic output: %v", err)
-				}
 			}
 			for _, sfi := range txn.SiafundInputs {
 				relevant = relevant || w.isWalletAddress(sfi.UnlockConditions.UnlockHash())
 			}
-
-			for i, sfo := range txn.SiafundOutputs {
+			for _, sfo := range txn.SiafundOutputs {
 				relevant = relevant || w.isWalletAddress(sfo.UnlockHash)
-				id := txn.SiafundOutputID(uint64(i))
-				err := dbPutHistoricOutput(tx, types.OutputID(id), sfo.Value)
-				if err != nil {
-					return fmt.Errorf("could not put historic output: %v", err)
-				}
-				err = dbPutHistoricClaimStart(tx, id, sfo.ClaimStart)
-				if err != nil {
-					return fmt.Errorf("could not put historic claim start: %v", err)
-				}
 			}
 
 			// only create a ProcessedTransaction if txn is relevant
@@ -307,7 +307,7 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 
 // ReceiveUpdatedUnconfirmedTransactions updates the wallet's unconfirmed
 // transaction set.
-func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction, _ modules.ConsensusChange) {
+func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction, cc modules.ConsensusChange) {
 	if err := w.tg.Add(); err != nil {
 		// Gracefully reject transactions if the wallet's Close method has
 		// closed the wallet's ThreadGroup already.
@@ -318,6 +318,17 @@ func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction,
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	// record the historic outputs.
+	// NOTE: it's safe to add unconfirmed outputs to the historic output set.
+	for _, diff := range cc.SiacoinOutputDiffs {
+		if diff.Direction == modules.DiffApply {
+			err := dbPutHistoricOutput(w.dbTx, types.OutputID(diff.ID), diff.SiacoinOutput.Value)
+			if err != nil {
+				w.log.Severe("Could not add historic output:", err)
+			}
+		}
+	}
+
 	w.unconfirmedProcessedTransactions = nil
 	for _, txn := range txns {
 		// determine whether transaction is relevant to the wallet
@@ -325,12 +336,8 @@ func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction,
 		for _, sci := range txn.SiacoinInputs {
 			relevant = relevant || w.isWalletAddress(sci.UnlockConditions.UnlockHash())
 		}
-		for i, sco := range txn.SiacoinOutputs {
+		for _, sco := range txn.SiacoinOutputs {
 			relevant = relevant || w.isWalletAddress(sco.UnlockHash)
-			err := dbPutHistoricOutput(w.dbTx, types.OutputID(txn.SiacoinOutputID(uint64(i))), sco.Value)
-			if err != nil {
-				w.log.Println("ERROR: could not put historic output:", err)
-			}
 		}
 
 		// only create a ProcessedTransaction if txn is relevant


### PR DESCRIPTION
Previously, the wallet manually computed SiacoinOutputIDs when constructing the historic output set. This worked fine for most use cases, but broke down for more complex outputs, such as those derived from file contracts. The wallet now uses the IDs made available in `ConsensusChange.SiacoinOutputDiffs`, which is precomputed by the consensus module.

As a historical note, I investigated the git history prior to the wallet db upgrade. Looking at commits as old as [wallet/update.go@3566874](https://github.com/NebulousLabs/Sia/blob/3566874375a73aa34b6dfdd3af1b3312ab825d4b/modules/wallet/update.go), it is clear that the wallet has never handled these outputs correctly. This may clear up some long-standing (but subtle) discrepancies in the wallet's transaction reporting.

Fixes #1653.