### PR TITLE
add trylock to wallet

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -17,8 +17,9 @@ import (
 type (
 	// WalletGET contains general information about the wallet.
 	WalletGET struct {
-		Encrypted bool `json:"encrypted"`
-		Unlocked  bool `json:"unlocked"`
+		Encrypted  bool `json:"encrypted"`
+		Unlocked   bool `json:"unlocked"`
+		Rescanning bool `json:"rescanning"`
 
 		ConfirmedSiacoinBalance     types.Currency `json:"confirmedsiacoinbalance"`
 		UnconfirmedOutgoingSiacoins types.Currency `json:"unconfirmedoutgoingsiacoins"`
@@ -114,8 +115,9 @@ func (api *API) walletHandler(w http.ResponseWriter, req *http.Request, _ httpro
 	siacoinBal, siafundBal, siaclaimBal := api.wallet.ConfirmedBalance()
 	siacoinsOut, siacoinsIn := api.wallet.UnconfirmedBalance()
 	WriteJSON(w, WalletGET{
-		Encrypted: api.wallet.Encrypted(),
-		Unlocked:  api.wallet.Unlocked(),
+		Encrypted:  api.wallet.Encrypted(),
+		Unlocked:   api.wallet.Unlocked(),
+		Rescanning: api.wallet.Rescanning(),
 
 		ConfirmedSiacoinBalance:     siacoinBal,
 		UnconfirmedOutgoingSiacoins: siacoinsOut,

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -86,6 +86,158 @@ func TestWalletGETEncrypted(t *testing.T) {
 	}
 }
 
+// TestWalletRescanning verifies that the `rescanning` bool is set by the
+// wallet correctly.
+func TestWalletRescanning(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	st, err := createServerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.panicClose()
+
+	// mine a few blocks to make rescanning take some time
+	for i := 0; i < 100; i++ {
+		_, err = st.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// verify the wallet is not currently rescanning
+	var wg WalletGET
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wg.Rescanning {
+		t.Fatal("wallet was rescanning before we even started rescanning!")
+	}
+
+	// sweep a seed, causing a rescan
+	var seed modules.Seed
+	fastrand.Read(seed[:])
+	seedStr, _ := modules.SeedToString(seed, "english")
+	qs := url.Values{}
+	qs.Set("seed", seedStr)
+	doneChan := make(chan struct{})
+	go func() {
+		defer close(doneChan)
+		st.stdPostAPI("/wallet/sweep/seed", qs)
+	}()
+	time.Sleep(time.Millisecond * 10)
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wg.Rescanning {
+		t.Fatal("expected wallet to be rescanning when sweeping a seed")
+	}
+	<-doneChan
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wg.Rescanning {
+		t.Fatal("expected wallet not to be rescanning when finished")
+	}
+
+	// init from a seed, causing a rescan
+	doneChan = make(chan struct{})
+	qs.Set("force", "true")
+	go func() {
+		defer close(doneChan)
+		st.stdPostAPI("/wallet/init/seed", qs)
+	}()
+	time.Sleep(time.Millisecond * 10)
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wg.Rescanning {
+		t.Fatal("expected wallet to be rescanning when initializing from a seed")
+	}
+	<-doneChan
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wg.Rescanning {
+		t.Fatal("wallet still rescanning after init seed completed")
+	}
+
+	// unlock should cause a rescan
+	doneChan = make(chan struct{})
+	unlockValues := url.Values{}
+	unlockValues.Set("encryptionpassword", seedStr)
+	go func() {
+		defer close(doneChan)
+		st.stdPostAPI("/wallet/unlock", unlockValues)
+	}()
+	time.Sleep(time.Millisecond * 10)
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wg.Rescanning {
+		t.Fatal("expected unlock to cause a rescan")
+	}
+	<-doneChan
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wg.Rescanning {
+		t.Fatal("wallet still rescanning after unlock")
+	}
+
+	// concurrent unlocks should fail
+	doneChan = make(chan struct{})
+	go func() {
+		defer close(doneChan)
+		st.stdPostAPI("/wallet/unlock", unlockValues)
+	}()
+	time.Sleep(time.Millisecond * 10)
+	if err = st.stdPostAPI("/wallet/unlock", unlockValues); err == nil {
+		t.Fatal("concurrent call to /wallet/unlock succeeded")
+	}
+	<-doneChan
+
+	// unlock calls should fail if init seed is occuring
+	fastrand.Read(seed[:])
+	seedStr, _ = modules.SeedToString(seed, "english")
+	qs.Set("seed", seedStr)
+	doneChan = make(chan struct{})
+	go func() {
+		defer close(doneChan)
+		st.stdPostAPI("/wallet/init/seed", qs)
+	}()
+	time.Sleep(time.Millisecond * 10)
+	if err = st.stdPostAPI("/wallet/unlock", unlockValues); err == nil {
+		t.Fatal("concurrent call to /wallet/unlock succeeded")
+	}
+	<-doneChan
+
+	// unlock calls should fail if sweep seed is occuring
+	fastrand.Read(seed[:])
+	seedStr, _ = modules.SeedToString(seed, "english")
+	qs.Set("seed", seedStr)
+	doneChan = make(chan struct{})
+	go func() {
+		defer close(doneChan)
+		st.stdPostAPI("/wallet/sweep/seed", qs)
+	}()
+	time.Sleep(time.Millisecond * 10)
+	if err = st.stdPostAPI("/wallet/unlock", unlockValues); err == nil {
+		t.Fatal("concurrent call to /wallet/unlock succeeded")
+	}
+	<-doneChan
+}
+
 // TestWalletEncrypt tries to encrypt and unlock the wallet through the api
 // using a provided encryption key.
 func TestWalletEncrypt(t *testing.T) {

--- a/doc/API.md
+++ b/doc/API.md
@@ -975,8 +975,9 @@ locked or unlocked.
 ###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response)
 ```javascript
 {
-  "encrypted": true,
-  "unlocked":  true,
+  "encrypted":  true,
+  "unlocked":   true,
+  "rescanning": false,
 
   "confirmedsiacoinbalance":     "123456", // hastings, big int
   "unconfirmedoutgoingsiacoins": "0",      // hastings, big int

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -68,6 +68,11 @@ locked or unlocked.
   // become unavailable when the wallet is locked.
   "unlocked": true,
 
+  // Indicates whether the wallet is currently rescanning the blockchain. This
+  // will be true for the duration of calls to /unlock, /seeds, /init/seed,
+  // and /sweep/seed.
+  "rescanning": false,
+
   // Number of siacoins, in hastings, available to the wallet as of the most
   // recent block in the blockchain.
   "confirmedsiacoinbalance": "123456", // hastings, big int

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -363,6 +363,10 @@ type (
 		// a TransactionBuilder which can be used to expand the transaction.
 		RegisterTransaction(t types.Transaction, parents []types.Transaction) TransactionBuilder
 
+		// Rescanning reports whether the wallet is currently rescanning the
+		// blockchain.
+		Rescanning() bool
+
 		// StartTransaction is a convenience method that calls
 		// RegisterTransaction(types.Transaction{}, nil)
 		StartTransaction() TransactionBuilder

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -55,7 +55,7 @@ func checkMasterKey(tx *bolt.Tx, masterKey crypto.TwofishKey) error {
 }
 
 // initEncryption initializes and encrypts the primary SeedFile.
-func (w *Wallet) initEncryption(masterKey crypto.TwofishKey, seed modules.Seed) (modules.Seed, error) {
+func (w *Wallet) initEncryption(masterKey crypto.TwofishKey, seed modules.Seed, progress uint64) (modules.Seed, error) {
 	wb := w.dbTx.Bucket(bucketWallet)
 	// Check if the wallet encryption key has already been set.
 	if wb.Get(keyEncryptionVerification) != nil {
@@ -70,7 +70,7 @@ func (w *Wallet) initEncryption(masterKey crypto.TwofishKey, seed modules.Seed) 
 	if err != nil {
 		return modules.Seed{}, err
 	}
-	err = wb.Put(keyPrimarySeedProgress, encoding.Marshal(uint64(0)))
+	err = wb.Put(keyPrimarySeedProgress, encoding.Marshal(progress))
 	if err != nil {
 		return modules.Seed{}, err
 	}
@@ -306,8 +306,8 @@ func (w *Wallet) Encrypt(masterKey crypto.TwofishKey) (modules.Seed, error) {
 	if masterKey == (crypto.TwofishKey{}) {
 		masterKey = crypto.TwofishKey(crypto.HashObject(seed))
 	}
-
-	return w.initEncryption(masterKey, seed)
+	// Initial seed progress is 0.
+	return w.initEncryption(masterKey, seed, 0)
 }
 
 // Reset will reset the wallet, clearing the database and returning it to
@@ -368,13 +368,6 @@ func (w *Wallet) InitFromSeed(masterKey crypto.TwofishKey, seed modules.Seed) er
 	}
 	defer w.scanLock.Unlock()
 
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	if _, err := w.initEncryption(masterKey, seed); err != nil {
-		return err
-	}
-
 	// estimate the primarySeedProgress by scanning the blockchain
 	s := newSeedScanner(seed, w.log)
 	if err := s.scan(w.cs); err != nil {
@@ -387,8 +380,12 @@ func (w *Wallet) InitFromSeed(masterKey crypto.TwofishKey, seed modules.Seed) er
 	progress := s.largestIndexSeen + 1
 	progress += progress / 10
 	w.log.Printf("INFO: found key index %v in blockchain. Setting primary seed progress to %v", s.largestIndexSeen, progress)
-	// set primarySeedProgress
-	return dbPutPrimarySeedProgress(w.dbTx, uint64(progress))
+
+	// initialize the wallet with the appropriate seed progress
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, err := w.initEncryption(masterKey, seed, progress)
+	return err
 }
 
 // Unlocked indicates whether the wallet is locked or unlocked.

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -280,11 +280,20 @@ func TestInitFromSeedParallelUnlock(t *testing.T) {
 	// pause for 10ms to allow the seed sweeper to start
 	time.Sleep(time.Millisecond * 10)
 
-	// unlock
+	// unlock should now return an error
 	err = w.Unlock(crypto.TwofishKey(crypto.HashObject(seed)))
-	if err != nil {
-		t.Fatal(err)
+	if err != errScanInProgress {
+		t.Fatal("expected errScanInProgress, got", err)
 	}
+	// wait for init to finish
+	for i := 0; i < 100; i++ {
+		time.Sleep(time.Millisecond * 10)
+		err = w.Unlock(crypto.TwofishKey(crypto.HashObject(seed)))
+		if err == nil {
+			break
+		}
+	}
+
 	// starting balance should match the original wallet
 	newBal, _, _ := w.ConfirmedBalance()
 	if newBal.Cmp(origBal) != 0 {

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -191,6 +191,11 @@ func (w *Wallet) LoadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error 
 		return errors.New("cannot load seed until blockchain is synced")
 	}
 
+	if !w.scanLock.TryLock() {
+		return errScanInProgress
+	}
+	defer w.scanLock.Unlock()
+
 	// Because the recovery seed does not have a UID, duplication must be
 	// prevented by comparing with the list of decrypted seeds. This can only
 	// occur while the wallet is unlocked.
@@ -291,6 +296,11 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 		return
 	}
 	defer w.tg.Done()
+
+	if !w.scanLock.TryLock() {
+		return types.Currency{}, types.Currency{}, errScanInProgress
+	}
+	defer w.scanLock.Unlock()
 
 	w.mu.RLock()
 	match := seed == w.primarySeed

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -181,3 +181,13 @@ func (w *Wallet) AllAddresses() []types.UnlockHash {
 	})
 	return addrs
 }
+
+// Rescanning reports whether the wallet is currently rescanning the
+// blockchain.
+func (w *Wallet) Rescanning() bool {
+	rescanning := !w.scanLock.TryLock()
+	if !rescanning {
+		w.scanLock.Unlock()
+	}
+	return rescanning
+}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -84,6 +84,11 @@ type Wallet struct {
 	persistDir string
 	log        *persist.Logger
 	mu         sync.RWMutex
+
+	// A separate TryMutex is used to protect against concurrent unlocking or
+	// initialization.
+	scanLock siasync.TryMutex
+
 	// The wallet's ThreadGroup tells tracked functions to shut down and
 	// blocks until they have all exited before returning from Close.
 	tg siasync.ThreadGroup


### PR DESCRIPTION
This should prevent double-subscriptions and accidentally queuing multiple load / sweep operations.