### PR TITLE
do not upload inodes in renter

### DIFF
--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -72,13 +72,7 @@ func validateSiapath(siapath string) error {
 // validateSource verifies that a sourcePath meets the
 // requirements for upload.
 func validateSource(sourcePath string) error {
-	f, err := os.Open(sourcePath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	finfo, err := f.Stat()
+	finfo, err := os.Stat(sourcePath)
 	if err != nil {
 		return err
 	}

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	errInsufficientContracts = errors.New("not enough contracts to upload file")
-	errUploadInode           = errors.New("cannot upload inode")
+	errUploadDirectory       = errors.New("cannot upload directory")
 
 	// Erasure-coded piece size
 	pieceSize = modules.SectorSize - crypto.TwofishOverhead
@@ -77,7 +77,7 @@ func validateSource(sourcePath string) error {
 		return err
 	}
 	if finfo.IsDir() {
-		return errUploadInode
+		return errUploadDirectory
 	}
 
 	return nil

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	errInsufficientContracts = errors.New("not enough contracts to upload file")
+	errUploadEmptyInode      = errors.New("cannot upload empty inode")
 
 	// Erasure-coded piece size
 	pieceSize = modules.SectorSize - crypto.TwofishOverhead

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -65,7 +65,7 @@ func TestRenterUploadInode(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Upload to fail with empty inode as source")
 	}
-	if err != errUploadEmptyInode {
+	if err != errUploadInode {
 		t.Fatal("expected errUploadEmptyInode, got", err)
 	}
 }

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -1,7 +1,11 @@
 package renter
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/NebulousLabs/Sia/modules"
 )
 
 // TestRenterSiapathValidate verifies that the validateSiapath function correctly validates SiaPaths.
@@ -30,5 +34,38 @@ func TestRenterSiapathValidate(t *testing.T) {
 		if err == nil && !pathtest.valid {
 			t.Fatal("validateSiapath succeeded on invalid path: ", pathtest.in)
 		}
+	}
+}
+
+// TestRenterUploadInode verifies that the renter returns an error if an inode
+// is provided as the source of an upload.
+func TestRenterUploadInode(t *testing.T) {
+	rt, err := newRenterTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+
+	testUploadPath, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testUploadPath)
+
+	ec, err := NewRSCode(defaultDataPieces, defaultParityPieces)
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := modules.FileUploadParams{
+		Source:      testUploadPath,
+		SiaPath:     "test",
+		ErasureCode: ec,
+	}
+	err = rt.renter.Upload(params)
+	if err == nil {
+		t.Fatal("expected Upload to fail with empty inode as source")
+	}
+	if err != errUploadEmptyInode {
+		t.Fatal("expected errUploadEmptyInode, got", err)
 	}
 }

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -37,8 +37,8 @@ func TestRenterSiapathValidate(t *testing.T) {
 	}
 }
 
-// TestRenterUploadInode verifies that the renter returns an error if an inode
-// is provided as the source of an upload.
+// TestRenterUploadDirectory verifies that the renter returns an error if a
+// directory is provided as the source of an upload.
 func TestRenterUploadInode(t *testing.T) {
 	rt, err := newRenterTester(t.Name())
 	if err != nil {
@@ -63,9 +63,9 @@ func TestRenterUploadInode(t *testing.T) {
 	}
 	err = rt.renter.Upload(params)
 	if err == nil {
-		t.Fatal("expected Upload to fail with empty inode as source")
+		t.Fatal("expected Upload to fail with empty directory as source")
 	}
-	if err != errUploadInode {
-		t.Fatal("expected errUploadEmptyInode, got", err)
+	if err != errUploadDirectory {
+		t.Fatal("expected errUploadDirectory, got", err)
 	}
 }

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -499,6 +499,9 @@ func renterfilesuploadcmd(source, path string) {
 				fmt.Println("Warning: skipping file:", err)
 				return nil
 			}
+			if info.IsDir() {
+				return nil
+			}
 			files = append(files, path)
 			return nil
 		})


### PR DESCRIPTION
See #1855, #913, #1334. `renter.Upload()` now disallows uploading directories, and `siac renter upload` will skip over directories in its Walk.