### PR TITLE
Close all server testers

### DIFF
--- a/api/ecosystem_test.go
+++ b/api/ecosystem_test.go
@@ -272,30 +272,37 @@ func TestHostPoorConnectivity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stLeader.server.Close()
 	stHost1, err := blankServerTester(t.Name() + " - Host 1")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost1.server.Close()
 	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost2.server.Close()
 	stHost3, err := blankServerTester(t.Name() + " - Host 3")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost3.server.Close()
 	stHost4, err := blankServerTester(t.Name() + " - Host 4")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost4.server.Close()
 	stRenter1, err := blankServerTester(t.Name() + " - Renter 1")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stRenter1.server.Close()
 	stRenter2, err := blankServerTester(t.Name() + " - Renter 2")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stRenter2.server.Close()
 
 	// Fetch all of the addresses of the nodes that got created.
 	var ggSTL, ggSTH1, ggSTH2, ggSTH3, ggSTH4, ggSTR1, ggSTR2 GatewayGET

--- a/api/gateway_test.go
+++ b/api/gateway_test.go
@@ -44,6 +44,7 @@ func TestGatewayPeerConnect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer peer.Close()
 	err = st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -76,6 +77,7 @@ func TestGatewayPeerDisconnect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer peer.Close()
 	err = st.stdPostAPI("/gateway/connect/"+string(peer.Address()), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -325,10 +325,12 @@ func TestHostDBScanOnlineOffline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost.server.Close()
 	sts := []*serverTester{st, stHost}
 	err = fullyConnectNodes(sts)
 	if err != nil {
@@ -425,10 +427,12 @@ func TestHostDBAndRenterDownloadDynamicIPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost.server.Close()
 	sts := []*serverTester{st, stHost}
 	err = fullyConnectNodes(sts)
 	if err != nil {
@@ -643,10 +647,12 @@ func TestHostDBAndRenterUploadDynamicIPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost.server.Close()
 	sts := []*serverTester{st, stHost}
 	err = fullyConnectNodes(sts)
 	if err != nil {
@@ -892,10 +898,12 @@ func TestHostDBAndRenterFormDynamicIPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost.server.Close()
 	sts := []*serverTester{st, stHost}
 	err = fullyConnectNodes(sts)
 	if err != nil {
@@ -1096,10 +1104,12 @@ func TestHostDBAndRenterRenewDynamicIPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	stHost, err := blankServerTester(t.Name() + "-Host")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost.server.Close()
 	sts := []*serverTester{st, stHost}
 	err = fullyConnectNodes(sts)
 	if err != nil {

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -937,10 +937,12 @@ func TestRenterPricesHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost1.server.Close()
 	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost2.server.Close()
 
 	// Connect all the nodes and announce all of the hosts.
 	sts := []*serverTester{st, stHost1, stHost2}
@@ -1009,10 +1011,12 @@ func TestRenterPricesHandlerCheap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost1.server.Close()
 	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost2.server.Close()
 
 	var hg HostGET
 	err = st.getAPI("/host", &hg)
@@ -1110,22 +1114,27 @@ func TestRenterPricesHandlerIgnorePricey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost1.server.Close()
 	stHost2, err := blankServerTester(t.Name() + " - Host 2")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost2.server.Close()
 	stHost3, err := blankServerTester(t.Name() + " - Host 3")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost3.server.Close()
 	stHost4, err := blankServerTester(t.Name() + " - Host 4")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost4.server.Close()
 	stHost5, err := blankServerTester(t.Name() + " - Host 5")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer stHost5.server.Close()
 
 	// Set host 5 to be cheaper than the rest by a substantial amount. This
 	// should result in a reduction for the price estimation.

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -470,6 +470,7 @@ func TestIntegrationWalletLoadSeedPOST(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer st.server.Close()
 	// Mine blocks until the wallet has confirmed money.
 	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
 		st.miner.AddBlock()


### PR DESCRIPTION
At least, all the ones I could find. Seems like the high memory usage was due to unclosed server testers calling a bunch of RPCs on each other. I believe the RPCs just continued to build up due a deadlock, and as a result they just allocated more and more memory.

This code currently deadlocks. You can reproduce the deadlock much faster with:
```
go test -v -tags='testing' -run=TestRenterPrices ./api
```