### PR TITLE
add support for user-set txn fees

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -377,8 +377,17 @@ func (api *API) walletSiacoinsHandler(w http.ResponseWriter, req *http.Request, 
 		WriteError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
-
-	txns, err := api.wallet.SendSiacoins(amount, dest)
+	var txns []types.Transaction
+	if req.FormValue("fee") != "" {
+		fee, ok := scanAmount(req.FormValue("fee"))
+		if !ok {
+			WriteError(w, Error{"could not read 'fee' from POST call to /wallet/siacoins"}, http.StatusBadRequest)
+			return
+		}
+		txns, err = api.wallet.SendSiacoinsFee(amount, fee, dest)
+	} else {
+		txns, err = api.wallet.SendSiacoins(amount, dest)
+	}
 	if err != nil {
 		WriteError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusInternalServerError)
 		return
@@ -405,7 +414,17 @@ func (api *API) walletSiafundsHandler(w http.ResponseWriter, req *http.Request, 
 		return
 	}
 
-	txns, err := api.wallet.SendSiafunds(amount, dest)
+	var txns []types.Transaction
+	if req.FormValue("fee") != "" {
+		fee, ok := scanAmount(req.FormValue("fee"))
+		if !ok {
+			WriteError(w, Error{"could not read 'fee' from POST call to /wallet/siafunds"}, http.StatusBadRequest)
+			return
+		}
+		txns, err = api.wallet.SendSiafundsFee(amount, fee, dest)
+	} else {
+		txns, err = api.wallet.SendSiafunds(amount, dest)
+	}
 	if err != nil {
 		WriteError(w, Error{"error after call to /wallet/siafunds: " + err.Error()}, http.StatusInternalServerError)
 		return

--- a/doc/API.md
+++ b/doc/API.md
@@ -1138,12 +1138,13 @@ dictionary
 #### /wallet/siacoins [POST]
 
 sends siacoins to an address. The outputs are arbitrarily selected from
-addresses in the wallet.
+addresses in the wallet. A custom fee may be supplied.
 
 ###### Query String Parameters [(with comments)](/doc/api/Wallet.md#query-string-parameters-6)
 ```
 amount      // hastings
 destination // address
+fee         // Optional, hastings
 ```
 
 ###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response-5)
@@ -1171,6 +1172,7 @@ while still letting you control the siafunds).
 ```
 amount      // siafunds
 destination // address
+fee         // Optional, hastings
 ```
 
 ###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response-6)

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -315,7 +315,7 @@ dictionary
 #### /wallet/siacoins [POST]
 
 Function: Send siacoins to an address. The outputs are arbitrarily selected
-from addresses in the wallet.
+from addresses in the wallet. A custom fee may be supplied.
 
 ###### Query String Parameters
 ```
@@ -325,6 +325,9 @@ amount      // hastings
 
 // Address that is receiving the coins.
 destination // address
+
+// Fee to be paid to miner.
+fee // Optional, hastings
 ```
 
 ###### JSON Response
@@ -358,6 +361,9 @@ amount      // siafunds
 
 // Address that is receiving the funds.
 destination // address
+
+// Fee to be paid to miner.
+fee // Optional, hastings
 ```
 
 ###### JSON Response

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -383,11 +383,19 @@ type (
 		// are also returned to the caller.
 		SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
 
+		// SendSiacoinsFee behaves like SendSiacoins, but with a custom
+		// transaction fee.
+		SendSiacoinsFee(amount, fee types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
+
 		// SendSiafunds is a tool for sending siafunds from the wallet to an
 		// address. Sending money usually results in multiple transactions. The
 		// transactions are automatically given to the transaction pool, and
 		// are also returned to the caller.
 		SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
+
+		// SendSiafundsFee behaves like SendSiafunds, but with a custom
+		// transaction fee.
+		SendSiafundsFee(amount, fee types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
 	}
 )
 

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -70,6 +70,15 @@ func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incoming
 // SendSiacoins creates a transaction sending 'amount' to 'dest'. The transaction
 // is submitted to the transaction pool and is also returned.
 func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error) {
+	_, tpoolFee := w.tpool.FeeEstimation()
+	tpoolFee = tpoolFee.Mul64(750) // Estimated transaction size in bytes
+	return w.SendSiacoinsFee(amount, tpoolFee, dest)
+}
+
+// SendSiacoinsFee creates a transaction sending 'amount' to 'dest', with 'fee'
+// paid to the miner that includes the transaction in a block. The transaction
+// is submitted to the transaction pool and is also returned.
+func (w *Wallet) SendSiacoinsFee(amount, fee types.Currency, dest types.UnlockHash) ([]types.Transaction, error) {
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
@@ -78,20 +87,16 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]t
 		return nil, modules.ErrLockedWallet
 	}
 
-	_, tpoolFee := w.tpool.FeeEstimation()
-	tpoolFee = tpoolFee.Mul64(750) // Estimated transaction size in bytes
-	output := types.SiacoinOutput{
-		Value:      amount,
-		UnlockHash: dest,
-	}
-
 	txnBuilder := w.StartTransaction()
-	err := txnBuilder.FundSiacoins(amount.Add(tpoolFee))
+	err := txnBuilder.FundSiacoins(amount.Add(fee))
 	if err != nil {
 		return nil, build.ExtendErr("unable to fund transaction", err)
 	}
-	txnBuilder.AddMinerFee(tpoolFee)
-	txnBuilder.AddSiacoinOutput(output)
+	txnBuilder.AddMinerFee(fee)
+	txnBuilder.AddSiacoinOutput(types.SiacoinOutput{
+		Value:      amount,
+		UnlockHash: dest,
+	})
 	txnSet, err := txnBuilder.Sign(true)
 	if err != nil {
 		return nil, build.ExtendErr("unable to sign transaction", err)
@@ -106,6 +111,16 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]t
 // SendSiafunds creates a transaction sending 'amount' to 'dest'. The transaction
 // is submitted to the transaction pool and is also returned.
 func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error) {
+	_, tpoolFee := w.tpool.FeeEstimation()
+	tpoolFee = tpoolFee.Mul64(750) // Estimated transaction size in bytes
+	tpoolFee = tpoolFee.Mul64(5)   // use large fee to ensure siafund transactions are selected by miners
+	return w.SendSiafundsFee(amount, tpoolFee, dest)
+}
+
+// SendSiafundsFee creates a transaction sending 'amount' to 'dest', with 'fee'
+// paid to the miner that includes the transaction in a block. The transaction
+// is submitted to the transaction pool and is also returned.
+func (w *Wallet) SendSiafundsFee(amount, fee types.Currency, dest types.UnlockHash) ([]types.Transaction, error) {
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
@@ -114,25 +129,16 @@ func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]t
 		return nil, modules.ErrLockedWallet
 	}
 
-	_, tpoolFee := w.tpool.FeeEstimation()
-	tpoolFee = tpoolFee.Mul64(750) // Estimated transaction size in bytes
-	tpoolFee = tpoolFee.Mul64(5)   // use large fee to ensure siafund transactions are selected by miners
-	output := types.SiafundOutput{
+	txnBuilder := w.StartTransaction()
+	err := txnBuilder.FundSiacoins(amount.Add(fee))
+	if err != nil {
+		return nil, err
+	}
+	txnBuilder.AddMinerFee(fee)
+	txnBuilder.AddSiafundOutput(types.SiafundOutput{
 		Value:      amount,
 		UnlockHash: dest,
-	}
-
-	txnBuilder := w.StartTransaction()
-	err := txnBuilder.FundSiacoins(tpoolFee)
-	if err != nil {
-		return nil, err
-	}
-	err = txnBuilder.FundSiafunds(amount)
-	if err != nil {
-		return nil, err
-	}
-	txnBuilder.AddMinerFee(tpoolFee)
-	txnBuilder.AddSiafundOutput(output)
+	})
 	txnSet, err := txnBuilder.Sign(true)
 	if err != nil {
 		return nil, err

--- a/siac/main.go
+++ b/siac/main.go
@@ -22,8 +22,9 @@ var (
 	initPassword      bool   // supply a custom password when creating a wallet
 	initForce         bool   // destroy and reencrypt the wallet on init if it already exists
 	hostVerbose       bool   // display additional host info
-	renterShowHistory bool   // Show download history in addition to download queue.
-	renterListVerbose bool   // Show additional info about uploaded files.
+	renterShowHistory bool   // show download history in addition to download queue
+	renterListVerbose bool   // show additional info about uploaded files.
+	walletTxnFee      string // supply a custom transaction fee when sending coins or funds
 
 	// Globals.
 	rootCmd *cobra.Command // Root command cobra object, used by bash completion cmd.
@@ -267,10 +268,11 @@ func main() {
 		walletLoadCmd, walletLockCmd, walletSeedsCmd, walletSendCmd, walletSweepCmd,
 		walletBalanceCmd, walletTransactionsCmd, walletUnlockCmd)
 	walletInitCmd.Flags().BoolVarP(&initPassword, "password", "p", false, "Prompt for a custom password")
-	walletInitCmd.Flags().BoolVarP(&initForce, "force", "", false, "destroy the existing wallet and re-encrypt")
-	walletInitSeedCmd.Flags().BoolVarP(&initForce, "force", "", false, "destroy the existing wallet")
+	walletInitCmd.Flags().BoolVarP(&initForce, "force", "", false, "Destroy the existing wallet and re-encrypt")
+	walletInitSeedCmd.Flags().BoolVarP(&initForce, "force", "", false, "Destroy the existing wallet")
 	walletLoadCmd.AddCommand(walletLoad033xCmd, walletLoadSeedCmd, walletLoadSiagCmd)
 	walletSendCmd.AddCommand(walletSendSiacoinsCmd, walletSendSiafundsCmd)
+	walletSendCmd.Flags().StringVar(&walletTxnFee, "fee", "", "Set miner fee for including transaction")
 
 	root.AddCommand(renterCmd)
 	renterCmd.AddCommand(renterFilesDeleteCmd, renterFilesDownloadCmd,

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -123,9 +123,7 @@ By default the wallet encryption / unlock password is the same as the generated 
 		Short: "Send siacoins to an address",
 		Long: `Send siacoins to an address. 'dest' must be a 76-byte hexadecimal address.
 'amount' can be specified in units, e.g. 1.23KS. Run 'wallet --help' for a list of units.
-If no unit is supplied, hastings will be assumed.
-
-A miner fee of 10 SC is levied on all transactions.`,
+If no unit is supplied, hastings will be assumed.`,
 		Run: wrap(walletsendsiacoinscmd),
 	}
 
