### PR TITLE
Don't kick outbound or local peers on accept

### DIFF
--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -226,9 +226,9 @@ func (g *Gateway) acceptPeer(p *peer) {
 	// Select a peer to kick. Outbound peers and local peers are not
 	// available to be kicked.
 	var addrs []modules.NetAddress
-	for addr := range g.peers {
+	for addr, peer := range g.peers {
 		// Do not kick outbound peers or local peers.
-		if !p.Inbound || p.Local {
+		if !peer.Inbound || peer.Local {
 			continue
 		}
 

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"testing"
@@ -46,6 +47,83 @@ func TestAddPeer(t *testing.T) {
 	})
 	if len(g.peers) != 1 {
 		t.Fatal("gateway did not add peer")
+	}
+}
+
+// TestAcceptPeer tests that acceptPeer does't kick outbound or local peers.
+func TestAcceptPeer(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	g := newTestingGateway(t)
+	defer g.Close()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// Add only unkickable peers.
+	var unkickablePeers []*peer
+	for i := 0; i < fullyConnectedThreshold+1; i++ {
+		addr := modules.NetAddress(fmt.Sprintf("1.2.3.%d", i))
+		p := &peer{
+			Peer: modules.Peer{
+				NetAddress: addr,
+				Inbound:    false,
+				Local:      false,
+			},
+			sess: muxado.Client(new(dummyConn)),
+		}
+		unkickablePeers = append(unkickablePeers, p)
+	}
+	for i := 0; i < fullyConnectedThreshold+1; i++ {
+		addr := modules.NetAddress(fmt.Sprintf("127.0.0.1:%d", i))
+		p := &peer{
+			Peer: modules.Peer{
+				NetAddress: addr,
+				Inbound:    true,
+				Local:      true,
+			},
+			sess: muxado.Client(new(dummyConn)),
+		}
+		unkickablePeers = append(unkickablePeers, p)
+	}
+	for _, p := range unkickablePeers {
+		g.addPeer(p)
+	}
+
+	// Test that accepting another peer doesn't kick any of the peers.
+	g.acceptPeer(&peer{
+		Peer: modules.Peer{
+			NetAddress: "9.9.9.9",
+			Inbound:    true,
+		},
+		sess: muxado.Client(new(dummyConn)),
+	})
+	for _, p := range unkickablePeers {
+		if _, exists := g.peers[p.NetAddress]; !exists {
+			t.Error("accept peer kicked an outbound or local peer")
+		}
+	}
+
+	// Add a kickable peer.
+	g.addPeer(&peer{
+		Peer: modules.Peer{
+			NetAddress: "9.9.9.9",
+			Inbound:    true,
+		},
+		sess: muxado.Client(new(dummyConn)),
+	})
+	// Test that accepting a local peer will kick a kickable peer.
+	g.acceptPeer(&peer{
+		Peer: modules.Peer{
+			NetAddress: "127.0.0.1:99",
+			Inbound:    true,
+			Local:      true,
+		},
+		sess: muxado.Client(new(dummyConn)),
+	})
+	if _, exists := g.peers["9.9.9.9"]; exists {
+		t.Error("acceptPeer didn't kick a peer to make room for a local peer")
 	}
 }
 


### PR DESCRIPTION
Hello old friends.

Fixes a bug where outbound and local peers could be kicked, and where no peers would be kicked if the peer being accepted was local.