### PR TITLE
Gracefully handle absent storage folders

### DIFF
--- a/api/host_test.go
+++ b/api/host_test.go
@@ -3,11 +3,13 @@ package api
 import (
 	"io"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/host/contractmanager"
@@ -510,6 +512,126 @@ func TestResizeNonexistentFolder(t *testing.T) {
 	err = st.stdPostAPI("/host/storage/folders/resize", resizeValues)
 	if err == nil || err.Error() != errStorageFolderNotFound.Error() {
 		t.Fatalf("expected error to be %v, got %v", errStorageFolderNotFound, err)
+	}
+}
+
+// TestStorageFolderUnavailable simulates the situation where a storage folder
+// is not available to the host when the host starts, verifying that it sets
+// FailedWrites and FailedReads correctly and eventually finds the storage
+// folder when it is made available to the host again.
+func TestStorageFolderUnavailable(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	st, err := createServerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// add a storage folder
+	sfPath := build.TempDir(t.Name(), "storagefolder")
+	err = os.MkdirAll(sfPath, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sfValues := url.Values{}
+	sfValues.Set("path", sfPath)
+	sfValues.Set("size", "1048576")
+	err = st.stdPostAPI("/host/storage/folders/add", sfValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sfs StorageGET
+	err = st.getAPI("/host/storage", &sfs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sfs.Folders[0].FailedReads != 0 || sfs.Folders[0].FailedWrites != 0 {
+		t.Fatal("newly added folder has failed reads or writes")
+	}
+
+	// remove the folder on disk
+	sfPath2 := build.TempDir(t.Name(), "storagefolder-old")
+	err = os.Rename(sfPath, sfPath2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// reload the host
+	st, err = st.reloadedServerTester()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	err = st.getAPI("/host/storage", &sfs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sfs.Folders[0].FailedWrites < 999 {
+		t.Fatal("storage folder should have lots of failed writes after being moved on disk")
+	}
+	if sfs.Folders[0].FailedReads < 999 {
+		t.Fatal("storage folder should have lots of failed reads after being moved on disk")
+	}
+
+	// try some actions on the dead storage folder
+	// resize
+	sfValues.Set("size", "2097152")
+	err = st.stdPostAPI("/host/storage/folders/resize", sfValues)
+	if err == nil {
+		t.Fatal("expected resize on unavailable storage folder to fail")
+	}
+	// remove
+	err = st.stdPostAPI("/host/storage/folders/remove", sfValues)
+	if err == nil {
+		t.Fatal("expected remove on unavailable storage folder to fail")
+	}
+
+	// move the folder back
+	err = os.Rename(sfPath2, sfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for the contract manager to recheck the storage folder
+	// NOTE: this is a hard-coded constant based on the contractmanager's maxFolderRecheckInterval constant.
+	time.Sleep(time.Second * 10)
+
+	// verify the storage folder is reset to normal
+	err = st.getAPI("/host/storage", &sfs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sfs.Folders[0].FailedWrites > 0 {
+		t.Fatal("storage folder should have no failed writes after being moved back")
+	}
+	if sfs.Folders[0].FailedReads > 0 {
+		t.Fatal("storage folder should have no failed reads after being moved back")
+	}
+
+	// reload the host and verify the storage folder is still good
+	st, err = st.reloadedServerTester()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.Close()
+
+	// storage folder should still be good
+	err = st.getAPI("/host/storage", &sfs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sfs.Folders[0].FailedWrites > 0 {
+		t.Fatal("storage folder should have no failed writes after being moved back")
+	}
+	if sfs.Folders[0].FailedReads > 0 {
+		t.Fatal("storage folder should have no failed reads after being moved back")
 	}
 }
 

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -556,6 +556,7 @@ func TestStorageFolderUnavailable(t *testing.T) {
 	}
 
 	// remove the folder on disk
+	st.server.Close()
 	sfPath2 := build.TempDir(t.Name(), "storagefolder-old")
 	err = os.Rename(sfPath, sfPath2)
 	if err != nil {
@@ -616,6 +617,7 @@ func TestStorageFolderUnavailable(t *testing.T) {
 	}
 
 	// reload the host and verify the storage folder is still good
+	st.server.Close()
 	st, err = st.reloadedServerTester()
 	if err != nil {
 		t.Fatal(err)

--- a/modules/consensus/synchronize_ibd_test.go
+++ b/modules/consensus/synchronize_ibd_test.go
@@ -384,7 +384,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	// Add a peer that is synced to the peer that is not synced. IBD should not
 	// be considered completed when there is a tie between synced and
 	// not-synced peers.
-	gatewayNoTimeout, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - no timeout", modules.GatewayDir))
+	gatewayNoTimeout, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - no timeout1", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	// Test when there is 2 peers that are synced and one that is not synced.
 	// There is now a majority synced peers and the minIBDWaitTime has passed,
 	// so the IBD function should finish.
-	gatewayNoTimeout2, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - no timeout", modules.GatewayDir))
+	gatewayNoTimeout2, err := gateway.New("localhost:0", false, filepath.Join(testdir, "remote - no timeout2", modules.GatewayDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -426,7 +426,7 @@ func TestInitialBlockchainDownloadDoneRules(t *testing.T) {
 	// Test when there are >= minNumOutbound peers and >= minNumOutbound peers are synced.
 	gatewayNoTimeouts := make([]modules.Gateway, minNumOutbound-1)
 	for i := 0; i < len(gatewayNoTimeouts); i++ {
-		tmpG, err := gateway.New("localhost:0", false, filepath.Join(testdir, fmt.Sprintf("remote - no timeout %v", i), modules.GatewayDir))
+		tmpG, err := gateway.New("localhost:0", false, filepath.Join(testdir, fmt.Sprintf("remote - no timeout%v", i+2), modules.GatewayDir))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/modules/host/contractmanager/consts.go
+++ b/modules/host/contractmanager/consts.go
@@ -1,6 +1,8 @@
 package contractmanager
 
 import (
+	"time"
+
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/persist"
 )
@@ -102,4 +104,24 @@ var (
 		Standard: uint64(1 << 6), // 512 MiB
 		Testing:  uint64(1 << 6), // 256 KiB
 	}).(uint64)
+)
+
+var (
+	// folderRecheckInitialInterval specifies the amount of time that the
+	// contract manager will initially wait when checking to see if an
+	// unavailable storage folder has become available.
+	folderRecheckInitialInterval = build.Select(build.Var{
+		Dev:      time.Second,
+		Standard: time.Second * 5,
+		Testing:  time.Second,
+	}).(time.Duration)
+
+	// maxFolderRecheckInterval specifies the maximum amount of time that the
+	// contract manager will wait between checking if an unavailable storage
+	// folder has become available.
+	maxFolderRecheckInterval = build.Select(build.Var{
+		Dev:      time.Second * 30,
+		Standard: time.Second * 60 * 5,
+		Testing:  time.Second * 8,
+	}).(time.Duration)
 )

--- a/modules/host/contractmanager/persist_test.go
+++ b/modules/host/contractmanager/persist_test.go
@@ -391,19 +391,25 @@ func TestLoadMissingStorageFolder(t *testing.T) {
 	if len(sfs) != 2 {
 		t.Fatal("wrong number of storage folders being reported")
 	}
-	if sfs[0].FailedReads > 0 {
+	var sfOne modules.StorageFolderMetadata
+	for _, sf := range sfs {
+		if sf.Index == sfOneIndex {
+			sfOne = sf
+		}
+	}
+	if sfOne.FailedReads > 0 {
 		t.Error("folder should be visible again")
 	}
-	if sfs[0].FailedWrites > 0 {
+	if sfOne.FailedWrites > 0 {
 		t.Error("folder should be visible again")
 	}
-	if sfs[0].Capacity != sfs[0].CapacityRemaining+modules.SectorSize {
+	if sfOne.Capacity != sfOne.CapacityRemaining+modules.SectorSize {
 		cmt.cm.wal.mu.Lock()
-		t.Log("Usage len:", len(cmt.cm.storageFolders[sfs[0].Index].usage))
-		t.Log("Reported Sectors:", cmt.cm.storageFolders[sfs[0].Index].sectors)
-		t.Log("Avail:", len(cmt.cm.storageFolders[sfs[0].Index].availableSectors))
+		t.Log("Usage len:", len(cmt.cm.storageFolders[sfOne.Index].usage))
+		t.Log("Reported Sectors:", cmt.cm.storageFolders[sfOne.Index].sectors)
+		t.Log("Avail:", len(cmt.cm.storageFolders[sfOne.Index].availableSectors))
 		cmt.cm.wal.mu.Unlock()
-		t.Error("One sector's worth of capacity should be consumed:", sfs[0].Capacity, sfs[0].CapacityRemaining)
+		t.Error("One sector's worth of capacity should be consumed:", sfOne.Capacity, sfOne.CapacityRemaining)
 	}
 
 	// See if the sector is still available.

--- a/modules/host/contractmanager/persist_test.go
+++ b/modules/host/contractmanager/persist_test.go
@@ -1,0 +1,446 @@
+package contractmanager
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// TestLoadMissingStorageFolder checks that loading a storage folder which is
+// missing doesn't result in a complete loss of the storage folder on subsequent
+// startups.
+func TestLoadMissingStorageFolder(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	cmt, err := newContractManagerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmt.panicClose()
+
+	// Add a storage folder to the contract manager tester.
+	storageFolderDir := filepath.Join(cmt.persistDir, "storageFolderOne")
+	// Create the storage folder dir.
+	err = os.MkdirAll(storageFolderDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmt.cm.AddStorageFolder(storageFolderDir, modules.SectorSize*storageFolderGranularity*2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the storage folder has been added.
+	sfs := cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Fatal("There should be one storage folder reported")
+	}
+	// Check that the storage folder has the right path and size.
+	if sfs[0].Path != storageFolderDir {
+		t.Error("storage folder reported with wrong path")
+	}
+	if sfs[0].Capacity != modules.SectorSize*storageFolderGranularity*2 {
+		t.Error("storage folder reported with wrong sector size")
+	}
+
+	// Add a sector to the storage folder.
+	root, data := randSector()
+	err = cmt.cm.AddSector(root, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the sector was successfully added.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Fatal("There should be one storage folder in the contract manager", len(sfs))
+	}
+	if sfs[0].Capacity != sfs[0].CapacityRemaining+modules.SectorSize {
+		t.Error("One sector's worth of capacity should be consumed:", sfs[0].Capacity, sfs[0].CapacityRemaining)
+	}
+	sfOneIndex := sfs[0].Index
+
+	// Try reloading the contract manager after the storage folder has been
+	// moved somewhere else.
+	err = cmt.cm.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Move the storage folder directory to a new location - hiding it from the
+	// contract manager.
+	err = os.Rename(storageFolderDir, storageFolderDir+"-moved")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Re-open the contract manager.
+	cmt.cm, err = New(filepath.Join(cmt.persistDir, modules.ContractManagerDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The contract manager should still be reporting the storage folder, but
+	// with errors reported.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Fatal("wrong number of storage folders being reported")
+	}
+	if sfs[0].FailedReads < 100000000 {
+		t.Error("Not enough failures reported for absent storage folder")
+	}
+	if sfs[0].FailedWrites < 100000000 {
+		t.Error("Not enough failures reported for absent storage folder")
+	}
+	if sfs[0].Capacity != sfs[0].CapacityRemaining+modules.SectorSize {
+		t.Error("One sector's worth of capacity should be consumed:", sfs[0].Capacity, sfs[0].CapacityRemaining)
+	}
+
+	// Reload the contract manager and make sure the storage folder is still
+	// there.
+	err = cmt.cm.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Re-open the contract manager.
+	cmt.cm, err = New(filepath.Join(cmt.persistDir, modules.ContractManagerDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The contract manager should still be reporting the storage folder with
+	// errors.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Fatal("wrong number of storage folders being reported")
+	}
+	if sfs[0].FailedReads < 100000000 {
+		t.Error("Not enough failures reported for absent storage folder")
+	}
+	if sfs[0].FailedWrites < 100000000 {
+		t.Error("Not enough failures reported for absent storage folder")
+	}
+
+	// Try reading the sector from the missing storage folder.
+	_, err = cmt.cm.ReadSector(root)
+	if err == nil {
+		t.Fatal("Expecting error when reading missing sector.")
+	}
+
+	// Check that you can add folders, add sectors while the contract manager
+	// correctly works around the missing storage folder.
+	storageFolderTwo := filepath.Join(cmt.persistDir, "storageFolderTwo")
+	err = os.MkdirAll(storageFolderTwo, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmt.cm.AddStorageFolder(storageFolderTwo, modules.SectorSize*storageFolderGranularity*2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Add a sector to the storage folder.
+	root2, data2 := randSector()
+	err = cmt.cm.AddSector(root2, data2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the sector was successfully added.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 2 {
+		t.Fatal("There should be one storage folder in the contract manager", len(sfs))
+	}
+	for i := range sfs {
+		if sfs[i].Capacity != sfs[i].CapacityRemaining+modules.SectorSize {
+			t.Error("One sector's worth of capacity should be consumed:", sfs[i].Capacity, sfs[i].CapacityRemaining, sfs[i].Path)
+		}
+	}
+	var sfTwoIndex uint16
+	if sfs[0].Index == sfOneIndex {
+		sfTwoIndex = sfs[1].Index
+	} else {
+		sfTwoIndex = sfs[0].Index
+	}
+
+	// Add two more sectors.
+	root3, data3 := randSector()
+	err = cmt.cm.AddSector(root3, data3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root4, data4 := randSector()
+	err = cmt.cm.AddSector(root4, data4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the sector was successfully added.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 2 {
+		t.Fatal("There should be one storage folder in the contract manager", len(sfs))
+	}
+	if sfs[0].Capacity != sfs[0].CapacityRemaining+modules.SectorSize*3 && sfs[1].Capacity != sfs[1].CapacityRemaining+modules.SectorSize*3 {
+		t.Error("One sector's worth of capacity should be consumed")
+	}
+
+	// Try to shrink the missing storage folder.
+	err = cmt.cm.ResizeStorageFolder(sfOneIndex, modules.SectorSize*storageFolderGranularity, false)
+	if err == nil {
+		t.Fatal("should not be able to resize a missing storage folder")
+	}
+	err = cmt.cm.ResizeStorageFolder(sfOneIndex, modules.SectorSize*storageFolderGranularity, true)
+	if err == nil {
+		t.Fatal("should not be able to resize a missing storage folder")
+	}
+
+	// Check that the storage folder is still the original size.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 2 {
+		t.Fatal("wrong storage folder count")
+	}
+	if sfs[0].Index == sfOneIndex && sfs[0].Capacity != modules.SectorSize*storageFolderGranularity*2 {
+		t.Error("Storage folder has wrong size after failing to resize")
+	}
+	if sfs[1].Index == sfOneIndex && sfs[1].Capacity != modules.SectorSize*storageFolderGranularity*2 {
+		t.Error("Storage folder has wrong size after failing to resize")
+	}
+
+	// Try to grow the missing storage folder.
+	err = cmt.cm.ResizeStorageFolder(sfOneIndex, modules.SectorSize*storageFolderGranularity*4, false)
+	if err == nil {
+		t.Fatal("should not be able to resize a missing storage folder")
+	}
+	err = cmt.cm.ResizeStorageFolder(sfOneIndex, modules.SectorSize*storageFolderGranularity*4, true)
+	if err == nil {
+		t.Fatal("should not be able to resize a missing storage folder")
+	}
+
+	// Check that the storage folder is still the original size.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 2 {
+		t.Fatal("wrong storage folder count")
+	}
+	if sfs[0].Index == sfOneIndex && sfs[0].Capacity != modules.SectorSize*storageFolderGranularity*2 {
+		t.Error("Storage folder has wrong size after failing to resize")
+	}
+	if sfs[1].Index == sfOneIndex && sfs[1].Capacity != modules.SectorSize*storageFolderGranularity*2 {
+		t.Error("Storage folder has wrong size after failing to resize")
+	}
+
+	// Check that you can delete sectors and have the contract manager work
+	// correctly around the missing storage folder.
+	err = cmt.cm.DeleteSector(root2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmt.cm.DeleteSector(root3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmt.cm.DeleteSector(root4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that the sectors are no longer reported.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 2 {
+		t.Fatal("There should be one storage folder in the contract manager", len(sfs))
+	}
+	if sfs[0].Capacity != sfs[0].CapacityRemaining && sfs[1].Capacity != sfs[1].CapacityRemaining {
+		t.Error("Deleted sector does not seem to have been deleted correctly.")
+	}
+	// Try reading the deleted sector.
+	_, err = cmt.cm.ReadSector(root2)
+	if err == nil {
+		t.Fatal("should get an error when reading a deleted sector")
+	}
+
+	// Check that it's okay to shrink a storage folder while missing a storage
+	// folder.
+	//
+	// Start by resizing the second storage folder so it can hold a lot of
+	// sectors.
+	err = cmt.cm.ResizeStorageFolder(sfTwoIndex, modules.SectorSize*storageFolderGranularity*4, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Add enough sectors to the storage folder that doing a shrink operation
+	// causes sectors to be moved around.
+	num := int(storageFolderGranularity*3 + 2)
+	roots := make([]crypto.Hash, num)
+	datas := make([][]byte, num)
+	var wg sync.WaitGroup // Add in parallel to get massive performance boost.
+	for i := 0; i < num; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			rootI, dataI := randSector()
+			roots[i] = rootI
+			datas[i] = dataI
+			err := cmt.cm.AddSector(rootI, dataI)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	// Make a new storage folder so the sectors have somewhere to go.
+	storageFolderThree := filepath.Join(cmt.persistDir, "storageFolderThree")
+	err = os.MkdirAll(storageFolderThree, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmt.cm.AddStorageFolder(storageFolderThree, modules.SectorSize*storageFolderGranularity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Shrink the second storage folder such that some of the sectors are forced
+	// to move.
+	err = cmt.cm.ResizeStorageFolder(sfTwoIndex, modules.SectorSize*storageFolderGranularity*3, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that all of the sectors are still recoverable.
+	for i := range roots {
+		data, err := cmt.cm.ReadSector(roots[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(data, datas[i]) {
+			t.Error("read sector does not have the same data that was inserted")
+		}
+	}
+
+	// Shrink the second storage folder again, such that there is not enough
+	// room in the available storage folders to accept the data.
+	err = cmt.cm.ResizeStorageFolder(sfTwoIndex, modules.SectorSize*storageFolderGranularity*2, false)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// Check that all of the sectors are still recoverable.
+	for i := range roots {
+		data, err := cmt.cm.ReadSector(roots[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(data, datas[i]) {
+			t.Error("read sector does not have the same data that was inserted")
+		}
+	}
+
+	// Shrink the second storage folder again, such that there is not enough
+	// room in the available storage folders to accept the data.
+	err = cmt.cm.ResizeStorageFolder(sfTwoIndex, modules.SectorSize*storageFolderGranularity, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// There is now data loss.
+
+	// Try deleting the second storage folder, which again will cause data loss.
+	err = cmt.cm.RemoveStorageFolder(sfTwoIndex, false)
+	if err == nil {
+		t.Fatal("should have gotten an error when trying to remove the storage folder.")
+	}
+	err = cmt.cm.RemoveStorageFolder(sfTwoIndex, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to recover the missing storage folder by closing and moving the
+	// storage folder to the right place.
+	err = cmt.cm.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Rename(storageFolderDir+"-moved", storageFolderDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Re-open the contract manager.
+	cmt.cm, err = New(filepath.Join(cmt.persistDir, modules.ContractManagerDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The contract manager should still be reporting the storage folder, but
+	// with errors reported.
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 2 {
+		t.Fatal("wrong number of storage folders being reported")
+	}
+	if sfs[0].FailedReads > 0 {
+		t.Error("folder should be visible again")
+	}
+	if sfs[0].FailedWrites > 0 {
+		t.Error("folder should be visible again")
+	}
+	if sfs[0].Capacity != sfs[0].CapacityRemaining+modules.SectorSize {
+		t.Error("One sector's worth of capacity should be consumed:", sfs[0].Capacity, sfs[0].CapacityRemaining)
+	}
+
+	// See if the sector is still available.
+	recoveredData, err := cmt.cm.ReadSector(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(recoveredData, data) {
+		t.Error("recovered data is not equal to original data")
+	}
+
+	// Redo the storage folder move, so we can test deleting a missing storage
+	// folder.
+	err = cmt.cm.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Move the storage folder directory to a new location - hiding it from the
+	// contract manager.
+	err = os.Rename(storageFolderDir, storageFolderDir+"-moved")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Re-open the contract manager.
+	cmt.cm, err = New(filepath.Join(cmt.persistDir, modules.ContractManagerDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try removing the storage folder without the --force option. It should
+	// fail.
+	err = cmt.cm.RemoveStorageFolder(sfOneIndex, false)
+	if err == nil {
+		t.Fatal("should have gotten an error")
+	}
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 2 {
+		t.Error("there should be two storage folders after a removal failed.")
+	}
+	err = cmt.cm.RemoveStorageFolder(sfOneIndex, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Error("there should be only one storage folder remaining")
+	}
+
+	// Close and re-open the contract maanger, storage folder should still be
+	// missing.
+	err = cmt.cm.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Re-open the contract manager.
+	cmt.cm, err = New(filepath.Join(cmt.persistDir, modules.ContractManagerDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sfs = cmt.cm.StorageFolders()
+	if len(sfs) != 1 {
+		t.Error("there should be only one storage folder remaining")
+	}
+}
+
+// TODO: Add a loop that infrequently checks for the missing storage folder, and
+// can load it as a non-missing storage folder. Then run another battery of
+// tests to make sure that the now-loaded storage folder is usable again.

--- a/modules/host/contractmanager/sector.go
+++ b/modules/host/contractmanager/sector.go
@@ -147,6 +147,10 @@ func (cm *ContractManager) ReadSector(root crypto.Hash) ([]byte, error) {
 		cm.log.Critical("Unable to load storage folder despite having sector metadata")
 		return nil, ErrSectorNotFound
 	}
+	if atomic.LoadUint64(&sf.atomicUnavailable) == 1 {
+		// TODO: Pick a new error instead.
+		return nil, ErrSectorNotFound
+	}
 
 	// Read the sector.
 	sectorData, err := readSector(sf.sectorFile, sl.index)

--- a/modules/host/contractmanager/storagefolderadd.go
+++ b/modules/host/contractmanager/storagefolderadd.go
@@ -47,7 +47,7 @@ func (wal *writeAheadLog) cleanupUnfinishedStorageFolderAdditions(scs []stateCha
 	usfs := findUnfinishedStorageFolderAdditions(scs)
 	for _, usf := range usfs {
 		sf, exists := wal.cm.storageFolders[usf.Index]
-		if exists {
+		if exists && atomic.LoadUint64(&sf.atomicUnavailable) == 0 {
 			// Close the storage folder file handles.
 			err := sf.metadataFile.Close()
 			if err != nil {

--- a/modules/host/contractmanager/writeaheadlogsync.go
+++ b/modules/host/contractmanager/writeaheadlogsync.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -52,6 +53,11 @@ func (wal *writeAheadLog) syncResources() {
 
 	// Sync all of the storage folders.
 	for _, sf := range wal.cm.storageFolders {
+		// Skip operation on unavailable storage folders.
+		if atomic.LoadUint64(&sf.atomicUnavailable) == 1 {
+			continue
+		}
+
 		wg.Add(2)
 		go func(sf *storageFolder) {
 			defer wg.Done()

--- a/modules/storagemanager.go
+++ b/modules/storagemanager.go
@@ -97,7 +97,9 @@ type (
 		// RemoveStorageFolder will remove a storage folder from the manager.
 		// All storage on the folder will be moved to other storage folders,
 		// meaning that no data will be lost. If the manager is unable to save
-		// data, an error will be returned and the operation will be stopped.
+		// data, an error will be returned and the operation will be stopped. If
+		// the force flag is set to true, errors will be ignored and the remove
+		// operation will be completed, meaning that data will be lost.
 		RemoveStorageFolder(index uint16, force bool) error
 
 		// ResetStorageFolderHealth will reset the health statistics on a


### PR DESCRIPTION
Wanted some comments and ideas on the overall design. This PR (assuming it builds - didn't check b/c 5am) adds code to gracefully handle the situation where siad loads and a storage folder is not available.

Today the behavior is to delete that storage folder from memory, including all of the metadata. This means the host will lose that storage folder if they load siad at boot and the host starts up before the storage folder is available. v1.1.2 and earlier would fail silently, dropping all historic data as well and then putting the new data in the wrong location.

New behavior basically will still report the storage folder to the user, and will still retain all metadata, but will return some gross error statistics, and it will also prevent all operations involving the storage folder (reads + writes, namely).

I could also add some sort of background check which regularly checks whether the storage folder has been added and then logs an error if not, and marks the storage folder as available (opening all needed file handles) if it does? That part isn't implemented yet.

This PR could have more safety, though not quite sure how best to achieve it. Mostly this moves the host in the direction of robustness.

Side note: right now we have a json bitfield being encoded as a series of uint64s. Json prints numbers as a string, meaning that we end up with things taking 20+ bytes each (plus formatting overhead - burdens the CPU) when they should really only be taking up 8 bytes each (and ideally no formatting overhead). Not sure if there's an easy encoding fix here but @lukechampine it'd make the host run a lot smoother, and also it'd make the disks last longer. A better solution would not have us writing out a giant bitfield in JSON every half second, but that's a more difficult change to make.