### PR TITLE
add `ConnectabilityState` and `WorkingState` fields to the host

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -26,12 +26,12 @@ type (
 	// HostGET contains the information that is returned after a GET request to
 	// /host - a bunch of information about the status of the host.
 	HostGET struct {
-		ExternalSettings    modules.HostExternalSettings    `json:"externalsettings"`
-		FinancialMetrics    modules.HostFinancialMetrics    `json:"financialmetrics"`
-		InternalSettings    modules.HostInternalSettings    `json:"internalsettings"`
-		NetworkMetrics      modules.HostNetworkMetrics      `json:"networkmetrics"`
-		ConnectabilityState modules.HostConnectabilityState `json:"connectabilitystate"`
-		WorkingState        modules.HostWorkingState        `json:"workingstate"`
+		ExternalSettings     modules.HostExternalSettings     `json:"externalsettings"`
+		FinancialMetrics     modules.HostFinancialMetrics     `json:"financialmetrics"`
+		InternalSettings     modules.HostInternalSettings     `json:"internalsettings"`
+		NetworkMetrics       modules.HostNetworkMetrics       `json:"networkmetrics"`
+		ConnectabilityStatus modules.HostConnectabilityStatus `json:"connectabilitystate"`
+		WorkingStatus        modules.HostWorkingStatus        `json:"workingstate"`
 	}
 
 	// StorageGET contains the information that is returned after a GET request
@@ -60,15 +60,15 @@ func (api *API) hostHandlerGET(w http.ResponseWriter, req *http.Request, _ httpr
 	fm := api.host.FinancialMetrics()
 	is := api.host.InternalSettings()
 	nm := api.host.NetworkMetrics()
-	cs := api.host.ConnectabilityState()
-	ws := api.host.WorkingState()
+	cs := api.host.ConnectabilityStatus()
+	ws := api.host.WorkingStatus()
 	hg := HostGET{
-		ExternalSettings:    es,
-		FinancialMetrics:    fm,
-		InternalSettings:    is,
-		NetworkMetrics:      nm,
-		ConnectabilityState: cs,
-		WorkingState:        ws,
+		ExternalSettings:     es,
+		FinancialMetrics:     fm,
+		InternalSettings:     is,
+		NetworkMetrics:       nm,
+		ConnectabilityStatus: cs,
+		WorkingStatus:        ws,
 	}
 	WriteJSON(w, hg)
 }

--- a/api/host.go
+++ b/api/host.go
@@ -30,8 +30,8 @@ type (
 		FinancialMetrics     modules.HostFinancialMetrics     `json:"financialmetrics"`
 		InternalSettings     modules.HostInternalSettings     `json:"internalsettings"`
 		NetworkMetrics       modules.HostNetworkMetrics       `json:"networkmetrics"`
-		ConnectabilityStatus modules.HostConnectabilityStatus `json:"connectabilitystate"`
-		WorkingStatus        modules.HostWorkingStatus        `json:"workingstate"`
+		ConnectabilityStatus modules.HostConnectabilityStatus `json:"connectabilitystatus"`
+		WorkingStatus        modules.HostWorkingStatus        `json:"workingstatus"`
 	}
 
 	// StorageGET contains the information that is returned after a GET request

--- a/api/host.go
+++ b/api/host.go
@@ -26,10 +26,12 @@ type (
 	// HostGET contains the information that is returned after a GET request to
 	// /host - a bunch of information about the status of the host.
 	HostGET struct {
-		ExternalSettings modules.HostExternalSettings `json:"externalsettings"`
-		FinancialMetrics modules.HostFinancialMetrics `json:"financialmetrics"`
-		InternalSettings modules.HostInternalSettings `json:"internalsettings"`
-		NetworkMetrics   modules.HostNetworkMetrics   `json:"networkmetrics"`
+		ExternalSettings    modules.HostExternalSettings    `json:"externalsettings"`
+		FinancialMetrics    modules.HostFinancialMetrics    `json:"financialmetrics"`
+		InternalSettings    modules.HostInternalSettings    `json:"internalsettings"`
+		NetworkMetrics      modules.HostNetworkMetrics      `json:"networkmetrics"`
+		ConnectabilityState modules.HostConnectabilityState `json:"connectabilitystate"`
+		WorkingState        modules.HostWorkingState        `json:"workingstate"`
 	}
 
 	// StorageGET contains the information that is returned after a GET request
@@ -58,11 +60,15 @@ func (api *API) hostHandlerGET(w http.ResponseWriter, req *http.Request, _ httpr
 	fm := api.host.FinancialMetrics()
 	is := api.host.InternalSettings()
 	nm := api.host.NetworkMetrics()
+	cs := api.host.ConnectabilityState()
+	ws := api.host.WorkingState()
 	hg := HostGET{
-		ExternalSettings: es,
-		FinancialMetrics: fm,
-		InternalSettings: is,
-		NetworkMetrics:   nm,
+		ExternalSettings:    es,
+		FinancialMetrics:    fm,
+		InternalSettings:    is,
+		NetworkMetrics:      nm,
+		ConnectabilityState: cs,
+		WorkingState:        ws,
 	}
 	WriteJSON(w, hg)
 }

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
-	"github.com/NebulousLabs/Sia/modules/host"
 	"github.com/NebulousLabs/Sia/modules/host/contractmanager"
 )
 
@@ -110,7 +109,7 @@ func TestWorkingStatus(t *testing.T) {
 	var hg HostGET
 	st.getAPI("/host", &hg)
 
-	if hg.WorkingStatus != host.WorkingStatusWorking {
+	if hg.WorkingStatus != modules.HostWorkingStatusWorking {
 		t.Fatal("expected host to be working")
 	}
 }
@@ -141,7 +140,7 @@ func TestConnectabilityStatus(t *testing.T) {
 	var hg HostGET
 	st.getAPI("/host", &hg)
 
-	if hg.ConnectabilityStatus != host.ConnectabilityStatusConnectable {
+	if hg.ConnectabilityStatus != modules.HostConnectabilityStatusConnectable {
 		t.Fatal("expected host to be connectable")
 	}
 }

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -135,7 +135,7 @@ func TestConnectabilityState(t *testing.T) {
 	}
 
 	// wait a bit for the check to run
-	time.Sleep(time.Second * 15)
+	time.Sleep(time.Second * 30)
 
 	// check that the field was set correctly
 	var hg HostGET

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -48,8 +48,8 @@ var (
 	}
 )
 
-// TestWorkingState tests that the host's WorkingState field is set correctly.
-func TestWorkingState(t *testing.T) {
+// TestWorkingStatus tests that the host's WorkingStatus field is set correctly.
+func TestWorkingStatus(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -110,14 +110,14 @@ func TestWorkingState(t *testing.T) {
 	var hg HostGET
 	st.getAPI("/host", &hg)
 
-	if hg.WorkingState != host.WorkingStateWorking {
+	if hg.WorkingStatus != host.WorkingStatusWorking {
 		t.Fatal("expected host to be working")
 	}
 }
 
-// TestConnectabilityState tests that the host's ConnectabilityState field is
+// TestConnectabilityStatus tests that the host's ConnectabilityStatus field is
 // set correctly.
-func TestConnectabilityState(t *testing.T) {
+func TestConnectabilityStatus(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -141,7 +141,7 @@ func TestConnectabilityState(t *testing.T) {
 	var hg HostGET
 	st.getAPI("/host", &hg)
 
-	if hg.ConnectabilityState != host.ConnectabilityStateConnectable {
+	if hg.ConnectabilityStatus != host.ConnectabilityStatusConnectable {
 		t.Fatal("expected host to be connectable")
 	}
 }

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -105,7 +105,7 @@ func TestWorkingState(t *testing.T) {
 		t.Fatal("uploading has failed")
 	}
 
-	time.Sleep(time.Second * 30)
+	time.Sleep(time.Second * 31)
 
 	var hg HostGET
 	st.getAPI("/host", &hg)
@@ -135,7 +135,7 @@ func TestConnectabilityState(t *testing.T) {
 	}
 
 	// wait a bit for the check to run
-	time.Sleep(time.Second * 30)
+	time.Sleep(time.Second * 31)
 
 	// check that the field was set correctly
 	var hg HostGET

--- a/doc/API.md
+++ b/doc/API.md
@@ -343,8 +343,8 @@ fetches status information about the host.
     "unrecognizedcalls": 6
   },
 
-	"connectabilitystate": "checking",
-	"workingstate": "checking"
+  "connectabilitystate": "checking",
+  "workingstate": "checking"
 }
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -343,8 +343,8 @@ fetches status information about the host.
     "unrecognizedcalls": 6
   },
 
-  "connectabilitystate": "checking",
-  "workingstate": "checking"
+  "connectabilitystatus": "checking",
+  "workingstatus":        "checking"
 }
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -341,7 +341,10 @@ fetches status information about the host.
     "revisecalls":       4,
     "settingscalls":     5,
     "unrecognizedcalls": 6
-  }
+  },
+
+	"connectabilitystate": "checking",
+	"workingstate": "checking"
 }
 ```
 

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -312,7 +312,18 @@ fetches status information about the host.
     // The number of times that a renter has attempted to use an
     // unrecognized call. Larger numbers typically indicate buggy software.
     "unrecognizedcalls": 6
-  }
+  },
+
+	// Information about the health of the host.
+
+	// connectabilitystate is one of "checking", "connectable",
+	// or "not connectable", and indicates if the host can connect to
+	// itself on its configured NetAddress.
+	"connectabilitystate": "checking",
+
+	// workingstate is one of "checking", "working", or "not working"
+	// and indicates if the host is being actively used by renters.
+	"workingstate": "checking"
 }
 ```
 

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -314,16 +314,16 @@ fetches status information about the host.
     "unrecognizedcalls": 6
   },
 
