### PR TITLE
Add input/output/payout IDs to ProcessedTranasctions

### DIFF
--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -782,6 +782,18 @@ func TestWalletTransactionGETid(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check the unconfirmed transactions in the sending wallet to see the id of
+	// the output being spent.
+	err = st.getAPI("/wallet/transactions?startheight=0&endheight=10000", &wtg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wtg.UnconfirmedTransactions) != 2 {
+		t.Fatal("expecting two unconfirmed transactions in sender wallet")
+	}
+	// Get the id of the non-change output sent to the receiving wallet.
+	expectedOutputID := wtg.UnconfirmedTransactions[1].Outputs[0].ID
+
 	// Check the unconfirmed transactions struct to make sure all fields are
 	// filled out correctly in the receiving wallet.
 	err = st2.getAPI("/wallet/transactions?startheight=0&endheight=10000", &wtg)
@@ -813,6 +825,9 @@ func TestWalletTransactionGETid(t *testing.T) {
 			if output.Value.IsZero() {
 				t.Error("output should not have zero value")
 			}
+		}
+		if txn.Outputs[0].ID != expectedOutputID {
+			t.Error("transactions should have matching output ids for the same transaction")
 		}
 	}
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -1248,6 +1248,7 @@ gets the transaction associated with a specific transaction id.
     "confirmationtimestamp": 1257894000,
     "inputs": [
       {
+        "parentid":       "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         "fundtype":       "siacoin input",
         "walletaddress":  false,
         "relatedaddress": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
@@ -1256,6 +1257,7 @@ gets the transaction associated with a specific transaction id.
     ],
     "outputs": [
       {
+        "id":             "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         "fundtype":       "siacoin output",
         "maturityheight": 50000,
         "walletaddress":  false,

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -471,6 +471,9 @@ gets the transaction associated with a specific transaction id.
     // Array of processed inputs detailing the inputs to the transaction.
     "inputs": [
       {
+        // The id of the output being spent.
+        "parentid": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
         // Type of fund represented by the input. Possible values are
         // 'siacoin input' and 'siafund input'.
         "fundtype": "siacoin input",
@@ -491,6 +494,9 @@ gets the transaction associated with a specific transaction id.
     // Outputs related to file contracts are excluded.
     "outputs": [
       {
+        // The id of the output that was created.
+        "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
         // Type of fund is represented by the output. Possible values are
         // 'siacoin output', 'siafund output', 'claim output', and 'miner
         // payout'. Siacoin outputs and claim outputs both relate to siacoins.

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -55,6 +55,7 @@ type (
 	// coming from an address and going to the outputs. The fund types are
 	// 'SiacoinInput', 'SiafundInput'.
 	ProcessedInput struct {
+		ParentID       types.OutputID   `json:"parentid"`
 		FundType       types.Specifier  `json:"fundtype"`
 		WalletAddress  bool             `json:"walletaddress"`
 		RelatedAddress types.UnlockHash `json:"relatedaddress"`
@@ -74,6 +75,7 @@ type (
 	// available. SiacoinInputs and SiafundInputs become available immediately.
 	// ClaimInputs and MinerPayouts become available after 144 confirmations.
 	ProcessedOutput struct {
+		ID             types.OutputID    `json:"id"`
 		FundType       types.Specifier   `json:"fundtype"`
 		MaturityHeight types.BlockHeight `json:"maturityheight"`
 		WalletAddress  bool              `json:"walletaddress"`

--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -221,6 +221,12 @@ func dbAppendProcessedTransaction(tx *bolt.Tx, pt modules.ProcessedTransaction) 
 func dbGetLastProcessedTransaction(tx *bolt.Tx) (pt modules.ProcessedTransaction, err error) {
 	_, val := tx.Bucket(bucketProcessedTransactions).Cursor().Last()
 	err = encoding.Unmarshal(val, &pt)
+	if err != nil {
+		// COMPATv1.2.1: try decoding into old transaction type
+		var oldpt v121ProcessedTransaction
+		err = encoding.Unmarshal(val, &oldpt)
+		pt = convertProcessedTransaction(oldpt)
+	}
 	return
 }
 func dbDeleteLastProcessedTransaction(tx *bolt.Tx) error {
@@ -235,6 +241,45 @@ func dbForEachProcessedTransaction(tx *bolt.Tx, fn func(modules.ProcessedTransac
 	return dbForEach(tx.Bucket(bucketProcessedTransactions), func(_ uint64, pt modules.ProcessedTransaction) {
 		fn(pt)
 	})
+}
+
+// A processedTransactionsIter iterates through the ProcessedTransactions bucket.
+type processedTransactionsIter struct {
+	c  *bolt.Cursor
+	pt modules.ProcessedTransaction
+}
+
+// next decodes the next ProcessedTransaction, returning false if the end of
+// the bucket has been reached.
+func (it *processedTransactionsIter) next() bool {
+	var ptBytes []byte
+	if it.pt.TransactionID == (types.TransactionID{}) {
+		// this is the first time next has been called, so cursor is not
+		// initialized yet
+		_, ptBytes = it.c.First()
+	} else {
+		_, ptBytes = it.c.Next()
+	}
+	err := encoding.Unmarshal(ptBytes, &it.pt)
+	if err != nil {
+		// COMPATv1.2.1: try decoding into old transaction type
+		var oldpt v121ProcessedTransaction
+		err = encoding.Unmarshal(ptBytes, &oldpt)
+		it.pt = convertProcessedTransaction(oldpt)
+	}
+	return err == nil
+}
+
+// value returns the most recently decoded ProcessedTransaction.
+func (it *processedTransactionsIter) value() modules.ProcessedTransaction {
+	return it.pt
+}
+
+// dbProcessedTransactionsIterator creates a new processedTransactionsIter.
+func dbProcessedTransactionsIterator(tx *bolt.Tx) *processedTransactionsIter {
+	return &processedTransactionsIter{
+		c: tx.Bucket(bucketProcessedTransactions).Cursor(),
+	}
 }
 
 // dbGetWalletUID returns the UID assigned to the wallet's primary seed.
@@ -286,4 +331,58 @@ func dbGetSiafundPool(tx *bolt.Tx) (pool types.Currency, err error) {
 // dbPutSiafundPool stores the value of the siafund pool.
 func dbPutSiafundPool(tx *bolt.Tx, pool types.Currency) error {
 	return tx.Bucket(bucketWallet).Put(keySiafundPool, encoding.Marshal(pool))
+}
+
+// COMPATv121: these types were stored in the db in v1.2.2 and earlier.
+type (
+	v121ProcessedInput struct {
+		FundType       types.Specifier
+		WalletAddress  bool
+		RelatedAddress types.UnlockHash
+		Value          types.Currency
+	}
+
+	v121ProcessedOutput struct {
+		FundType       types.Specifier
+		MaturityHeight types.BlockHeight
+		WalletAddress  bool
+		RelatedAddress types.UnlockHash
+		Value          types.Currency
+	}
+
+	v121ProcessedTransaction struct {
+		Transaction           types.Transaction
+		TransactionID         types.TransactionID
+		ConfirmationHeight    types.BlockHeight
+		ConfirmationTimestamp types.Timestamp
+		Inputs                []v121ProcessedInput
+		Outputs               []v121ProcessedOutput
+	}
+)
+
+func convertProcessedTransaction(oldpt v121ProcessedTransaction) (pt modules.ProcessedTransaction) {
+	pt.Transaction = oldpt.Transaction
+	pt.TransactionID = oldpt.TransactionID
+	pt.ConfirmationHeight = oldpt.ConfirmationHeight
+	pt.ConfirmationTimestamp = oldpt.ConfirmationTimestamp
+	pt.Inputs = make([]modules.ProcessedInput, len(oldpt.Inputs))
+	for i, in := range oldpt.Inputs {
+		pt.Inputs[i] = modules.ProcessedInput{
+			FundType:       in.FundType,
+			WalletAddress:  in.WalletAddress,
+			RelatedAddress: in.RelatedAddress,
+			Value:          in.Value,
+		}
+	}
+	pt.Outputs = make([]modules.ProcessedOutput, len(oldpt.Outputs))
+	for i, out := range oldpt.Outputs {
+		pt.Outputs[i] = modules.ProcessedOutput{
+			FundType:       out.FundType,
+			MaturityHeight: out.MaturityHeight,
+			WalletAddress:  out.WalletAddress,
+			RelatedAddress: out.RelatedAddress,
+			Value:          out.Value,
+		}
+	}
+	return
 }

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -164,8 +164,9 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 				ConfirmationHeight:    consensusHeight,
 				ConfirmationTimestamp: block.Timestamp,
 			}
-			for _, mp := range block.MinerPayouts {
+			for i, mp := range block.MinerPayouts {
 				minerPT.Outputs = append(minerPT.Outputs, modules.ProcessedOutput{
+					ID:             types.OutputID(block.MinerPayoutID(uint64(i))),
 					FundType:       types.SpecifierMinerPayout,
 					MaturityHeight: consensusHeight + types.MaturityDelay,
 					WalletAddress:  w.isWalletAddress(mp.UnlockHash),
@@ -208,6 +209,7 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 
 			for _, sci := range txn.SiacoinInputs {
 				pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
+					ParentID:       types.OutputID(sci.ParentID),
 					FundType:       types.SpecifierSiacoinInput,
 					WalletAddress:  w.isWalletAddress(sci.UnlockConditions.UnlockHash()),
 					RelatedAddress: sci.UnlockConditions.UnlockHash(),
@@ -215,8 +217,9 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 				})
 			}
 
-			for _, sco := range txn.SiacoinOutputs {
+			for i, sco := range txn.SiacoinOutputs {
 				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+					ID:             types.OutputID(txn.SiacoinOutputID(uint64(i))),
 					FundType:       types.SpecifierSiacoinOutput,
 					MaturityHeight: consensusHeight,
 					WalletAddress:  w.isWalletAddress(sco.UnlockHash),
@@ -227,6 +230,7 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 
 			for _, sfi := range txn.SiafundInputs {
 				pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
+					ParentID:       types.OutputID(sfi.ParentID),
 					FundType:       types.SpecifierSiafundInput,
 					WalletAddress:  w.isWalletAddress(sfi.UnlockConditions.UnlockHash()),
 					RelatedAddress: sfi.UnlockConditions.UnlockHash(),
@@ -240,6 +244,7 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 
 				sfo := spentSiafundOutputs[sfi.ParentID]
 				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+					ID:             types.OutputID(sfi.ParentID),
 					FundType:       types.SpecifierClaimOutput,
 					MaturityHeight: consensusHeight + types.MaturityDelay,
 					WalletAddress:  w.isWalletAddress(sfi.UnlockConditions.UnlockHash()),
@@ -248,8 +253,9 @@ func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 				})
 			}
 
-			for _, sfo := range txn.SiafundOutputs {
+			for i, sfo := range txn.SiafundOutputs {
 				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+					ID:             types.OutputID(txn.SiafundOutputID(uint64(i))),
 					FundType:       types.SpecifierSiafundOutput,
 					MaturityHeight: consensusHeight,
 					WalletAddress:  w.isWalletAddress(sfo.UnlockHash),
@@ -338,14 +344,16 @@ func (w *Wallet) ReceiveUpdatedUnconfirmedTransactions(txns []types.Transaction,
 		}
 		for _, sci := range txn.SiacoinInputs {
 			pt.Inputs = append(pt.Inputs, modules.ProcessedInput{
+				ParentID:       types.OutputID(sci.ParentID),
 				FundType:       types.SpecifierSiacoinInput,
 				WalletAddress:  w.isWalletAddress(sci.UnlockConditions.UnlockHash()),
 				RelatedAddress: sci.UnlockConditions.UnlockHash(),
 				Value:          spentSiacoinOutputs[sci.ParentID].Value,
 			})
 		}
-		for _, sco := range txn.SiacoinOutputs {
+		for i, sco := range txn.SiacoinOutputs {
 			pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+				ID:             types.OutputID(txn.SiacoinOutputID(uint64(i))),
 				FundType:       types.SpecifierSiacoinOutput,
 				MaturityHeight: types.BlockHeight(math.MaxUint64),
 				WalletAddress:  w.isWalletAddress(sco.UnlockHash),


### PR DESCRIPTION
Exchanges have been using txids. Mining pools have started making payouts to many people in a single transaction, meaning txids is no longer useful for these payouts.

Exchanges are forced to switch to using output ids, which aren't available in the API yet. This PR extends the API to provide the output ids.

This PR is rushed so that the exchanges can pull the code and start testing on it right away. Before merging, this will need to update the API docs, and need to add some proper testing.