### PR TITLE
add logging to the wallet

### DIFF
--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -560,7 +560,7 @@ func TestHostDBAndRenterDownloadDynamicIPs(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Pull the host's net address and pubkey from the hostdb.
-	err = retry(50, time.Millisecond*100, func() error {
+	err = retry(100, time.Millisecond*200, func() error {
 		// Get the hostdb internals.
 		if err = st.getAPI("/hostdb/active", &ah); err != nil {
 			return err

--- a/modules/consensus/synchronize_test.go
+++ b/modules/consensus/synchronize_test.go
@@ -1161,7 +1161,7 @@ func TestIntegrationBroadcastRelayHeader(t *testing.T) {
 	cst1.cs.gateway.Broadcast("RelayHeader", validBlock.Header(), cst1.cs.gateway.Peers())
 	select {
 	case <-mg.broadcastCalled:
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(1500 * time.Millisecond):
 		t.Fatal("RelayHeader didn't broadcast a valid block header")
 	}
 }

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -678,6 +678,10 @@ func TestAutoRevisionSubmission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = ht.host.tg.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = ht.host.db.View(func(tx *bolt.Tx) error {
 		so, err = getStorageObligation(tx, so.id())

--- a/modules/renter/upload_test.go
+++ b/modules/renter/upload_test.go
@@ -40,6 +40,9 @@ func TestRenterSiapathValidate(t *testing.T) {
 // TestRenterUploadDirectory verifies that the renter returns an error if a
 // directory is provided as the source of an upload.
 func TestRenterUploadInode(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	rt, err := newRenterTester(t.Name())
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -145,5 +145,10 @@ func (w *Wallet) threadedDefragWallet() {
 	err = w.tpool.AcceptTransactionSet(txnSet)
 	if err != nil {
 		w.log.Println("WARN: defrag transaction was rejected:", err)
+		return
+	}
+	w.log.Println("Submitting a transaction set to defragment the wallet's outputs, IDs:")
+	for _, txn := range txnSet {
+		w.log.Println("\t", txn.ID())
 	}
 }

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -100,6 +100,10 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]t
 	if err != nil {
 		return nil, build.ExtendErr("unable to get transaction accepted", err)
 	}
+	w.log.Println("Submitted a siacoin transfer transaction set for value", amount, "with fees", tpoolFee, "IDs:")
+	for _, txn := range txnSet {
+		w.log.Println("\t", txn.ID())
+	}
 	return txnSet, nil
 }
 
@@ -140,6 +144,10 @@ func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]t
 	err = w.tpool.AcceptTransactionSet(txnSet)
 	if err != nil {
 		return nil, err
+	}
+	w.log.Println("Submitted a siafund transfer transaction set for value", amount, "with fees", tpoolFee, "IDs:")
+	for _, txn := range txnSet {
+		w.log.Println("\t", txn.ID())
 	}
 	return txnSet, nil
 }

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -100,7 +100,7 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]t
 	if err != nil {
 		return nil, build.ExtendErr("unable to get transaction accepted", err)
 	}
-	w.log.Println("Submitted a siacoin transfer transaction set for value", amount, "with fees", tpoolFee, "IDs:")
+	w.log.Println("Submitted a siacoin transfer transaction set for value", amount.HumanString(), "with fees", tpoolFee.HumanString(), "IDs:")
 	for _, txn := range txnSet {
 		w.log.Println("\t", txn.ID())
 	}
@@ -145,7 +145,7 @@ func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]t
 	if err != nil {
 		return nil, err
 	}
-	w.log.Println("Submitted a siafund transfer transaction set for value", amount, "with fees", tpoolFee, "IDs:")
+	w.log.Println("Submitted a siafund transfer transaction set for value", amount.HumanString(), "with fees", tpoolFee.HumanString(), "IDs:")
 	for _, txn := range txnSet {
 		w.log.Println("\t", txn.ID())
 	}

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -437,5 +437,12 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 	// submit the transaction
 	txnSet := append(parents, txn)
 	err = w.tpool.AcceptTransactionSet(txnSet)
+	if err != nil {
+		return
+	}
+	w.log.Println("Creating a transaction set to sweep a seed, IDs:")
+	for _, txn := range txnSet {
+		w.log.Println("\t", txn.ID())
+	}
 	return
 }

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -529,3 +529,35 @@ func TestUnlockHashStringMarshalling(t *testing.T) {
 		t.Error("Got wrong error:", err)
 	}
 }
+
+// TestCurrencyHumanString checks that the HumanString method of the currency
+// type is correctly formatting values.
+func TestCurrencyUnits(t *testing.T) {
+	tests := []struct {
+		in  Currency
+		out string
+	}{
+		{NewCurrency64(1), "1 H"},
+		{NewCurrency64(1000), "1000 H"},
+		{NewCurrency64(100000000000), "100000000000 H"},
+		{NewCurrency64(1000000000000), "1 pS"},
+		{NewCurrency64(1234560000000), "1.235 pS"},
+		{NewCurrency64(12345600000000), "12.35 pS"},
+		{NewCurrency64(123456000000000), "123.5 pS"},
+		{NewCurrency64(1000000000000000), "1 nS"},
+		{NewCurrency64(1000000000000000000), "1 uS"},
+		{NewCurrency64(1000000000).Mul64(1000000000000), "1 mS"},
+		{NewCurrency64(1).Mul(SiacoinPrecision), "1 SC"},
+		{NewCurrency64(1000).Mul(SiacoinPrecision), "1 KS"},
+		{NewCurrency64(1000000).Mul(SiacoinPrecision), "1 MS"},
+		{NewCurrency64(1000000000).Mul(SiacoinPrecision), "1 GS"},
+		{NewCurrency64(1000000000000).Mul(SiacoinPrecision), "1 TS"},
+		{NewCurrency64(1234560000000).Mul(SiacoinPrecision), "1.235 TS"},
+		{NewCurrency64(1234560000000000).Mul(SiacoinPrecision), "1235 TS"},
+	}
+	for _, test := range tests {
+		if test.in.HumanString() != test.out {
+			t.Errorf("currencyUnits(%v): expected %v, got %v", test.in, test.out, test.in.HumanString())
+		}
+	}
+}


### PR DESCRIPTION
Now there are logging statements any time that a wallet-relevant transaction is added to consensus, or reverted from consensus.

This PR is partially to help Poloniex, so there is a log of transactions that may or may not have confirmed.