### PR TITLE
Add ScanHeight to Wallet

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -17,9 +17,11 @@ import (
 type (
 	// WalletGET contains general information about the wallet.
 	WalletGET struct {
-		Encrypted  bool `json:"encrypted"`
-		Unlocked   bool `json:"unlocked"`
-		Rescanning bool `json:"rescanning"`
+		Encrypted bool `json:"encrypted"`
+		Unlocked  bool `json:"unlocked"`
+
+		Rescanning bool              `json:"rescanning"`
+		ScanHeight types.BlockHeight `json:"scanheight"`
 
 		ConfirmedSiacoinBalance     types.Currency `json:"confirmedsiacoinbalance"`
 		UnconfirmedOutgoingSiacoins types.Currency `json:"unconfirmedoutgoingsiacoins"`
@@ -114,10 +116,13 @@ func encryptionKeys(seedStr string) (validKeys []crypto.TwofishKey) {
 func (api *API) walletHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	siacoinBal, siafundBal, siaclaimBal := api.wallet.ConfirmedBalance()
 	siacoinsOut, siacoinsIn := api.wallet.UnconfirmedBalance()
+	rescanning, scanHeight := api.wallet.Rescanning()
 	WriteJSON(w, WalletGET{
-		Encrypted:  api.wallet.Encrypted(),
-		Unlocked:   api.wallet.Unlocked(),
-		Rescanning: api.wallet.Rescanning(),
+		Encrypted: api.wallet.Encrypted(),
+		Unlocked:  api.wallet.Unlocked(),
+
+		Rescanning: rescanning,
+		ScanHeight: scanHeight,
 
 		ConfirmedSiacoinBalance:     siacoinBal,
 		UnconfirmedOutgoingSiacoins: siacoinsOut,

--- a/doc/API.md
+++ b/doc/API.md
@@ -977,7 +977,9 @@ locked or unlocked.
 {
   "encrypted":  true,
   "unlocked":   true,
+
   "rescanning": false,
+  "scanheight": 0,
 
   "confirmedsiacoinbalance":     "123456", // hastings, big int
   "unconfirmedoutgoingsiacoins": "0",      // hastings, big int

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -73,6 +73,10 @@ locked or unlocked.
   // and /sweep/seed.
   "rescanning": false,
 
+  // Highest blockheight scanned during a rescan operation. Only valid if
+  // rescanning is true.
+  "scanheight": 1234,
+
   // Number of siacoins, in hastings, available to the wallet as of the most
   // recent block in the blockchain.
   "confirmedsiacoinbalance": "123456", // hastings, big int

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -364,8 +364,8 @@ type (
 		RegisterTransaction(t types.Transaction, parents []types.Transaction) TransactionBuilder
 
 		// Rescanning reports whether the wallet is currently rescanning the
-		// blockchain.
-		Rescanning() bool
+		// blockchain, and if so, the highest blockheight scanned.
+		Rescanning() (bool, types.BlockHeight)
 
 		// StartTransaction is a convenience method that calls
 		// RegisterTransaction(types.Transaction{}, nil)

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -369,8 +369,8 @@ func (w *Wallet) InitFromSeed(masterKey crypto.TwofishKey, seed modules.Seed) er
 	defer w.scanLock.Unlock()
 
 	// estimate the primarySeedProgress by scanning the blockchain
-	s := newSeedScanner(seed, &w.scanHeight, w.log)
-	if err := s.scan(w.cs); err != nil {
+	s := w.newSeedScanner(seed)
+	if err := s.scan(); err != nil {
 		return err
 	}
 	// NOTE: each time the wallet generates a key for index n, it sets its

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -369,7 +369,7 @@ func (w *Wallet) InitFromSeed(masterKey crypto.TwofishKey, seed modules.Seed) er
 	defer w.scanLock.Unlock()
 
 	// estimate the primarySeedProgress by scanning the blockchain
-	s := newSeedScanner(seed, w.log)
+	s := newSeedScanner(seed, &w.scanHeight, w.log)
 	if err := s.scan(w.cs); err != nil {
 		return err
 	}

--- a/modules/wallet/scan_test.go
+++ b/modules/wallet/scan_test.go
@@ -56,7 +56,7 @@ func TestScanLargeIndex(t *testing.T) {
 
 	// create seed scanner and scan the block
 	seed, _, _ := wt.wallet.PrimarySeed()
-	ss := newSeedScanner(seed, wt.wallet.log)
+	ss := newSeedScanner(seed, &wt.wallet.scanHeight, wt.wallet.log)
 	err = ss.scan(wt.cs)
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestScanLoop(t *testing.T) {
 
 	// create seed scanner and scan the block
 	seed, _, _ := wt.wallet.PrimarySeed()
-	ss := newSeedScanner(seed, wt.wallet.log)
+	ss := newSeedScanner(seed, &wt.wallet.scanHeight, wt.wallet.log)
 	err = ss.scan(wt.cs)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/scan_test.go
+++ b/modules/wallet/scan_test.go
@@ -56,8 +56,8 @@ func TestScanLargeIndex(t *testing.T) {
 
 	// create seed scanner and scan the block
 	seed, _, _ := wt.wallet.PrimarySeed()
-	ss := newSeedScanner(seed, &wt.wallet.scanHeight, wt.wallet.log)
-	err = ss.scan(wt.cs)
+	ss := wt.wallet.newSeedScanner(seed)
+	err = ss.scan()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,8 +112,8 @@ func TestScanLoop(t *testing.T) {
 
 	// create seed scanner and scan the block
 	seed, _, _ := wt.wallet.PrimarySeed()
-	ss := newSeedScanner(seed, &wt.wallet.scanHeight, wt.wallet.log)
-	err = ss.scan(wt.cs)
+	ss := wt.wallet.newSeedScanner(seed)
+	err = ss.scan()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -214,8 +214,8 @@ func (w *Wallet) LoadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error 
 	w.mu.RUnlock()
 
 	// scan blockchain to determine how many keys to generate for the seed
-	s := newSeedScanner(seed, &w.scanHeight, w.log)
-	if err := s.scan(w.cs); err != nil {
+	s := w.newSeedScanner(seed)
+	if err := s.scan(); err != nil {
 		return err
 	}
 	// Add 10% as a buffer because the seed may have addresses in the wild
@@ -325,11 +325,11 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 
 	// scan blockchain for outputs, filtering out 'dust' (outputs that cost
 	// more in fees than they are worth)
-	s := newSeedScanner(seed, &w.scanHeight, w.log)
+	s := w.newSeedScanner(seed)
 	_, maxFee := w.tpool.FeeEstimation()
 	const outputSize = 350 // approx. size in bytes of an output and accompanying signature
 	s.dustThreshold = maxFee.Mul64(outputSize)
-	if err = s.scan(w.cs); err != nil {
+	if err = s.scan(); err != nil {
 		return
 	}
 

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -276,11 +276,6 @@ func (w *Wallet) LoadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error 
 	w.cs.Unsubscribe(w)
 	w.tpool.Unsubscribe(w)
 	atomic.StoreUint64(&w.scanHeight, 0)
-
-	done := make(chan struct{})
-	go w.rescanMessage(done)
-	defer close(done)
-
 	err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return err

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"errors"
-	"sync/atomic"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -191,7 +190,13 @@ func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 		if err != nil {
 			return err
 		}
-		return dbPutConsensusHeight(w.dbTx, 0)
+		err = dbPutConsensusHeight(w.dbTx, 0)
+		if err != nil {
+			return err
+		}
+		// reset scanHeight to 0
+		w.scanHeight = 0
+		return nil
 	}()
 	if err != nil {
 		return err
@@ -201,7 +206,6 @@ func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 	w.cs.Unsubscribe(w)
 	w.tpool.Unsubscribe(w)
 
-	atomic.StoreUint64(&w.scanHeight, 0)
 	err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return err
@@ -258,7 +262,13 @@ func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string
 		if err != nil {
 			return err
 		}
-		return dbPutConsensusHeight(w.dbTx, 0)
+		err = dbPutConsensusHeight(w.dbTx, 0)
+		if err != nil {
+			return err
+		}
+		// reset scanHeight to 0
+		w.scanHeight = 0
+		return nil
 	}()
 	if err != nil {
 		return err
@@ -268,7 +278,6 @@ func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string
 	w.cs.Unsubscribe(w)
 	w.tpool.Unsubscribe(w)
 
-	atomic.StoreUint64(&w.scanHeight, 0)
 	err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return err

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"errors"
+	"sync/atomic"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
@@ -204,6 +205,7 @@ func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 	go w.rescanMessage(done)
 	defer close(done)
 
+	atomic.StoreUint64(&w.scanHeight, 0)
 	err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return err
@@ -274,6 +276,7 @@ func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string
 	go w.rescanMessage(done)
 	defer close(done)
 
+	atomic.StoreUint64(&w.scanHeight, 0)
 	err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
 	if err != nil {
 		return err

--- a/modules/wallet/unseeded.go
+++ b/modules/wallet/unseeded.go
@@ -201,10 +201,6 @@ func (w *Wallet) LoadSiagKeys(masterKey crypto.TwofishKey, keyfiles []string) er
 	w.cs.Unsubscribe(w)
 	w.tpool.Unsubscribe(w)
 
-	done := make(chan struct{})
-	go w.rescanMessage(done)
-	defer close(done)
-
 	atomic.StoreUint64(&w.scanHeight, 0)
 	err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
 	if err != nil {
@@ -271,10 +267,6 @@ func (w *Wallet) Load033xWallet(masterKey crypto.TwofishKey, filepath033x string
 	// rescan the blockchain
 	w.cs.Unsubscribe(w)
 	w.tpool.Unsubscribe(w)
-
-	done := make(chan struct{})
-	go w.rescanMessage(done)
-	defer close(done)
 
 	atomic.StoreUint64(&w.scanHeight, 0)
 	err = w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -3,7 +3,6 @@ package wallet
 import (
 	"fmt"
 	"math"
-	"sync/atomic"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -283,18 +282,16 @@ func (w *Wallet) ProcessConsensusChange(cc modules.ConsensusChange) {
 	defer w.mu.Unlock()
 
 	// update scanHeight
-	currentHeight := atomic.LoadUint64(&w.scanHeight)
 	for _, block := range cc.AppliedBlocks {
-		if currentHeight > 0 || block.ID() != types.GenesisID {
-			currentHeight++
+		if w.scanHeight > 0 || block.ID() != types.GenesisID {
+			w.scanHeight++
 		}
 	}
 	for _, block := range cc.RevertedBlocks {
-		if currentHeight > 0 || block.ID() != types.GenesisID {
-			currentHeight--
+		if w.scanHeight > 0 || block.ID() != types.GenesisID {
+			w.scanHeight--
 		}
 	}
-	atomic.StoreUint64(&w.scanHeight, currentHeight)
 
 	if err := w.updateConfirmedSet(w.dbTx, cc); err != nil {
 		w.log.Println("ERROR: failed to update confirmed set:", err)

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/NebulousLabs/bolt"
 
@@ -85,9 +86,10 @@ type Wallet struct {
 	log        *persist.Logger
 	mu         sync.RWMutex
 
-	// A separate TryMutex is used to protect against concurrent unlocking or
-	// initialization.
-	scanLock siasync.TryMutex
+	// A separate TryMutex is used to ensure that only one blockchain scan
+	// occurs at a time. During the scan, the scanHeight is also recorded.
+	scanLock   siasync.TryMutex
+	scanHeight uint64 // must be 8-byte aligned
 
 	// The wallet's ThreadGroup tells tracked functions to shut down and
 	// blocks until they have all exited before returning from Close.
@@ -183,11 +185,11 @@ func (w *Wallet) AllAddresses() []types.UnlockHash {
 }
 
 // Rescanning reports whether the wallet is currently rescanning the
-// blockchain.
-func (w *Wallet) Rescanning() bool {
+// blockchain, and if so, the highest blockheight scanned.
+func (w *Wallet) Rescanning() (bool, types.BlockHeight) {
 	rescanning := !w.scanLock.TryLock()
 	if !rescanning {
 		w.scanLock.Unlock()
 	}
-	return rescanning
+	return rescanning, types.BlockHeight(atomic.LoadUint64(&w.scanHeight))
 }

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"sync/atomic"
 
 	"github.com/NebulousLabs/bolt"
 
@@ -89,7 +88,7 @@ type Wallet struct {
 	// A separate TryMutex is used to ensure that only one blockchain scan
 	// occurs at a time. During the scan, the scanHeight is also recorded.
 	scanLock   siasync.TryMutex
-	scanHeight uint64 // must be 8-byte aligned
+	scanHeight types.BlockHeight
 
 	// The wallet's ThreadGroup tells tracked functions to shut down and
 	// blocks until they have all exited before returning from Close.
@@ -191,5 +190,7 @@ func (w *Wallet) Rescanning() (bool, types.BlockHeight) {
 	if !rescanning {
 		w.scanLock.Unlock()
 	}
-	return rescanning, types.BlockHeight(atomic.LoadUint64(&w.scanHeight))
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return rescanning, types.BlockHeight(w.scanHeight)
 }

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -235,7 +235,7 @@ func TestRescanning(t *testing.T) {
 	defer wt.closeWt()
 
 	// A fresh wallet should not be rescanning.
-	if wt.wallet.Rescanning() {
+	if rescanning, _ := wt.wallet.Rescanning(); rescanning {
 		t.Fatal("fresh wallet should not report that a scan is underway")
 	}
 
@@ -253,7 +253,7 @@ func TestRescanning(t *testing.T) {
 
 	// wait for goroutine to start, after which Rescanning should return true
 	time.Sleep(time.Millisecond * 10)
-	if !wt.wallet.Rescanning() {
+	if rescanning, _ := wt.wallet.Rescanning(); !rescanning {
 		t.Fatal("wallet should report that a scan is underway")
 	}
 
@@ -264,7 +264,7 @@ func TestRescanning(t *testing.T) {
 	}
 
 	// Rescanning should now return false again
-	if wt.wallet.Rescanning() {
+	if rescanning, _ := wt.wallet.Rescanning(); rescanning {
 		t.Fatal("wallet should not report that a scan is underway")
 	}
 }

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -233,32 +233,38 @@ func TestRescanning(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer wt.closeWt()
+	// mine some blocks with the wallet locked
+	if err := wt.wallet.Lock(); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 100; i++ {
+		wt.miner.AddBlock()
+	}
 
 	// A fresh wallet should not be rescanning.
 	if rescanning, _ := wt.wallet.Rescanning(); rescanning {
 		t.Fatal("fresh wallet should not report that a scan is underway")
 	}
 
-	// lock the wallet
-	wt.wallet.Lock()
-
 	// spawn an unlock goroutine
 	errChan := make(chan error)
 	go func() {
-		// acquire the write lock so that Unlock acquires the trymutex, but
-		// cannot proceed further
-		wt.wallet.mu.Lock()
 		errChan <- wt.wallet.Unlock(wt.walletMasterKey)
 	}()
 
-	// wait for goroutine to start, after which Rescanning should return true
-	time.Sleep(time.Millisecond * 10)
-	if rescanning, _ := wt.wallet.Rescanning(); !rescanning {
+	// Rescanning should now return true once the unlock begins
+	var rescanning bool
+	for i := 0; i < 100; i++ {
+		if rescanning, _ = wt.wallet.Rescanning(); rescanning {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !rescanning {
 		t.Fatal("wallet should report that a scan is underway")
 	}
 
-	// release the mutex and allow the call to complete
-	wt.wallet.mu.Unlock()
+	// Wait for the unlock call to complete
 	if err := <-errChan; err != nil {
 		t.Fatal("unlock failed:", err)
 	}

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -359,6 +359,11 @@ Unlock the wallet to view balance
 		return
 	}
 
+	scanMessage := ""
+	if status.Rescanning {
+		scanMessage = " (not final, scan in progress)"
+	}
+
 	unconfirmedBalance := status.ConfirmedSiacoinBalance.Add(status.UnconfirmedIncomingSiacoins).Sub(status.UnconfirmedOutgoingSiacoins)
 	var delta string
 	if unconfirmedBalance.Cmp(status.ConfirmedSiacoinBalance) >= 0 {
@@ -369,12 +374,12 @@ Unlock the wallet to view balance
 
 	fmt.Printf(`Wallet status:
 %s, Unlocked
-Confirmed Balance:   %v
+Confirmed Balance:   %v%v
 Unconfirmed Delta:  %v
 Exact:               %v H
 Siafunds:            %v SF
 Siafund Claims:      %v H
-`, encStatus, currencyUnits(status.ConfirmedSiacoinBalance), delta,
+`, encStatus, currencyUnits(status.ConfirmedSiacoinBalance), scanMessage, delta,
 		status.ConfirmedSiacoinBalance, status.SiafundBalance, status.SiacoinClaimBalance)
 }
 

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/bgentry/speakeasy"
 	"github.com/spf13/cobra"
@@ -457,10 +458,45 @@ func walletunlockcmd() {
 	if err != nil {
 		die("Reading password failed:", err)
 	}
+
+	done := make(chan struct{})
+	go rescanMessage(done)
+
 	qs := fmt.Sprintf("encryptionpassword=%s&dictonary=%s", password, "english")
 	err = post("/wallet/unlock", qs)
 	if err != nil {
 		die("Could not unlock wallet:", err)
 	}
+
+	close(done)
 	fmt.Println("Wallet unlocked")
+}
+
+// rescanMessage prints the wallet's scanheight every 3 seconds until done is
+// closed.
+func rescanMessage(done chan struct{}) {
+	// sleep first because we may not need to print a message at all if
+	// done is closed quickly.
+	select {
+	case <-done:
+		return
+	case <-time.After(3 * time.Second):
+	}
+
+	for {
+		var wg api.WalletGET
+		err := getAPI("/wallet", &wg)
+		if err != nil || !wg.Rescanning {
+			continue
+		}
+		fmt.Printf("\rScanned to height %v...", wg.ScanHeight)
+
+		select {
+		case <-done:
+			// when finished, complete the line
+			fmt.Println()
+			return
+		case <-time.After(3 * time.Second):
+		}
+	}
 }


### PR DESCRIPTION
siad no longer prints the current height during unlocking. Instead, it is printed by siac. Currently only `siac wallet unlock` prints the scan height, but this could easily be added to `load seed` and `sweep seed` as well.

Side note: should the api field be `Rescanning` or just `Scanning`? `Rescanning` doesn't make sense if you're unlocking for the first time.