### PR TITLE
Add offset, length, async, http response parameters to download.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -220,6 +220,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 
 		router.POST("/renter/delete/*siapath", RequirePassword(api.renterDeleteHandler, requiredPassword))
 		router.GET("/renter/download/*siapath", RequirePassword(api.renterDownloadHandler, requiredPassword))
+		router.GET("/renter/downloadchunk/*siapath", RequirePassword(api.renterDownloadchunkHandler, requiredPassword))
 		router.GET("/renter/downloadasync/*siapath", RequirePassword(api.renterDownloadAsyncHandler, requiredPassword))
 		router.POST("/renter/rename/*siapath", RequirePassword(api.renterRenameHandler, requiredPassword))
 		router.POST("/renter/upload/*siapath", RequirePassword(api.renterUploadHandler, requiredPassword))

--- a/api/api.go
+++ b/api/api.go
@@ -220,7 +220,6 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 
 		router.POST("/renter/delete/*siapath", RequirePassword(api.renterDeleteHandler, requiredPassword))
 		router.GET("/renter/download/*siapath", RequirePassword(api.renterDownloadHandler, requiredPassword))
-		router.GET("/renter/downloadchunk/*siapath", RequirePassword(api.renterDownloadchunkHandler, requiredPassword))
 		router.GET("/renter/downloadasync/*siapath", RequirePassword(api.renterDownloadAsyncHandler, requiredPassword))
 		router.POST("/renter/rename/*siapath", RequirePassword(api.renterRenameHandler, requiredPassword))
 		router.POST("/renter/upload/*siapath", RequirePassword(api.renterUploadHandler, requiredPassword))

--- a/api/api.go
+++ b/api/api.go
@@ -220,6 +220,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 
 		router.POST("/renter/delete/*siapath", RequirePassword(api.renterDeleteHandler, requiredPassword))
 		router.GET("/renter/download/*siapath", RequirePassword(api.renterDownloadHandler, requiredPassword))
+		router.HEAD("/renter/download/*siapath", api.renterHeadDownloadHandler)
 		router.GET("/renter/downloadasync/*siapath", RequirePassword(api.renterDownloadAsyncHandler, requiredPassword))
 		router.POST("/renter/rename/*siapath", RequirePassword(api.renterRenameHandler, requiredPassword))
 		router.POST("/renter/upload/*siapath", RequirePassword(api.renterUploadHandler, requiredPassword))

--- a/api/renter.go
+++ b/api/renter.go
@@ -481,6 +481,10 @@ func (api *API) parseAndValidateDownloadParameters(w http.ResponseWriter, req *h
 		return nil, errmsg
 	}
 
+	if async && httpresp {
+		return nil, &Error{"only one of the async and httpresp flags can be specified."}
+	}
+
 	siapath := strings.TrimPrefix(ps.ByName("siapath"), "/") // Sia file name.
 
 	// Lookup the file associated with the nickname.

