### PR TITLE
add API support for send-to-many

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -367,22 +367,53 @@ func (api *API) walletSeedsHandler(w http.ResponseWriter, req *http.Request, _ h
 
 // walletSiacoinsHandler handles API calls to /wallet/siacoins.
 func (api *API) walletSiacoinsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	amount, ok := scanAmount(req.FormValue("amount"))
-	if !ok {
-		WriteError(w, Error{"could not read 'amount' from POST call to /wallet/siacoins"}, http.StatusBadRequest)
-		return
-	}
-	dest, err := scanAddress(req.FormValue("destination"))
-	if err != nil {
-		WriteError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusBadRequest)
-		return
+	var txns []types.Transaction
+	if req.FormValue("destination") != "" {
+		// single amount + destination
+		amount, ok := scanAmount(req.FormValue("amount"))
+		if !ok {
+			WriteError(w, Error{"could not read 'amount' from POST call to /wallet/siacoins"}, http.StatusBadRequest)
+			return
+		}
+		dest, err := scanAddress(req.FormValue("destination"))
+		if err != nil {
+			WriteError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusBadRequest)
+			return
+		}
+		txns, err = api.wallet.SendSiacoins(amount, dest)
+		if err != nil {
+			WriteError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusInternalServerError)
+			return
+		}
+	} else {
+		// multiple amounts + destinations
+		amountStrs := strings.Split(req.FormValue("amounts"), ",")
+		destStrs := strings.Split(req.FormValue("destinations"), ",")
+		amounts := make([]types.Currency, len(amountStrs))
+		dests := make([]types.UnlockHash, len(destStrs))
+		for i, amountStr := range amountStrs {
+			var ok bool
+			amounts[i], ok = scanAmount(amountStr)
+			if !ok {
+				WriteError(w, Error{"could not read amount from POST call to /wallet/siacoins"}, http.StatusBadRequest)
+				return
+			}
+		}
+		var err error
+		for i, destStr := range destStrs {
+			dests[i], err = scanAddress(destStr)
+			if err != nil {
+				WriteError(w, Error{"could not read address from POST call to /wallet/siacoins"}, http.StatusBadRequest)
+				return
+			}
+		}
+		txns, err = api.wallet.SendSiacoinsMulti(amounts, dests)
+		if err != nil {
+			WriteError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusInternalServerError)
+			return
+		}
 	}
 