-	// Information about the health of the host.
+  // Information about the health of the host.
 
-	// connectabilitystate is one of "checking", "connectable",
-	// or "not connectable", and indicates if the host can connect to
-	// itself on its configured NetAddress.
-	"connectabilitystate": "checking",
+  // connectabilitystate is one of "checking", "connectable",
+  // or "not connectable", and indicates if the host can connect to
+  // itself on its configured NetAddress.
+  "connectabilitystate": "checking",
 
-	// workingstate is one of "checking", "working", or "not working"
-	// and indicates if the host is being actively used by renters.
-	"workingstate": "checking"
+  // workingstate is one of "checking", "working", or "not working"
+  // and indicates if the host is being actively used by renters.
+  "workingstate": "checking"
 }
 ```
 

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -316,14 +316,14 @@ fetches status information about the host.
 
   // Information about the health of the host.
 
-  // connectabilitystate is one of "checking", "connectable",
+  // connectabilitystatus is one of "checking", "connectable",
   // or "not connectable", and indicates if the host can connect to
   // itself on its configured NetAddress.
-  "connectabilitystate": "checking",
+  "connectabilitystatus": "checking",
 
-  // workingstate is one of "checking", "working", or "not working"
+  // workingstatus is one of "checking", "working", or "not working"
   // and indicates if the host is being actively used by renters.
-  "workingstate": "checking"
+  "workingstatus": "checking"
 }
 ```
 

