### PR TITLE
add score information for active hosts in ./siac hostdb -v

### DIFF
--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -182,6 +182,9 @@ func TestHostDBHostsHandler(t *testing.T) {
 	// Check that none of the values equal zero. A value of zero indicates that
 	// the field is no longer being tracked/reported, which could break
 	// compatibility for some apps. The default needs to be '1', not zero.
+	if hh.ScoreBreakdown.Score.IsZero() {
+		t.Error("Zero vaue score in score breakdown")
+	}
 	if hh.ScoreBreakdown.AgeAdjustment == 0 {
 		t.Error("Zero value in host score breakdown")
 	}

--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -47,8 +47,8 @@ func TestHostAndRentVanilla(t *testing.T) {
 	// Set an allowance for the renter, allowing a contract to be formed.
 	allowanceValues := url.Values{}
 	testFunds := "10000000000000000000000000000" // 10k SC
-	testPeriod := "10"
-	testPeriodInt := 10
+	testPeriod := "20"
+	testPeriodInt := 20
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
 	err = st.stdPostAPI("/renter", allowanceValues)
@@ -172,7 +172,7 @@ func TestHostAndRentVanilla(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 200)
 	}
 
 	// Check that the host was able to get the file contract confirmed on the
@@ -191,7 +191,7 @@ func TestHostAndRentVanilla(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 200)
 	}
 
 	success := false

