### PR TITLE
fix TestRenterAllowance

### DIFF
--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -80,9 +80,7 @@ func (p *stdPersist) save(data contractorPersist) error {
 	if p.journal == nil {
 		var err error
 		p.journal, err = newJournal(p.filename, data)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	return p.journal.checkpoint(data)
 }

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -80,7 +80,9 @@ func (p *stdPersist) save(data contractorPersist) error {
 	if p.journal == nil {
 		var err error
 		p.journal, err = newJournal(p.filename, data)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return p.journal.checkpoint(data)
 }


### PR DESCRIPTION
This actually fixes a fairly substantial bug in contractor persist (the journal would not be checkpointed after it was first created), in addition to fixing the appveyor failure on TestRenterAllowance