--- a/api/renter.go
+++ b/api/renter.go
@@ -358,6 +358,7 @@ func (api *API) renterDownloadHandler(w http.ResponseWriter, req *http.Request, 
 	p, errmsg := parseDownloadParameters(w, req, ps)
 	if errmsg != nil {
 		WriteError(w, *errmsg, http.StatusBadRequest)
+		return
 	}
 
 	if p.Async { // Create goroutine if `async` param set.

--- a/api/renter.go
+++ b/api/renter.go
@@ -410,15 +410,12 @@ func (api *API) renterDownloadHandler(w http.ResponseWriter, req *http.Request, 
 
 // renterDownloadAsyncHandler handles the API call to download a file asynchronously.
 func (api *API) renterDownloadAsyncHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	// Set async flag to true.
+	req.Form.Add("async", "true")
 	p, errmsg := api.parseAndValidateDownloadParameters(w, req, ps)
 	if errmsg != nil {
 		WriteError(w, *errmsg, http.StatusBadRequest)
 	}
-
-	// Set async param to true.
-	// This parameter may be used in the future so it is set for safety reasons,
-	// its intended use is to determine whether to call DownloadSection in a goroutine.
-	p.Async = true
 
 	go api.renter.DownloadSection(p)
 

--- a/api/renter.go
+++ b/api/renter.go
@@ -386,9 +386,9 @@ func (api *API) renterDownloadHandler(w http.ResponseWriter, req *http.Request, 
 	}
 
 	if params.Async { // Create goroutine if `async` param set.
-		go api.renter.DownloadSection(params)
+		go api.renter.Download(params)
 	} else {
-		err := api.renter.DownloadSection(params)
+		err := api.renter.Download(params)
 		if err != nil {
 			WriteError(w, Error{"download failed: " + err.Error()}, http.StatusInternalServerError)
 			return

--- a/api/renter.go
+++ b/api/renter.go
@@ -444,8 +444,7 @@ func (api *API) parseDownloadParameters(w http.ResponseWriter, req *http.Request
 	if len(lengthparam) > 0 {
 		length, err = strconv.ParseUint(lengthparam, 10, 64)
 		if err != nil {
-			return nil, &Error{"could not decode the length as uint64: " +
-				err.Error()}
+			return nil, build.ExtendErr("could not decode the length as uint64: ", err)
 		}
 	}
 	// Verify that if either offset or length have been provided that both were provided.

--- a/api/renter.go
+++ b/api/renter.go
@@ -151,6 +151,7 @@ type (
 		ASCIIsia string `json:"asciisia"`
 	}
 
+	// DownloadInfo contains all client-facing information of a file.
 	DownloadInfo struct {
 		SiaPath     string    `json:"siapath"`
 		Destination string    `json:"destination"`
@@ -612,6 +613,7 @@ func (api *API) renterUploadHandler(w http.ResponseWriter, req *http.Request, ps
 	WriteSuccess(w)
 }
 
+// stringToBool converts "true" and "false" strings to their respective boolean value and returns an error if conversion is not possible.
 func stringToBool(param string) (bool, *Error) {
 	// Parse the async parameter.
 	var out bool

--- a/api/renter.go
+++ b/api/renter.go
@@ -403,7 +403,9 @@ func (api *API) renterDownloadHandler(w http.ResponseWriter, req *http.Request, 
 		}
 	}
 
-	WriteSuccess(w)
+	if !p.Httpresp {
+		WriteSuccess(w)
+	}
 }
 
 // renterDownloadAsyncHandler handles the API call to download a file asynchronously.

--- a/api/renter.go
+++ b/api/renter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/julienschmidt/httprouter"
+	"strconv"
 )
 
 var (
@@ -358,6 +359,25 @@ func (api *API) renterDownloadHandler(w http.ResponseWriter, req *http.Request, 
 	}
 
 	err := api.renter.Download(strings.TrimPrefix(ps.ByName("siapath"), "/"), destination)
+	if err != nil {
+		WriteError(w, Error{"download failed: " + err.Error()}, http.StatusInternalServerError)
+		return
+	}
+
+	WriteSuccess(w)
+}
+
+// renterDownloadchunkHandler handles the API call to download a specific chunk from a file.
+func (api *API) renterDownloadchunkHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	destination := req.FormValue("destination")
+	cindparam := req.FormValue("chunkindex")
+
+	cindex, err := strconv.ParseUint(cindparam, 10, 64)
+	if err != nil {
+		WriteError(w, Error{"could not decode the chunk index as uint64: " + err.Error()}, http.StatusBadRequest)
+	}
+
+	err = api.renter.DownloadChunk(strings.TrimPrefix(ps.ByName("siapath"), "/"), destination, cindex)
 	if err != nil {
 		WriteError(w, Error{"download failed: " + err.Error()}, http.StatusInternalServerError)
 		return

--- a/api/renter.go
+++ b/api/renter.go
@@ -505,7 +505,7 @@ func (api *API) parseAndValidateDownloadParameters(w http.ResponseWriter, req *h
 		if !filepath.IsAbs(destination) {
 			return nil, &Error{"destination must be an absolute path"}
 		}
-		dw = modules.NewDownloadFileWriter(destination)
+		dw = modules.NewDownloadFileWriter(destination, offset, length)
 	}
 
 	return &modules.RenterDownloadParameters{

--- a/api/renter.go
+++ b/api/renter.go
@@ -402,7 +402,7 @@ func parseDownloadParameters(w http.ResponseWriter, req *http.Request, ps httpro
 
 	// Determines whether to return on completion of download or straight away.
 	// If httprespparam is present, this parameter is ignored.
-	asyncparam := req.FormValue("httpresp")
+	asyncparam := req.FormValue("async")
 
 	// Parse the offset and length parameters. TODO(rnabel): Handle empty string.
 	offset, err := strconv.ParseUint(offsetparam, 10, 64)

--- a/api/renter.go
+++ b/api/renter.go
@@ -486,7 +486,7 @@ func (api *API) parseAndValidateDownloadParameters(w http.ResponseWriter, req *h
 	// Lookup the file associated with the nickname.
 	file, exists := api.renter.GetFile(siapath)
 	if !exists {
-		return nil, &Error{Message: "file could not be found"}
+		return nil, &Error{Message: "download failed: no file with that path"}
 	}
 
 	if !offparampassed { // Determine if entire file is to be downloaded.

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -149,7 +149,10 @@ func setupDownloadTest(t *testing.T, filesize, offset, length int64, useHttpResp
 		if err != nil {
 			t.Fatal(err)
 		}
-		buf := bytes.NewBuffer(make([]byte, 0, 1e8)) // TODO: Replace with correct buffer length
+		defer resp.Body.Close()
+
+		buf := bytes.NewBuffer(make([]byte, 0, length))
+
 		_, readErr := buf.ReadFrom(resp.Body)
 		if readErr != nil {
 			t.Fatal(readErr)
@@ -254,7 +257,7 @@ func TestRenterDownloadShortLengthThreeChunkInSecondChunk(t *testing.T) {
 }
 
 func TestRenterDownloadShortLengthMultiChunk(t *testing.T) {
-	filesize := int64(modules.SectorSize * 8)
+	filesize := int64(modules.SectorSize * 5)
 	setupDownloadTest(t, filesize, 0, int64(float64(filesize)*0.75), false)
 }
 
@@ -1113,7 +1116,7 @@ func TestRenterRelativePathErrorDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 	var rf RenterFiles
-	for i := 0; i < 100 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
+	for i := 0; i < 200 && (len(rf.Files) != 1 || rf.Files[0].UploadProgress < 10); i++ {
 		st.getAPI("/renter/files", &rf)
 		time.Sleep(200 * time.Millisecond)
 	}

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -174,6 +174,8 @@ func runDownloadTest(t *testing.T, filesize, offset, length int64, useHttpResp b
 		}
 		downbytes = make([]byte, length)
 		df.Read(downbytes)
+		df.Close()
+		os.Remove(downpath)
 	}
 
 	eq := bytes.Compare(b, downbytes)

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -289,6 +289,28 @@ func TestRenterDownloadHttpRespOffsetManyChunks(t *testing.T) {
 	setupDownloadTest(t, filesize, 40, filesize-40, true)
 }
 
+func TestRenterDownloadHttpRespOffsetAndLengthSingleChunk(t *testing.T) {
+	filesize := int64(modules.SectorSize)
+	setupDownloadTest(t, filesize, 40, 4*filesize/5, true)
+}
+
+func TestRenterDownloadHttpRespOffsetAndLengthTwoChunk(t *testing.T) {
+	filesize := int64(modules.SectorSize) * 2
+	setupDownloadTest(t, filesize, 80, 3*filesize/4, true)
+}
+
+func TestRenterDownloadHttpRespOffsetAndLengthManyChunks(t *testing.T) {
+	filesize := int64(modules.SectorSize) * 5
+	fmt.Println(modules.SectorSize)
+	setupDownloadTest(t, filesize, 150, 3*filesize/4, true)
+}
+
+func TestRenterDownloadHttpRespOffsetAndLengthManyChunksSubsetOfChunks(t *testing.T) {
+	filesize := int64(modules.SectorSize) * 5
+	fmt.Println(modules.SectorSize)
+	setupDownloadTest(t, filesize, 150, 1*filesize/4, true)
+}
+
 func TestRenterDownloadLengthOnlyError(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -101,6 +101,35 @@ func TestRenterDownloadError(t *testing.T) {
 	}
 }
 
+func TestRenterDownloadOffsetSingleChunk(t *testing.T) {
+	t.Fail()
+}
+
+func TestRenterDownloadOffsetMultiChunk(t *testing.T) {
+	t.Fail()
+}
+
+func TestRenterDownloadShortLengthSingleChunk(t *testing.T) {
+	t.Fail()
+}
+
+func TestRenterDownloadShortLengthAndOffsetSingleChunk(t *testing.T) {
+	t.Fail()
+}
+
+func TestRenterDownloadShortLengthMultiChunk(t *testing.T) {
+	t.Fail()
+}
+
+func TestRenterDownloadShortLengthAndOffsetMultiChunk(t *testing.T) {
+	t.Fail()
+}
+
+// TODO: Factor out relevant parts from other test.
+// TODO: Add tests for Async
+// TODO: Add tests for httpresp.
+
+
 // TestRenterAsyncDownloadError tests that the /renter/asyncdownload route sets the download's error field if it fails.
 func TestRenterAsyncDownloadError(t *testing.T) {
 	if testing.Short() {

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -284,7 +284,6 @@ func TestRenterDownloadHttpRespOffsetTwoChunk(t *testing.T) {
 
 func TestRenterDownloadHttpRespOffsetManyChunks(t *testing.T) {
 	filesize := int64(modules.SectorSize) * 5
-	fmt.Println(modules.SectorSize)
 	setupDownloadTest(t, filesize, 40, filesize-40, true)
 }
 
@@ -300,13 +299,11 @@ func TestRenterDownloadHttpRespOffsetAndLengthTwoChunk(t *testing.T) {
 
 func TestRenterDownloadHttpRespOffsetAndLengthManyChunks(t *testing.T) {
 	filesize := int64(modules.SectorSize) * 5
-	fmt.Println(modules.SectorSize)
 	setupDownloadTest(t, filesize, 150, 3*filesize/4, true)
 }
 
 func TestRenterDownloadHttpRespOffsetAndLengthManyChunksSubsetOfChunks(t *testing.T) {
 	filesize := int64(modules.SectorSize) * 5
-	fmt.Println(modules.SectorSize)
 	setupDownloadTest(t, filesize, 150, 1*filesize/4, true)
 }
 

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -135,7 +135,7 @@ func setupDownloadTest(t *testing.T, filesize, offset, length int64, useHttpResp
 	uf.Seek(offset, 0)
 	uf.Read(b)
 
-	// Download the original file from offset 40 and length 10.
+	// Download the original file from the passed offsets.
 	fname := "offsetsinglechunk.dat"
 	downpath := filepath.Join(st.dir, fname)
 	dlURL := fmt.Sprintf("/renter/download/%s?offset=%d&length=%d", ulSiaPath, offset, length)

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -123,7 +123,6 @@ func setupDownloadTest(t *testing.T, filesize, offset, length int64, useHttpResp
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	ulSiaPath := "test.dat"
 	st, path := setupTestDownload(t, int(filesize), ulSiaPath, true)

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -9,16 +9,19 @@ import (
 	"testing"
 	"time"
 
+	"bytes"
+	"fmt"
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter"
 	"github.com/NebulousLabs/Sia/modules/renter/contractor"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/fastrand"
+	"os"
 )
 
 const (
-	testFunds  = "10000000000000000000000000000"
+	testFunds  = "10000000000000000000000000000" // 10k SC
 	testPeriod = "5"
 )
 
@@ -27,18 +30,12 @@ func createRandFile(path string, size int) error {
 	return ioutil.WriteFile(path, fastrand.Bytes(size), 0600)
 }
 
-// TestRenterDownloadError tests that the /renter/download route sets the download's error field if it fails.
-func TestRenterDownloadError(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	t.Parallel()
-
+func setupTestDownload(t *testing.T, size int, name string, waitOnAvailability bool) (*serverTester, string) {
 	st, err := createServerTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.server.Close()
+	//defer st.server.Close()
 
 	// Announce the host and start accepting contracts.
 	err = st.announceHost()
@@ -56,7 +53,7 @@ func TestRenterDownloadError(t *testing.T) {
 
 	// Set an allowance for the renter, allowing a contract to be formed.
 	allowanceValues := url.Values{}
-	testFunds := "10000000000000000000000000000" // 10k SC
+	testFunds := testFunds
 	testPeriod := "10"
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
@@ -66,8 +63,8 @@ func TestRenterDownloadError(t *testing.T) {
 	}
 
 	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
-	err = createRandFile(path, 1e4)
+	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), name)
+	err = createRandFile(path, size)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,10 +73,59 @@ func TestRenterDownloadError(t *testing.T) {
 	uploadValues := url.Values{}
 	uploadValues.Set("source", path)
 	uploadValues.Set("renew", "true")
-	err = st.stdPostAPI("/renter/upload/test.dat", uploadValues)
+	err = st.stdPostAPI("/renter/upload/"+name, uploadValues)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if waitOnAvailability {
+		// wait for the file to become available
+		var rf RenterFiles
+		for i := 0; i < 100 && (len(rf.Files) != 1 || !rf.Files[0].Available); i++ {
+			st.getAPI("/renter/files", &rf)
+			time.Sleep(100 * time.Millisecond)
+		}
+		if len(rf.Files) != 1 || !rf.Files[0].Available {
+			t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
+		}
+	}
+
+	return st, path
+}
+
+func waitForDownloadToComplete(t *testing.T, st *serverTester, siapath string, errmsg string) {
+	var rdq RenterDownloadQueue
+
+	// download should eventually complete
+	success := false
+	for start := time.Now(); time.Since(start) < 30*time.Second; time.Sleep(time.Millisecond * 10) {
+		err := st.getAPI("/renter/downloads", &rdq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, download := range rdq.Downloads {
+			if download.Received == download.Filesize && download.SiaPath == siapath {
+				success = true
+			}
+		}
+		if success {
+			break
+		}
+	}
+	if !success {
+		t.Fatal(errmsg)
+	}
+}
+
+// TestRenterDownloadError tests that the /renter/download route sets the download's error field if it fails.
+func TestRenterDownloadError(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	st, _ := setupTestDownload(t, 1e4, "test.dat", false)
+	defer st.server.Close()
 
 	// don't wait for the upload to complete, try to download immediately to intentionally cause a download error
 	downpath := filepath.Join(st.dir, "down.dat")
@@ -90,7 +136,7 @@ func TestRenterDownloadError(t *testing.T) {
 
 	// verify the file has the expected error
 	var rdq RenterDownloadQueue
-	err = st.getAPI("/renter/downloads", &rdq)
+	err := st.getAPI("/renter/downloads", &rdq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +148,47 @@ func TestRenterDownloadError(t *testing.T) {
 }
 
 func TestRenterDownloadOffsetSingleChunk(t *testing.T) {
-	t.Fail()
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	offset := 40
+	length := 10
+
+	ulSiaPath := "test.dat"
+	st, path := setupTestDownload(t, 1e4, ulSiaPath, true)
+	defer st.server.Close()
+
+	// Read the section to be downloaded from the original file.
+	uf, _ := os.Open(path) // Uploaded file.
+	b := make([]byte, length)
+	uf.Seek(int64(offset), 0)
+	uf.Read(b)
+
+	// Download the original file from offset 40 and length 10.
+	fname := "offsetsinglechunk.dat"
+	downpath := filepath.Join(st.dir, fname)
+	dlURL := fmt.Sprintf("/renter/download/%s?destination=%s&offset=%d&length=%d", ulSiaPath, downpath, offset, length)
+	err := st.getAPI(dlURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitForDownloadToComplete(t, st, ulSiaPath, "/renter/download with offset failed.")
+
+	// Read from the resulting file.
+	df, _ := os.Open(downpath) // Downloaded file.
+	fInfo, _ := df.Stat()
+	if int(fInfo.Size()) != length {
+		t.Fatalf("Downloaded file has incorrect size: %d, %d expected.", fInfo.Size(), length)
+	}
+	db := make([]byte, length)
+	df.Read(db)
+	eq := bytes.Compare(b, db)
+	if eq != 0 {
+		t.Fatalf("Downloaded content does not equal expected. eq=%d", eq)
+	}
 }
 
 func TestRenterDownloadOffsetMultiChunk(t *testing.T) {
@@ -129,7 +215,6 @@ func TestRenterDownloadShortLengthAndOffsetMultiChunk(t *testing.T) {
 // TODO: Add tests for Async
 // TODO: Add tests for httpresp.
 
-
 // TestRenterAsyncDownloadError tests that the /renter/asyncdownload route sets the download's error field if it fails.
 func TestRenterAsyncDownloadError(t *testing.T) {
 	if testing.Short() {
@@ -137,56 +222,12 @@ func TestRenterAsyncDownloadError(t *testing.T) {
 	}
 	t.Parallel()
 
-	st, err := createServerTester(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	st, _ := setupTestDownload(t, 1e4, "test.dat", false)
 	defer st.server.Close()
-
-	// Announce the host and start accepting contracts.
-	err = st.announceHost()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = st.acceptContracts()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = st.setHostStorage()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Set an allowance for the renter, allowing a contract to be formed.
-	allowanceValues := url.Values{}
-	testFunds := "10000000000000000000000000000" // 10k SC
-	testPeriod := "10"
-	allowanceValues.Set("funds", testFunds)
-	allowanceValues.Set("period", testPeriod)
-	err = st.stdPostAPI("/renter", allowanceValues)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
-	err = createRandFile(path, 1e4)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Upload to host.
-	uploadValues := url.Values{}
-	uploadValues.Set("source", path)
-	uploadValues.Set("renew", "true")
-	err = st.stdPostAPI("/renter/upload/test.dat", uploadValues)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// don't wait for the upload to complete, try to download immediately to intentionally cause a download error
 	downpath := filepath.Join(st.dir, "asyncdown.dat")
-	err = st.getAPI("/renter/downloadasync/test.dat?destination="+downpath, nil)
+	err := st.getAPI("/renter/downloadasync/test.dat?destination="+downpath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,66 +253,12 @@ func TestRenterAsyncDownload(t *testing.T) {
 	}
 	t.Parallel()
 
-	st, err := createServerTester(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	st, _ := setupTestDownload(t, 1e4, "test.dat", true)
 	defer st.server.Close()
-
-	// Announce the host and start accepting contracts.
-	err = st.announceHost()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = st.acceptContracts()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = st.setHostStorage()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Set an allowance for the renter, allowing a contract to be formed.
-	allowanceValues := url.Values{}
-	testFunds := "10000000000000000000000000000" // 10k SC
-	testPeriod := "10"
-	allowanceValues.Set("funds", testFunds)
-	allowanceValues.Set("period", testPeriod)
-	err = st.stdPostAPI("/renter", allowanceValues)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Create a file.
-	path := filepath.Join(build.SiaTestingDir, "api", t.Name(), "test.dat")
-	err = createRandFile(path, 1e4)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Upload to host.
-	uploadValues := url.Values{}
-	uploadValues.Set("source", path)
-	uploadValues.Set("renew", "true")
-	err = st.stdPostAPI("/renter/upload/test.dat", uploadValues)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// wait for the file to become available
-	var rf RenterFiles
-	for i := 0; i < 100 && (len(rf.Files) != 1 || !rf.Files[0].Available); i++ {
-		st.getAPI("/renter/files", &rf)
-		time.Sleep(100 * time.Millisecond)
-	}
-	if len(rf.Files) != 1 || !rf.Files[0].Available {
-		t.Fatal("the uploading is not succeeding for some reason:", rf.Files[0])
-	}
 
 	// download the file asynchronously
 	downpath := filepath.Join(st.dir, "asyncdown.dat")
-	err = st.getAPI("/renter/downloadasync/test.dat?destination="+downpath, nil)
+	err := st.getAPI("/renter/downloadasync/test.dat?destination="+downpath, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -123,6 +123,7 @@ func setupDownloadTest(t *testing.T, filesize, offset, length int64, useHttpResp
 	if testing.Short() {
 		t.SkipNow()
 	}
+	t.Parallel()
 
 	ulSiaPath := "test.dat"
 	st, path := setupTestDownload(t, int(filesize), ulSiaPath, true)
@@ -307,15 +308,13 @@ func TestRenterDownloadHttpRespOffsetAndLengthManyChunksSubsetOfChunks(t *testin
 	setupDownloadTest(t, filesize, 150, 1*filesize/4, true)
 }
 
-func TestRenterDownloadLengthOnlyError(t *testing.T) {
+func setupDownloadParamTest(t *testing.T, useLength bool, length int, useOffset bool, offset, filesize int) error {
 	if testing.Short() {
 		t.SkipNow()
 	}
 	t.Parallel()
 
-	filesize := 1e4
 	ulSiaPath := "test.dat"
-	length := 100
 
 	st, _ := setupTestDownload(t, int(filesize), ulSiaPath, true)
 	defer st.server.Close()
@@ -323,33 +322,77 @@ func TestRenterDownloadLengthOnlyError(t *testing.T) {
 	// Download the original file from offset 40 and length 10.
 	fname := "offsetsinglechunk.dat"
 	downpath := filepath.Join(st.dir, fname)
-	dlURL := fmt.Sprintf("/renter/download/%s?destination=%s&length=%d", ulSiaPath, downpath, length)
-	err := st.getAPI(dlURL, nil)
+	dlURL := fmt.Sprintf("/renter/download/%s?destination=%s", ulSiaPath, downpath)
+	if useLength {
+		dlURL += fmt.Sprintf("&length=%d", length)
+	}
+	if useOffset {
+		dlURL += fmt.Sprintf("&offset=%d", offset)
+	}
+	return st.getAPI(dlURL, nil)
+}
+
+func TestRenterDownloadLengthOnlyError(t *testing.T) {
+	err := setupDownloadParamTest(t, true, 10, false, 0, 1e4)
+
 	if err == nil {
-		t.Fatalf("/download not prompting error when only passing length.")
+		t.Fatal("/download not prompting error when only passing length.")
 	}
 }
 
 func TestRenterDownloadOffsetOnlyError(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	t.Parallel()
+	err := setupDownloadParamTest(t, false, 0, true, 10, 1e4)
 
-	filesize := 1e4
-	ulSiaPath := "test.dat"
-	offset := 100
-
-	st, _ := setupTestDownload(t, int(filesize), ulSiaPath, true)
-	defer st.server.Close()
-
-	// Download the original file from offset 40 and length 10.
-	fname := "offsetsinglechunk.dat"
-	downpath := filepath.Join(st.dir, fname)
-	dlURL := fmt.Sprintf("/renter/download/%s?destination=%s&offset=%d", ulSiaPath, downpath, offset)
-	err := st.getAPI(dlURL, nil)
 	if err == nil {
-		t.Fatalf("/download not prompting error when only passing offset.")
+		t.Fatal("/download not prompting error when only passing offset.")
+	}
+}
+
+func TestRenterDownloadOffsetNegativeError(t *testing.T) {
+	err := setupDownloadParamTest(t, true, 0, true, -10, 1e4)
+
+	if err == nil {
+		t.Fatal("/download not prompting error when passing negative offset.")
+	}
+}
+
+func TestRenterDownloadOffsetGreaterEqualThanFilesizeError(t *testing.T) {
+	err := setupDownloadParamTest(t, true, 0, true, 1e4, 1e4)
+
+	if err == nil {
+		t.Fatal("/download not prompting error when passing offset equal to filesize.")
+	}
+}
+
+func TestRenterDownloadLengthGreaterThanFilesizeOffsetZeroError(t *testing.T) {
+	err := setupDownloadParamTest(t, true, 1e4+1, true, 0, 1e4)
+
+	if err == nil {
+		t.Fatal("/download not prompting error when passing length exceeding filesize.")
+	}
+}
+
+func TestRenterDownloadLengthGreaterThanFilesizeOffsetNonZeroError(t *testing.T) {
+	err := setupDownloadParamTest(t, true, 1e4+11, true, 10, 1e4)
+
+	if err == nil {
+		t.Fatal("/download not prompting error when passing length exceeding filesize with non-zero offset.")
+	}
+}
+
+func TestRenterDownloadLengthZeroError(t *testing.T) {
+	err := setupDownloadParamTest(t, true, 0, true, 0, 1e4)
+
+	if err == nil {
+		t.Fatal("/download not prompting error when passing length = 0.")
+	}
+}
+
+func TestRenterDownloadLengthNegativeError(t *testing.T) {
+	err := setupDownloadParamTest(t, true, -1, true, 0, 1e4)
+
+	if err == nil {
+		t.Fatal("/download not prompting error when passing negative length.")
 	}
 }
 
@@ -408,6 +451,23 @@ func TestRenterAsyncDownloadError(t *testing.T) {
 	}
 }
 
+func TestRenterAsyncSpecifyAsyncFalseError(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	st, _ := setupTestDownload(t, 1e4, "test.dat", false)
+	defer st.server.Close()
+
+	// don't wait for the upload to complete, try to download immediately to intentionally cause a download error
+	downpath := filepath.Join(st.dir, "asyncdown.dat")
+	err := st.getAPI("/renter/downloadasync/test.dat?async=false&destination="+downpath, nil)
+	if err == nil {
+		t.Fatal("/downloadasync does not return error when passing `async=false`")
+	}
+}
+
 // TestRenterAsyncDownload tests that the /renter/downloadasync route works
 // correctly.
 func TestRenterAsyncDownload(t *testing.T) {
@@ -419,7 +479,7 @@ func TestRenterAsyncDownload(t *testing.T) {
 	st, _ := setupTestDownload(t, 1e4, "test.dat", true)
 	defer st.server.Close()
 
-	// download the file asynchronously
+	// Download the file asynchronously.
 	downpath := filepath.Join(st.dir, "asyncdown.dat")
 	err := st.getAPI("/renter/downloadasync/test.dat?destination="+downpath, nil)
 	if err != nil {

--- a/api/scan.go
+++ b/api/scan.go
@@ -3,6 +3,7 @@ package api
 import (
 	"math/big"
 
+	"errors"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -34,4 +35,21 @@ func scanHash(s string) (h crypto.Hash, err error) {
 		return crypto.Hash{}, err
 	}
 	return h, nil
+}
+
+// stringToBool converts "true" and "false" strings to their respective
+// boolean value and returns an error if conversion is not possible.
+func stringToBool(param string) (bool, error) {
+	// Parse the async parameter.
+	var out bool
+	switch {
+	case param == "true":
+		out = true
+	case len(param) == 0 || param == "false":
+		out = false
+	default:
+		return false, errors.New(`bool parameter has to be either "true" or "false"`)
+	}
+
+	return out, nil
 }

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -354,7 +354,7 @@ type Renter interface {
 	DeleteFile(path string) error
 
 	// DownloadSection performs a download according to the parameters passed, including downloads of `offset` and `length` type.
-	DownloadSection(params *RenterDownloadParameters) error
+	Download(params *RenterDownloadParameters) error
 
 	// DownloadQueue lists all the files that have been scheduled for download.
 	DownloadQueue() []DownloadInfo

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -254,6 +254,9 @@ type Renter interface {
 	// Download downloads a file to the given destination.
 	Download(path, destination string) error
 
+	// DownloadChunk downloads a specific chunk from a file to the specified location.
+	DownloadChunk(path, destination string, cindex uint64) error
+
 	// DownloadQueue lists all the files that have been scheduled for download.
 	DownloadQueue() []DownloadInfo
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -107,7 +107,13 @@ func (dw *DownloadHttpWriter) WriteAt(b []byte, off int64) (int, error) {
 
 	// Write to response if content is exactly at offset.
 	if uint64(off) == dw.offset {
-		r, err = dw.w.Write(b)
+		// Truncate b if necessary.
+		var byts = b
+		if blen > dw.length {
+			byts = b[:dw.length]
+		}
+
+		r, err = dw.w.Write(byts)
 		dw.offset += blen
 		dw.length -= blen
 
@@ -116,6 +122,7 @@ func (dw *DownloadHttpWriter) WriteAt(b []byte, off int64) (int, error) {
 		copy(dw.buffer[off:int64(blen)+off], b)
 
 		// TODO: Add boundaries to list of written chunks.
+
 	}
 
 	return r, err

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -15,6 +15,7 @@ import (
 const (
 	// RenterDir is the name of the directory that is used to store the
 	// renter's persistent data.
+	defaultFilePerm         = 0666
 	RenterDir = "renter"
 )
 
@@ -71,7 +72,7 @@ type DownloadFileWriter struct {
 }
 
 func NewDownloadFileWriter(fname string) *DownloadFileWriter {
-	l, _ := os.Open(fname)
+	l, _ := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, defaultFilePerm)
 	return &DownloadFileWriter{f: l}
 }
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
+	defaultFilePerm = 0666
 	// RenterDir is the name of the directory that is used to store the
 	// renter's persistent data.
-	defaultFilePerm = 0666
-	RenterDir       = "renter"
+	RenterDir = "renter"
 )
 
 // An ErasureCoder is an error-correcting encoder and decoder.
@@ -61,7 +61,7 @@ type DownloadInfo struct {
 	Error       string         `json:"error"`
 }
 
-// DownloadWriter provides an interface which all possible outputs have to implement.
+// DownloadWriter provides an interface which all output writers have to implement.
 type DownloadWriter interface {
 	WriteAt(b []byte, off int64) (int, error)
 }
@@ -88,7 +88,7 @@ func (dw *DownloadFileWriter) WriteAt(b []byte, off int64) (int, error) {
 }
 
 // DownloadHttpWriter is a http response writer-backed implementation of DownloadWriter.
-// The writer writes all content that is written to location `offset` directly to the ResponseWriter,
+// The writer writes all content that is written to the current `offset` directly to the ResponseWriter,
 // and buffers all content that is written at other offsets.
 // After every write to the ResponseWriter the `offset` and `length` fields are updated, and buffer content written until
 type DownloadHttpWriter struct {
@@ -122,9 +122,6 @@ func (dw *DownloadHttpWriter) WriteAt(b []byte, off int64) (int, error) {
 		// TODO: Flush buffer until no more available bytes at offset.
 	} else {
 		copy(dw.buffer[off:int64(blen)+off], b)
-
-		// TODO: Add boundaries to list of written chunks.
-
 	}
 
 	return r, err
@@ -373,6 +370,7 @@ type Renter interface {
 	Upload(FileUploadParams) error
 }
 
+// RenterDownloadParameters contains all parameters that can be passed to the `/download` endpoint.
 type RenterDownloadParameters struct {
 	Async    bool
 	DlWriter DownloadWriter

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -15,8 +15,8 @@ import (
 const (
 	// RenterDir is the name of the directory that is used to store the
 	// renter's persistent data.
-	defaultFilePerm         = 0666
-	RenterDir = "renter"
+	defaultFilePerm = 0666
+	RenterDir       = "renter"
 )
 
 // An ErasureCoder is an error-correcting encoder and decoder.
@@ -68,12 +68,13 @@ type DownloadWriter interface {
 
 // DownloadFileWriter is a file-backed implementation of DownloadWriter.
 type DownloadFileWriter struct {
-	f *os.File
+	f        *os.File
+	Location string
 }
 
 func NewDownloadFileWriter(fname string) *DownloadFileWriter {
 	l, _ := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, defaultFilePerm)
-	return &DownloadFileWriter{f: l}
+	return &DownloadFileWriter{f: l, Location: fname}
 }
 
 func (dw *DownloadFileWriter) WriteAt(b []byte, off int64) (int, error) {
@@ -330,6 +331,9 @@ type Renter interface {
 
 	// FileList returns information on all of the files stored by the renter.
 	FileList() []FileInfo
+
+	// GetFile returns information on the requested file name. If file does not exist (nil, false) is returned.
+	GetFile(name string) (*FileInfo, bool)
 
 	// Host provides the DB entry and score breakdown for the requested host.
 	Host(pk types.SiaPublicKey) (HostDBEntry, bool)

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	defaultFilePerm         = 0666
 	downloadFailureCooldown = time.Minute * 30
 	maxUint64               = ^uint64(0)
 )
@@ -151,7 +150,7 @@ func (r *Renter) newSectionDownload(f *file, destination modules.DownloadWriter,
 	max_chunk := uint64(math.Floor(float64((offset + length) / f.chunkSize())))
 
 	d.dlChunks = 1 + max_chunk - min_chunk
-	d.finishedChunks = makeRange(int(min_chunk), int(max_chunk), d.finishedChunks)
+	d.finishedChunks = makeRange(int(min_chunk), int(max_chunk + 1), d.finishedChunks)
 	d.initPieceSetChunk(offset, f, currentContracts, r)
 	return d
 }
@@ -641,7 +640,7 @@ func (r *Renter) threadedDownloadLoop() {
 }
 
 func makeRange(min, max int, m map[int]bool) map[int]bool {
-	for i := min; i <= max; i++ {
+	for i := min; i < max; i++ {
 		m[i] = false
 	}
 	return m

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -150,7 +150,6 @@ func (r *Renter) newSectionDownload(f *file, destination modules.DownloadWriter,
 	min_chunk := uint64(math.Floor(float64(offset / f.chunkSize())))
 	max_chunk := uint64(math.Floor(float64((offset + length) / f.chunkSize())))
 
-	r.log.Printf("maxchunk: %d, minchunk: %d", max_chunk, min_chunk)
 	d.dlChunks = 1 + max_chunk - min_chunk
 	d.finishedChunks = makeRange(int(min_chunk), int(max_chunk), d.finishedChunks)
 	d.initPieceSetChunk(offset, f, currentContracts, r)
@@ -214,15 +213,7 @@ func (d *download) initPieceSetRaw(cind uint64, f *file,
 		// Iterate through all pieces of the current contract and add
 		// all relevant to the current chunk to the chunk's pieceSet.
 		for i := range contract.Pieces {
-			pieceSetIndex := contract.Pieces[i].Chunk
-			/*if cind != maxUint64 { // Single-chunk download is a special case.
-				if contract.Pieces[i].Chunk == cind {
-					pieceSetIndex = 0
-				} else {
-					continue
-				}
-			}*/
-			d.pieceSet[pieceSetIndex][id] = contract.Pieces[i]
+			d.pieceSet[contract.Pieces[i].Chunk][id] = contract.Pieces[i]
 		}
 	}
 	f.mu.RUnlock()

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -120,7 +120,6 @@ type (
 
 // newSectionDownload initialises and returns a download object for the specified chunk.
 func (r *Renter) newSectionDownload(f *file, destination modules.DownloadWriter, currentContracts map[modules.NetAddress]types.FileContractID, offset, length uint64) *download {
-	r.log.Println("Chunk download called.")
 	d := &download{}
 	d.initDownload(f, destination)
 

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -165,7 +165,7 @@ func (d *download) initPieceSet(f *file,
 	d.atomicDataReceived = dlSize - (d.reportedPieceSize * numChunks * uint64(d.erasureCode.MinPieces()))
 
 	// Assemble the piece set for the download.
-	d.pieceSet = make([]map[types.FileContractID]pieceData, numChunks)
+	d.pieceSet = make([]map[types.FileContractID]pieceData, d.numChunks)
 	for i := range d.pieceSet {
 		d.pieceSet[i] = make(map[types.FileContractID]pieceData)
 	}
@@ -183,7 +183,7 @@ func (d *download) initPieceSet(f *file,
 		}
 
 		for i := range contract.Pieces {
-			d.pieceSet[contract.Pieces[i].Chunk][id] = contract.Pieces[i]
+			d.pieceSet[int(contract.Pieces[i].Chunk)][id] = contract.Pieces[i]
 		}
 	}
 	f.mu.RUnlock()

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -29,7 +29,7 @@ func (r *Renter) DownloadSection(p *modules.RenterDownloadParameters) error {
 		d = r.newDownload(file, p.DlWriter, currentContracts)
 	} else {
 		// Check whether offset and length is valid.
-		if p.Offset < 0 || p.Offset + p.Length > file.size {
+		if p.Offset < 0 || p.Offset+p.Length > file.size {
 			emsg := "offset and length combination invalid, max byte is at index" + string(file.size-1)
 			return errors.New(emsg)
 		}

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -63,12 +63,10 @@ func (r *Renter) DownloadQueue() []modules.DownloadInfo {
 	for i := range r.downloadQueue {
 		d := r.downloadQueue[len(r.downloadQueue)-i-1]
 
-		dlsize := d.length
-
 		downloads[i] = modules.DownloadInfo{
 			SiaPath:     d.siapath,
 			Destination: d.destination,
-			Filesize:    dlsize,
+			Filesize:    d.length,
 			StartTime:   d.startTime,
 		}
 		downloads[i].Received = atomic.LoadUint64(&d.atomicDataReceived)

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DownloadSection performs a file download according to the download parameters passed.
-func (r *Renter) DownloadSection(p *modules.RenterDownloadParameters) error {
+func (r *Renter) Download(p *modules.RenterDownloadParameters) error {
 	// Lookup the file associated with the nickname.
 	lockID := r.mu.RLock()
 	file, exists := r.files[p.Siapath]

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -25,7 +25,7 @@ func (r *Renter) DownloadSection(p *modules.RenterDownloadParameters) error {
 
 	// Create the download object and add it to the queue.
 	var d *download
-	if p.Offset == maxUint64 { // If whole file download.
+	if p.Length == maxUint64 { // If whole file download.
 		d = r.newDownload(file, p.DlWriter, currentContracts)
 	} else {
 		// Check whether offset and length is valid.

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// DownloadSection performs a file download according to the download parameters passed.
 func (r *Renter) DownloadSection(p *modules.RenterDownloadParameters) error {
 	// Lookup the file associated with the nickname.
 	lockID := r.mu.RLock()

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -71,6 +71,10 @@ func (r *Renter) Download(p *modules.RenterDownloadParameters) error {
 	}
 }
 
+//func (r *Renter) DownloadChunk(f *file, index, offset, length uint64) ([]byte, error) {
+//	return
+//}
+
 // DownloadQueue returns the list of downloads in the queue.
 func (r *Renter) DownloadQueue() []modules.DownloadInfo {
 	lockID := r.mu.RLock()

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -25,16 +25,24 @@ func (r *Renter) Download(p *modules.RenterDownloadParameters) error {
 		currentContracts[contract.NetAddress] = contract.ID
 	}
 
-	// Ensure that both offset and length were passed or neither.
-	if (p.OffsetPassed || p.LengthPassed) && !(p.OffsetPassed && p.LengthPassed) {
-		var missingfield = "offset"
-		if p.LengthPassed {
-			missingfield = "length"
-		}
-		return errors.New("either both \"offset\" and " +
-			"\"length\" have to be specified or neither. " +
-			missingfield + " has not been specified.")
+	// Handle special cases.
+	if !p.OffsetPassed {
+		p.Offset = 0
 	}
+
+	if !p.LengthPassed {
+		p.Length = file.size - p.Offset
+	}
+	//// Ensure that both offset and length were passed or neither.
+	//if (p.OffsetPassed || p.LengthPassed) && !(p.OffsetPassed && p.LengthPassed) {
+	//	var missingfield = "offset"
+	//	if p.LengthPassed {
+	//		missingfield = "length"
+	//	}
+	//	return errors.New("either both \"offset\" and " +
+	//		"\"length\" have to be specified or neither. " +
+	//		missingfield + " has not been specified.")
+	//}
 
 	// Determine if entire file is to be downloaded.
 	if !p.OffsetPassed {
@@ -47,9 +55,9 @@ func (r *Renter) Download(p *modules.RenterDownloadParameters) error {
 		emsg := fmt.Sprintf("offset and length combination invalid, max byte is at index %d", file.size-1)
 		return errors.New(emsg)
 	}
-	if p.Length == 0 {
-		return errors.New("the length parameter has to be greater than 0.")
-	}
+	//if p.Length == 0 {
+	//	return errors.New("the length parameter has to be greater than 0.")
+	//}
 
 	// Create the download object and add it to the queue.
 	d := r.newSectionDownload(file, p.DlWriter, currentContracts, p.Offset, p.Length)

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -66,7 +66,7 @@ func (f *file) chunkSize() uint64 {
 	return f.pieceSize * uint64(f.erasureCode.MinPieces())
 }
 
-// numChunks returns the number of chunks that f was split into.
+// dlChunks returns the number of chunks that f was split into.
 func (f *file) numChunks() uint64 {
 	// empty files still need at least one chunk
 	if f.size == 0 {

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -214,20 +214,6 @@ func (r *Renter) FileList() []modules.FileInfo {
 	return files
 }
 
-// GetFile returns file information about the file with the provided name and returns false if the file does not exist.
-func (r *Renter) GetFile(name string) (*modules.FileInfo, bool) {
-	// Lookup the file associated with the nickname.
-	files := r.FileList()
-
-	for _, f := range files {
-		if f.SiaPath == name {
-			return &f, true
-		}
-	}
-
-	return nil, false
-}
-
 // RenameFile takes an existing file and changes the nickname. The original
 // file must exist, and there must not be any file that already has the
 // replacement nickname.

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -214,6 +214,19 @@ func (r *Renter) FileList() []modules.FileInfo {
 	return files
 }
 
+func (r *Renter) GetFile(name string) (*modules.FileInfo, bool) {
+	// Lookup the file associated with the nickname.
+	files := r.FileList()
+
+	for _, f := range files {
+		if f.SiaPath == name {
+			return &f, true
+		}
+	}
+
+	return nil, false
+}
+
 // RenameFile takes an existing file and changes the nickname. The original
 // file must exist, and there must not be any file that already has the
 // replacement nickname.

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -214,6 +214,7 @@ func (r *Renter) FileList() []modules.FileInfo {
 	return files
 }
 
+// GetFile returns file information about the file with the provided name and returns false if the file does not exist.
 func (r *Renter) GetFile(name string) (*modules.FileInfo, bool) {
 	// Lookup the file associated with the nickname.
 	files := r.FileList()

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// TestFileNumChunks checks the numChunks method of the file type.
+// TestFileNumChunks checks the dlChunks method of the file type.
 func TestFileNumChunks(t *testing.T) {
 	tests := []struct {
 		size           uint64

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -294,55 +294,6 @@ func TestRenterFileList(t *testing.T) {
 	}
 }
 
-// TestRenterGetFile tests the renter.GetFile(name string) method.
-func TestRenterGetFile(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-	rt, err := newRenterTester(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer rt.Close()
-
-	// Check that neither "one" nor "two" exists.
-	if _, exists := rt.renter.GetFile("one"); exists {
-		t.Error("GetFile shows non-existent file as existing.")
-	}
-	if _, exists := rt.renter.GetFile("two"); exists {
-		t.Error("GetFile shows non-existent file as existing.")
-	}
-
-	// Put a file in the renter.
-	rsc, _ := NewRSCode(1, 1)
-	rt.renter.files["1"] = &file{
-		name:        "one",
-		erasureCode: rsc,
-		pieceSize:   1,
-	}
-	// Check file now returned by GetFile but "two" is not.
-	if _, exists := rt.renter.GetFile("one"); !exists {
-		t.Error("GetFile does not return existing file.")
-	}
-	if _, exists := rt.renter.GetFile("two"); exists {
-		t.Error("GetFile shows non-existent file as existing.")
-	}
-
-	// Put multiple files in the renter.
-	rt.renter.files["2"] = &file{
-		name:        "two",
-		erasureCode: rsc,
-		pieceSize:   1,
-	}
-	// Check file now returned by GetFile but "two" is not.
-	if _, exists := rt.renter.GetFile("one"); !exists {
-		t.Error("GetFile does not return existing file.")
-	}
-	if _, exists := rt.renter.GetFile("two"); !exists {
-		t.Error("GetFile does not return existing file.")
-	}
-}
-
 // TestRenterRenameFile probes the rename method of the renter.
 func TestRenterRenameFile(t *testing.T) {
 	rt, err := newRenterTester(t.Name())

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -294,6 +294,55 @@ func TestRenterFileList(t *testing.T) {
 	}
 }
 
+// TestRenterGetFile tests the renter.GetFile(name string) method.
+func TestRenterGetFile(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	rt, err := newRenterTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+
+	// Check that neither "one" nor "two" exists.
+	if _, exists := rt.renter.GetFile("one"); exists {
+		t.Error("GetFile shows non-existent file as existing.")
+	}
+	if _, exists := rt.renter.GetFile("two"); exists {
+		t.Error("GetFile shows non-existent file as existing.")
+	}
+
+	// Put a file in the renter.
+	rsc, _ := NewRSCode(1, 1)
+	rt.renter.files["1"] = &file{
+		name:        "one",
+		erasureCode: rsc,
+		pieceSize:   1,
+	}
+	// Check file now returned by GetFile but "two" is not.
+	if _, exists := rt.renter.GetFile("one"); !exists {
+		t.Error("GetFile does not return existing file.")
+	}
+	if _, exists := rt.renter.GetFile("two"); exists {
+		t.Error("GetFile shows non-existent file as existing.")
+	}
+
+	// Put multiple files in the renter.
+	rt.renter.files["2"] = &file{
+		name:        "two",
+		erasureCode: rsc,
+		pieceSize:   1,
+	}
+	// Check file now returned by GetFile but "two" is not.
+	if _, exists := rt.renter.GetFile("one"); !exists {
+		t.Error("GetFile does not return existing file.")
+	}
+	if _, exists := rt.renter.GetFile("two"); !exists {
+		t.Error("GetFile does not return existing file.")
+	}
+}
+
 // TestRenterRenameFile probes the rename method of the renter.
 func TestRenterRenameFile(t *testing.T) {
 	rt, err := newRenterTester(t.Name())

--- a/siac/main.go
+++ b/siac/main.go
@@ -273,7 +273,7 @@ func main() {
 	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)
 
 	root.AddCommand(renterCmd)
-	renterCmd.AddCommand(renterFilesDeleteCmd, renterFilesDownloadCmd, renterDownloadChunkCmd,
+	renterCmd.AddCommand(renterFilesDeleteCmd, renterFilesDownloadCmd, renterDownloadSectionCmd,
 		renterDownloadsCmd, renterAllowanceCmd, renterSetAllowanceCmd,
 		renterContractsCmd, renterFilesListCmd, renterFilesRenameCmd,
 		renterFilesUploadCmd, renterUploadsCmd, renterExportCmd,

--- a/siac/main.go
+++ b/siac/main.go
@@ -273,7 +273,7 @@ func main() {
 	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)
 
 	root.AddCommand(renterCmd)
-	renterCmd.AddCommand(renterFilesDeleteCmd, renterFilesDownloadCmd,
+	renterCmd.AddCommand(renterFilesDeleteCmd, renterFilesDownloadCmd, renterDownloadChunkCmd,
 		renterDownloadsCmd, renterAllowanceCmd, renterSetAllowanceCmd,
 		renterContractsCmd, renterFilesListCmd, renterFilesRenameCmd,
 		renterFilesUploadCmd, renterUploadsCmd, renterExportCmd,

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -203,7 +203,7 @@ func renterdownloadscmd() {
 		die("Could not get download queue:", err)
 	}
 	// Filter out files that have been downloaded.
-	var downloading []modules.DownloadInfo
+	var downloading []api.DownloadInfo
 	for _, file := range queue.Downloads {
 		if file.Received != file.Filesize {
 			downloading = append(downloading, file)
@@ -222,7 +222,7 @@ func renterdownloadscmd() {
 	}
 	fmt.Println()
 	// Filter out files that are downloading.
-	var downloaded []modules.DownloadInfo
+	var downloaded []api.DownloadInfo
 	for _, file := range queue.Downloads {
 		if file.Received == file.Filesize {
 			downloaded = append(downloaded, file)
@@ -414,7 +414,7 @@ func downloadprogress(done chan struct{}, siapath string) {
 			if err != nil {
 				continue // benign
 			}
-			var d modules.DownloadInfo
+			var d api.DownloadInfo
 			for _, d = range queue.Downloads {
 				if d.SiaPath == siapath {
 					break

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -88,6 +88,13 @@ have a reasonable number (>30) of hosts in your hostdb.`,
 		Run:   wrap(renterfilesdownloadcmd),
 	}
 
+	renterDownloadChunkCmd = &cobra.Command{
+		Use:   "downloadchunk [path] [chunkid] [destination]",
+		Short: "Download a chunk",
+		Long:  "Download a specific chunk from a previously uploaded file.",
+		Run:   wrap(renterfilesdownloadchunkcmd),
+	}
+
 	renterFilesListCmd = &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -364,37 +371,7 @@ func renterfilesdeletecmd(path string) {
 func renterfilesdownloadcmd(path, destination string) {
 	destination = abs(destination)
 	done := make(chan struct{})
-	go func() {
-		time.Sleep(time.Second) // give download time to initialize
-		for {
-			select {
-			case <-done:
-				return
-
-			case <-time.Tick(time.Second):
-				// get download progress of file
-				var queue api.RenterDownloadQueue
-				err := getAPI("/renter/downloads", &queue)
-				if err != nil {
-					continue // benign
-				}
-				var d modules.DownloadInfo
-				for _, d = range queue.Downloads {
-					if d.Destination == destination {
-						break
-					}
-				}
-				if d.Filesize == 0 {
-					continue // file hasn't appeared in queue yet
-				}
-				pct := 100 * float64(d.Received) / float64(d.Filesize)
-				elapsed := time.Since(d.StartTime)
-				elapsed -= elapsed % time.Second // round to nearest second
-				mbps := (float64(d.Received*8) / 1e6) / time.Since(d.StartTime).Seconds()
-				fmt.Printf("\rDownloading... %5.1f%% of %v, %v elapsed, %.2f Mbps    ", pct, filesizeUnits(int64(d.Filesize)), elapsed, mbps)
-			}
-		}
-	}()
+	go downloadprogress(done, destination)
 
 	err := get("/renter/download/" + path + "?destination=" + destination)
 	close(done)
@@ -402,6 +379,58 @@ func renterfilesdownloadcmd(path, destination string) {
 		die("Could not download file:", err)
 	}
 	fmt.Printf("\nDownloaded '%s' to %s.\n", path, abs(destination))
+}
+
+// renterfilesdownloadchunkcmd is the handler for the command `siac renter downloadchunk [path]
+// [chunk id] [destination]`.
+// Downloads a specific chunk to the local specified destination.
+func renterfilesdownloadchunkcmd(path string, cind string, destination string) {
+	destination = abs(destination)
+	done := make(chan struct{})
+
+	go downloadprogress(done, destination)
+
+	req := fmt.Sprintf("/renter/downloadchunk/%s?destination=%s&chunkindex=%s", path, destination, cind)
+
+	err := get(req)
+	close(done)
+	if err != nil {
+		die("could not download chunk:", err)
+	}
+	fmt.Printf("\nDownloaded chunk %s of '%s' to %s.\n", cind, path, abs(destination))
+}
+
+func downloadprogress(done chan struct{}, destination string) {
+	time.Sleep(time.Second) // give download time to initialize
+	for {
+		select {
+		case <-done:
+			return
+
+		case <-time.Tick(time.Second):
+			// get download progress of file
+			var queue api.RenterDownloadQueue
+			err := getAPI("/renter/downloads", &queue)
+			if err != nil {
+				continue // benign
+			}
+			var d modules.DownloadInfo
+			for _, d = range queue.Downloads {
+				if d.Destination == destination {
+					break
+				}
+			}
+			if d.Filesize == 0 {
+				continue // file hasn't appeared in queue yet
+			}
+			pct := 100 * float64(d.Received) / float64(d.Filesize)
+			elapsed := time.Since(d.StartTime)
+			elapsed -= elapsed % time.Second // round to nearest second
+			mbps := (float64(d.Received*8) / 1e6) / time.Since(d.StartTime).Seconds()
+			fmt.Printf("\rDownloading... %5.1f%% of %v, %v elapsed, %.2f Mbps    ", pct, filesizeUnits(int64(d.Filesize)), elapsed, mbps)
+		}
+	}
+
 }
 
 // bySiaPath implements sort.Interface for [] modules.FileInfo based on the

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -88,11 +88,11 @@ have a reasonable number (>30) of hosts in your hostdb.`,
 		Run:   wrap(renterfilesdownloadcmd),
 	}
 
-	renterDownloadChunkCmd = &cobra.Command{
-		Use:   "downloadchunk [path] [offset] [length] [destination]",
+	renterDownloadSectionCmd = &cobra.Command{
+		Use:   "downloadsection [path] [offset] [length] [destination]",
 		Short: "Download a chunk",
 		Long:  "Download a specific chunk from a previously uploaded file.",
-		Run:   wrap(renterfilesdownloadchunkcmd),
+		Run:   wrap(renterfilesdownloadsectioncmd),
 	}
 
 	renterFilesListCmd = &cobra.Command{
@@ -381,16 +381,16 @@ func renterfilesdownloadcmd(path, destination string) {
 	fmt.Printf("\nDownloaded '%s' to %s.\n", path, abs(destination))
 }
 
-// renterfilesdownloadchunkcmd is the handler for the command `siac renter downloadchunk [path]
-// [chunk id] [destination]`.
+// renterfilesdownloadsectioncmd is the handler for the command `siac renter downloadsection [path]
+// [offset] [length] [destination]`.
 // Downloads a specific chunk to the local specified destination.
-func renterfilesdownloadchunkcmd(path, offset, length, destination string) {
+func renterfilesdownloadsectioncmd(path, offset, length, destination string) {
 	destination = abs(destination)
 	done := make(chan struct{})
 
 	go downloadprogress(done, destination)
 
-	req := fmt.Sprintf("/renter/download/%s?destination=%s&offset=%s&length=%s&httpresp=true", path, destination, offset, length)
+	req := fmt.Sprintf("/renter/download/%s?destination=%s&offset=%s&length=%s", path, destination, offset, length)
 
 	err := get(req)
 	close(done)

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -371,7 +371,7 @@ func renterfilesdeletecmd(path string) {
 func renterfilesdownloadcmd(path, destination string) {
 	destination = abs(destination)
 	done := make(chan struct{})
-	go downloadprogress(done, destination)
+	go downloadprogress(done, path)
 
 	err := get("/renter/download/" + path + "?destination=" + destination)
 	close(done)
@@ -400,7 +400,7 @@ func renterfilesdownloadchunkcmd(path string, cind string, destination string) {
 	fmt.Printf("\nDownloaded chunk %s of '%s' to %s.\n", cind, path, abs(destination))
 }
 
-func downloadprogress(done chan struct{}, destination string) {
+func downloadprogress(done chan struct{}, siapath string) {
 	time.Sleep(time.Second) // give download time to initialize
 	for {
 		select {
@@ -416,7 +416,7 @@ func downloadprogress(done chan struct{}, destination string) {
 			}
 			var d modules.DownloadInfo
 			for _, d = range queue.Downloads {
-				if d.Destination == destination {
+				if d.SiaPath == siapath {
 					break
 				}
 			}

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -89,7 +89,7 @@ have a reasonable number (>30) of hosts in your hostdb.`,
 	}
 
 	renterDownloadChunkCmd = &cobra.Command{
-		Use:   "downloadchunk [path] [chunkid] [destination]",
+		Use:   "downloadchunk [path] [offset] [length] [destination]",
 		Short: "Download a chunk",
 		Long:  "Download a specific chunk from a previously uploaded file.",
 		Run:   wrap(renterfilesdownloadchunkcmd),
@@ -384,20 +384,20 @@ func renterfilesdownloadcmd(path, destination string) {
 // renterfilesdownloadchunkcmd is the handler for the command `siac renter downloadchunk [path]
 // [chunk id] [destination]`.
 // Downloads a specific chunk to the local specified destination.
-func renterfilesdownloadchunkcmd(path string, cind string, destination string) {
+func renterfilesdownloadchunkcmd(path, offset, length, destination string) {
 	destination = abs(destination)
 	done := make(chan struct{})
 
 	go downloadprogress(done, destination)
 
-	req := fmt.Sprintf("/renter/downloadchunk/%s?destination=%s&chunkindex=%s", path, destination, cind)
+	req := fmt.Sprintf("/renter/download/%s?destination=%s&offset=%s&length=%s&httpresp=true", path, destination, offset, length)
 
 	err := get(req)
 	close(done)
 	if err != nil {
 		die("could not download chunk:", err)
 	}
-	fmt.Printf("\nDownloaded chunk %s of '%s' to %s.\n", cind, path, abs(destination))
+	fmt.Printf("\nDownloaded offset %s and length %s of '%s' to %s.\n", offset, length, path, abs(destination))
 }
 
 func downloadprogress(done chan struct{}, siapath string) {


### PR DESCRIPTION
- Creates a new `siad` endpoint at `/renter/downloadchunk/<path>?destination=<dst>&chunkindex=<cind>`
- Adds a new `siac` command: `siac renter downloadchunk [path] [chunk index] [destination]` (analog to the order of args in `renter download`)
- Refactors the `download.go` and `downloadqueue.go` to minimize duplicated logic.
- Extends the `download` struct to store metadata for the special case of a chunk download. It could be changed to handle a whole file download as a special case of a chunk download, but this would add a lot of complexity.

This could be the basis for repairing files which are not stored locally.