### PR TITLE
add `/wallet/changekey` API endpoint for change the wallet's encryption key

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -257,6 +257,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.GET("/wallet/transactions/:addr", api.walletTransactionsAddrHandler)
 		router.GET("/wallet/verify/address/:addr", api.walletVerifyAddressHandler)
 		router.POST("/wallet/unlock", RequirePassword(api.walletUnlockHandler, requiredPassword))
+		router.POST("/wallet/changekey", RequirePassword(api.walletChangeKeyHandler, requiredPassword))
 	}
 
 	// Apply UserAgent middleware and return the API

--- a/api/api.go
+++ b/api/api.go
@@ -257,7 +257,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.GET("/wallet/transactions/:addr", api.walletTransactionsAddrHandler)
 		router.GET("/wallet/verify/address/:addr", api.walletVerifyAddressHandler)
 		router.POST("/wallet/unlock", RequirePassword(api.walletUnlockHandler, requiredPassword))
-		router.POST("/wallet/changekey", RequirePassword(api.walletChangeKeyHandler, requiredPassword))
+		router.POST("/wallet/changepassword", RequirePassword(api.walletChangePasswordHandler, requiredPassword))
 	}
 
 	// Apply UserAgent middleware and return the API

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -538,7 +538,7 @@ func (api *API) walletChangeKeyHandler(w http.ResponseWriter, req *http.Request,
 	var newKey crypto.TwofishKey
 
 	originalKeys := encryptionKeys(req.FormValue("encryptionpassword"))
-	if len(potentialOriginalKeys) != 1 {
+	if len(originalKeys) != 1 {
 		WriteError(w, Error{"expected one encryption key passed to encryptionpassword"}, http.StatusBadRequest)
 		return
 	}

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -535,12 +535,12 @@ func (api *API) walletUnlockHandler(w http.ResponseWriter, req *http.Request, _ 
 // walletChangePasswordHandler handles API calls to /wallet/changepassword
 func (api *API) walletChangePasswordHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	var newKey crypto.TwofishKey
-	newKeys := encryptionKeys(req.FormValue("newpassword"))
-	if len(newKeys) != 1 {
-		WriteError(w, Error{"expected one encryption key to be passed to newpassword"}, http.StatusBadRequest)
+	newPassword := req.FormValue("newpassword")
+	if newPassword == "" {
+		WriteError(w, Error{"a password must be provided to newpassword"}, http.StatusBadRequest)
 		return
 	}
-	newKey = newKeys[0]
+	newKey = crypto.TwofishKey(crypto.HashObject(newPassword))
 
 	originalKeys := encryptionKeys(req.FormValue("encryptionpassword"))
 	if len(originalKeys) != 1 {

--- a/api/wallet.go
+++ b/api/wallet.go
@@ -532,6 +532,33 @@ func (api *API) walletUnlockHandler(w http.ResponseWriter, req *http.Request, _ 
 	WriteError(w, Error{"error when calling /wallet/unlock: " + modules.ErrBadEncryptionKey.Error()}, http.StatusBadRequest)
 }
 
+// walletChangeKeyHandler handles API calls to /wallet/changekey.
+func (api *API) walletChangeKeyHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	var originalKey crypto.TwofishKey
+	var newKey crypto.TwofishKey
+
+	originalKeys := encryptionKeys(req.FormValue("encryptionpassword"))
+	if len(potentialOriginalKeys) != 1 {
+		WriteError(w, Error{"expected one encryption key passed to encryptionpassword"}, http.StatusBadRequest)
+		return
+	}
+	originalKey = originalKeys[0]
+
+	newKeys := encryptionKeys(req.FormValue("newpassword"))
+	if len(newKeys) != 1 {
+		WriteError(w, Error{"expected one encryption key to be passed to newpassword"}, http.StatusBadRequest)
+		return
+	}
+	newKey = newKeys[0]
+
+	if err := api.wallet.ChangeKey(originalKey, newKey); err != nil {
+		WriteError(w, Error{"error when calling /wallet/changekey: " + err.Error()}, http.StatusBadRequest)
+		return
+	}
+
+	WriteSuccess(w)
+}
+
 // walletVerifyAddressHandler handles API calls to /wallet/verify/address/:addr.
 func (api *API) walletVerifyAddressHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	addrString := ps.ByName("addr")

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -1326,9 +1326,9 @@ func TestWalletVerifyAddress(t *testing.T) {
 	}
 }
 
-// TestWalletChangeKey verifies that the /wallet/changekey endpoint works
-// correctly and changes a wallet password.
-func TestWalletChangeKey(t *testing.T) {
+// TestWalletChangePassword verifies that the /wallet/changepassword endpoint
+// works correctly and changes a wallet password.
+func TestWalletChangePassword(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -1368,13 +1368,13 @@ func TestWalletChangeKey(t *testing.T) {
 	changeKeyValues := url.Values{}
 	changeKeyValues.Set("encryptionpassword", originalPassword)
 	changeKeyValues.Set("newpassword", newPassword)
-	err = st.stdPostAPI("/wallet/changekey", changeKeyValues)
+	err = st.stdPostAPI("/wallet/changepassword", changeKeyValues)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// wallet should still be unlocked
 	if !st.wallet.Unlocked() {
-		t.Fatal("changekey locked the wallet")
+		t.Fatal("changepassword locked the wallet")
 	}
 
 	// lock the wallet and verify unlocking works with the new password

--- a/doc/API.md
+++ b/doc/API.md
@@ -964,6 +964,7 @@ Wallet
 | [/wallet/transactions/___:addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
 | [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
+| [/wallet/changekey](#walletchangekey-post)                      | POST      |
 
 For examples and detailed descriptions of request and response parameters,
 refer to [Wallet.md](/doc/api/Wallet.md).
@@ -1337,3 +1338,17 @@ takes the address specified by :addr and returns a JSON response indicating if t
 	"valid": true
 }
 ```
+
+#### /wallet/changekey [POST]
+
+changes the wallet's encryption key.
+
+###### Query String Parameters [(with comments)](/doc/api/Wallet.md#query-string-parameters-12)
+```
+encryptionpassword
+newpassword
+```
+
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).

--- a/doc/API.md
+++ b/doc/API.md
@@ -964,7 +964,7 @@ Wallet
 | [/wallet/transactions/___:addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
 | [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
-| [/wallet/changekey](#walletchangekey-post)                      | POST      |
+| [/wallet/changepassword](#walletchangepassword-post)            | POST      |
 
 For examples and detailed descriptions of request and response parameters,
 refer to [Wallet.md](/doc/api/Wallet.md).
@@ -1339,7 +1339,7 @@ takes the address specified by :addr and returns a JSON response indicating if t
 }
 ```
 
-#### /wallet/changekey [POST]
+#### /wallet/changepassword  [POST]
 
 changes the wallet's encryption key.
 

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -48,7 +48,7 @@ Index
 | [/wallet/transactions/___:addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
 | [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
-| [/wallet/changekey](#walletchangekey-post)                      | POST      |
+| [/wallet/changepassword](#walletchangepassword-post)            | POST      |
 
 #### /wallet [GET]
 
@@ -611,9 +611,9 @@ takes the address specified by :addr and returns a JSON response indicating if t
 }
 ```
 
-#### /wallet/changekey [POST]
+#### /wallet/changepassword [POST]
 
-changes the wallet's encryption key.
+changes the wallet's encryption password.
 
 ###### Query String Parameter
 ```

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -48,6 +48,7 @@ Index
 | [/wallet/transactions/___:addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
 | [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
+| [/wallet/changekey](#walletchangekey-post)                      | POST      |
 
 #### /wallet [GET]
 
@@ -609,3 +610,19 @@ takes the address specified by :addr and returns a JSON response indicating if t
 	"valid": true
 }
 ```
+
+#### /wallet/changekey [POST]
+
+changes the wallet's encryption key.
+
+###### Query String Parameter
+```
+// encryptionpassword is the wallet's current encryption password.
+encryptionpassword
+// newpassword is the new password for the wallet.
+newpassword
+```
+
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -254,6 +254,10 @@ type (
 		// derived from the master key.
 		Unlock(masterKey crypto.TwofishKey) error
 
+		// ChangeKey changes the wallet's materKey from masterKey to newKey,
+		// re-encrypting the wallet with the provided key.
+		ChangeKey(masterKey crypto.TwofishKey, newKey crypto.TwofishKey) error
+
 		// Unlocked returns true if the wallet is currently unlocked, false
 		// otherwise.
 		Unlocked() bool

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -550,11 +550,6 @@ func (w *Wallet) ChangeKey(masterKey crypto.TwofishKey, newKey crypto.TwofishKey
 	}
 	defer w.tg.Done()
 
-	if !w.scanLock.TryLock() {
-		return errScanInProgress
-	}
-	defer w.scanLock.Unlock()
-
 	return w.managedChangeKey(masterKey, newKey)
 }
 


### PR DESCRIPTION
This PR adds the ability to change the wallet's encryption password, using a new EncryptionManager method `ChangeKey`. It also adds a `/wallet/changekey` api endpoint so API consumers can change their wallet passwords without having to initialize a new wallet.