### PR TITLE
fix InitFromSeed concurrency bug

### DIFF
--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -363,11 +363,11 @@ func (w *Wallet) InitFromSeed(masterKey crypto.TwofishKey, seed modules.Seed) er
 	}
 
 	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if _, err := w.initEncryption(masterKey, seed); err != nil {
-		w.mu.Unlock()
 		return err
 	}
-	w.mu.Unlock()
 
 	// estimate the primarySeedProgress by scanning the blockchain
 	s := newSeedScanner(seed, w.log)


### PR DESCRIPTION
This PR fixes https://github.com/NebulousLabs/Sia-UI/issues/583 and https://github.com/NebulousLabs/Sia-UI/issues/581, the wallet was not holding a lock during the duration of the InitFromSeed call, causing users to unlock their wallets while the seed sweeper was still running, resulting in an incorrect seed progress value.

