### PR TITLE
prune unconfirmed transactions older than 12 blocks from the tpool

### DIFF
--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -73,9 +73,10 @@ func TestHostWorkingStatus(t *testing.T) {
 	}
 	defer ht.Close()
 
-	// this causes an ndf, because it relies on the host tester starting up and
-	// fully returning faster than the first check, which isnt always the case.
-	// Disabled for now.
+	// TODO: this causes an ndf, because it relies on the host tester starting up
+	// and fully returning faster than the first check, which isnt always the
+	// case.  This check is disabled for now, but can be fixed by using the
+	// disrupt() pattern.
 	// if ht.host.WorkingStatus() != modules.HostWorkingStatusChecking {
 	// 	t.Fatal("expected working state to initially be modules.HostWorkingStatusChecking")
 	// }
@@ -122,9 +123,10 @@ func TestHostConnectabilityStatus(t *testing.T) {
 	}
 	defer ht.Close()
 
-	// this causes an ndf, because it relies on the host tester starting up and
-	// fully returning faster than the first check, which isnt always the case.
-	// Disabled for now.
+	// TODO: this causes an ndf, because it relies on the host tester starting up
+	// and fully returning faster than the first check, which isnt always the
+	// case.  This check is disabled for now, but can be fixed by using the
+	// disrupt() pattern.
 	// if ht.host.ConnectabilityStatus() != modules.HostConnectabilityStatusChecking {
 	// 		t.Fatal("expected connectability state to initially be ConnectablityStateChecking")
 	// }

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -73,9 +73,12 @@ func TestHostWorkingStatus(t *testing.T) {
 	}
 	defer ht.Close()
 
