### PR TITLE
add scoring for v1.2.2, heavy penalties for <v1.0.0

### DIFF
--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -195,23 +195,26 @@ func storageRemainingAdjustments(entry modules.HostDBEntry) float64 {
 // version reported by the host.
 func versionAdjustments(entry modules.HostDBEntry) float64 {
 	base := float64(1)
-	if build.VersionCmp(entry.Version, "1.2.1") < 0 {
+	if build.VersionCmp(entry.Version, "1.2.2") < 0 {
 		base = base * 0.99999 // Safety value to make sure we update the version penalties every time we update the host.
 	}
-	if build.VersionCmp(entry.Version, "1.2.0") < 0 {
+	if build.VersionCmp(entry.Version, "1.2.1") < 0 {
 		base = base / 2 // 2x total penalty.
 	}
-	if build.VersionCmp(entry.Version, "1.1.2") < 0 {
+	if build.VersionCmp(entry.Version, "1.2.0") < 0 {
 		base = base / 2 // 4x total penalty.
 	}
-	if build.VersionCmp(entry.Version, "1.1.1") < 0 {
+	if build.VersionCmp(entry.Version, "1.1.2") < 0 {
 		base = base / 2 // 8x total penalty.
 	}
-	if build.VersionCmp(entry.Version, "1.0.3") < 0 {
+	if build.VersionCmp(entry.Version, "1.1.1") < 0 {
 		base = base / 2 // 16x total penalty.
 	}
+	if build.VersionCmp(entry.Version, "1.0.3") < 0 {
+		base = base / 2 // 32x total penalty.
+	}
 	if build.VersionCmp(entry.Version, "1.0.0") < 0 {
-		base = base / 100 // 1600x total penalty.
+		base = base / 1000 // 32,000x total penalty.
 	}
 	return base
 }


### PR DESCRIPTION
This should fix the build.