### PR TITLE
unsubscribe when locking wallet

### DIFF
--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -400,6 +400,10 @@ func (w *Wallet) Lock() error {
 	}
 	w.log.Println("INFO: Locking wallet.")
 
+	// Unsubscribe from Consensus Set and Transaction Pool
+	w.cs.Unsubscribe(w)
+	w.tpool.Unsubscribe(w)
+
 	// Wipe all of the seeds and secret keys. They will be replaced upon
 	// calling 'Unlock' again. Note that since the public keys are not wiped,
 	// we can continue processing blocks.

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -156,9 +156,6 @@ func (w *Wallet) Close() error {
 		}
 	}
 
-	w.cs.Unsubscribe(w)
-	w.tpool.Unsubscribe(w)
-
 	if err := w.log.Close(); err != nil {
 		errs = append(errs, fmt.Errorf("log.Close failed: %v", err))
 	}


### PR DESCRIPTION
This fixes a bug where locking the wallet caused the wallet to miss blocks.

This also seems like a good place to discuss the wallet memory usage. Using a global bolt tx speeds up IBD and rescans, but causes transaction data to build up in memory. A shorter commit interval alleviates this somewhat. In my testing, committing the transaction pool (which uses the same db model) once per second caused a peak of 100MB RAM usage, while committing after each block reduced that to 4MB. Committing after each block is prohibitively slow, but if fsync is disabled on the db it runs slightly faster than committing once per second. I suggest that we explore disabling fsync during IBD and rescans. It seems like fsync can be enabled and disabled at will during execution, i.e. we don't need to close and reopen the database.