--- a/doc/API.md
+++ b/doc/API.md
@@ -588,6 +588,8 @@ overall.
     "publickeystring": "ed25519:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
   },
   "scorebreakdown": {
+    "score": 1,
+
     "ageadjustment":              0.1234,
     "burnadjustment":             0.1234,
     "collateraladjustment":       23.456,

--- a/doc/api/HostDB.md
+++ b/doc/api/HostDB.md
@@ -254,6 +254,15 @@ overall.
   // guide for the score of a host, as every renter sees the world differently
   // and uses different metrics to evaluate hosts.
   "scorebreakdown": {
+	// The overall score for the host. Scores are entriely relative, and are
+	// consistent only within the current hostdb. Between different machines,
+	// different configurations, and different versions the absolute scores for
+	// a given host can be off by many orders of magnitude. When displaying to a
+	// human, some form of normalization with respect to the other hosts (for
+	// example, divide all scores by the median score of the hosts) is
+	// recommended.
+	"score":                      123456,
+
     // The multiplier that gets applied to the host based on how long it has
     // been a host. Older hosts typically have a lower penalty.
     "ageadjustment":              0.1234,

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -111,6 +111,8 @@ type HostDBScan struct {
 // results provided by this struct can only be used as a guide, and may vary
 // significantly from machine to machine.
 type HostScoreBreakdown struct {
+	Score types.Currency `json:"score"`
+
 	AgeAdjustment              float64 `json:"ageadjustment"`
 	BurnAdjustment             float64 `json:"burnadjustment"`
 	CollateralAdjustment       float64 `json:"collateraladjustment"`

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -159,25 +159,34 @@ func storageRemainingAdjustments(entry modules.HostDBEntry) float64 {
 		base = base / 2 // 4x total penalty
 	}
 	if entry.RemainingStorage < 100*requiredStorage {
-		base = base / 3 // 12x total penalty
+		base = base / 2 // 8x total penalty
 	}
 	if entry.RemainingStorage < 80*requiredStorage {
-		base = base / 3 // 36x total penalty
+		base = base / 2 // 16x total penalty
 	}
 	if entry.RemainingStorage < 40*requiredStorage {
-		base = base / 4 // 144x total penalty
+		base = base / 2 // 32x total penalty
 	}
 	if entry.RemainingStorage < 20*requiredStorage {
-		base = base / 5 // 720x total penalty
+		base = base / 2 // 64x total penalty
+	}
+	if entry.RemainingStorage < 15*requiredStorage {
+		base = base / 2 // 128x total penalty
 	}
 	if entry.RemainingStorage < 10*requiredStorage {
-		base = base / 5 // 3,600x total penalty
+		base = base / 2 // 256x total penalty
 	}
 	if entry.RemainingStorage < 5*requiredStorage {
-		base = base / 5 // 14,400x total penalty
+		base = base / 2 // 512x total penalty
+	}
+	if entry.RemainingStorage < 3*requiredStorage {
+		base = base / 2 // 1024x total penalty
+	}
+	if entry.RemainingStorage < 2*requiredStorage {
+		base = base / 2 // 2048x total penalty
 	}
 	if entry.RemainingStorage < requiredStorage {
-		base = base / 5 // 72,000x total penalty
+		base = base / 2 // 4096x total penalty
 	}
 	return base
 }

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -229,13 +229,16 @@ func (hdb *HostDB) lifetimeAdjustments(entry modules.HostDBEntry) float64 {
 			base = base / 2 // 8x total
 		}
 		if age < 1000 {
-			base = base / 8 // 64x total
+			base = base / 2 // 16x total
 		}
 		if age < 576 {
-			base = base / 2 // 128x total
+			base = base / 2 // 32x total
 		}
 		if age < 288 {
-			base = base / 2 // 256x total
+			base = base / 2 // 64x total
+		}
+		if age < 144 {
+			base = base / 2 // 128x total
 		}
 	}
 	return base

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -43,7 +43,7 @@ var (
 
 	// priceExponentiation is the number of times that the weight is divided by
 	// the price.
-	priceExponentiation = 5
+	priceExponentiation = 4
 
 	// requiredStorage indicates the amount of storage that the host must be
 	// offering in order to be considered a valuable/worthwhile host.

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -340,6 +340,8 @@ func (hdb *HostDB) calculateHostWeight(entry modules.HostDBEntry) types.Currency
 // elements of the host's overall score.
 func (hdb *HostDB) ScoreBreakdown(entry modules.HostDBEntry) modules.HostScoreBreakdown {
 	return modules.HostScoreBreakdown{
+		Score: hdb.calculateHostWeight(entry),
+
 		AgeAdjustment:              hdb.lifetimeAdjustments(entry),
 		BurnAdjustment:             1,
 		CollateralAdjustment:       hdb.collateralAdjustments(entry),

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -195,17 +195,20 @@ func storageRemainingAdjustments(entry modules.HostDBEntry) float64 {
 // version reported by the host.
 func versionAdjustments(entry modules.HostDBEntry) float64 {
 	base := float64(1)
-	if build.VersionCmp(entry.Version, "1.1.2") <= 0 {
+	if build.VersionCmp(entry.Version, "1.2.0") < 0 {
 		base = base * 0.99999 // Safety value to make sure we update the version penalties every time we update the host.
 	}
+	if build.VersionCmp(entry.Version, "1.1.2") < 0 {
+		base = base / 2 // 2x total penalty.
+	}
 	if build.VersionCmp(entry.Version, "1.1.1") < 0 {
-		base = base / 5 // 5x total penalty.
+		base = base / 2 // 4x total penalty.
 	}
 	if build.VersionCmp(entry.Version, "1.0.3") < 0 {
-		base = base / 5 // 25x total penalty.
+		base = base / 2 // 8x total penalty.
 	}
 	if build.VersionCmp(entry.Version, "1.0.0") < 0 {
-		base = base / 20 // 500x total penalty.
+		base = base / 2 // 16x total penalty.
 	}
 	return base
 }

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -191,7 +191,7 @@ func hostdbcmd() {
 		// Grab the host at the 1/5th point and use it as the reference. (it's
 		// like using the median, except at the 1/5th point instead of the 1/2
 		// point.)
-		referenceScore := float64(1)
+		referenceScore := big.NewFloat(1)
 		if len(activeHosts) > 0 {
 			referenceIndex := len(activeHosts) / 5
 			hostInfo := new(api.HostdbHostsGET)
@@ -199,7 +199,7 @@ func hostdbcmd() {
 			if err != nil {
 				die("Could not fetch provided host:", err)
 			}
-			referenceScore, _ = big.NewFloat(1).SetInt(hostInfo.ScoreBreakdown.Score.Big()).Float64()
+			referenceScore = big.NewFloat(1).SetInt(hostInfo.ScoreBreakdown.Score.Big())
 		}
 
 		fmt.Println()
@@ -248,8 +248,7 @@ func hostdbcmd() {
 			if err != nil {
 				die("Could not fetch provided host:", err)
 			}
-			score, _ := big.NewFloat(1).SetInt(hostInfo.ScoreBreakdown.Score.Big()).Float64()
-			score /= referenceScore
+			score := new(big.Float).Quo(new(big.Float).SetInt(hostInfo.ScoreBreakdown.Score.Big()), referenceScore)
 
 			price := host.StoragePrice.Mul(modules.BlockBytesPerMonthTerabyte)
 			downloadBWPrice := host.DownloadBandwidthPrice.Mul(modules.BytesPerTerabyte)

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -194,7 +194,7 @@ func hostdbcmd() {
 		// point.)
 		referenceScore := float64(1)
 		if len(activeHosts) > 0 {
-			referenceIndex := len(activeHosts)/5
+			referenceIndex := len(activeHosts) / 5
 			hostInfo := new(api.HostdbHostsGET)
 			err := getAPI("/hostdb/hosts/"+activeHosts[referenceIndex].PublicKeyString, hostInfo)
 			if err != nil {

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"os"
 	"text/tabwriter"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -105,8 +104,8 @@ func hostdbcmd() {
 			// host.
 			uptimeRatio := float64(0)
 			if len(host.ScanHistory) > 1 {
-				var uptime time.Duration
-				var downtime time.Duration
+				downtime := host.HistoricDowntime
+				uptime := host.HistoricUptime
 				recentTime := host.ScanHistory[0].Timestamp
 				recentSuccess := host.ScanHistory[0].Success
 				for _, scan := range host.ScanHistory[1:] {
@@ -152,8 +151,8 @@ func hostdbcmd() {
 			// host.
 			uptimeRatio := float64(0)
 			if len(host.ScanHistory) > 1 {
-				var uptime time.Duration
-				var downtime time.Duration
+				downtime := host.HistoricDowntime
+				uptime := host.HistoricUptime
 				recentTime := host.ScanHistory[0].Timestamp
 				recentSuccess := host.ScanHistory[0].Success
 				for _, scan := range host.ScanHistory[1:] {
@@ -212,8 +211,8 @@ func hostdbcmd() {
 			// host.
 			uptimeRatio := float64(0)
 			if len(host.ScanHistory) > 1 {
-				var uptime time.Duration
-				var downtime time.Duration
+				downtime := host.HistoricDowntime
+				uptime := host.HistoricUptime
 				recentTime := host.ScanHistory[0].Timestamp
 				recentSuccess := host.ScanHistory[0].Success
 				for _, scan := range host.ScanHistory[1:] {


### PR DESCRIPTION
This PR is a PR that is helping to lead up to an overhaul of how the allowance works. I'm programming the allowance to switch away from hosts if they become uncompetitive, which requires understanding what counts as competitive.

This PR makes it a lot easier to understand how competitive the hosts are relative to eachother, given the current scoring methods.