### PR TITLE
Update progress cap from 99 to 100

### DIFF
--- a/siac/consensuscmd.go
+++ b/siac/consensuscmd.go
@@ -37,8 +37,8 @@ Difficulty: %v
 	} else {
 		estimatedHeight := estimatedHeightAt(time.Now())
 		estimatedProgress := float64(cg.Height) / float64(estimatedHeight) * 100
-		if estimatedProgress > 99 {
-			estimatedProgress = 99
+		if estimatedProgress > 100 {
+			estimatedProgress = 100
 		}
 		fmt.Printf(`Synced: %v
 Height: %v


### PR DESCRIPTION
Why? Otherwise from 99% to 100% the progress siac reports will always be printed as 99.0% even if progress is being made.