### PR TITLE
more realistic host connectability check

### DIFF
--- a/api/host_test.go
+++ b/api/host_test.go
@@ -128,7 +128,7 @@ func TestConnectabilityStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer st.server.panicClose()
+	defer host.server.panicClose()
 
 	node, err := blankServerTester(t.Name() + " - node")
 	if err != nil {

--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -275,7 +275,7 @@ func assembleHostPort(key crypto.TwofishKey, hostHostname string, testdir string
 	if err != nil {
 		return nil, err
 	}
-	h, err := host.New(cs, tp, w, hostHostname, filepath.Join(testdir, modules.HostDir))
+	h, err := host.New(g, cs, tp, w, hostHostname, filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		return nil, err
 	}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -193,7 +193,7 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	if err != nil {
 		return nil, err
 	}
-	h, err := host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	h, err := host.New(g, cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func assembleAuthenticatedServerTester(requiredPassword string, key crypto.Twofi
 	if err != nil {
 		return nil, err
 	}
-	h, err := host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	h, err := host.New(g, cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -176,6 +176,14 @@ var (
 		Dev:      5,
 		Testing:  4,
 	}).(int)
+
+	// connectabilityCheckTimeout defines how long a connectability check's dial
+	// will be allowed to block before it times out.
+	connectabilityCheckTimeout = build.Select(build.Var{
+		Standard: time.Minute * 2,
+		Dev:      time.Minute * 5,
+		Testing:  time.Second * 90,
+	}).(time.Duration)
 )
 
 var (

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -263,10 +263,12 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 
 	// Register RPCs.
 	g.RegisterRPC("ShareNodes", g.shareNodes)
+	g.RegisterRPC("CheckHost", g.checkHost)
 	g.RegisterConnectCall("ShareNodes", g.requestNodes)
 	// Establish the de-registration of the RPCs.
 	g.threads.OnStop(func() {
 		g.UnregisterRPC("ShareNodes")
+		g.UnregisterRPC("CheckHost")
 		g.UnregisterConnectCall("ShareNodes")
 	})
 

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -16,6 +16,10 @@ const (
 	// support 6 month contracts when Sia leaves beta.
 	defaultMaxDuration = 144 * 30 * 6 // 6 months.
 
+	// checkHostTimeout indicates the amount of time that a peer has to check the
+	// connectability of a host.
+	checkHostTimeout = 2 * time.Minute
+
 	// fileContractNegotiationTimeout indicates the amount of time that a
 	// renter has to negotiate a file contract with the host. A timeout is
 	// necessary to limit the impact of DoS attacks.

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -18,7 +18,7 @@ const (
 
 	// checkHostTimeout indicates the amount of time that a peer has to check the
 	// connectability of a host.
-	checkHostTimeout = 2 * time.Minute
+	checkHostTimeout = 30 * time.Second
 
 	// fileContractNegotiationTimeout indicates the amount of time that a
 	// renter has to negotiate a file contract with the host. A timeout is
@@ -155,6 +155,14 @@ var (
 		Dev:      time.Minute * 5,
 		Testing:  time.Second * 90,
 	}).(time.Duration)
+
+	// hostCheckNodes indicates the number of nodes that will be used to
+	// determine the connectability status of a host.
+	hostCheckNodes = build.Select(build.Var{
+		Standard: uint64(2),
+		Dev:      uint64(1),
+		Testing:  uint64(1),
+	}).(uint64)
 
 	// defaultWindowSize is the size of the proof of storage window requested
 	// by the host. The host will not delete any obligations until the window

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -290,12 +290,6 @@ func newHost(dependencies dependencies, g modules.Gateway, cs modules.ConsensusS
 		}
 	})
 
-	// register gateway RPCs
-	g.RegisterRPC("CheckHost", h.threadedRPCCheckHost)
-	h.tg.OnStop(func() {
-		h.gateway.UnregisterRPC("CheckHost")
-	})
-
 	// Initialize the networking.
 	err = h.initNetworking(listenerAddress)
 	if err != nil {

--- a/modules/host/host_errors_test.go
+++ b/modules/host/host_errors_test.go
@@ -38,14 +38,14 @@ func TestHostFailedMkdirAll(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host, err = newHost(dependencyErrMkdirAll{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(dependencyErrMkdirAll{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrMkdirAll {
 		t.Fatal(err)
 	}
 	// Set ht.host to something non-nil - nil was returned because startup was
 	// incomplete. If ht.host is nil at the end of the function, the ht.Close()
 	// operation will fail.
-	ht.host, err = newHost(productionDependencies{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(productionDependencies{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,14 +78,14 @@ func TestHostFailedNewLogger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host, err = newHost(dependencyErrNewLogger{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(dependencyErrNewLogger{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrNewLogger {
 		t.Fatal(err)
 	}
 	// Set ht.host to something non-nil - nil was returned because startup was
 	// incomplete. If ht.host is nil at the end of the function, the ht.Close()
 	// operation will fail.
-	ht.host, err = newHost(productionDependencies{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(productionDependencies{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,14 +118,14 @@ func TestHostFailedOpenDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host, err = newHost(dependencyErrOpenDatabase{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(dependencyErrOpenDatabase{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if !strings.Contains(err.Error(), "simulated OpenDatabase failure") {
 		t.Fatal(err)
 	}
 	// Set ht.host to something non-nil - nil was returned because startup was
 	// incomplete. If ht.host is nil at the end of the function, the ht.Close()
 	// operation will fail.
-	ht.host, err = newHost(productionDependencies{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(productionDependencies{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,14 +158,14 @@ func TestHostFailedLoadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host, err = newHost(dependencyErrLoadFile{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(dependencyErrLoadFile{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrLoadFile {
 		t.Fatal(err)
 	}
 	// Set ht.host to something non-nil - nil was returned because startup was
 	// incomplete. If ht.host is nil at the end of the function, the ht.Close()
 	// operation will fail.
-	ht.host, err = newHost(productionDependencies{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(productionDependencies{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,14 +198,14 @@ func TestHostFailedListen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host, err = newHost(dependencyErrListen{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(dependencyErrListen{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != mockErrListen {
 		t.Fatal(err)
 	}
 	// Set ht.host to something non-nil - nil was returned because startup was
 	// incomplete. If ht.host is nil at the end of the function, the ht.Close()
 	// operation will fail.
-	ht.host, err = newHost(productionDependencies{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(productionDependencies{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/host_test.go
+++ b/modules/host/host_test.go
@@ -131,7 +131,7 @@ func blankMockHostTester(d dependencies, name string) (*hostTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	h, err := newHost(d, cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	h, err := newHost(d, g, cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func TestHostMultiClose(t *testing.T) {
 	// Set ht.host to something non-nil - nil was returned because startup was
 	// incomplete. If ht.host is nil at the end of the function, the ht.Close()
 	// operation will fail.
-	ht.host, err = newHost(productionDependencies{}, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = newHost(productionDependencies{}, ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,15 +304,19 @@ func TestNilValues(t *testing.T) {
 	defer ht.Close()
 
 	hostDir := filepath.Join(ht.persistDir, modules.HostDir)
-	_, err = New(nil, ht.tpool, ht.wallet, "localhost:0", hostDir)
+	_, err = New(nil, ht.cs, ht.tpool, ht.wallet, "localhost:0", hostDir)
+	if err != errNilGateway {
+		t.Fatal("could not trigger errNilGateway")
+	}
+	_, err = New(ht.gateway, nil, ht.tpool, ht.wallet, "localhost:0", hostDir)
 	if err != errNilCS {
 		t.Fatal("could not trigger errNilCS")
 	}
-	_, err = New(ht.cs, nil, ht.wallet, "localhost:0", hostDir)
+	_, err = New(ht.gateway, ht.cs, nil, ht.wallet, "localhost:0", hostDir)
 	if err != errNilTpool {
 		t.Fatal("could not trigger errNilTpool")
 	}
-	_, err = New(ht.cs, ht.tpool, nil, "localhost:0", hostDir)
+	_, err = New(ht.gateway, ht.cs, ht.tpool, nil, "localhost:0", hostDir)
 	if err != errNilWallet {
 		t.Fatal("Could not trigger errNilWallet")
 	}
@@ -405,7 +409,7 @@ func TestSetAndGetInternalSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rebootHost, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	rebootHost, err := New(ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -105,7 +105,7 @@ func (h *Host) threadedTrackWorkingStatus(closeChan chan struct{}) {
 	}
 }
 
-// threadedRPCCheckHost handles a CheckHost RPC cal and informs the caller if
+// threadedRPCCheckHost handles a CheckHost RPC call and informs the caller if
 // it can connected to on the requested NetAddress.
 func (h *Host) threadedRPCCheckHost(conn modules.PeerConn) error {
 	err := conn.SetDeadline(time.Now().Add(checkHostTimeout))

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -16,6 +16,7 @@ package host
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"sync/atomic"
 	"time"
@@ -162,7 +163,7 @@ func (h *Host) threadedRPCCheckHost(conn modules.PeerConn) error {
 		}
 	}
 	if !isValid {
-		return errors.New("CheckHost can only be used on your own IP address.")
+		return fmt.Errorf("blocked CheckHost call for %v from %v, requested host does not match ip address of remote host.", checkAddress, conn.RemoteAddr().String())
 	}
 
 	dialer := &net.Dialer{

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -187,7 +187,7 @@ func (h *Host) threadedRPCCheckHost(conn modules.PeerConn) error {
 }
 
 // threadedRPCRequestHostCheck asks the node at conn if the host's NetAddress
-// is connectable, and sets h.connectabilityStatus accordingly.
+// is connectable and returns the result on the resultChan.
 func (h *Host) threadedRPCRequestHostCheck(resultChan chan modules.HostConnectabilityStatus) modules.RPCFunc {
 	return func(conn modules.PeerConn) error {
 		err := conn.SetDeadline(time.Now().Add(checkHostTimeout))

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -106,7 +106,8 @@ func (h *Host) threadedTrackWorkingStatus(closeChan chan struct{}) {
 }
 
 // threadedRPCCheckHost handles a CheckHost RPC call and informs the caller if
-// it can connected to on the requested NetAddress.
+// it can connected to on the requested NetAddress. The requested NetAddress
+// must resolve to a net.IP owned by the conn's RemoteAddress.
 func (h *Host) threadedRPCCheckHost(conn modules.PeerConn) error {
 	err := conn.SetDeadline(time.Now().Add(checkHostTimeout))
 	if err != nil {

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -117,7 +117,23 @@ func TestHostConnectabilityStatus(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
+
 	ht, err := newHostTester(t.Name())
+
+	// create a peer for the check to run on
+	peer, err := newHostTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer peer.Close()
+
+	ht, err := newHostTester(t.Name() + "-peer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ht.Close()
+
+	err = ht.gateway.Connect(peer.gateway.Address())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -136,7 +136,6 @@ func TestHostConnectabilityStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ht.Close()
 
 	// TODO: this causes an ndf, because it relies on the host tester starting up
 	// and fully returning faster than the first check, which isnt always the

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 )
 
@@ -156,5 +157,57 @@ func TestHostConnectabilityStatus(t *testing.T) {
 	}
 	if !success {
 		t.Fatal("expected connectability state to flip to HostConnectabilityStatusConnectable")
+	}
+}
+
+// TestHostConnectabilityStatusAdversarialCallers verifies that an adversary
+// cannot abuse the host status check, using nodes to connect scan arbitrary
+// hosts.
+func TestHostConnectabilityStatusAdversarialCallers(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	evilpeer, err := newHostTester(t.Name() + "-evilpeer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer evilpeer.Close()
+
+	host, err := newHostTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer host.Close()
+
+	err = evilpeer.gateway.Connect(host.gateway.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evilCheckHostRPC := func(conn modules.PeerConn) error {
+		defer conn.Close()
+
+		err = encoding.WriteObject(conn, "google.com:80")
+		if err != nil {
+			return err
+		}
+
+		var status modules.HostConnectabilityStatus
+		err = encoding.ReadObject(conn, &status, 256)
+		if err != nil {
+			return err
+		}
+
+		if status != "" {
+			t.Fatal("status checked on external domain")
+		}
+
+		return nil
+	}
+
+	err = evilpeer.gateway.RPC(host.gateway.Address(), "CheckHost", evilCheckHostRPC)
+	if err == nil {
+		t.Fatal("expected malicious CheckHost call to fail")
 	}
 }

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -119,8 +119,6 @@ func TestHostConnectabilityStatus(t *testing.T) {
 	}
 	t.Parallel()
 
-	ht, err := newHostTester(t.Name())
-
 	// create a peer for the check to run on
 	peer, err := newHostTester(t.Name())
 	if err != nil {

--- a/modules/host/persist_compat_1.0.0_test.go
+++ b/modules/host/persist_compat_1.0.0_test.go
@@ -34,7 +34,7 @@ func TestHostPersistCompat100(t *testing.T) {
 		t.Log(filepath.Abs(source))
 		t.Fatal(err)
 	}
-	h, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	h, err := New(ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/persist_compat_1.2.0_test.go
+++ b/modules/host/persist_compat_1.2.0_test.go
@@ -44,7 +44,7 @@ func loadExistingHostWithNewDeps(modulesDir, hostDir string) (modules.Host, erro
 	}
 
 	// Create the host.
-	h, err := newHost(productionDependencies{}, cs, tp, w, "localhost:0", hostDir)
+	h, err := newHost(productionDependencies{}, g, cs, tp, w, "localhost:0", hostDir)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/host/persist_test.go
+++ b/modules/host/persist_test.go
@@ -75,7 +75,7 @@ func TestHostAddressPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host, err = New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = New(ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/persist_test.go
+++ b/modules/host/persist_test.go
@@ -40,7 +40,7 @@ func TestHostContractCountPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ht.host, err = New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	ht.host, err = New(ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/host/update_test.go
+++ b/modules/host/update_test.go
@@ -165,7 +165,7 @@ func TestIntegrationAutoRescan(t *testing.T) {
 
 	// Create a new host and check that the persist variables have correctly
 	// reset.
-	h, err := New(ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
+	h, err := New(ht.gateway, ht.cs, ht.tpool, ht.wallet, "localhost:0", filepath.Join(ht.persistDir, modules.HostDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -61,7 +61,11 @@ func newTestingHost(testdir string, cs modules.ConsensusSet, tp modules.Transact
 	if err != nil {
 		return nil, err
 	}
-	h, err := host.New(cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
+	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
+	if err != nil {
+		return nil, err
+	}
+	h, err := host.New(g, cs, tp, w, "localhost:0", filepath.Join(testdir, modules.HostDir))
 	if err != nil {
 		return nil, err
 	}

--- a/siad/daemon.go
+++ b/siad/daemon.go
@@ -231,7 +231,7 @@ func startDaemon(config Config) (err error) {
 	if strings.Contains(config.Siad.Modules, "h") {
 		i++
 		fmt.Printf("(%d/%d) Loading host...\n", i, len(config.Siad.Modules))
-		h, err = host.New(cs, tpool, w, config.Siad.HostAddr, filepath.Join(config.Siad.SiaDir, modules.HostDir))
+		h, err = host.New(g, cs, tpool, w, config.Siad.HostAddr, filepath.Join(config.Siad.SiaDir, modules.HostDir))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds a more realistic host connectability checking algorithm. Instead of simply attempting to dial itself and setting its status based on the success or failure of that Dial, this PR adds a new rpc `CheckHost`. `threadedTrackConnectabilityStatus` selects at random two outbound peers and asks them to check the host's netaddress, using `CheckHost`. If both peers agree on the host's ConnectabilityStatus, the host will set its ConnectabilityStatus accordingly.

