### PR TITLE
Fees

### DIFF
--- a/modules/host/announce.go
+++ b/modules/host/announce.go
@@ -45,7 +45,7 @@ func (h *Host) managedAnnounce(addr modules.NetAddress) error {
 	// Create a transaction, with a fee, that contains the full announcement.
 	txnBuilder := h.wallet.StartTransaction()
 	_, fee := h.tpool.FeeEstimation()
-	fee = fee.Mul64(500) // Estimated txn size (in bytes) of a host announcement.
+	fee = fee.Mul64(600) // Estimated txn size (in bytes) of a host announcement.
 	err = txnBuilder.FundSiacoins(fee)
 	if err != nil {
 		txnBuilder.Drop()

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -57,7 +57,7 @@ var (
 	// with the host. The default is set to 30 siacoins, which the file
 	// contract revision can have 15 siacoins put towards it, and the storage
 	// proof can have 15 siacoins put towards it.
-	defaultContractPrice = types.SiacoinPrecision.Mul64(20) // 20 siacoins
+	defaultContractPrice = types.SiacoinPrecision.Mul64(5) // 5 siacoins
 
 	// defaultDownloadBandwidthPrice defines the default price of upload
 	// bandwidth. The default is set to 10 siacoins per gigabyte, because

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -120,7 +120,7 @@ func (hdb *HostDB) priceAdjustments(entry modules.HostDBEntry) float64 {
 	//
 	// In the future, the renter should be able to track average user behavior
 	// and adjust accordingly. This flexibility will be added later.
-	adjustedContractPrice := entry.ContractPrice.Div64(6048).Div64(25e9)        // Adjust contract price to match 25GB for 6 weeks.
+	adjustedContractPrice := entry.ContractPrice.Div64(6048).Div64(15e9)        // Adjust contract price to match 25GB for 6 weeks.
 	adjustedUploadPrice := entry.UploadBandwidthPrice.Div64(24192)              // Adjust upload price to match a single upload over 24 weeks.
 	adjustedDownloadPrice := entry.DownloadBandwidthPrice.Div64(12096).Div64(3) // Adjust download price to match one download over 12 weeks, 1 redundancy.
 	siafundFee := adjustedContractPrice.Add(adjustedUploadPrice).Add(adjustedDownloadPrice).Add(entry.Collateral).MulTax()

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -36,7 +36,10 @@ var (
 	errLowMinerFees        = errors.New("transaction set needs more miner fees to be accepted")
 	errEmptySet            = errors.New("transaction set is empty")
 
-	TransactionMinFee = types.SiacoinPrecision.Mul64(2)
+	// TransactionMinFee defines the minimum fee required for a transaction in
+	// order for it to be accepted if there is already more than
+	// TransactionPoolSizeForFee transactions in the transaction pool.
+	TransactionMinFee = types.SiacoinPrecision.Div64(3)
 
 	// relayTransactionSetTimeout establishes the timeout for a relay
 	// transaction set call.

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -135,7 +135,7 @@ func (tp *TransactionPool) FeeEstimation() (min, max types.Currency) {
 	// a much lower value, which means hosts would be incompatible if the
 	// minimum recommended were set to 10. The value has been set to 1, which
 	// should be okay temporarily while the renters are given time to upgrade.
-	return types.SiacoinPrecision.Mul64(1).Div64(1e3), types.SiacoinPrecision.Mul64(5).Div64(1e3)
+	return types.SiacoinPrecision.Mul64(1).Div64(3).Div64(1e3), types.SiacoinPrecision.Mul64(1).Div64(1e3)
 }
 
 // TransactionList returns a list of all transactions in the transaction pool.

--- a/modules/wallet/consts.go
+++ b/modules/wallet/consts.go
@@ -23,7 +23,7 @@ const (
 // TODO: These need to be functions of the wallet that interact with the
 // transaction pool.
 func dustValue() types.Currency {
-	return types.SiacoinPrecision.Mul64(3)
+	return types.SiacoinPrecision
 }
 
 // defragFee is the miner fee paid to miners when performing a defrag

--- a/modules/wallet/consts.go
+++ b/modules/wallet/consts.go
@@ -35,7 +35,7 @@ func defragFee() types.Currency {
 	// 35 outputs at an estimated 250 bytes needed per output means about a 10kb
 	// total transaction, much larger than your average transaction. So you need
 	// a lot of fees.
-	return types.SiacoinPrecision.Mul64(20)
+	return types.SiacoinPrecision.Mul64(10)
 }
 
 func init() {

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -62,7 +62,8 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]t
 	}
 	defer w.tg.Done()
 
-	tpoolFee := types.SiacoinPrecision.Mul64(10) // TODO: better fee algo.
+	_, tpoolFee := w.tpool.FeeEstimation()
+	tpoolFee = tpoolFee.Mul64(750) // Estimated transaction size in bytes
 	output := types.SiacoinOutput{
 		Value:      amount,
 		UnlockHash: dest,
@@ -93,7 +94,9 @@ func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]t
 		return nil, err
 	}
 	defer w.tg.Done()
-	tpoolFee := types.SiacoinPrecision.Mul64(10) // TODO: better fee algo.
+
+	_, tpoolFee := w.tpool.FeeEstimation()
+	tpoolFee = tpoolFee.Mul64(750) // Estimated transaction size in bytes
 	output := types.SiafundOutput{
 		Value:      amount,
 		UnlockHash: dest,

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -35,8 +35,10 @@ func TestSendSiacoins(t *testing.T) {
 	// Send 5000 hastings. The wallet will automatically add a fee. Outgoing
 	// unconfirmed siacoins - incoming unconfirmed siacoins should equal 5000 +
 	// fee.
-	tpoolFee := types.SiacoinPrecision.Mul64(10)
-	_, err = wt.wallet.SendSiacoins(types.NewCurrency64(5000), types.UnlockHash{})
+	sendValue := types.SiacoinPrecision.Mul64(3)
+	_, tpoolFee := wt.wallet.tpool.FeeEstimation()
+	tpoolFee = tpoolFee.Mul64(750)
+	_, err = wt.wallet.SendSiacoins(sendValue, types.UnlockHash{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +47,7 @@ func TestSendSiacoins(t *testing.T) {
 	if !confirmedBal2.Equals(confirmedBal) {
 		t.Error("confirmed balance changed without introduction of blocks")
 	}
-	if !unconfirmedOut2.Equals(unconfirmedIn2.Add(types.NewCurrency64(5000)).Add(tpoolFee)) {
+	if !unconfirmedOut2.Equals(unconfirmedIn2.Add(sendValue).Add(tpoolFee)) {
 		t.Error("sending siacoins appears to be ineffective")
 	}
 
@@ -57,7 +59,7 @@ func TestSendSiacoins(t *testing.T) {
 	}
 	confirmedBal3, _, _ := wt.wallet.ConfirmedBalance()
 	unconfirmedOut3, unconfirmedIn3 := wt.wallet.UnconfirmedBalance()
-	if !confirmedBal3.Equals(confirmedBal2.Add(types.CalculateCoinbase(2)).Sub(types.NewCurrency64(5000)).Sub(tpoolFee)) {
+	if !confirmedBal3.Equals(confirmedBal2.Add(types.CalculateCoinbase(2)).Sub(sendValue).Sub(tpoolFee)) {
 		t.Error("confirmed balance did not adjust to the expected value")
 	}
 	if !unconfirmedOut3.Equals(types.ZeroCurrency) {


### PR DESCRIPTION
Adjust the transaction fees and contract fees by a lot to make renting more economical. We'll have to ping all of the hosts and let them know that it's safe to reduce the contract fees.