### PR TITLE
add shutdown message to siad

### DIFF
--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -310,4 +310,7 @@ func startDaemonCmd(cmd *cobra.Command, _ []string) {
 	if err != nil {
 		die(err)
 	}
+
+	// Daemon seems to have closed cleanly. Print a 'closed' mesasge.
+	fmt.Println("Shutdown complete.")
 }


### PR DESCRIPTION
Looking at redirected output alone I was unable to tell whether the gateway was in the process of closing or had finished closing, because the output is the same both ways. This fixes that.