-	txns, err := api.wallet.SendSiacoins(amount, dest)
-	if err != nil {
-		WriteError(w, Error{"error after call to /wallet/siacoins: " + err.Error()}, http.StatusInternalServerError)
-		return
-	}
 	var txids []types.TransactionID
 	for _, txn := range txns {
 		txids = append(txids, txn.ID())

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -1497,7 +1497,7 @@ func TestWalletSiacoins(t *testing.T) {
 	}
 
 	// mine blocks until the send is confirmed
-	for i := 0; i < 5; i++ {
+	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
 		_, err := st.miner.AddBlock()
 		if err != nil {
 			t.Fatal(err)
@@ -1511,7 +1511,7 @@ func TestWalletSiacoins(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !wg.ConfirmedSiacoinBalance.Equals(sendAmount) {
-			t.Errorf("wallet %d should have %v coins, has %v", i+1, sendAmount, wg.ConfirmedSiacoinBalance)
+			t.Errorf("wallet %d should have %v coins, has %v", i+2, sendAmount, wg.ConfirmedSiacoinBalance)
 		}
 	}
 }

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -1452,60 +1452,111 @@ func TestWalletSiacoins(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer st.server.panicClose()
-
 	st2, err := blankServerTester(t.Name() + "-wallet2")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st2.server.Close()
-
 	st3, err := blankServerTester(t.Name() + "-wallet3")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st3.server.Close()
-
 	st4, err := blankServerTester(t.Name() + "-wallet4")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer st4.server.Close()
+	st5, err := blankServerTester(t.Name() + "-wallet5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st5.server.Close()
+	st6, err := blankServerTester(t.Name() + "-wallet6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st6.server.Close()
 
-	wallets := []*serverTester{st, st2, st3, st4}
+	// Mine two more blocks with 'st' to get extra outputs to spend.
+	for i := 0; i < 2; i++ {
+		_, err := st.miner.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Connect all the wallets together.
+	wallets := []*serverTester{st, st2, st3, st4, st5, st6}
 	err = fullyConnectNodes(wallets)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// send 10KS to each of the blank wallets
+	// Send 10KS in a single-send to st2.
 	sendAmount := types.SiacoinPrecision.Mul64(10000)
+	var wag WalletAddressGET
+	err = st2.getAPI("/wallet/address", &wag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sendSiacoinsValues := url.Values{}
+	sendSiacoinsValues.Set("amount", sendAmount.String())
+	sendSiacoinsValues.Set("destination", wag.Address.String())
+	if err = st.stdPostAPI("/wallet/siacoins", sendSiacoinsValues); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send 10KS to 3, 4, 5 in a single send.
 	var amounts, dests []string
-	for _, w := range wallets[1:] {
+	for _, w := range wallets[2:5] {
 		var wag WalletAddressGET
 		err = w.getAPI("/wallet/address", &wag)
 		if err != nil {
 			t.Fatal(err)
 		}
-		dests = append(dests, wag.Address.String())
 		amounts = append(amounts, sendAmount.String())
+		dests = append(dests, wag.Address.String())
 	}
-	sendSiacoinsValues := url.Values{}
+	sendSiacoinsValues = url.Values{}
 	sendSiacoinsValues.Set("amount", strings.Join(amounts, ","))
 	sendSiacoinsValues.Set("destination", strings.Join(dests, ","))
 	if err = st.stdPostAPI("/wallet/siacoins", sendSiacoinsValues); err != nil {
 		t.Fatal(err)
 	}
 
-	// mine blocks until the send is confirmed
-	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
-		_, err := st.miner.AddBlock()
+	// Send 10KS to 6 through a joined 250 sends.
+	amounts = nil
+	dests = nil
+	smallSend := sendAmount.Div64(250)
+	for i := 0; i < 250; i++ {
+		var wag WalletAddressGET
+		err = st6.getAPI("/wallet/address", &wag)
 		if err != nil {
 			t.Fatal(err)
 		}
+		amounts = append(amounts, smallSend.String())
+		dests = append(dests, wag.Address.String())
 	}
-	// allow some time for blocks to propagate
-	time.Sleep(time.Second)
+	sendSiacoinsValues = url.Values{}
+	sendSiacoinsValues.Set("amount", strings.Join(amounts, ","))
+	sendSiacoinsValues.Set("destination", strings.Join(dests, ","))
+	if err = st.stdPostAPI("/wallet/siacoins", sendSiacoinsValues); err != nil {
+		t.Fatal(err)
+	}
 
+	// Mine a block to confirm the send.
+	_, err = st.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Wait for the block to propagate.
+	_, err = synchronizationCheck(wallets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the wallets all have 10KS.
 	for i, w := range wallets[1:] {
 		var wg WalletGET
 		err = w.getAPI("/wallet", &wg)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -1503,6 +1503,8 @@ func TestWalletSiacoins(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// allow some time for blocks to propagate
+	time.Sleep(time.Second)
 
 	for i, w := range wallets[1:] {
 		var wg WalletGET

--- a/doc/API.md
+++ b/doc/API.md
@@ -89,8 +89,8 @@ Table of contents
 - [Host DB](#host-db)
 - [Miner](#miner)
 - [Renter](#renter)
-- [Wallet](#wallet)
 - [Transaction Pool](#transaction-pool)
+- [Wallet](#wallet)
 
 Daemon
 ------
@@ -941,6 +941,46 @@ standard success or error response. See
 [#standard-responses](#standard-responses).
 
 
+Transaction Pool
+------
+
+| Route                           | HTTP verb |
+| ------------------------------- | --------- |
+| [/tpool/raw/:id](#tpoolraw-get) | GET       |
+| [/tpool/raw](#tpoolraw-post)    | POST      |
+
+#### /tpool/raw/:id [GET]
+
+returns the ID for the requested transaction and its raw encoded parents and transaction data.
+
+###### JSON Response [(with comments)](/doc/api/Transactionpool.md#json-response)
+```javascript
+{
+	// id of the transaction
+	"id": "124302d30a219d52f368ecd94bae1bfb922a3e45b6c32dd7fb5891b863808788",
+
+	// raw, base64 encoded transaction data
+	"transaction": "AQAAAAAAAADBM1ca/FyURfizmSukoUQ2S0GwXMit1iNSeYgrnhXOPAAAAAAAAAAAAQAAAAAAAABlZDI1NTE5AAAAAAAAAAAAIAAAAAAAAACdfzoaJ1MBY7L0fwm7O+BoQlFkkbcab5YtULa6B9aecgEAAAAAAAAAAQAAAAAAAAAMAAAAAAAAAAM7Ljyf0IA86AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACgAAAAAAAACe0ZTbGbI4wAAAAAAAAAAAAAABAAAAAAAAAMEzVxr8XJRF+LOZK6ShRDZLQbBcyK3WI1J5iCueFc48AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAA+z4P1wc98IqKxykTSJxiVT+BVbWezIBnIBO1gRRlLq2x/A+jIc6G7/BA5YNJRbdnqPHrzsZvkCv4TKYd/XzwBA==",
+	"parents": "AQAAAAAAAAABAAAAAAAAAJYYmFUdXXfLQ2p6EpF+tcqM9M4Pw5SLSFHdYwjMDFCjAAAAAAAAAAABAAAAAAAAAGVkMjU1MTkAAAAAAAAAAAAgAAAAAAAAAAHONvdzzjHfHBx6psAN8Z1rEVgqKPZ+K6Bsqp3FbrfjAQAAAAAAAAACAAAAAAAAAAwAAAAAAAAAAzvNDjSrme8gwAAA4w8ODnW8DxbOV/JribivvTtjJ4iHVOug0SXJc31BdSINAAAAAAAAAAPGHY4699vggx5AAAC2qBhm5vwPaBsmwAVPho/1Pd8ecce/+BGv4UimnEPzPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAACWGJhVHV13y0NqehKRfrXKjPTOD8OUi0hR3WMIzAxQowAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAABnt64wN1qxym/CfiMgOx5fg/imVIEhY+4IiiM7gwvSx8qtqKniOx50ekrGv8B+gTKDXpmm2iJibWTI9QLZHWAY=",
+}
+```
+
+#### /tpool/raw [POST]
+
+submits a raw transaction to the transaction pool, broadcasting it to the transaction pool's peers.
+
+###### Query String Parameters [(with comments)](/doc/api/Transactionpool.md#query-string-parameters)
+
+```
+parents     string // raw base64 encoded transaction parents
+transaction string // raw base64 encoded transaction
+```
+
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
+
+
 Wallet
 ------
 
@@ -1351,46 +1391,6 @@ changes the wallet's encryption key.
 ```
 encryptionpassword
 newpassword
-```
-
-###### Response
-standard success or error response. See
-[#standard-responses](#standard-responses).
-
-
-Transaction Pool
-------
-
-| Route                           | HTTP verb |
-| ------------------------------- | --------- |
-| [/tpool/raw/:id](#tpoolraw-get) | GET       |
-| [/tpool/raw](#tpoolraw-post)    | POST      |
-
-#### /tpool/raw/:id [GET]
-
-returns the ID for the requested transaction and its raw encoded parents and transaction data.
-
-###### JSON Response [(with comments)](/doc/api/Transactionpool.md#json-response)
-```javascript
-{
-	// id of the transaction
-	"id": "124302d30a219d52f368ecd94bae1bfb922a3e45b6c32dd7fb5891b863808788",
-
-	// raw, base64 encoded transaction data
-	"transaction": "AQAAAAAAAADBM1ca/FyURfizmSukoUQ2S0GwXMit1iNSeYgrnhXOPAAAAAAAAAAAAQAAAAAAAABlZDI1NTE5AAAAAAAAAAAAIAAAAAAAAACdfzoaJ1MBY7L0fwm7O+BoQlFkkbcab5YtULa6B9aecgEAAAAAAAAAAQAAAAAAAAAMAAAAAAAAAAM7Ljyf0IA86AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACgAAAAAAAACe0ZTbGbI4wAAAAAAAAAAAAAABAAAAAAAAAMEzVxr8XJRF+LOZK6ShRDZLQbBcyK3WI1J5iCueFc48AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAA+z4P1wc98IqKxykTSJxiVT+BVbWezIBnIBO1gRRlLq2x/A+jIc6G7/BA5YNJRbdnqPHrzsZvkCv4TKYd/XzwBA==",
-	"parents": "AQAAAAAAAAABAAAAAAAAAJYYmFUdXXfLQ2p6EpF+tcqM9M4Pw5SLSFHdYwjMDFCjAAAAAAAAAAABAAAAAAAAAGVkMjU1MTkAAAAAAAAAAAAgAAAAAAAAAAHONvdzzjHfHBx6psAN8Z1rEVgqKPZ+K6Bsqp3FbrfjAQAAAAAAAAACAAAAAAAAAAwAAAAAAAAAAzvNDjSrme8gwAAA4w8ODnW8DxbOV/JribivvTtjJ4iHVOug0SXJc31BdSINAAAAAAAAAAPGHY4699vggx5AAAC2qBhm5vwPaBsmwAVPho/1Pd8ecce/+BGv4UimnEPzPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAACWGJhVHV13y0NqehKRfrXKjPTOD8OUi0hR3WMIzAxQowAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAABnt64wN1qxym/CfiMgOx5fg/imVIEhY+4IiiM7gwvSx8qtqKniOx50ekrGv8B+gTKDXpmm2iJibWTI9QLZHWAY=",
-}
-```
-
-#### /tpool/raw [POST]
-
-submits a raw transaction to the transaction pool, broadcasting it to the transaction pool's peers.
-
-###### Query String Parameters [(with comments)](/doc/api/Transactionpool.md#query-string-parameters)
-
-```
-parents     string // raw base64 encoded transaction parents
-transaction string // raw base64 encoded transaction
 ```
 
 ###### Response

--- a/doc/API.md
+++ b/doc/API.md
@@ -1137,13 +1137,14 @@ dictionary
 
 #### /wallet/siacoins [POST]
 
-sends siacoins to an address. The outputs are arbitrarily selected from
-addresses in the wallet.
+sends siacoins to a set of addresses. The outputs are arbitrarily selected
+from addresses in the wallet. The number of amounts must match the number of
+destinations.
 
 ###### Query String Parameters [(with comments)](/doc/api/Wallet.md#query-string-parameters-6)
 ```
-amount      // hastings
-destination // address
+amount      // list of hastings (comma separated)
+destination // list of addresses (comma separated)
 ```
 
 ###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response-5)

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -316,7 +316,9 @@ dictionary
 
 Function: Send siacoins to a set of addresses. The outputs are arbitrarily
 selected from addresses in the wallet. Each address is paired with an amount;
-the number of amounts must match the number of addresses.
+the number of amounts must match the number of addresses. The number of pairs
+should not exceed 250; this may result in a transaction too large to fit in
+the transaction pool.
 
 ###### Query String Parameters
 ```

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -314,16 +314,17 @@ dictionary
 
 #### /wallet/siacoins [POST]
 
-Function: Send siacoins to an address. The outputs are arbitrarily selected
-from addresses in the wallet.
+Function: Send siacoins to a set of addresses. The outputs are arbitrarily
+selected from addresses in the wallet. Each address is paired with an amount;
+the number of amounts must match the number of addresses.
 
 ###### Query String Parameters
 ```
-// Number of hastings being sent. A hasting is the smallest unit in Sia. There
-// are 10^24 hastings in a siacoin.
+// Comma-separated list of hastings being sent to each address. A hasting is
+// the smallest unit in Sia. There are 10^24 hastings in a siacoin.
 amount      // hastings
 
-// Address that is receiving the coins.
+// Comma-separated list of addresses that are receiving coins.
 destination // address
 ```
 

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -383,6 +383,10 @@ type (
 		// are also returned to the caller.
 		SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
 
+		// SendSiacoinsMulti sends coins to multiple addresses. The number of
+		// amounts and destinations must match.
+		SendSiacoinsMulti(amounts []types.Currency, dests []types.UnlockHash) ([]types.Transaction, error)
+
 		// SendSiafunds is a tool for sending siafunds from the wallet to an
 		// address. Sending money usually results in multiple transactions. The
 		// transactions are automatically given to the transaction pool, and

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -133,7 +133,7 @@ func (w *Wallet) SendSiacoinsMulti(amounts []types.Currency, dests []types.Unloc
 
 	// Add estimated transaction fee.
 	_, tpoolFee := w.tpool.FeeEstimation()
-	tpoolFee = tpoolFee.Mul64(750 * uint64(len(dests))) // Estimated transaction size in bytes
+	tpoolFee = tpoolFee.Mul64(1000 + 60*uint64(len(dests))) // Estimated transaction size in bytes
 	txnBuilder.AddMinerFee(tpoolFee)
 
 	// Calculate total cost to wallet.


### PR DESCRIPTION
This allows users to post a set of amounts and addresses to `/wallet/siacoins`, the same endpoint currently used for single amount+address pairs. The rationale is to make it easy to split a large input among many outputs without requiring a separate transaction for each (which is slower and can cause fragmentation).
To create a send-to-many transaction, post a list of comma-separated amounts/addrs in the `amounts`/`destinations` form values, instead of the typical `amount`/`destination` form values. The backing logic is implemented in a new `SendSiacoinsMulti` method of the wallet.

PR'ing this early to invite discussion. Should we create a new route for send-to-many, instead of overloading `/wallet/siacoins`? Should the api handler construct the transaction itself using a transaction builder? And how should this PR interact with #1849?