--- a/modules/host.go
+++ b/modules/host.go
@@ -15,6 +15,35 @@ var (
 
 	// BlockBytesPerMonthTerabyte is the conversion rate between block-bytes and month-TB.
 	BlockBytesPerMonthTerabyte = BytesPerTerabyte.Mul64(4320)
+
+	// HostWorkingStatusChecking is returned from WorkingStatus() if the host is
+	// still determining if it is working, that is, if settings calls are
+	// incrementing.
+	HostWorkingStatusChecking = HostWorkingStatus("checking")
+
+	// HostWorkingStatusNotWorking is returned from WorkingStatus() if the host
+	// has not received any settings calls over the duration of
+	// workingStatusFrequency.
+	HostWorkingStatusNotWorking = HostWorkingStatus("not working")
+
+	// HostWorkingStatusWorking is returned from WorkingStatus() if the host has
+	// received more than workingThreshold settings calls over the duration of
+	// workingStatusFrequency.
+	HostWorkingStatusWorking = HostWorkingStatus("working")
+
+	// HostConnectabilityStatusChecking is returned from ConnectabilityStatus()
+	// if the host is still determining if it is connectable.
+	HostConnectabilityStatusChecking = HostConnectabilityStatus("checking")
+
+	// HostConnectabilityStatusConnectable is returned from
+	// ConnectabilityStatus() if the host is connectable at its configured
+	// netaddress.
+	HostConnectabilityStatusConnectable = HostConnectabilityStatus("connectable")
+
+	// HostConnectabilityStatusNotConnectable is returned from
+	// ConnectabilityStatus() if the host is not connectable at its configured
+	// netaddress.
+	HostConnectabilityStatusNotConnectable = HostConnectabilityStatus("not connectable")
 )
 
 type (

--- a/modules/host.go
+++ b/modules/host.go
@@ -31,7 +31,7 @@ type (
 		ContractCompensation          types.Currency `json:"contractcompensation"`
 		PotentialContractCompensation types.Currency `json:"potentialcontractcompensation"`
 
-		// Metrics related to storage proofs, collateral, and submitting //
+		// Metrics related to storage proofs, collateral, and submitting
 		// transactions to the blockchain.
 		LockedStorageCollateral types.Currency `json:"lockedstoragecollateral"`
 		LostRevenue             types.Currency `json:"lostrevenue"`

--- a/modules/host.go
+++ b/modules/host.go
@@ -92,10 +92,12 @@ type (
 		ObligationStatus    uint64 `json:"obligationstatus"`
 	}
 
-	// HostWorkingState reports the working state of a host.
+	// HostWorkingState reports the working state of a host. Can be one of
+	// "checking", "working", or "not working.
 	HostWorkingState string
 
-	// HostConnectabilityState reports the connectability state of a host.
+	// HostConnectabilityState reports the connectability state of a host. Can be
+	// one of "checking", "connectable", or "not connectable"
 	HostConnectabilityState string
 
 	// A Host can take storage from disk and offer it to the network, managing

--- a/modules/host.go
+++ b/modules/host.go
@@ -95,6 +95,9 @@ type (
 	// HostWorkingState reports the working state of a host.
 	HostWorkingState string
 
+	// HostConnectabilityState reports the connectability state of a host.
+	HostConnectabilityState string
+
 	// A Host can take storage from disk and offer it to the network, managing
 	// things such as announcements, settings, and implementing all of the RPCs
 	// of the host protocol.

--- a/modules/host.go
+++ b/modules/host.go
@@ -133,6 +133,14 @@ type (
 		// the host.
 		StorageObligations() []StorageObligation
 
+		// ConnectabilityState returns the connectability status of the host, that
+		// is, if it can connect to itself on the configured NetAddress.
+		ConnectabilityState() HostConnectabilityState
+
+		// WorkingState returns the working state of the host, determined by if
+		// settings calls are increasing.
+		WorkingState() HostWorkingState
+
 		// The storage manager provides an interface for adding and removing
 		// storage folders and data sectors to the host.
 		StorageManager

--- a/modules/host.go
+++ b/modules/host.go
@@ -92,13 +92,13 @@ type (
 		ObligationStatus    uint64 `json:"obligationstatus"`
 	}
 
-	// HostWorkingState reports the working state of a host. Can be one of
+	// HostWorkingStatus reports the working state of a host. Can be one of
 	// "checking", "working", or "not working.
-	HostWorkingState string
+	HostWorkingStatus string
 
-	// HostConnectabilityState reports the connectability state of a host. Can be
+	// HostConnectabilityStatus reports the connectability state of a host. Can be
 	// one of "checking", "connectable", or "not connectable"
-	HostConnectabilityState string
+	HostConnectabilityStatus string
 
 	// A Host can take storage from disk and offer it to the network, managing
 	// things such as announcements, settings, and implementing all of the RPCs
@@ -135,13 +135,13 @@ type (
 		// the host.
 		StorageObligations() []StorageObligation
 
-		// ConnectabilityState returns the connectability status of the host, that
+		// ConnectabilityStatus returns the connectability status of the host, that
 		// is, if it can connect to itself on the configured NetAddress.
-		ConnectabilityState() HostConnectabilityState
+		ConnectabilityStatus() HostConnectabilityStatus
 
-		// WorkingState returns the working state of the host, determined by if
+		// WorkingStatus returns the working state of the host, determined by if
 		// settings calls are increasing.
-		WorkingState() HostWorkingState
+		WorkingStatus() HostWorkingStatus
 
 		// The storage manager provides an interface for adding and removing
 		// storage folders and data sectors to the host.

--- a/modules/host.go
+++ b/modules/host.go
@@ -31,7 +31,7 @@ type (
 		ContractCompensation          types.Currency `json:"contractcompensation"`
 		PotentialContractCompensation types.Currency `json:"potentialcontractcompensation"`
 
-		// Metrics related to storage proofs, collateral, and submitting
+		// Metrics related to storage proofs, collateral, and submitting //
 		// transactions to the blockchain.
 		LockedStorageCollateral types.Currency `json:"lockedstoragecollateral"`
 		LostRevenue             types.Currency `json:"lostrevenue"`
@@ -91,6 +91,9 @@ type (
 		ProofConfirmed      bool   `json:"proofconfirmed"`
 		ObligationStatus    uint64 `json:"obligationstatus"`
 	}
+
+	// HostWorkingState reports the working state of a host.
+	HostWorkingState string
 
 	// A Host can take storage from disk and offer it to the network, managing
 	// things such as announcements, settings, and implementing all of the RPCs

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -31,6 +31,21 @@ const (
 	// Typically, this transaction will contain either a file contract, a file
 	// contract revision, or a storage proof.
 	resubmissionTimeout = 3
+
+	// WorkingStateChecking is returned from WorkingState() if the host is
+	// still determining if it is working, that is, if settings calls are
+	// incrementing.
+	WorkingStateChecking = "checking"
+
+	// WorkingStateNotWorking is returned from WorkingState() if the host has
+	// not received any settings calls over the duration of
+	// workingStatusFrequency.
+	WorkingStateNotWorking = "not working"
+
+	// WorkingStateWorking is returned from WorkingState() if the host has
+	// received more than workingThreshold settings calls over the duration of
+	// workingStatusFrequency.
+	WorkingStateWorking = "working"
 )
 
 var (
@@ -103,6 +118,14 @@ var (
 	// the data, meaning that the host serves to profit from accepting the
 	// data.
 	defaultUploadBandwidthPrice = types.SiacoinPrecision.Mul64(10).Div(modules.BytesPerTerabyte) // 10 SC / TB
+
+	// workingStateFrequency defines how frequently the Host's working status
+	// check runs
+	workingStateFrequency = 15 * time.Minute
+
+	// workingStateThreshold defines how many settings calls must occur over the
+	// workingStateFrequency for the host to be considered working.
+	workingStateThreshold = uint64(3)
 
 	// defaultWindowSize is the size of the proof of storage window requested
 	// by the host. The host will not delete any obligations until the window

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -31,33 +31,6 @@ const (
 	// Typically, this transaction will contain either a file contract, a file
 	// contract revision, or a storage proof.
 	resubmissionTimeout = 3
-
-	// WorkingStatusChecking is returned from WorkingStatus() if the host is
-	// still determining if it is working, that is, if settings calls are
-	// incrementing.
-	WorkingStatusChecking = "checking"
-
-	// WorkingStatusNotWorking is returned from WorkingStatus() if the host has
-	// not received any settings calls over the duration of
-	// workingStatusFrequency.
-	WorkingStatusNotWorking = "not working"
-
-	// WorkingStatusWorking is returned from WorkingStatus() if the host has
-	// received more than workingThreshold settings calls over the duration of
-	// workingStatusFrequency.
-	WorkingStatusWorking = "working"
-
-	// ConnectabilityStatusChecking is returned from ConnectabilityStatus() if the
-	// host is still determining if it is connectable.
-	ConnectabilityStatusChecking = "checking"
-
-	// ConnectabilityStatusConnectable is returned from ConnectabilityStatus() if
-	// the host is connectable at its configured netaddress.
-	ConnectabilityStatusConnectable = "connectable"
-
-	// ConnectabilityStatusNotConnectable is returned from ConnectabilityStatus()
-	// if the host is not connectable at its configured netaddress.
-	ConnectabilityStatusNotConnectable = "not connectable"
 )
 
 var (

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -32,32 +32,32 @@ const (
 	// contract revision, or a storage proof.
 	resubmissionTimeout = 3
 
-	// WorkingStateChecking is returned from WorkingState() if the host is
+	// WorkingStatusChecking is returned from WorkingStatus() if the host is
 	// still determining if it is working, that is, if settings calls are
 	// incrementing.
-	WorkingStateChecking = "checking"
+	WorkingStatusChecking = "checking"
 
-	// WorkingStateNotWorking is returned from WorkingState() if the host has
+	// WorkingStatusNotWorking is returned from WorkingStatus() if the host has
 	// not received any settings calls over the duration of
 	// workingStatusFrequency.
-	WorkingStateNotWorking = "not working"
+	WorkingStatusNotWorking = "not working"
 
-	// WorkingStateWorking is returned from WorkingState() if the host has
+	// WorkingStatusWorking is returned from WorkingStatus() if the host has
 	// received more than workingThreshold settings calls over the duration of
 	// workingStatusFrequency.
-	WorkingStateWorking = "working"
+	WorkingStatusWorking = "working"
 
-	// ConnectabilityStateChecking is returned from ConnectabilityState() if the
+	// ConnectabilityStatusChecking is returned from ConnectabilityStatus() if the
 	// host is still determining if it is connectable.
-	ConnectabilityStateChecking = "checking"
+	ConnectabilityStatusChecking = "checking"
 
-	// ConnectabilityStateConnectable is returned from ConnectabilityState() if
+	// ConnectabilityStatusConnectable is returned from ConnectabilityStatus() if
 	// the host is connectable at its configured netaddress.
-	ConnectabilityStateConnectable = "connectable"
+	ConnectabilityStatusConnectable = "connectable"
 
-	// ConnectabilityStateNotConnectable is returned from ConnectabilityState()
+	// ConnectabilityStatusNotConnectable is returned from ConnectabilityStatus()
 	// if the host is not connectable at its configured netaddress.
-	ConnectabilityStateNotConnectable = "not connectable"
+	ConnectabilityStatusNotConnectable = "not connectable"
 )
 
 var (
@@ -131,17 +131,17 @@ var (
 	// data.
 	defaultUploadBandwidthPrice = types.SiacoinPrecision.Mul64(10).Div(modules.BytesPerTerabyte) // 10 SC / TB
 
-	// workingStateFrequency defines how frequently the Host's working status
+	// workingStatusFrequency defines how frequently the Host's working status
 	// check runs
-	workingStateFrequency = build.Select(build.Var{
+	workingStatusFrequency = build.Select(build.Var{
 		Standard: time.Minute * 15,
 		Dev:      time.Minute * 5,
 		Testing:  time.Second * 30,
 	}).(time.Duration)
 
-	// workingStateThreshold defines how many settings calls must occur over the
-	// workingStateFrequency for the host to be considered working.
-	workingStateThreshold = build.Select(build.Var{
+	// workingStatusThreshold defines how many settings calls must occur over the
+	// workingStatusFrequency for the host to be considered working.
+	workingStatusThreshold = build.Select(build.Var{
 		Standard: uint64(3),
 		Dev:      uint64(1),
 		Testing:  uint64(1),

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -146,9 +146,9 @@ var (
 	// connectablityCheckFrequency defines how often the host's connectability
 	// check is run.
 	connectabilityCheckFrequency = build.Select(build.Var{
-		Standard: time.Minute * 3,
-		Dev:      time.Minute,
-		Testing:  time.Second * 10,
+		Standard: time.Minute * 15,
+		Dev:      time.Minute * 5,
+		Testing:  time.Second * 30,
 	}).(time.Duration)
 
 	// defaultWindowSize is the size of the proof of storage window requested

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -46,6 +46,18 @@ const (
 	// received more than workingThreshold settings calls over the duration of
 	// workingStatusFrequency.
 	WorkingStateWorking = "working"
+
+	// ConnectabilityStateChecking is returned from ConnectabilityState() if the
+	// host is still determining if it is connectable.
+	ConnectabilityStateChecking = "checking"
+
+	// ConnectabilityStateConnectable is returned from ConnectabilityState() if
+	// the host is connectable at its configured netaddress.
+	ConnectabilityStateConnectable = "connectable"
+
+	// ConnectabilityStateNotConnectable is returned from ConnectabilityState()
+	// if the host is not connectable at its configured netaddress.
+	ConnectabilityStateNotConnectable = "not connectable"
 )
 
 var (
@@ -126,6 +138,10 @@ var (
 	// workingStateThreshold defines how many settings calls must occur over the
 	// workingStateFrequency for the host to be considered working.
 	workingStateThreshold = uint64(3)
+
+	// connectablityCheckFrequency defines how often the host's connectability
+	// check is run.
+	connectabilityCheckFrequency = 3 * time.Minute
 
 	// defaultWindowSize is the size of the proof of storage window requested
 	// by the host. The host will not delete any obligations until the window

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -133,7 +133,11 @@ var (
 
 	// workingStateFrequency defines how frequently the Host's working status
 	// check runs
-	workingStateFrequency = 15 * time.Minute
+	workingStateFrequency = build.Select(build.Var{
+		Standard: time.Minute * 15,
+		Dev:      time.Minute * 5,
+		Testing:  time.Second * 30,
+	}).(time.Duration)
 
 	// workingStateThreshold defines how many settings calls must occur over the
 	// workingStateFrequency for the host to be considered working.
@@ -141,7 +145,11 @@ var (
 
 	// connectablityCheckFrequency defines how often the host's connectability
 	// check is run.
-	connectabilityCheckFrequency = 3 * time.Minute
+	connectabilityCheckFrequency = build.Select(build.Var{
+		Standard: time.Minute * 3,
+		Dev:      time.Minute,
+		Testing:  time.Second * 10,
+	}).(time.Duration)
 
 	// defaultWindowSize is the size of the proof of storage window requested
 	// by the host. The host will not delete any obligations until the window

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -155,6 +155,14 @@ var (
 		Testing:  time.Second * 30,
 	}).(time.Duration)
 
+	// connectabilityCheckTimeout defines how long a connectability check's dial
+	// will be allowed to block before it times out.
+	connectabilityCheckTimeout = build.Select(build.Var{
+		Standard: time.Minute * 2,
+		Dev:      time.Minute * 5,
+		Testing:  time.Second * 90,
+	}).(time.Duration)
+
 	// defaultWindowSize is the size of the proof of storage window requested
 	// by the host. The host will not delete any obligations until the window
 	// has closed and buried under several confirmations. For release builds,

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -141,7 +141,11 @@ var (
 
 	// workingStateThreshold defines how many settings calls must occur over the
 	// workingStateFrequency for the host to be considered working.
-	workingStateThreshold = uint64(3)
+	workingStateThreshold = build.Select(build.Var{
+		Standard: uint64(3),
+		Dev:      uint64(1),
+		Testing:  uint64(1),
+	}).(uint64)
 
 	// connectablityCheckFrequency defines how often the host's connectability
 	// check is run.

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -154,12 +154,12 @@ type Host struct {
 
 	// Host transient fields - these fields are either determined at startup or
 	// otherwise are not critical to always be correct.
-	autoAddress         modules.NetAddress // Determined using automatic tooling in network.go
-	financialMetrics    modules.HostFinancialMetrics
-	settings            modules.HostInternalSettings
-	revisionNumber      uint64
-	workingState        modules.HostWorkingState
-	connectabilityState modules.HostConnectabilityState
+	autoAddress          modules.NetAddress // Determined using automatic tooling in network.go
+	financialMetrics     modules.HostFinancialMetrics
+	settings             modules.HostInternalSettings
+	revisionNumber       uint64
+	workingStatus        modules.HostWorkingStatus
+	connectabilityStatus modules.HostConnectabilityStatus
 
 	// A map of storage obligations that are currently being modified. Locks on
 	// storage obligations can be long-running, and each storage obligation can
@@ -317,21 +317,21 @@ func (h *Host) ExternalSettings() modules.HostExternalSettings {
 	return h.externalSettings()
 }
 
-// WorkingState returns the working state of the host, where working is
+// WorkingStatus returns the working state of the host, where working is
 // defined as having received more than workingStatusThreshold settings calls
 // over the period of workingStatusFrequency.
-func (h *Host) WorkingState() modules.HostWorkingState {
+func (h *Host) WorkingStatus() modules.HostWorkingStatus {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return h.workingState
+	return h.workingStatus
 }
 
-// ConnectabilityState returns the connectability state of the host, whether
+// ConnectabilityStatus returns the connectability state of the host, whether
 // the host can connect to itself on its configured netaddress.
-func (h *Host) ConnectabilityState() modules.HostConnectabilityState {
+func (h *Host) ConnectabilityStatus() modules.HostConnectabilityStatus {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return h.connectabilityState
+	return h.connectabilityStatus
 }
 
 // FinancialMetrics returns information about the financial commitments,

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -154,11 +154,12 @@ type Host struct {
 
 	// Host transient fields - these fields are either determined at startup or
 	// otherwise are not critical to always be correct.
-	autoAddress      modules.NetAddress // Determined using automatic tooling in network.go
-	financialMetrics modules.HostFinancialMetrics
-	settings         modules.HostInternalSettings
-	revisionNumber   uint64
-	workingState     modules.HostWorkingState
+	autoAddress         modules.NetAddress // Determined using automatic tooling in network.go
+	financialMetrics    modules.HostFinancialMetrics
+	settings            modules.HostInternalSettings
+	revisionNumber      uint64
+	workingState        modules.HostWorkingState
+	connectabilityState modules.HostConnectabilityState
 
 	// A map of storage obligations that are currently being modified. Locks on
 	// storage obligations can be long-running, and each storage obligation can
@@ -323,6 +324,14 @@ func (h *Host) WorkingState() modules.HostWorkingState {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.workingState
+}
+
+// ConnectabilityState returns the connectability state of the host, whether
+// the host can connect to itself on its configured netaddress.
+func (h *Host) ConnectabilityState() modules.HostConnectabilityState {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.connectabilityState
 }
 
 // FinancialMetrics returns information about the financial commitments,

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -158,6 +158,7 @@ type Host struct {
 	financialMetrics modules.HostFinancialMetrics
 	settings         modules.HostInternalSettings
 	revisionNumber   uint64
+	workingState     modules.HostWorkingState
 
 	// A map of storage obligations that are currently being modified. Locks on
 	// storage obligations can be long-running, and each storage obligation can
@@ -313,6 +314,15 @@ func (h *Host) ExternalSettings() modules.HostExternalSettings {
 	}
 	defer h.tg.Done()
 	return h.externalSettings()
+}
+
+// WorkingState returns the working state of the host, where working is
+// defined as having received more than workingStatusThreshold settings calls
+// over the period of workingStatusFrequency.
+func (h *Host) WorkingState() modules.HostWorkingState {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.workingState
 }
 
 // FinancialMetrics returns information about the financial commitments,

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -107,16 +107,16 @@ func (h *Host) threadedTrackConnectabilityStatus(closeChan chan struct{}) {
 			Timeout: connectabilityCheckTimeout,
 		}
 		conn, err := dialer.Dial("tcp", string(activeAddr))
-		if err != nil {
-			h.mu.Lock()
-			h.connectabilityStatus = ConnectabilityStatusNotConnectable
-			h.mu.Unlock()
-			continue
-		}
-		conn.Close()
 
+		var status modules.HostConnectabilityStatus
+		if err != nil {
+			status = ConnectabilityStatusNotConnectable
+		} else {
+			conn.Close()
+			status = ConnectabilityStatusConnectable
+		}
 		h.mu.Lock()
-		h.connectabilityStatus = ConnectabilityStatusConnectable
+		h.connectabilityStatus = status
 		h.mu.Unlock()
 	}
 }

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -99,15 +99,15 @@ func (h *Host) threadedTrackConnectabilityState(closeChan chan struct{}) {
 		}
 
 		conn, err := net.Dial("tcp", string(activeAddr))
+
+		h.mu.Lock()
 		if err == nil {
-			h.mu.Lock()
 			h.connectabilityState = ConnectabilityStateConnectable
-			h.mu.Unlock()
 		} else {
-			h.mu.Lock()
 			h.connectabilityState = ConnectabilityStateNotConnectable
-			h.mu.Unlock()
 		}
+		h.mu.Unlock()
+
 		conn.Close()
 	}
 }

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -66,6 +66,12 @@ func (h *Host) threadedTrackWorkingState(closeChan chan struct{}) {
 
 		settingsCalls := atomic.LoadUint64(&h.atomicSettingsCalls)
 
+		// sanity check
+		if prevSettingsCalls > settingsCalls {
+			build.Severe("the host's settings calls decremented")
+			continue
+		}
+
 		h.mu.Lock()
 		if settingsCalls-prevSettingsCalls >= workingStateThreshold {
 			h.workingState = WorkingStateWorking

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -109,21 +109,11 @@ func (h *Host) threadedTrackConnectabilityStatus(closeChan chan struct{}) {
 			h.mu.Unlock()
 			continue
 		}
-
-		connCloseChan := make(chan struct{})
-		go func() {
-			select {
-			case <-h.tg.StopChan():
-			case <-connCloseChan:
-			}
-			conn.Close()
-		}()
+		conn.Close()
 
 		h.mu.Lock()
 		h.connectabilityStatus = ConnectabilityStatusConnectable
 		h.mu.Unlock()
-
-		close(connCloseChan)
 	}
 }
 

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -102,7 +102,11 @@ func (h *Host) threadedTrackConnectabilityStatus(closeChan chan struct{}) {
 			activeAddr = userAddr
 		}
 
-		conn, err := net.Dial("tcp", string(activeAddr))
+		dialer := &net.Dialer{
+			Cancel:  h.tg.StopChan(),
+			Timeout: connectabilityCheckTimeout,
+		}
+		conn, err := dialer.Dial("tcp", string(activeAddr))
 		if err != nil {
 			h.mu.Lock()
 			h.connectabilityStatus = ConnectabilityStatusNotConnectable

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -57,13 +57,11 @@ func (h *Host) threadedTrackWorkingState(closeChan chan struct{}) {
 
 	for {
 		prevSettingsCalls := atomic.LoadUint64(&h.atomicSettingsCalls)
-
 		select {
 		case <-h.tg.StopChan():
 			return
 		case <-time.After(workingStateFrequency):
 		}
-
 		settingsCalls := atomic.LoadUint64(&h.atomicSettingsCalls)
 
 		// sanity check

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -72,9 +72,9 @@ func (h *Host) threadedTrackWorkingStatus(closeChan chan struct{}) {
 
 		h.mu.Lock()
 		if settingsCalls-prevSettingsCalls >= workingStatusThreshold {
-			h.workingStatus = WorkingStatusWorking
+			h.workingStatus = modules.HostWorkingStatusWorking
 		} else {
-			h.workingStatus = WorkingStatusNotWorking
+			h.workingStatus = modules.HostWorkingStatusNotWorking
 		}
 		h.mu.Unlock()
 	}
@@ -110,10 +110,10 @@ func (h *Host) threadedTrackConnectabilityStatus(closeChan chan struct{}) {
 
 		var status modules.HostConnectabilityStatus
 		if err != nil {
-			status = ConnectabilityStatusNotConnectable
+			status = modules.HostConnectabilityStatusNotConnectable
 		} else {
 			conn.Close()
-			status = ConnectabilityStatusConnectable
+			status = modules.HostConnectabilityStatusConnectable
 		}
 		h.mu.Lock()
 		h.connectabilityStatus = status
@@ -142,10 +142,10 @@ func (h *Host) initNetworking(address string) (err error) {
 	})
 
 	// Set the initial working state of the host
-	h.workingStatus = WorkingStatusChecking
+	h.workingStatus = modules.HostWorkingStatusChecking
 
 	// Set the initial connectability state of the host
-	h.connectabilityStatus = ConnectabilityStatusChecking
+	h.connectabilityStatus = modules.HostConnectabilityStatusChecking
 
 	// Set the port.
 	_, port, err := net.SplitHostPort(h.listener.Addr().String())

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -63,9 +63,10 @@ func TestHostWorkingState(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	workingStateFrequency = 5 * time.Second
+
+	t.Parallel()
 
 	ht, err := newHostTester(t.Name())
 	if err != nil {
@@ -99,9 +100,10 @@ func TestHostConnectabilityState(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	t.Parallel()
 
 	connectabilityCheckFrequency = 5 * time.Second
+
+	t.Parallel()
 
 	ht, err := newHostTester(t.Name())
 	if err != nil {

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -4,6 +4,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // blockingPortForward is a dependency set that causes the host port forward
@@ -73,8 +75,8 @@ func TestHostWorkingStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ht.host.WorkingStatus() != WorkingStatusChecking {
-		t.Fatal("expected working state to initially be WorkingStatusChecking")
+	if ht.host.WorkingStatus() != modules.HostWorkingStatusChecking {
+		t.Fatal("expected working state to initially be modules.HostWorkingStatusChecking")
 	}
 
 	atomic.StoreUint64(&ht.host.atomicSettingsCalls, workingStatusThreshold+1)
@@ -82,15 +84,15 @@ func TestHostWorkingStatus(t *testing.T) {
 	time.Sleep(workingStatusFrequency)
 	time.Sleep(time.Second)
 
-	if ht.host.WorkingStatus() != WorkingStatusWorking {
-		t.Fatal("expected host working status to be WorkingStatusWorking after incrementing status calls")
+	if ht.host.WorkingStatus() != modules.HostWorkingStatusWorking {
+		t.Fatal("expected host working status to be modules.HostWorkingStatusWorking after incrementing status calls")
 	}
 
 	time.Sleep(workingStatusFrequency)
 	time.Sleep(time.Second)
 
-	if ht.host.WorkingStatus() != WorkingStatusNotWorking {
-		t.Fatal("expected host working status to be WorkingStatusNotWorking after waiting workingStatusFrequency with no settings calls")
+	if ht.host.WorkingStatus() != modules.HostWorkingStatusNotWorking {
+		t.Fatal("expected host working status to be modules.HostWorkingStatusNotWorking after waiting workingStatusFrequency with no settings calls")
 	}
 }
 
@@ -110,14 +112,14 @@ func TestHostConnectabilityStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ht.host.ConnectabilityStatus() != ConnectabilityStatusChecking {
+	if ht.host.ConnectabilityStatus() != modules.HostConnectabilityStatusChecking {
 		t.Fatal("expected connectability state to initially be ConnectablityStateChecking")
 	}
 
 	time.Sleep(connectabilityCheckFrequency)
 	time.Sleep(time.Second)
 
-	if ht.host.ConnectabilityStatus() != ConnectabilityStatusConnectable {
-		t.Fatal("expected connectability state to be ConnectabilityStatusConnectable")
+	if ht.host.ConnectabilityStatus() != modules.HostConnectabilityStatusConnectable {
+		t.Fatal("expected connectability state to be modules.HostConnectabilityStatusConnectable")
 	}
 }

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -73,7 +73,7 @@ func TestHostWorkingState(t *testing.T) {
 	}
 
 	if ht.host.WorkingState() != WorkingStateChecking {
-		t.Fatal("expected working status to initially WorkingStateChecking")
+		t.Fatal("expected working state to initially be WorkingStateChecking")
 	}
 
 	atomic.StoreUint64(&ht.host.atomicSettingsCalls, workingStateThreshold+1)
@@ -90,5 +90,32 @@ func TestHostWorkingState(t *testing.T) {
 
 	if ht.host.WorkingState() != WorkingStateNotWorking {
 		t.Fatal("expected host working status to be WorkingStateNotWorking after waiting workingStateFrequency with no settings calls")
+	}
+}
+
+// TestHostConnectabilityState checks that the host properly updates its connectable
+// state
+func TestHostConnectabilityState(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	connectabilityCheckFrequency = 5 * time.Second
+
+	ht, err := newHostTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ht.host.ConnectabilityState() != ConnectabilityStateChecking {
+		t.Fatal("expected connectability state to initially be ConnectablityStateChecking")
+	}
+
+	time.Sleep(connectabilityCheckFrequency)
+	time.Sleep(time.Second)
+
+	if ht.host.ConnectabilityState() != ConnectabilityStateConnectable {
+		t.Fatal("expected connectability state to be ConnectabilityStateConnectable")
 	}
 }

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -57,14 +57,14 @@ func TestPortForwardBlocking(t *testing.T) {
 	time.Sleep(time.Second * 4)
 }
 
-// TestHostWorkingState checks that the host properly updates its working
+// TestHostWorkingStatus checks that the host properly updates its working
 // state
-func TestHostWorkingState(t *testing.T) {
+func TestHostWorkingStatus(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	workingStateFrequency = 5 * time.Second
+	workingStatusFrequency = 5 * time.Second
 
 	t.Parallel()
 
@@ -73,30 +73,30 @@ func TestHostWorkingState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ht.host.WorkingState() != WorkingStateChecking {
-		t.Fatal("expected working state to initially be WorkingStateChecking")
+	if ht.host.WorkingStatus() != WorkingStatusChecking {
+		t.Fatal("expected working state to initially be WorkingStatusChecking")
 	}
 
-	atomic.StoreUint64(&ht.host.atomicSettingsCalls, workingStateThreshold+1)
+	atomic.StoreUint64(&ht.host.atomicSettingsCalls, workingStatusThreshold+1)
 
-	time.Sleep(workingStateFrequency)
+	time.Sleep(workingStatusFrequency)
 	time.Sleep(time.Second)
 
-	if ht.host.WorkingState() != WorkingStateWorking {
-		t.Fatal("expected host working status to be WorkingStateWorking after incrementing status calls")
+	if ht.host.WorkingStatus() != WorkingStatusWorking {
+		t.Fatal("expected host working status to be WorkingStatusWorking after incrementing status calls")
 	}
 
-	time.Sleep(workingStateFrequency)
+	time.Sleep(workingStatusFrequency)
 	time.Sleep(time.Second)
 
-	if ht.host.WorkingState() != WorkingStateNotWorking {
-		t.Fatal("expected host working status to be WorkingStateNotWorking after waiting workingStateFrequency with no settings calls")
+	if ht.host.WorkingStatus() != WorkingStatusNotWorking {
+		t.Fatal("expected host working status to be WorkingStatusNotWorking after waiting workingStatusFrequency with no settings calls")
 	}
 }
 
-// TestHostConnectabilityState checks that the host properly updates its connectable
+// TestHostConnectabilityStatus checks that the host properly updates its connectable
 // state
-func TestHostConnectabilityState(t *testing.T) {
+func TestHostConnectabilityStatus(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -110,14 +110,14 @@ func TestHostConnectabilityState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ht.host.ConnectabilityState() != ConnectabilityStateChecking {
+	if ht.host.ConnectabilityStatus() != ConnectabilityStatusChecking {
 		t.Fatal("expected connectability state to initially be ConnectablityStateChecking")
 	}
 
 	time.Sleep(connectabilityCheckFrequency)
 	time.Sleep(time.Second)
 
-	if ht.host.ConnectabilityState() != ConnectabilityStateConnectable {
-		t.Fatal("expected connectability state to be ConnectabilityStateConnectable")
+	if ht.host.ConnectabilityStatus() != ConnectabilityStatusConnectable {
+		t.Fatal("expected connectability state to be ConnectabilityStatusConnectable")
 	}
 }

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -268,8 +268,8 @@ Working Status:        %v,
 			nm.ErrorCalls, nm.UnrecognizedCalls, nm.DownloadCalls,
 			nm.RenewCalls, nm.ReviseCalls, nm.SettingsCalls,
 			nm.FormContractCalls,
-			hg.ConnectabilityState,
-			hg.WorkingState)
+			hg.ConnectabilityStatus,
+			hg.WorkingStatus)
 	} else {
 		fmt.Printf(`Host info:
 	Estimated Competitive Price: %v
@@ -294,8 +294,8 @@ Working Status:        %v,
 			yesNo(is.AcceptingContracts), currencyUnits(totalPotentialRevenue),
 			currencyUnits(fm.LockedStorageCollateral),
 			currencyUnits(totalRevenue),
-			hg.ConnectabilityState,
-			hg.WorkingState)
+			hg.ConnectabilityStatus,
+			hg.WorkingStatus)
 	}
 
 	fmt.Println("\nStorage Folders:")

--- a/siac/hostcmd.go
+++ b/siac/hostcmd.go
@@ -229,6 +229,9 @@ RPC Stats:
 	Revise Calls:       %v
 	Settings Calls:     %v
 	FormContract Calls: %v
+
+Connectability Status: %v,
+Working Status:        %v,
 `,
 			competitivePrice,
 
@@ -264,7 +267,9 @@ RPC Stats:
 
 			nm.ErrorCalls, nm.UnrecognizedCalls, nm.DownloadCalls,
 			nm.RenewCalls, nm.ReviseCalls, nm.SettingsCalls,
-			nm.FormContractCalls)
+			nm.FormContractCalls,
+			hg.ConnectabilityState,
+			hg.WorkingState)
 	} else {
 		fmt.Printf(`Host info:
 	Estimated Competitive Price: %v
@@ -273,10 +278,12 @@ RPC Stats:
 	Price:        %v / TB / Month
 	Max Duration: %v Weeks
 
-	Accepting Contracts: %v
-	Anticipated Revenue: %v
-	Locked Collateral:   %v
-	Revenue:             %v
+	Accepting Contracts:  %v
+	Anticipated Revenue:  %v
+	Locked Collateral:    %v
+	Revenue:              %v
+	Connectablity Status: %v
+	Working Status:       %v
 `,
 			competitivePrice,
 
@@ -286,7 +293,9 @@ RPC Stats:
 
 			yesNo(is.AcceptingContracts), currencyUnits(totalPotentialRevenue),
 			currencyUnits(fm.LockedStorageCollateral),
-			currencyUnits(totalRevenue))
+			currencyUnits(totalRevenue),
+			hg.ConnectabilityState,
+			hg.WorkingState)
 	}
 
 	fmt.Println("\nStorage Folders:")


### PR DESCRIPTION
This PR moves the functionality described in https://github.com/NebulousLabs/Sia-UI/pull/530 to the back-end, exposing two new API fields, `ConnectabilityState` and `WorkingState`. The commits are pretty easy to follow and should be well commented.