### PR TITLE
add wallet reinitialization (--force)

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -190,7 +190,14 @@ func (api *API) walletInitHandler(w http.ResponseWriter, req *http.Request, _ ht
 	if req.FormValue("encryptionpassword") != "" {
 		encryptionKey = crypto.TwofishKey(crypto.HashObject(req.FormValue("encryptionpassword")))
 	}
-	seed, err := api.wallet.Encrypt(encryptionKey)
+
+	var seed modules.Seed
+	var err error
+	if req.FormValue("force") == "true" {
+		seed, err = api.wallet.Reencrypt(encryptionKey)
+	} else {
+		seed, err = api.wallet.Encrypt(encryptionKey)
+	}
 	if err != nil {
 		WriteError(w, Error{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
 		return

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -199,6 +199,10 @@ func (api *API) walletInitHandler(w http.ResponseWriter, req *http.Request, _ ht
 		}
 	}
 	seed, err := api.wallet.Encrypt(encryptionKey)
+	if err != nil {
+		WriteError(w, Error{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
+		return
+	}
 
 	dictID := mnemonics.DictionaryID(req.FormValue("dictionary"))
 	if dictID == "" {

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -191,17 +191,14 @@ func (api *API) walletInitHandler(w http.ResponseWriter, req *http.Request, _ ht
 		encryptionKey = crypto.TwofishKey(crypto.HashObject(req.FormValue("encryptionpassword")))
 	}
 
-	var seed modules.Seed
-	var err error
 	if req.FormValue("force") == "true" {
-		seed, err = api.wallet.Reencrypt(encryptionKey)
-	} else {
-		seed, err = api.wallet.Encrypt(encryptionKey)
+		err := api.wallet.Reset()
+		if err != nil {
+			WriteError(w, Error{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
+			return
+		}
 	}
-	if err != nil {
-		WriteError(w, Error{"error when calling /wallet/init: " + err.Error()}, http.StatusBadRequest)
-		return
-	}
+	seed, err := api.wallet.Encrypt(encryptionKey)
 
 	dictID := mnemonics.DictionaryID(req.FormValue("dictionary"))
 	if dictID == "" {

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -229,6 +229,15 @@ func (api *API) walletInitSeedHandler(w http.ResponseWriter, req *http.Request, 
 		WriteError(w, Error{"error when calling /wallet/init/seed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
+
+	if req.FormValue("force") == "true" {
+		err = api.wallet.Reset()
+		if err != nil {
+			WriteError(w, Error{"error when calling /wallet/init/seed: " + err.Error()}, http.StatusBadRequest)
+			return
+		}
+	}
+
 	err = api.wallet.InitFromSeed(encryptionKey, seed)
 	if err != nil {
 		WriteError(w, Error{"error when calling /wallet/init/seed: " + err.Error()}, http.StatusBadRequest)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -758,3 +758,78 @@ func TestWalletRelativePathErrorSiag(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestWalletReencrypt(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	testdir := build.TempDir("api", t.Name())
+
+	walletPassword := "testpass"
+	key := crypto.TwofishKey(crypto.HashObject(walletPassword))
+
+	st, err := assembleServerTester(key, testdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// lock the wallet
+	err = st.stdPostAPI("/wallet/lock", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// reencrypt the wallet
+	newPassword := "testpass2"
+	newKey := crypto.TwofishKey(crypto.HashObject(newPassword))
+
+	initValues := url.Values{}
+	initValues.Set("force", "true")
+	initValues.Set("encryptionpassword", newPassword)
+	err = st.stdPostAPI("/wallet/init", initValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use the password to call /wallet/unlock.
+	unlockValues := url.Values{}
+	unlockValues.Set("encryptionpassword", newPassword)
+	err = st.stdPostAPI("/wallet/unlock", unlockValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the wallet actually unlocked.
+	if !st.wallet.Unlocked() {
+		t.Error("wallet is not unlocked")
+	}
+
+	// reload the server and verify unlocking still works
+	err = st.server.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st2, err := assembleServerTester(newKey, st.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st2.server.Close()
+
+	// lock the wallet
+	err = st2.stdPostAPI("/wallet/lock", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use the password to call /wallet/unlock.
+	err = st2.stdPostAPI("/wallet/unlock", unlockValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the wallet actually unlocked.
+	if !st2.wallet.Unlocked() {
+		t.Error("wallet is not unlocked")
+	}
+}

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -759,7 +759,7 @@ func TestWalletRelativePathErrorSiag(t *testing.T) {
 	}
 }
 
-func TestWalletReencrypt(t *testing.T) {
+func TestWalletReset(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}

--- a/doc/API.md
+++ b/doc/API.md
@@ -1054,6 +1054,7 @@ is blank, then the password will be set to the same as the seed.
 ```
 encryptionpassword
 dictionary // Optional, default is english.
+force // Optional, when set to true it will destroy an existing wallet and reinitialize a new one.
 ```
 
 ###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response-3)
@@ -1079,6 +1080,7 @@ synced.
 encryptionpassword
 dictionary // Optional, default is english.
 seed
+force // Optional, when set to true it will destroy an existing wallet and reinitialize a new one.
 ```
 
 ###### Response

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -168,10 +168,11 @@ standard success or error response. See
 
 #### /wallet/init [POST]
 
-initializes the wallet. After the wallet has been initialized once, it does
-not need to be initialized again, and future calls to /wallet/init will return
-an error. The encryption password is provided by the api call. If the password
-is blank, then the password will be set to the same as the seed.
+initializes the wallet. After the wallet has been initialized once, it does not
+need to be initialized again, and future calls to /wallet/init will return an
+error, unless the force flag is set. The encryption password is provided by the
+api call. If the password is blank, then the password will be set to the same
+as the seed.
 
 ###### Query String Parameters
 ```
@@ -183,6 +184,11 @@ encryptionpassword
 // Name of the dictionary that should be used when encoding the seed. 'english'
 // is the most common choice when picking a dictionary.
 dictionary // Optional, default is english.
+
+// boolean, when set to true /wallet/init will Reset the wallet if one exists
+// instead of returning an error. This allows API callers to reinitialize a new
+// wallet.
+force
 ```
 
 ###### JSON Response
@@ -196,13 +202,13 @@ dictionary // Optional, default is english.
 #### /wallet/init/seed [POST]
 
 initializes the wallet using a preexisting seed. After the wallet has been
-initialized once, it does not need to be initialized again, and future calls
-to /wallet/init/seed will return an error. The encryption password is provided
-by the api call. If the password is blank, then the password will be set to
-the same as the seed. Note that loading a preexisting seed requires scanning
-the blockchain to determine how many keys have been generated from the seed.
-For this reason, /wallet/init/seed can only be called if the blockchain is
-synced.
+initialized once, it does not need to be initialized again, and future calls to
+/wallet/init/seed will return an error unless the force flag is set. The
+encryption password is provided by the api call. If the password is blank, then
+the password will be set to the same as the seed. Note that loading a
+preexisting seed requires scanning the blockchain to determine how many keys
+have been generated from the seed.  For this reason, /wallet/init/seed can only
+be called if the blockchain is synced.
 
 ###### Query String Parameters
 ```
@@ -218,6 +224,11 @@ dictionary // Optional, default is english.
 // Dictionary-encoded phrase that corresponds to the seed being used to
 // initialize the wallet.
 seed
+
+// boolean, when set to true /wallet/init will Reset the wallet if one exists
+// instead of returning an error. This allows API callers to reinitialize a new
+// wallet.
+force
 ```
 
 ###### Response

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -225,6 +225,8 @@ type (
 		// a different directory or deleted.
 		Encrypt(masterKey crypto.TwofishKey) (Seed, error)
 
+		Reencrypt(masterKey crypto.TwofishKey) (Seed, error)
+
 		// Encrypted returns whether or not the wallet has been encrypted yet.
 		// After being encrypted for the first time, the wallet can only be
 		// unlocked using the encryption password.

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -225,14 +225,10 @@ type (
 		// a different directory or deleted.
 		Encrypt(masterKey crypto.TwofishKey) (Seed, error)
 
-		// Reencrypt will create a primary seed for the wallet and encrypt it using
-		// masterKey. If masterKey is blank, then the hash of the primary seed will be
-		// used instead.
-		//
-		// Reencrypt can only be called on a wallet that has already
-		// been encrypted. Calling Reencrypt on an encrypted wallet destroys that
-		// wallet and creates a new wallet, encrypted with the supplied masterKey.
-		Reencrypt(masterKey crypto.TwofishKey) (Seed, error)
+		// Reset will reset the wallet, clearing the database and returning it to
+		// the unencrypted state. Reset can only be called on a wallet that has
+		// already been encrypted.
+		Reset() error
 
 		// Encrypted returns whether or not the wallet has been encrypted yet.
 		// After being encrypted for the first time, the wallet can only be

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -225,6 +225,13 @@ type (
 		// a different directory or deleted.
 		Encrypt(masterKey crypto.TwofishKey) (Seed, error)
 
+		// Reencrypt will create a primary seed for the wallet and encrypt it using
+		// masterKey. If masterKey is blank, then the hash of the primary seed will be
+		// used instead.
+		//
+		// Reencrypt can only be called on a wallet that has already
+		// been encrypted. Calling Reencrypt on an encrypted wallet destroys that
+		// wallet and creates a new wallet, encrypted with the supplied masterKey.
 		Reencrypt(masterKey crypto.TwofishKey) (Seed, error)
 
 		// Encrypted returns whether or not the wallet has been encrypted yet.

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -53,7 +53,8 @@ func checkMasterKey(tx *bolt.Tx, masterKey crypto.TwofishKey) error {
 	return verifyEncryption(uk, encryptedVerification)
 }
 
-// reinitEncryption re-encrypts a wallet using the given key and seed.
+// reinitEncryption re-encrypts a wallet using the given key and seed. Doing
+// this completely destroys the old wallet.
 func (w *Wallet) reinitEncryption(masterKey crypto.TwofishKey, seed modules.Seed) (modules.Seed, error) {
 	wb := w.dbTx.Bucket(bucketWallet)
 

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/bolt"
 	"github.com/NebulousLabs/fastrand"
 )
@@ -54,8 +55,6 @@ func checkMasterKey(tx *bolt.Tx, masterKey crypto.TwofishKey) error {
 
 // reinitEncryption re-encrypts a wallet using the given key and seed.
 func (w *Wallet) reinitEncryption(masterKey crypto.TwofishKey, seed modules.Seed) (modules.Seed, error) {
-	w.wipeSecrets()
-
 	wb := w.dbTx.Bucket(bucketWallet)
 
 	if wb.Get(keyEncryptionVerification) == nil {
@@ -66,6 +65,11 @@ func (w *Wallet) reinitEncryption(masterKey crypto.TwofishKey, seed modules.Seed
 	if err != nil {
 		return modules.Seed{}, err
 	}
+
+	w.wipeSecrets()
+	w.unconfirmedProcessedTransactions = []modules.ProcessedTransaction{}
+	w.siafundPool = types.Currency{}
+	w.unlocked = false
 
 	return w.initEncryption(masterKey, seed)
 }

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -336,6 +336,7 @@ func (w *Wallet) Reset() error {
 	w.siafundPool = types.Currency{}
 	w.unlocked = false
 	w.encrypted = false
+	w.subscribed = false
 
 	return nil
 }

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -2,12 +2,14 @@ package wallet
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/fastrand"
 )
@@ -285,8 +287,8 @@ func TestInitFromSeed(t *testing.T) {
 	}
 }
 
-// TestReencrypt tests that Reencrypt re-encrypts a wallet correctly.
-func TestReencrypt(t *testing.T) {
+// TestReset tests that Reset resets a wallet correctly.
+func TestReset(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -297,19 +299,36 @@ func TestReencrypt(t *testing.T) {
 	}
 	defer wt.closeWt()
 
-	var masterKey crypto.TwofishKey
-	fastrand.Read(masterKey[:])
-	_, err = wt.wallet.Encrypt(masterKey)
+	var originalKey crypto.TwofishKey
+	fastrand.Read(originalKey[:])
+	_, err = wt.wallet.Encrypt(originalKey)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
+	postEncryptionTesting(wt.miner, wt.wallet, originalKey)
 
-	var encryptionKey crypto.TwofishKey
-	seed, err := wt.wallet.Reencrypt(encryptionKey)
+	err = wt.wallet.Reset()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	walletKey := crypto.TwofishKey(crypto.HashObject(seed))
-	postEncryptionTesting(wt.miner, wt.wallet, walletKey)
+	// reinitialize the miner so it mines into the new seed
+	minerData := filepath.Join(wt.persistDir, modules.MinerDir)
+	err = os.RemoveAll(minerData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newminer, err := miner.New(wt.cs, wt.tpool, wt.wallet, filepath.Join(wt.persistDir, modules.MinerDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt.miner = newminer
+
+	var newKey crypto.TwofishKey
+	fastrand.Read(newKey[:])
+	_, err = wt.wallet.Encrypt(newKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	postEncryptionTesting(wt.miner, wt.wallet, newKey)
 }

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -313,6 +313,10 @@ func TestReset(t *testing.T) {
 	}
 
 	// reinitialize the miner so it mines into the new seed
+	err = wt.miner.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 	minerData := filepath.Join(wt.persistDir, modules.MinerDir)
 	err = os.RemoveAll(minerData)
 	if err != nil {

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -284,3 +284,32 @@ func TestInitFromSeed(t *testing.T) {
 		t.Fatalf("wallet should have correct balance after loading seed: wanted %v, got %v", origBal, newBal)
 	}
 }
+
+// TestReencrypt tests that Reencrypt re-encrypts a wallet correctly.
+func TestReencrypt(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	wt, err := createBlankWalletTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	var masterKey crypto.TwofishKey
+	fastrand.Read(masterKey[:])
+	_, err = wt.wallet.Encrypt(masterKey)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var encryptionKey crypto.TwofishKey
+	seed, err := wt.wallet.Reencrypt(encryptionKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	walletKey := crypto.TwofishKey(crypto.HashObject(seed))
+	postEncryptionTesting(wt.miner, wt.wallet, walletKey)
+}

--- a/siac/main.go
+++ b/siac/main.go
@@ -20,6 +20,7 @@ var (
 	// Flags.
 	addr              string // override default API address
 	initPassword      bool   // supply a custom password when creating a wallet
+	initForce         bool   // destroy and reencrypt the wallet on init if it already exists
 	hostVerbose       bool   // display additional host info
 	renterShowHistory bool   // Show download history in addition to download queue.
 	renterListVerbose bool   // Show additional info about uploaded files.
@@ -266,6 +267,7 @@ func main() {
 		walletLoadCmd, walletLockCmd, walletSeedsCmd, walletSendCmd, walletSweepCmd,
 		walletBalanceCmd, walletTransactionsCmd, walletUnlockCmd)
 	walletInitCmd.Flags().BoolVarP(&initPassword, "password", "p", false, "Prompt for a custom password")
+	walletInitCmd.Flags().BoolVarP(&initForce, "force", "f", false, "destroy the existing wallet and re-encrypt")
 	walletLoadCmd.AddCommand(walletLoad033xCmd, walletLoadSeedCmd, walletLoadSiagCmd)
 	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)
 

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -196,6 +196,9 @@ func walletinitcmd() {
 		}
 		qs += fmt.Sprintf("&encryptionpassword=%s", password)
 	}
+	if initForce {
+		qs += "&force=true"
+	}
 	err := postResp("/wallet/init", qs, &er)
 	if err != nil {
 		die("Error when encrypting wallet:", err)


### PR DESCRIPTION
This PR adds a new option to the `/wallet/init` endpoint, `force`, which when set to `true` will reinitialize the wallet, even if it has already been encrypted. This is useful for users who wish to destroy their wallet and start over, without meddling with persist data.