### PR TITLE
increase number of dl-pieces used by renter

### DIFF
--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -34,7 +34,7 @@ var (
 	//
 	// TODO: Allow this number to be established in the renter settings.
 	maxActiveDownloadPieces = build.Select(build.Var{
-		Standard: int(40),
+		Standard: int(60),
 		Dev:      int(10),
 		Testing:  int(5),
 	}).(int)


### PR DESCRIPTION
Increasing from 40 to 60 means that the peak memory usage of the renter for
downloads is now potentially 80 MiB higher, but it also means that instead of
being bottlenecked by your 4 slowest hosts during download, you are bottlenecked
by the 6 slowest hosts during download.

This change is acceptable becaues of memory efficieny gains in the wallet.
Future changes to the api, to the downloader scheduling, and to
uploader-downloader coordination will allow us to reduce this back down at some
point while simultaneously also incresaing download speeds.