### PR TITLE
fix contractor journal sanity check race condition

### DIFF
--- a/modules/renter/contractor/journal.go
+++ b/modules/renter/contractor/journal.go
@@ -125,28 +125,18 @@ func (j *journal) Close() error {
 // newJournal creates a new journal, using data as the initial object.
 func newJournal(filename string, data contractorPersist) (*journal, error) {
 	// safely create the journal
-	tmp, err := os.Create(filename + "_tmp")
+	f, err := os.Create(filename)
 	if err != nil {
 		return nil, err
 	}
-	enc := json.NewEncoder(tmp)
+	enc := json.NewEncoder(f)
 	if err := enc.Encode(journalMeta); err != nil {
 		return nil, err
 	}
 	if err := enc.Encode(data); err != nil {
 		return nil, err
 	}
-	if err := tmp.Sync(); err != nil {
-		return nil, err
-	}
-	if err := tmp.Close(); err != nil {
-		return nil, err
-	}
-	if err := os.Rename(tmp.Name(), filename); err != nil {
-		return nil, err
-	}
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_APPEND, 0)
-	if err != nil {
+	if err := f.Sync(); err != nil {
 		return nil, err
 	}
 

--- a/modules/renter/contractor/journal.go
+++ b/modules/renter/contractor/journal.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"sync"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
@@ -43,14 +42,11 @@ var journalMeta = persist.Metadata{
 type journal struct {
 	f        *os.File
 	filename string
-	mu       sync.Mutex
 }
 
 // update applies the updateSet atomically to j. It syncs the underlying file
 // before returning.
 func (j *journal) update(us updateSet) error {
-	j.mu.Lock()
-	defer j.mu.Unlock()
 	if err := json.NewEncoder(j.f).Encode(us); err != nil {
 		return err
 	}
@@ -60,8 +56,6 @@ func (j *journal) update(us updateSet) error {
 // Checkpoint refreshes the journal with a new initial object. It syncs the
 // underlying file before returning.
 func (j *journal) checkpoint(data contractorPersist) error {
-	j.mu.Lock()
-	defer j.mu.Unlock()
 	if build.DEBUG {
 		// Sanity check - applying the updates to the initial object should
 		// result in a contractorPersist that matches data.
@@ -125,8 +119,6 @@ func (j *journal) checkpoint(data contractorPersist) error {
 
 // Close closes the underlying file.
 func (j *journal) Close() error {
-	j.mu.Lock()
-	defer j.mu.Unlock()
 	return j.f.Close()
 }
 


### PR DESCRIPTION
This PR fixes a rare, nondeterministic race in the renter's contractor where the sanity check would sometimes fail. Instead of reloading the journal from disk and sanity checking against the loading data, the contractor now has a lock-protected `data contractorPersist` field that is continuously updated under lock and used for the sanity check.