-	if ht.host.WorkingStatus() != modules.HostWorkingStatusChecking {
-		t.Fatal("expected working state to initially be modules.HostWorkingStatusChecking")
-	}
+	// this causes an ndf, because it relies on the host tester starting up and
+	// fully returning faster than the first check, which isnt always the case.
+	// Disabled for now.
+	// if ht.host.WorkingStatus() != modules.HostWorkingStatusChecking {
+	// 	t.Fatal("expected working state to initially be modules.HostWorkingStatusChecking")
+	// }
 
 	for i := 0; i < 5; i++ {
 		// Simulate some setting calls, and see if the host picks up on it.
@@ -119,9 +122,12 @@ func TestHostConnectabilityStatus(t *testing.T) {
 	}
 	defer ht.Close()
 
-	if ht.host.ConnectabilityStatus() != modules.HostConnectabilityStatusChecking {
-		t.Fatal("expected connectability state to initially be ConnectablityStateChecking")
-	}
+	// this causes an ndf, because it relies on the host tester starting up and
+	// fully returning faster than the first check, which isnt always the case.
+	// Disabled for now.
+	// if ht.host.ConnectabilityStatus() != modules.HostConnectabilityStatusChecking {
+	// 		t.Fatal("expected connectability state to initially be ConnectablityStateChecking")
+	// }
 
 	success := false
 	for start := time.Now(); time.Since(start) < 30*time.Second; time.Sleep(time.Millisecond * 10) {

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -311,9 +311,13 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction, txnFn fu
 	tp.transactionSetDiffs[setID] = cc
 	tsetSize := len(encoding.Marshal(ts))
 	tp.transactionListSize += tsetSize
+	blockHeight, err := tp.getBlockHeight(tp.dbTx)
+	if err != nil {
+		return err
+	}
 	for _, txn := range ts {
 		if _, exists := tp.transactionHeights[txn.ID()]; !exists {
-			tp.transactionHeights[txn.ID()] = tp.blockHeight
+			tp.transactionHeights[txn.ID()] = blockHeight
 		}
 	}
 

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -311,6 +311,11 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction, txnFn fu
 	tp.transactionSetDiffs[setID] = cc
 	tsetSize := len(encoding.Marshal(ts))
 	tp.transactionListSize += tsetSize
+	for _, txn := range ts {
+		if _, exists := tp.transactionHeights[txn.ID()]; !exists {
+			tp.transactionHeights[txn.ID()] = tp.blockHeight
+		}
+	}
 
 	// debug logging
 	if build.DEBUG {

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -311,13 +311,9 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction, txnFn fu
 	tp.transactionSetDiffs[setID] = cc
 	tsetSize := len(encoding.Marshal(ts))
 	tp.transactionListSize += tsetSize
-	blockHeight, err := tp.getBlockHeight(tp.dbTx)
-	if err != nil {
-		return err
-	}
 	for _, txn := range ts {
 		if _, exists := tp.transactionHeights[txn.ID()]; !exists {
-			tp.transactionHeights[txn.ID()] = blockHeight
+			tp.transactionHeights[txn.ID()] = tp.blockHeight
 		}
 	}
 

--- a/modules/transactionpool/persist.go
+++ b/modules/transactionpool/persist.go
@@ -163,13 +163,15 @@ func (tp *TransactionPool) initPersist() error {
 	}
 
 	// Get the most recent block height
-	_, err = tp.getBlockHeight(tp.dbTx)
+	bh, err := tp.getBlockHeight(tp.dbTx)
 	if err != nil {
 		err = tp.putBlockHeight(tp.dbTx, types.BlockHeight(0))
 		if err != nil {
 			return build.ExtendErr("unable to initialize the block height in the tpool", err)
 		}
 		err = tp.putRecentConsensusChange(tp.dbTx, modules.ConsensusChangeBeginning)
+	} else {
+		tp.blockHeight = bh
 	}
 	if err != nil {
 		return build.ExtendErr("unable to initialize the block height in the tpool", err)
@@ -210,6 +212,7 @@ func (tp *TransactionPool) getBlockHeight(tx *bolt.Tx) (bh types.BlockHeight, er
 
 // putBlockHeight updates the transaction pool's block height.
 func (tp *TransactionPool) putBlockHeight(tx *bolt.Tx, height types.BlockHeight) error {
+	tp.blockHeight = height
 	return tx.Bucket(bucketBlockHeight).Put(fieldBlockHeight, encoding.Marshal(height))
 }
 

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -56,9 +56,11 @@ type (
 		// transactionSetDiffs map form a transaction set id to the set of
 		// diffs that resulted from the transaction set.
 		knownObjects        map[ObjectID]TransactionSetID
+		transactionHeights  map[types.TransactionID]types.BlockHeight
 		transactionSets     map[TransactionSetID][]types.Transaction
 		transactionSetDiffs map[TransactionSetID]modules.ConsensusChange
 		transactionListSize int
+		blockHeight         types.BlockHeight
 		// TODO: Write a consistency check comparing transactionSets,
 		// transactionSetDiffs.
 		//
@@ -97,6 +99,7 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string) (*Transa
 		gateway:      g,
 
 		knownObjects:        make(map[ObjectID]TransactionSetID),
+		transactionHeights:  make(map[types.TransactionID]types.BlockHeight),
 		transactionSets:     make(map[TransactionSetID][]types.Transaction),
 		transactionSetDiffs: make(map[TransactionSetID]modules.ConsensusChange),
 

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -105,8 +105,7 @@ func (tpt *tpoolTester) Close() error {
 		tpt.gateway.Close(),
 		tpt.tpool.Close(),
 		tpt.miner.Close(),
-		// TODO: implement modules.Wallet.Close()
-		// tpt.wallet.Close()
+		tpt.wallet.Close(),
 	}
 	if err := build.JoinErrors(errs, "; "); err != nil {
 		panic(err)

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -180,7 +180,7 @@ func TestTransactionPoolPruning(t *testing.T) {
 	// disconnect tpt, create an unconfirmed transaction on tpt, mine maxTxnAge
 	// blocks on tpt2 and reconnect. The unconfirmed transactions should be
 	// removed from tpt's pool.
-	err = tpt2.gateway.Disconnect(tpt.gateway.Address())
+	err = tpt.gateway.Disconnect(tpt2.gateway.Address())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,5 +219,14 @@ func TestTransactionPoolPruning(t *testing.T) {
 	}
 	if len(tpt.tpool.TransactionList()) != 0 {
 		t.Fatal("should have no unconfirmed transactions")
+	}
+	if len(tpt.tpool.knownObjects) != 0 {
+		t.Fatal("should have no known objects")
+	}
+	if len(tpt.tpool.transactionSetDiffs) != 0 {
+		t.Fatal("should have no transaction set diffs")
+	}
+	if tpt.tpool.transactionListSize != 0 {
+		t.Fatal("transactionListSize should be zero")
 	}
 }


### PR DESCRIPTION
This PR updates the transaction pool to prune transactions that have been in the pool for more than 12 blocks.