@@ -351,7 +349,7 @@ func walletsendsiacoinscmd(amount, dest string) {
 	if err != nil {
 		die("Could not parse amount:", err)
 	}
-	err = post("/wallet/siacoins", fmt.Sprintf("amount=%s&destination=%s", hastings, dest))
+	err = post("/wallet/siacoins", fmt.Sprintf("amount=%s&destination=%s&fee=%s", hastings, dest, walletTxnFee))
 	if err != nil {
 		die("Could not send siacoins:", err)
 	}
@@ -360,7 +358,7 @@ func walletsendsiacoinscmd(amount, dest string) {
 
 // walletsendsiafundscmd sends siafunds to a destination address.
 func walletsendsiafundscmd(amount, dest string) {
-	err := post("/wallet/siafunds", fmt.Sprintf("amount=%s&destination=%s", amount, dest))
+	err := post("/wallet/siafunds", fmt.Sprintf("amount=%s&destination=%s&fee=%s", amount, dest, walletTxnFee))
 	if err != nil {
 		die("Could not send siafunds:", err)
 	}


### PR DESCRIPTION
This allows you to do:
```go
$ siac wallet send siacoins -fee 10SC [amount] [addr]
```
This should be useful for power users that need to prioritize certain transactions.

I'm not super happy with the backend code (`SendSiacoinsFee`). An alternative would be to add an extra argument to `SendSiacoins`, but this requires changing dozens of calls to `SendSiacoins` throughout the codebase. We could get around this by making the fee an "optional argument" (using `...`) but historically we've avoided that pattern and I think we should continue avoiding it.
Lastly, we could move the logic into the api package. That is, the api handler would create a txnbuilder and apply the fee itself. This is ugly in its own way, but the ugliness feels somewhat justified since this is an edge case, and doing so avoids avoids polluting the rest of the code (the wallet module wouldn't change at all).

This also needs api tests.