### PR TITLE
add /wallet/verify/address/:addr endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -255,6 +255,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.GET("/wallet/transaction/:id", api.walletTransactionHandler)
 		router.GET("/wallet/transactions", api.walletTransactionsHandler)
 		router.GET("/wallet/transactions/:addr", api.walletTransactionsAddrHandler)
+		router.GET("/wallet/verify/address/:addr", api.walletVerifyAddressHandler)
 		router.POST("/wallet/unlock", RequirePassword(api.walletUnlockHandler, requiredPassword))
 	}
 

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -93,6 +93,12 @@ type (
 		ConfirmedTransactions   []modules.ProcessedTransaction `json:"confirmedtransactions"`
 		UnconfirmedTransactions []modules.ProcessedTransaction `json:"unconfirmedtransactions"`
 	}
+
+	// WalletVerifyAddressGET contains a bool indicating if the address passed to
+	// /wallet/verify/address/:addr is a valid address.
+	WalletVerifyAddressGET struct {
+		Valid bool
+	}
 )
 
 // encryptionKeys enumerates the possible encryption keys that can be derived
@@ -524,4 +530,16 @@ func (api *API) walletUnlockHandler(w http.ResponseWriter, req *http.Request, _ 
 		}
 	}
 	WriteError(w, Error{"error when calling /wallet/unlock: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
+}
+
+// walletVerifyAddressHandler handles API calls to /wallet/verify/address/:addr.
+func (api *API) walletVerifyAddressHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	addrString := ps.ByName("addr")
+	ulh := &types.UnlockHash{}
+
+	valid := true
+	if err := ulh.LoadString(addrString); err != nil {
+		valid = false
+	}
+	WriteJSON(w, WalletVerifyAddressGET{valid})
 }

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -535,11 +535,7 @@ func (api *API) walletUnlockHandler(w http.ResponseWriter, req *http.Request, _ 
 // walletVerifyAddressHandler handles API calls to /wallet/verify/address/:addr.
 func (api *API) walletVerifyAddressHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	addrString := ps.ByName("addr")
-	ulh := &types.UnlockHash{}
 
-	valid := true
-	if err := ulh.LoadString(addrString); err != nil {
-		valid = false
-	}
-	WriteJSON(w, WalletVerifyAddressGET{valid})
+	err := new(types.UnlockHash).LoadString(addrString)
+	WriteJSON(w, WalletVerifyAddressGET{Valid: err == nil})
 }

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -1304,7 +1304,7 @@ func TestWalletVerifyAddress(t *testing.T) {
 	}
 	defer st.server.panicClose()
 
-	var res WalletVerifyGET
+	var res WalletVerifyAddressGET
 	fakeaddr := "thisisaninvalidwalletaddress"
 	if err = st.getAPI("/wallet/verify/address/"+fakeaddr, &res); err != nil {
 		t.Fatal(err)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -1289,3 +1289,39 @@ func TestWalletSiafunds(t *testing.T) {
 		t.Fatal("expected non-zero claim balance")
 	}
 }
+
+// TestWalletVerifyAddress tests that the /wallet/verify/address/:addr endpoint
+// validates wallet addresses correctly.
+func TestWalletVerifyAddress(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	st, err := createServerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.panicClose()
+
+	var res WalletVerifyGET
+	fakeaddr := "thisisaninvalidwalletaddress"
+	if err = st.getAPI("/wallet/verify/address/"+fakeaddr, &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Valid == true {
+		t.Fatal("expected /wallet/verify to fail an invalid address")
+	}
+
+	var wag WalletAddressGET
+	err = st.getAPI("/wallet/address", &wag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = st.getAPI("/wallet/verify/address/"+wag.Address.String(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Valid == false {
+		t.Fatal("expected /wallet/verify to pass a valid address")
+	}
+}

--- a/doc/API.md
+++ b/doc/API.md
@@ -963,6 +963,7 @@ Wallet
 | [/wallet/transactions](#wallettransactions-get)                 | GET       |
 | [/wallet/transactions/___:addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
+| [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
 
 For examples and detailed descriptions of request and response parameters,
 refer to [Wallet.md](/doc/api/Wallet.md).
@@ -1325,3 +1326,14 @@ encryptionpassword
 ###### Response
 standard success or error response. See
 [#standard-responses](#standard-responses).
+
+#### /wallet/verify/address/:addr [GET]
+
+takes the address specified by :addr and returns a JSON response indicating if the address is valid.
+
+###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response-11)
+```javascript
+{
+	"valid": true
+}
+```

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -47,6 +47,7 @@ Index
 | [/wallet/transactions](#wallettransactions-get)                 | GET       |
 | [/wallet/transactions/___:addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
+| [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
 
 #### /wallet [GET]
 
@@ -596,3 +597,15 @@ encryptionpassword string
 ###### Response
 standard success or error response. See
 [API.md#standard-responses](/doc/API.md#standard-responses).
+
+#### /wallet/verify/address/:addr [GET]
+
+takes the address specified by :addr and returns a JSON response indicating if the address is valid.
+
+###### JSON Response
+```javascript
+{
+	// valid indicates if the address supplied to :addr is a valid UnlockHash.
+	"valid": true
+}
+```


### PR DESCRIPTION
This PR adds an endpoint that validates a supplied address, as requested by the bittrex dev.