### PR TITLE
update siac consensus progress estimation

### DIFF
--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -54,6 +54,6 @@ func estimatedHeightAt(t time.Time) types.BlockHeight {
 	block100kTimestamp := time.Date(2017, time.April, 13, 23, 29, 49, 0, time.UTC)
 	blockTime := float64(9) // overestimate block time for better UX
 	diff := t.Sub(block100kTimestamp)
-	estimatedHeight := 1e5 + (diff.Minutes() / blockTime)
+	estimatedHeight := 100e3 + (diff.Minutes() / blockTime)
 	return types.BlockHeight(estimatedHeight + 0.5) // round to the nearest block
 }

--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -42,7 +42,7 @@ Difficulty: %v
 		}
 		fmt.Printf(`Synced: %v
 Height: %v
-Progress (estimated): %.f%%
+Progress (estimated): %.1f%%
 `, yesNo(cg.Synced), cg.Height, estimatedProgress)
 	}
 }
@@ -51,8 +51,9 @@ Progress (estimated): %.f%%
 // Block height is estimated by calculating the minutes since a known block in
 // the past and dividing by 10 minutes (the block time).
 func estimatedHeightAt(t time.Time) types.BlockHeight {
-	block5e4Timestamp := time.Date(2016, time.May, 11, 19, 33, 0, 0, time.UTC)
-	diff := t.Sub(block5e4Timestamp)
-	estimatedHeight := 5e4 + (diff.Minutes() / 10)
+	block100kTimestamp := time.Date(2017, time.April, 13, 23, 29, 49, 0, time.UTC)
+	blockTime := float64(9) // overestimate block time for better UX
+	diff := t.Sub(block100kTimestamp)
+	estimatedHeight := 1e5 + (diff.Minutes() / blockTime)
 	return types.BlockHeight(estimatedHeight + 0.5) // round to the nearest block
 }

--- a/siac/consensuscmd_test.go
+++ b/siac/consensuscmd_test.go
@@ -17,27 +17,27 @@ func TestEstimatedHeightAt(t *testing.T) {
 		// Test on the same block that is used to estimate the height
 		{
 			time.Date(2017, time.April, 13, 23, 29, 49, 0, time.UTC),
-			1e5,
+			100e3,
 		},
 		// 4 minutes later
 		{
 			time.Date(2017, time.April, 13, 23, 33, 49, 0, time.UTC),
-			1e5,
+			100e3,
 		},
 		// 5 minutes later
 		{
 			time.Date(2017, time.April, 13, 23, 34, 49, 0, time.UTC),
-			1e5 + 1,
+			100e3 + 1,
 		},
 		// 15 minutes later
 		{
 			time.Date(2017, time.April, 13, 23, 44, 49, 0, time.UTC),
-			1e5 + 2,
+			100e3 + 2,
 		},
 		// 1 day later
 		{
 			time.Date(2017, time.April, 14, 23, 29, 49, 0, time.UTC),
-			1e5 + 160,
+			100e3 + 160,
 		},
 	}
 	for _, tt := range tests {

--- a/siac/consensuscmd_test.go
+++ b/siac/consensuscmd_test.go
@@ -16,28 +16,28 @@ func TestEstimatedHeightAt(t *testing.T) {
 	}{
 		// Test on the same block that is used to estimate the height
 		{
-			time.Date(2016, time.May, 11, 19, 33, 0, 0, time.UTC),
-			5e4,
+			time.Date(2017, time.April, 13, 23, 29, 49, 0, time.UTC),
+			1e5,
 		},
 		// 4 minutes later
 		{
-			time.Date(2016, time.May, 11, 19, 37, 0, 0, time.UTC),
-			5e4,
+			time.Date(2017, time.April, 13, 23, 33, 49, 0, time.UTC),
+			1e5,
 		},
 		// 5 minutes later
 		{
-			time.Date(2016, time.May, 11, 19, 38, 0, 0, time.UTC),
-			5e4 + 1,
+			time.Date(2017, time.April, 13, 23, 34, 49, 0, time.UTC),
+			1e5 + 1,
 		},
-		// 10 minutes later
+		// 15 minutes later
 		{
-			time.Date(2016, time.May, 11, 19, 43, 0, 0, time.UTC),
-			5e4 + 1,
+			time.Date(2017, time.April, 13, 23, 44, 49, 0, time.UTC),
+			1e5 + 2,
 		},
 		// 1 day later
 		{
-			time.Date(2016, time.May, 12, 19, 33, 0, 0, time.UTC),
-			5e4 + 144,
+			time.Date(2017, time.April, 14, 23, 29, 49, 0, time.UTC),
+			1e5 + 160,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR updates the consensus progress estimation algorithm, using 9 minutes as the block time since blocks generally happen a bit faster than 10 minutes and it's better to estimate a lower progress than a higher progress from a UX perspective.