### PR TITLE
Faster host upgrades + storage folder operations

### DIFF
--- a/modules/host/contractmanager/consts.go
+++ b/modules/host/contractmanager/consts.go
@@ -39,6 +39,11 @@ const (
 )
 
 const (
+	// folderAllocationStepSize is the amount of data that gets allocated at a
+	// time when writing out the sparse sector file during a storageFolderAdd or
+	// a storageFolderGrow.
+	folderAllocationStepSize = 50e6
+
 	// sectorMetadataDiskSize defines the number of bytes it takes to store the
 	// metadata of a single sector on disk.
 	sectorMetadataDiskSize = 14

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -195,20 +195,23 @@ func storageRemainingAdjustments(entry modules.HostDBEntry) float64 {
 // version reported by the host.
 func versionAdjustments(entry modules.HostDBEntry) float64 {
 	base := float64(1)
-	if build.VersionCmp(entry.Version, "1.2.0") < 0 {
+	if build.VersionCmp(entry.Version, "1.2.1") < 0 {
 		base = base * 0.99999 // Safety value to make sure we update the version penalties every time we update the host.
 	}
-	if build.VersionCmp(entry.Version, "1.1.2") < 0 {
+	if build.VersionCmp(entry.Version, "1.2.0") < 0 {
 		base = base / 2 // 2x total penalty.
 	}
-	if build.VersionCmp(entry.Version, "1.1.1") < 0 {
+	if build.VersionCmp(entry.Version, "1.1.2") < 0 {
 		base = base / 2 // 4x total penalty.
 	}
-	if build.VersionCmp(entry.Version, "1.0.3") < 0 {
+	if build.VersionCmp(entry.Version, "1.1.1") < 0 {
 		base = base / 2 // 8x total penalty.
 	}
-	if build.VersionCmp(entry.Version, "1.0.0") < 0 {
+	if build.VersionCmp(entry.Version, "1.0.3") < 0 {
 		base = base / 2 // 16x total penalty.
+	}
+	if build.VersionCmp(entry.Version, "1.0.0") < 0 {
+		base = base / 100 // 1600x total penalty.
 	}
 	return base
 }


### PR DESCRIPTION
PR is not finished - namely the test suite is broken now b/c it measures whether or not `WriteAt` gets called, but now we use `Truncate` instead, so the suite gets upset because it doesn't think we are writing out the file.

First reordered the upgrade process so that people with massive storage arrays can interrupt the growth phase without being forced to write out a full 500TB over NFS.

Second switched from doing 0-writes to doing incremental truncates. Some quick searching informed me that calling 'Truncate' is the correct way to create sparse files, and that writing zeroes is a lot slower. Updated my benchmarks PR as well, which now shows that calling Truncate is pretty fast. I guess I should also write a benchmark for tail-0 writing.

This new PR should provide great speedups for filesystems that support sparse files without impacting the performance or progress-ness of filesystems that don't support sparse files.

Made this PR quickly so that it could get reviewed faster.