### PR TITLE
Fix spelling errors in source comments and output messages

### DIFF
--- a/api/renter.go
+++ b/api/renter.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// recommendedHosts is the number of hosts that the renter will form
-	// contracts with if the value is not specified explicity in the call to
+	// contracts with if the value is not specified explicitly in the call to
 	// SetSettings.
 	recommendedHosts = build.Select(build.Var{
 		Standard: uint64(50),

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -400,7 +400,7 @@ func createServerTester(name string) (*serverTester, error) {
 
 // createAuthenticatedServerTester creates an authenticated server tester
 // object that is ready for testing, including money in the wallet and all
-// modules initalized.
+// modules initialized.
 func createAuthenticatedServerTester(name string, password string) (*serverTester, error) {
 	// createAuthenticatedServerTester should not get called during short
 	// tests, as it takes a long time to run.

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -101,7 +101,7 @@ hosts
 // Duration of contracts formed. Must be nonzero.
 period // block height
 
-// Renew window specifies how many blocks before the expriation of the current
+// Renew window specifies how many blocks before the expiration of the current
 // contracts the renter will wait before renewing the contracts. A smaller
 // renew window means that Sia must be run more frequently, but also means
 // fewer total transaction fees. Storage spending is not affected by the renew

--- a/doc/whitepaper.tex
+++ b/doc/whitepaper.tex
@@ -302,7 +302,7 @@ These siacoins are sent to the same address as the siafunds.
 
 \section{Economics of Sia}
 The primary currency of Sia is the siacoin.
-The supply of siacoins will increase permanently, and all fresh supply will be given to miners as a block subisdy.
+The supply of siacoins will increase permanently, and all fresh supply will be given to miners as a block subsidy.
 The first block will have 300,000 coins minted.
 This number will decrease by 1 coin per block, until a minimum of 30,000 coins per block is reached.
 Following a target of 10 minutes between blocks, the annual growth in supply is:\\

--- a/modules/consensus/consensusdb.go
+++ b/modules/consensus/consensusdb.go
@@ -108,7 +108,7 @@ func (cs *ConsensusSet) createConsensusDB(tx *bolt.Tx) error {
 		UnlockHash: types.UnlockHash{},
 	})
 
-	// Add the genesis block to the block strucutres - checksum must be taken
+	// Add the genesis block to the block structures - checksum must be taken
 	// after pushing the genesis block into the path.
 	pushPath(tx, cs.blockRoot.Block.ID())
 	if build.DEBUG {

--- a/modules/consensus/diffs.go
+++ b/modules/consensus/diffs.go
@@ -16,7 +16,7 @@ var (
 	errDiffsNotGenerated             = errors.New("applying diff set before generating errors")
 	errInvalidSuccessor              = errors.New("generating diffs for a block that's an invalid successsor to the current block")
 	errNegativePoolAdjustment        = errors.New("committing a siafund pool diff with a negative adjustment")
-	errNonApplySiafundPoolDiff       = errors.New("commiting a siafund pool diff that doesn't have the 'apply' direction")
+	errNonApplySiafundPoolDiff       = errors.New("committing a siafund pool diff that doesn't have the 'apply' direction")
 	errRevertSiafundPoolDiffMismatch = errors.New("committing a siafund pool diff with an invalid 'adjusted' field")
 	errWrongAppliedDiffSet           = errors.New("applying a diff set that isn't the current block")
 	errWrongRevertDiffSet            = errors.New("reverting a diff set that isn't the current block")

--- a/modules/consensus/maintenance.go
+++ b/modules/consensus/maintenance.go
@@ -184,7 +184,7 @@ func applyFileContractMaintenance(tx *bolt.Tx, pb *processedBlock) {
 }
 
 // applyMaintenance applies block-level alterations to the consensus set.
-// Maintenance is applied after all of the transcations for the block have been
+// Maintenance is applied after all of the transactions for the block have been
 // applied.
 func applyMaintenance(tx *bolt.Tx, pb *processedBlock) {
 	applyMinerPayouts(tx, pb)

--- a/modules/consensus/processedblock.go
+++ b/modules/consensus/processedblock.go
@@ -120,7 +120,7 @@ func (cs *ConsensusSet) setChildTarget(blockMap *bolt.Bucket, pb *processedBlock
 }
 
 // newChild creates a blockNode from a block and adds it to the parent's set of
-// children. The new node is also returned. It necessairly modifies the database
+// children. The new node is also returned. It necessarily modifies the database
 func (cs *ConsensusSet) newChild(tx *bolt.Tx, pb *processedBlock, b types.Block) *processedBlock {
 	// Create the child node.
 	childID := b.ID()

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -520,7 +520,7 @@ func (cs *ConsensusSet) managedReceiveBlock(id types.BlockID) modules.RPCFunc {
 // outbound peers <= v0.5.1 that are stalled in IBD.
 func (cs *ConsensusSet) threadedInitialBlockchainDownload() error {
 	// The consensus set will not recognize IBD as complete until it has enough
-	// peers. After the deadline though, it will recognize the blochchain
+	// peers. After the deadline though, it will recognize the blockchain
 	// download as complete even with only one peer. This deadline is helpful
 	// to local-net setups, where a machine will frequently only have one peer
 	// (and that peer will be another machine on the same local network, but

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -490,6 +490,6 @@ func TestGenesisBlockSync(t *testing.T) {
 
 	time.Sleep(time.Second * 12)
 	if len(cst1.gateway.Peers()) == 0 {
-		t.Error("disconnection occured!")
+		t.Error("disconnection occurred!")
 	}
 }

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -317,7 +317,7 @@ func validTransaction(tx *bolt.Tx, t types.Transaction) error {
 // determine if they are valid. An error is returned IFF they are not a valid
 // set in the current consensus set. The size of the transactions and the set
 // is not checked. After the transactions have been validated, a consensus
-// change is returned detailing the diffs that the transaciton set would have.
+// change is returned detailing the diffs that the transactions set would have.
 func (cs *ConsensusSet) tryTransactionSet(txns []types.Transaction) (modules.ConsensusChange, error) {
 	// applyTransaction will apply the diffs from a transaction and store them
 	// in a block node. diffHolder is the blockNode that tracks the temporary
@@ -359,7 +359,7 @@ func (cs *ConsensusSet) tryTransactionSet(txns []types.Transaction) (modules.Con
 // determine if they are valid. An error is returned IFF they are not a valid
 // set in the current consensus set. The size of the transactions and the set
 // is not checked. After the transactions have been validated, a consensus
-// change is returned detailing the diffs that the transaciton set would have.
+// change is returned detailing the diffs that the transactions set would have.
 func (cs *ConsensusSet) TryTransactionSet(txns []types.Transaction) (modules.ConsensusChange, error) {
 	err := cs.tg.Add()
 	if err != nil {

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -54,7 +54,7 @@ import (
 // after they successfully form a connection with the gateway. To limit the
 // attacker's ability to add nodes to the nodelist, connections are
 // ratelimited. An attacker with lots of IP addresses still has the ability to
-// fill up the nodelist, however getting 90% dominance of the nodelist requries
+// fill up the nodelist, however getting 90% dominance of the nodelist requires
 // forming thousands of connections, which will take hours or days. By that
 // time, the attacked node should already have its set of outbound peers,
 // limiting the amount of damage that the attacker can do.
@@ -88,7 +88,7 @@ import (
 // of bootstrap nodes. If there is any cross-polination (which an attacker
 // could do pretty easily), the gateways will not clean up over time, which
 // will degrade the quality of the flood network as the two networks will
-// continously flood eachother with irrelevant information. Additionally, there
+// continuously flood eachother with irrelevant information. Additionally, there
 // is no public key exhcange, so communications cannot be effectively encrypted
 // or authenticated. The nodes must have some way to share keys.
 //

--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -157,7 +157,7 @@ func (g *Gateway) permanentNodePurger(closeChan chan struct{}) {
 	for {
 		// Choose an amount of time to wait before attempting to prune a node.
 		// Nodes will occasionally go offline for some time, which can even be
-		// days. We don't want to too aggressivley prune nodes with low-moderate
+		// days. We don't want to too aggressively prune nodes with low-moderate
 		// uptime, as they are still useful to the network.
 		//
 		// But if there are a lot of nodes, we want to make sure that the node
@@ -167,7 +167,7 @@ func (g *Gateway) permanentNodePurger(closeChan chan struct{}) {
 		//
 		// This value is a ratelimit which tries to keep the nodes list in the
 		// gateawy healthy. A more complex algorithm might adjust this number
-		// according to the percentage of prune attemtps that are successful
+		// according to the percentage of prune attempts that are successful
 		// (decrease prune frequency if most nodes in the database are online,
 		// increase prune frequency if more nodes in the database are offline).
 		waitTime := nodePurgeDelay

--- a/modules/gateway/peersmanager.go
+++ b/modules/gateway/peersmanager.go
@@ -102,7 +102,7 @@ func (g *Gateway) permanentPeerManager(closedChan chan struct{}) {
 		// We need at least some of our outbound peers to be remote peers. If
 		// we already have reached a certain threshold of outbound peers and
 		// this peer is a local peer, do not consider it for an outbound peer.
-		// Sleep breifly to prevent the gateway from hogging the CPU if all
+		// Sleep briefly to prevent the gateway from hogging the CPU if all
 		// peers are local.
 		if numOutboundPeers >= maxLocalOutboundPeers && addr.IsLocal() && build.Release != "testing" {
 			g.log.Debugln("[PPM] Ignorning selected peer; this peer is local and we already have multiple outbound peers:", addr)

--- a/modules/host/contractmanager/sector.go
+++ b/modules/host/contractmanager/sector.go
@@ -49,7 +49,7 @@ type (
 		storageFolder uint16
 
 		// count indicates the number of virtual sectors represented by the
-		// phsyical sector described by this object. A maximum of 2^16 virtual
+		// physical sector described by this object. A maximum of 2^16 virtual
 		// sectors are allowed for each sector. Proper use by the renter should
 		// mean that the host never has more than 3 virtual sectors for any sector.
 		count uint16

--- a/modules/host/contractmanager/sectorupdate_test.go
+++ b/modules/host/contractmanager/sectorupdate_test.go
@@ -1354,7 +1354,7 @@ func TestDeleteSector(t *testing.T) {
 	}
 }
 
-// TestDeleteSectorVirtual tries to delete a sector with virutal pieces from
+// TestDeleteSectorVirtual tries to delete a sector with virtual pieces from
 // the contract manager.
 func TestDeleteSectorVirtual(t *testing.T) {
 	if testing.Short() {

--- a/modules/host/contractmanager/storagefolder.go
+++ b/modules/host/contractmanager/storagefolder.go
@@ -41,7 +41,7 @@ var (
 
 	// errNoFreeSectors is returned if there are no free sectors in the usage
 	// array fed to randFreeSector. This error should never be returned, as the
-	// contract manager should have sufficent internal consistency to know in
+	// contract manager should have sufficient internal consistency to know in
 	// advance that there are no free sectors.
 	errNoFreeSectors = errors.New("could not find a free sector in the usage array")
 

--- a/modules/host/contractmanager/storagefolderadd.go
+++ b/modules/host/contractmanager/storagefolderadd.go
@@ -83,7 +83,7 @@ func (wal *writeAheadLog) cleanupUnfinishedStorageFolderAdditions(scs []stateCha
 }
 
 // managedAddStorageFolder will add a storage folder to the contract manager.
-// The parent fucntion, contractmanager.AddStorageFolder, has already performed
+// The parent function, contractmanager.AddStorageFolder, has already performed
 // any error checking that can be performed without accessing the contract
 // manager state.
 //

--- a/modules/host/contractmanager/writeaheadlog.go
+++ b/modules/host/contractmanager/writeaheadlog.go
@@ -251,7 +251,7 @@ func (wal *writeAheadLog) recoverWAL(walFile file) error {
 	return nil
 }
 
-// load will pull any changes from the uncommited WAL into memory, decoding
+// load will pull any changes from the uncommitted WAL into memory, decoding
 // them and doing any necessary preprocessing. In the most common case (any
 // time the previous shutdown was clean), there will not be a WAL file.
 func (wal *writeAheadLog) load() error {

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -13,7 +13,7 @@ import (
 var (
 	// errLargeDownloadBatch is returned if the renter requests a download
 	// batch that exceeds the maximum batch size that the host will
-	// accomondate.
+	// accommodate.
 	errLargeDownloadBatch = ErrorCommunication("download request exceeded maximum batch size")
 
 	// errRequestOutOfBounds is returned when a download request is made which

--- a/modules/host/negotiaterecentrevision.go
+++ b/modules/host/negotiaterecentrevision.go
@@ -145,7 +145,7 @@ func (h *Host) managedRPCRecentRevision(conn net.Conn) (types.FileContractID, st
 	}
 	err = encoding.WriteObject(conn, revisionSigs)
 	if err != nil {
-		err = extendErr("failed to write recent revision singatures: ", ErrorConnection(err.Error()))
+		err = extendErr("failed to write recent revision signatures: ", ErrorConnection(err.Error()))
 		return types.FileContractID{}, storageObligation{}, err
 	}
 	return fcid, so, nil

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -1,7 +1,7 @@
 package host
 
 // TODO: seems like there would be problems with the negotiation protocols if
-// the renter tried something like 'form' or 'renew' but then the conncetion
+// the renter tried something like 'form' or 'renew' but then the connections
 // dropped after the host completed the transaction but before the host was
 // able to send the host signatures for the transaction.
 //

--- a/modules/host/persist_compat_1.2.0.go
+++ b/modules/host/persist_compat_1.2.0.go
@@ -111,7 +111,7 @@ type (
 // COMPAT v1.0.0
 //
 // A spelling error in pre-1.0 versions means that, if this is the first time
-// running after an upgrade, the misspelled field needs to be transfered over.
+// running after an upgrade, the misspelled field needs to be transferred over.
 func (h *Host) loadCompatV100(p *persistence) error {
 	var compatPersistence struct {
 		FinancialMetrics struct {
@@ -225,7 +225,7 @@ func (h *Host) upgradeFromV112ToV120() error {
 		return errors.New("cannot perform host upgrade - the contract manager must not be nil")
 	}
 
-	// Fetch the old set of storage folders, and create analagous storage
+	// Fetch the old set of storage folders, and create analogous storage
 	// folders in the contract manager. But create them to have sizes of zero,
 	// and grow them 112 sectors at a time. This is to make sure the user does
 	// not run out of disk space during the upgrade.
@@ -282,7 +282,7 @@ func (h *Host) upgradeFromV112ToV120() error {
 	// the new contract manager.
 	for _, sf := range oldPersist.StorageFolders {
 		// Nothing to do if the contract manager already has this storage
-		// folder (unusualy situation though).
+		// folder (unusually situation though).
 		_, exists := currentPaths[sf.Path]
 		if exists {
 			continue
@@ -398,7 +398,7 @@ func (h *Host) upgradeFromV112ToV120() error {
 	// version between v1.0.0 and v1.1.2.
 	err = h.loadCompatV100(p)
 	if err != nil {
-		return build.ExtendErr("upgrade appears complete, but having trouble relaoding:", err)
+		return build.ExtendErr("upgrade appears complete, but having trouble reloading:", err)
 	}
 	// Save the updated persist so that the upgrade is not triggered again.
 	err = h.saveSync()

--- a/modules/host/persist_compat_1.2.0_test.go
+++ b/modules/host/persist_compat_1.2.0_test.go
@@ -20,7 +20,7 @@ const (
 	v112Host = "v112Host.tar.gz"
 )
 
-// loadExistingHostWithNewDeps will create all of the depedencies for a host, then load
+// loadExistingHostWithNewDeps will create all of the dependencies for a host, then load
 // the host on top of the given directory.
 func loadExistingHostWithNewDeps(modulesDir, hostDir string) (modules.Host, error) {
 	testdir := build.TempDir(modules.HostDir, modulesDir)

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -350,7 +350,7 @@ func (h *Host) managedAddStorageObligation(so storageObligation) error {
 
 			// If the storage obligation already has sectors, it means that the
 			// file contract is being renewed, and that the sector should be
-			// re-added with a new expriation height. If there is an error at any
+			// re-added with a new expiration height. If there is an error at any
 			// point, all of the sectors should be removed.
 			if len(so.SectorRoots) != 0 {
 				err := h.AddSectorBatch(so.SectorRoots)
@@ -556,7 +556,7 @@ func (h *Host) removeStorageObligation(so storageObligation, sos storageObligati
 	}
 	if sos == obligationSucceeded {
 		// Remove the obligation statistics as potential risk and income.
-		h.log.Printf("Succesfully submitted a storage proof. Revenue is %v.\n", h.financialMetrics.PotentialContractCompensation.Add(h.financialMetrics.PotentialStorageRevenue).Add(h.financialMetrics.PotentialDownloadBandwidthRevenue).Add(h.financialMetrics.PotentialUploadBandwidthRevenue))
+		h.log.Printf("Successfully submitted a storage proof. Revenue is %v.\n", h.financialMetrics.PotentialContractCompensation.Add(h.financialMetrics.PotentialStorageRevenue).Add(h.financialMetrics.PotentialDownloadBandwidthRevenue).Add(h.financialMetrics.PotentialUploadBandwidthRevenue))
 		h.financialMetrics.PotentialContractCompensation = h.financialMetrics.PotentialContractCompensation.Sub(so.ContractCost)
 		h.financialMetrics.LockedStorageCollateral = h.financialMetrics.LockedStorageCollateral.Sub(so.LockedCollateral)
 		h.financialMetrics.PotentialStorageRevenue = h.financialMetrics.PotentialStorageRevenue.Sub(so.PotentialStorageRevenue)

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -21,7 +21,7 @@ var (
 func (m *Miner) blockForWork() types.Block {
 	b := m.persist.UnsolvedBlock
 
-	// Update the timestmap.
+	// Update the timestamp.
 	if b.Timestamp < types.CurrentTimestamp() {
 		b.Timestamp = types.CurrentTimestamp()
 	}

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -90,7 +90,7 @@ type Miner struct {
 }
 
 // startupRescan will rescan the blockchain in the event that the miner
-// persistance layer has become desynchronized from the consensus persistance
+// persistence layer has become desynchronized from the consensus persistence
 // layer. This might happen if a user replaces any of the folders with backups
 // or deletes any of the folders.
 func (m *Miner) startupRescan() error {

--- a/modules/negotiate.go
+++ b/modules/negotiate.go
@@ -93,12 +93,12 @@ const (
 
 	// NegotiateMaxTransactionSignatureSize defines the maximum size that a
 	// transaction signature is allowed to be when being sent over the wire
-	// during negoitation.
+	// during negotiation.
 	NegotiateMaxTransactionSignatureSize = 2e3
 
 	// NegotiateMaxTransactionSignaturesSize defines the maximum size that a
 	// transaction signature slice is allowed to be when being sent over the
-	// wire during negoitation.
+	// wire during negotiation.
 	NegotiateMaxTransactionSignaturesSize = 5e3
 )
 

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -133,9 +133,9 @@ func TestIsOffline(t *testing.T) {
 		{[]modules.HostDBScan{oldBadScan, newGoodScan}, false},
 		// data covers small range
 		{[]modules.HostDBScan{oldBadScan, oldBadScan, oldBadScan}, false},
-		// data covers large range, but at least 1 scan succeded
+		// data covers large range, but at least 1 scan succeeded
 		{[]modules.HostDBScan{oldBadScan, newGoodScan, currentBadScan}, false},
-		// data covers large range, no scans succeded
+		// data covers large range, no scans succeeded
 		{[]modules.HostDBScan{oldBadScan, newBadScan, currentBadScan}, true},
 		// old scan was good, recent scans are bad.
 		{[]modules.HostDBScan{oldGoodScan, newBadScan, newBadScan, currentBadScan}, true},

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -247,7 +247,7 @@ func (cd *chunkDownload) recoverChunk() error {
 	// Sync the write to provide proper durability.
 	err = fileDest.Sync()
 	if err != nil {
-		return build.ExtendErr("unable to sync downlaod destination", err)
+		return build.ExtendErr("unable to sync download destination", err)
 	}
 
 	cd.download.mu.Lock()

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -32,7 +32,7 @@ var (
 	// weak / cheap hosts on the network while the network is bootstrapping.
 	minCollateral = types.SiacoinPrecision.Mul64(25).Div64(tbMonth)
 
-	// Set a mimimum price, below which setting lower prices will no longer put
+	// Set a minimum price, below which setting lower prices will no longer put
 	// this host at an advatnage. This price is considered the bar for
 	// 'essentially free', and is kept to a minimum to prevent certain Sybil
 	// attack related attack vectors.

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -92,13 +92,13 @@ func TestSaveLoad(t *testing.T) {
 		t.Error("allHosts was not restored properly", ok0, ok1, ok2, len(hdbt.hdb.hostTree.All()))
 	}
 	if h1.FirstSeen != 1 {
-		t.Error("h1 block height loaded incorectly")
+		t.Error("h1 block height loaded incorrectly")
 	}
 	if h2.FirstSeen != 2 {
-		t.Error("h1 block height loaded incorectly")
+		t.Error("h1 block height loaded incorrectly")
 	}
 	if h3.FirstSeen != 2 {
-		t.Error("h1 block height loaded incorectly")
+		t.Error("h1 block height loaded incorrectly")
 	}
 }
 

--- a/modules/renter/hostdb/scan_test.go
+++ b/modules/renter/hostdb/scan_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// TestUpdateEntry checks that the various componenets of updateEntry are
+// TestUpdateEntry checks that the various components of updateEntry are
 // working correctly.
 func TestUpdateEntry(t *testing.T) {
 	if testing.Short() {

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -1,7 +1,7 @@
 package renter
 
 // TODO: Change the upload loop to have an upload state, and make it so that
-// instead of occasionally rebuildling the whole file matrix it has just a
+// instead of occasionally rebuilding the whole file matrix it has just a
 // single matrix that it's constantly pulling chunks from. Have a separate loop
 // which goes through the files and adds them to the matrix. Have the loop
 // listen on the channel for new files, so that they can go directly into the

--- a/modules/transactionpool/standard.go
+++ b/modules/transactionpool/standard.go
@@ -15,7 +15,7 @@ import (
 // Rule: Transaction size is limited
 //		There is a DoS vector where large transactions can both contain many
 //		signatures, and have each signature's CoveredFields object cover a
-//		unique but large portion of the transaciton. A 1mb transaction could
+//		unique but large portion of the transaction. A 1mb transaction could
 //		force a verifier to hash very large volumes of data, which takes a long
 //		time on nonspecialized hardware.
 //

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -125,7 +125,7 @@ func (tp *TransactionPool) Close() error {
 // transactions.
 func (tp *TransactionPool) FeeEstimation() (min, max types.Currency) {
 	// TODO: The fee estimation tool should look at the recent blocks and use
-	// them to guage what sort of fee should be required, as opposed to just
+	// them to gauge what sort of fee should be required, as opposed to just
 	// guessing blindly.
 	//
 	// TODO: The current minimum has been reduced significantly to account for

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -64,7 +64,7 @@ func createWalletTester(name string) (*walletTester, error) {
 		return nil, err
 	}
 
-	// Assemble all componenets into a wallet tester.
+	// Assemble all components into a wallet tester.
 	wt := &walletTester{
 		cs:      cs,
 		gateway: g,
@@ -114,7 +114,7 @@ func createBlankWalletTester(name string) (*walletTester, error) {
 		return nil, err
 	}
 
-	// Assemble all componenets into a wallet tester.
+	// Assemble all components into a wallet tester.
 	wt := &walletTester{
 		gateway: g,
 		cs:      cs,

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -304,7 +304,7 @@ func walletseedscmd() {
 		return
 	}
 	fmt.Println()
-	fmt.Println("Auxilliary Seeds:")
+	fmt.Println("Auxiliary Seeds:")
 	for _, seed := range seedInfo.AllSeeds {
 		if seed == seedInfo.PrimarySeed {
 			continue

--- a/types/constants.go
+++ b/types/constants.go
@@ -137,7 +137,7 @@ func init() {
 		GenesisTimestamp = Timestamp(1433600000) // June 6th, 2015 @ 2:13pm UTC.
 
 		// The RootTarget was set such that the developers could reasonable
-		// premine 100 blocks in a day. It was known to the developrs at launch
+		// premine 100 blocks in a day. It was known to the developers at launch
 		// this this was at least one and perhaps two orders of magnitude too
 		// small.
 		RootTarget = Target{0, 0, 0, 0, 32}
@@ -147,7 +147,7 @@ func init() {
 		// of miners to attack the network using rogue timestamps.
 		TargetWindow = 1e3
 
-		// The difficutly adjustment is clamped to 2.5x every 500 blocks. This
+		// The difficulty adjustment is clamped to 2.5x every 500 blocks. This
 		// corresponds to 6.25x every 2 weeks, which can be compared to
 		// Bitcoin's clamp of 4x every 2 weeks. The difficulty clamp is
 		// primarily to stop difficulty raising attacks. Sia's safety margin is


### PR DESCRIPTION
Fix spelling errors via the misspell tool. Excluded fixes to "marshalled" and
"marshalling" because they seemed ~to~ too deeply ingrained in the code.

This is easily repeatable:

```
go get -u github.com/client9/misspell/cmd/misspell
$GOPATH/bin/misspell -locale US -w -i "marshalled,marshalling,Marshalling,Marshalled" .
```