### PR TITLE
fix contractor.IsOffline

### DIFF
--- a/modules/renter/contractor/uptime.go
+++ b/modules/renter/contractor/uptime.go
@@ -39,11 +39,11 @@ func (c *Contractor) IsOffline(id types.FileContractID) bool {
 func (c *Contractor) isOffline(id types.FileContractID) bool {
 	contract, ok := c.contracts[id]
 	if !ok {
-		return false
+		return true
 	}
 	host, ok := c.hdb.Host(contract.HostPublicKey)
 	if !ok {
-		return false
+		return true
 	}
 
 	// Sanity check - ScanHistory should always be ordered from oldest to

--- a/modules/renter/contractor/uptime_test.go
+++ b/modules/renter/contractor/uptime_test.go
@@ -160,4 +160,13 @@ func TestIsOffline(t *testing.T) {
 			t.Errorf("IsOffline(%v) = %v, expected %v", i, offline, test.offline)
 		}
 	}
+	c := &Contractor{
+		contracts: map[types.FileContractID]modules.RenterContract{
+			{1}: {HostPublicKey: types.SiaPublicKey{Key: []byte("foo")}},
+		},
+	}
+	// should return true for an unknown contract id
+	if !c.IsOffline(types.FileContractID{4}) {
+		t.Fatal("IsOffline returned false for a nonexistent contract id")
+	}
 }


### PR DESCRIPTION
Previously, the contractor's `IsOffline` method would report that contracts that did not exist in the contractor database were online.