### PR TITLE
try reverted transactions in tpool Update()

### DIFF
--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -28,9 +28,9 @@ type tpoolTester struct {
 	persistDir string
 }
 
-// createTpoolTester returns a ready-to-use tpool tester, with all modules
-// initialized.
-func createTpoolTester(name string) (*tpoolTester, error) {
+// blankTpoolTester returns a ready-to-use tpool tester, with all modules
+// initialized, without mining a block.
+func blankTpoolTester(name string) (*tpoolTester, error) {
 	// Initialize the modules.
 	testdir := build.TempDir(modules.TransactionPoolDir, name)
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
@@ -65,7 +65,7 @@ func createTpoolTester(name string) (*tpoolTester, error) {
 	}
 
 	// Assemble all of the objects into a tpoolTester
-	tpt := &tpoolTester{
+	return &tpoolTester{
 		cs:        cs,
 		gateway:   g,
 		tpool:     tp,
@@ -74,6 +74,15 @@ func createTpoolTester(name string) (*tpoolTester, error) {
 		walletKey: key,
 
 		persistDir: testdir,
+	}, nil
+}
+
+// createTpoolTester returns a ready-to-use tpool tester, with all modules
+// initialized.
+func createTpoolTester(name string) (*tpoolTester, error) {
+	tpt, err := blankTpoolTester(name)
+	if err != nil {
+		return nil, err
 	}
 
 	// Mine blocks until there is money in the wallet.

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -105,7 +105,9 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// processing consensus changes. Overall, the locking is pretty fragile and
 	// more rules need to be put in place.
 	for _, set := range unconfirmedSets {
-		tp.acceptTransactionSet(set, cc.TryTransactionSet) // Error is not checked.
+		for _, txn := range set {
+			tp.acceptTransactionSet([]types.Transaction{txn}, cc.TryTransactionSet) // Error is not checked.
+		}
 	}
 
 	// Inform subscribers that an update has executed.

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -2,6 +2,7 @@ package transactionpool
 
 import (
 	"testing"
+	"time"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -38,5 +39,96 @@ func TestArbDataOnly(t *testing.T) {
 	}
 	if len(tpt.tpool.TransactionList()) != 0 {
 		t.Error("transaction was not cleared from the transaction pool")
+	}
+}
+
+// TestValidRevertedTransaction verifies that if a transaction appears in a
+// block's reverted transactions, it is added correctly to the pool.
+func TestValidRevertedTransaction(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	tpt, err := createTpoolTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tpt.Close()
+
+	tpt2, err := blankTpoolTester(t.Name() + "-tpt2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tpt2.Close()
+
+	// connect the testers and wait for them to have the same current block
+	err = tpt2.gateway.Connect(tpt.gateway.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+	success := false
+	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(time.Millisecond * 100) {
+		if tpt.cs.CurrentBlock().ID() == tpt2.cs.CurrentBlock().ID() {
+			success = true
+			break
+		}
+	}
+	if !success {
+		t.Fatal("testers did not have the same block height after one minute")
+	}
+
+	// disconnect the testers
+	err = tpt2.gateway.Disconnect(tpt.gateway.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make some transactions on tpt
+	var txnSets [][]types.Transaction
+	for i := 0; i < 5; i++ {
+		txns, err := tpt.wallet.SendSiacoins(types.SiacoinPrecision.Mul64(1000), types.UnlockHash{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		txnSets = append(txnSets, txns)
+	}
+	// mine some blocks to cause a re-org
+	for i := 0; i < 3; i++ {
+		_, err = tpt.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// put tpt2 at a higher height
+	for i := 0; i < 10; i++ {
+		_, err = tpt2.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// connect the testers and wait for them to have the same current block
+	err = tpt.gateway.Connect(tpt2.gateway.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+	success = false
+	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(time.Millisecond * 100) {
+		if tpt.cs.CurrentBlock().ID() == tpt2.cs.CurrentBlock().ID() {
+			success = true
+			break
+		}
+	}
+	if !success {
+		t.Fatal("testers did not have the same block height after one minute")
+	}
+
+	// verify the transaction pool still has the reorged txns
+	for _, txnSet := range txnSets {
+		for _, txn := range txnSet {
+			if !tpt.tpool.transactionConfirmed(tpt.tpool.dbTx, txn.ID()) {
+				t.Error("tpt did not have a valid reorged transaction:", txn.ID())
+			}
+		}
 	}
 }

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -126,8 +126,9 @@ func TestValidRevertedTransaction(t *testing.T) {
 	// verify the transaction pool still has the reorged txns
 	for _, txnSet := range txnSets {
 		for _, txn := range txnSet {
-			if !tpt.tpool.transactionConfirmed(tpt.tpool.dbTx, txn.ID()) {
-				t.Error("tpt did not have a valid reorged transaction:", txn.ID())
+			_, _, exists := tpt.tpool.Transaction(txn.ID())
+			if !exists {
+				t.Error("Transaction was not re-added to the transaction pool after being re-orged out of the blockchain:", txn.ID())
 			}
 		}
 	}

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -132,4 +132,13 @@ func TestValidRevertedTransaction(t *testing.T) {
 			}
 		}
 	}
+
+	// Try to get the transactoins into a block.
+	_, err = tpt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tpt.tpool.TransactionList()) != 0 {
+		t.Error("Does not seem that the transactions were added to the transaction pool.")
+	}
 }


### PR DESCRIPTION
previously, transactions that were reverted did not get retried. Now every reverted transaction will be tried, oldest to newest, and if `acceptTransactionSet` succeeds, the reverted transaction will be added back to the pool.