### PR TITLE
Pass -s and -w ldflags to reduce binary size.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ release:
 release-race:
 	go install -race -tags='debug profile' $(pkgs)
 release-std:
-	go install $(pkgs)
+	go install -ldflags='-s -w' $(pkgs)
 
 # clean removes all directories that get automatically created during
 # development.

--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ for os in darwin linux windows; do
 		if [ "$os" == "windows" ]; then
 			bin=${pkg}.exe
 		fi
-		GOOS=${os} go build -o $folder/$bin ./$pkg
+		GOOS=${os} go build -ldflags="-s -w" -o $folder/$bin ./$pkg
 		openssl dgst -sha256 -sign $keyfile -out $folder/${bin}.sig $folder/$bin
 		# verify signature
 		if [[ -n $pubkeyfile ]]; then


### PR DESCRIPTION
Those flags remove DWARF table used by go debugger in release mode.

**Before:**
siad: **16.5MB**
siac: **9.6MB**

**After:**
siad: **11.1MB**
siac: **6.5MB**