### PR TITLE
consensus: apply 10 blocks in one Bolt transaction

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -271,6 +271,9 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (bool, error) 
 			if build.DEBUG && len(changeEntry.AppliedBlocks) == 0 && len(changeEntry.RevertedBlocks) != 0 {
 				panic("appliedBlocks and revertedBlocks are mismatched!")
 			}
+			// We can group changes from many blocks because the blocks are
+			// consecutive as checked in the beginning of managedAcceptBlocks.
+			// See https://github.com/NebulousLabs/Sia/pull/1878#discussion_r123674511
 			changes.RevertedBlocks = append(changes.RevertedBlocks, changeEntry.RevertedBlocks...)
 			changes.AppliedBlocks = append(changes.AppliedBlocks, changeEntry.AppliedBlocks...)
 			chainExtended = true

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -282,6 +282,9 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (bool, error) 
 	if err != nil {
 		return chainExtended, err
 	}
+	// The order is important here: subscribers must be updated after
+	// the check for fatal errors (which result in rollback) but before
+	// the check for other errors which don't result in rollback.
 	if chainExtended {
 		cs.readlockUpdateSubscribers(changes)
 	}

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -259,6 +259,7 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) error {
 						cs.managedBroadcastBlock(b)
 					}()
 				}
+				return err
 			}
 
 			// Try adding the block to the block tree. This call will perform

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -147,9 +147,9 @@ func (cs *ConsensusSet) validateHeader(tx dbTx, h types.BlockHeader) error {
 // can be appropriately returned by the database and the transaction can be
 // committed. Switching to a managed tx through bolt will make this complexity
 // unneeded.
-func (cs *ConsensusSet) addBlockToTree(b types.Block, parent *processedBlock) (ce changeEntry, err error) {
+func (cs *ConsensusSet) addBlockToTree(tx *bolt.Tx, b types.Block, parent *processedBlock) (ce changeEntry, err error) {
 	var nonExtending bool
-	err = cs.db.Update(func(tx *bolt.Tx) error {
+	err = func() error {
 		currentNode := currentProcessedBlock(tx)
 		newNode := cs.newChild(tx, parent, b)
 
@@ -186,7 +186,7 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block, parent *processedBlock) (c
 			return err
 		}
 		return nil
-	})
+	}()
 	if err != nil {
 		return changeEntry{}, err
 	}
@@ -196,9 +196,9 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block, parent *processedBlock) (c
 	return ce, nil
 }
 
-// managedAcceptBlock will try to add a block to the consensus set. If the
-// block does not extend the longest currently known chain, an error is
-// returned but the block is still kept in memory. If the block extends a fork
+// managedAcceptBlocks will try to add blocks to the consensus set. If the
+// blocks do not extend the longest currently known chain, an error is
+// returned but the blocks are still kept in memory. If the blocks extend a fork
 // such that the fork becomes the longest currently known chain, the consensus
 // set will reorganize itself to recognize the new longest fork. Accepted
 // blocks are not relayed.
@@ -207,52 +207,74 @@ func (cs *ConsensusSet) addBlockToTree(b types.Block, parent *processedBlock) (c
 // This method is typically only be used when there would otherwise be multiple
 // consecutive calls to AcceptBlock with each successive call accepting the
 // child block of the previous call.
-func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
+func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) error {
 	// Grab a lock on the consensus set.
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
-	// Start verification inside of a bolt View tx.
-	var parent *processedBlock
-	err := cs.db.View(func(tx *bolt.Tx) error {
+	// Make sure that blocks are consecutive.
+	for i, b := range blocks {
+		if i > 0 && b.Header().ParentID != blocks[i-1].ID() {
+			return errOrphan
+		}
+	}
+
+	var changes changeEntry
+
+	err := cs.db.Update(func(tx *bolt.Tx) error {
 		// Do not accept a block if the database is inconsistent.
 		if inconsistencyDetected(tx) {
 			return errInconsistentSet
 		}
 
-		// Do some relatively inexpensive checks to validate the header and block.
-		// Validation generally occurs in the order of least expensive validation
-		// first.
-		var err error
-		parent, err = cs.validateHeaderAndBlock(boltTxWrapper{tx}, b)
-		if err != nil {
-			// If the block is in the near future, but too far to be acceptable, then
-			// save the block and add it to the consensus set after it is no longer
-			// too far in the future.
-			//
-			// TODO: an attacker could mine many blocks off the genesis block all in the
-			// future and we would spawn a goroutine per each block. To fix this, either
-			// ban peers that send lots of future blocks and stop spawning goroutines
-			// after we are already waiting on a large number of future blocks.
-			//
-			// TODO: an attacker could broadcast a future block many times and we would
-			// spawn a goroutine for each broadcast. To fix this we should create a
-			// cache of future blocks, like we already do for DoS blocks, and only spawn
-			// a goroutine if we haven't already spawned one for that block. To limit
-			// the size of the cache of future blocks, make it a constant size (say 50)
-			// over which we would evict the block furthest in the future before adding
-			// a new block to the cache.
-			if err == errFutureTimestamp {
-				go func() {
-					time.Sleep(time.Duration(b.Timestamp-(types.CurrentTimestamp()+types.FutureThreshold)) * time.Second)
-					err := cs.managedAcceptBlock(b)
-					if err != nil {
-						cs.log.Debugln("WARN: failed to accept a future block:", err)
-					}
-					cs.managedBroadcastBlock(b)
-				}()
+		for _, b := range blocks {
+			// Do some relatively inexpensive checks to validate the header and block.
+			// Validation generally occurs in the order of least expensive validation
+			// first.
+			parent, err := cs.validateHeaderAndBlock(boltTxWrapper{tx}, b)
+			if err != nil {
+				// If the block is in the near future, but too far to be acceptable, then
+				// save the block and add it to the consensus set after it is no longer
+				// too far in the future.
+				//
+				// TODO: an attacker could mine many blocks off the genesis block all in the
+				// future and we would spawn a goroutine per each block. To fix this, either
+				// ban peers that send lots of future blocks and stop spawning goroutines
+				// after we are already waiting on a large number of future blocks.
+				//
+				// TODO: an attacker could broadcast a future block many times and we would
+				// spawn a goroutine for each broadcast. To fix this we should create a
+				// cache of future blocks, like we already do for DoS blocks, and only spawn
+				// a goroutine if we haven't already spawned one for that block. To limit
+				// the size of the cache of future blocks, make it a constant size (say 50)
+				// over which we would evict the block furthest in the future before adding
+				// a new block to the cache.
+				if err == errFutureTimestamp {
+					go func() {
+						time.Sleep(time.Duration(b.Timestamp-(types.CurrentTimestamp()+types.FutureThreshold)) * time.Second)
+						err := cs.managedAcceptBlock(b)
+						if err != nil {
+							cs.log.Debugln("WARN: failed to accept a future block:", err)
+						}
+						cs.managedBroadcastBlock(b)
+					}()
+				}
 			}
-			return err
+
+			// Try adding the block to the block tree. This call will perform
+			// verification on the block before adding the block to the block tree. An
+			// error is returned if verification fails or if the block does not extend
+			// the longest fork.
+			changeEntry, err := cs.addBlockToTree(tx, b, parent)
+			if err != nil {
+				return err
+			}
+			// If appliedBlocks is 0, revertedBlocks will also be 0.
+			if build.DEBUG && len(changeEntry.AppliedBlocks) == 0 && len(changeEntry.RevertedBlocks) != 0 {
+				panic("appliedBlocks and revertedBlocks are mismatched!")
+			}
+			changes.RevertedBlocks = append(changes.RevertedBlocks, changeEntry.RevertedBlocks...)
+			changes.AppliedBlocks = append(changes.AppliedBlocks, changeEntry.AppliedBlocks...)
 		}
 		return nil
 	})
@@ -260,24 +282,15 @@ func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
 		return err
 	}
 
-	// Try adding the block to the block tree. This call will perform
-	// verification on the block before adding the block to the block tree. An
-	// error is returned if verification fails or if the block does not extend
-	// the longest fork.
-	changeEntry, err := cs.addBlockToTree(b, parent)
-	if err != nil {
-		return err
-	}
-	// If appliedBlocks is 0, revertedBlocks will also be 0.
-	if build.DEBUG && len(changeEntry.AppliedBlocks) == 0 && len(changeEntry.RevertedBlocks) != 0 {
-		panic("appliedBlocks and revertedBlocks are mismatched!")
-	}
-
 	// Updates complete, demote the lock.
-	if len(changeEntry.AppliedBlocks) > 0 {
-		cs.readlockUpdateSubscribers(changeEntry)
+	if len(changes.AppliedBlocks) > 0 {
+		cs.readlockUpdateSubscribers(changes)
 	}
 	return nil
+}
+
+func (cs *ConsensusSet) managedAcceptBlock(b types.Block) error {
+	return cs.managedAcceptBlocks([]types.Block{b})
 }
 
 // AcceptBlock will try to add a block to the consensus set. If the block does

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -284,14 +284,13 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) error {
 	if err != nil {
 		return err
 	}
+	if len(changes.AppliedBlocks) > 0 {
+		cs.readlockUpdateSubscribers(changes)
+	}
 	if err2 != nil {
 		return err2
 	}
 
-	// Updates complete, demote the lock.
-	if len(changes.AppliedBlocks) > 0 {
-		cs.readlockUpdateSubscribers(changes)
-	}
 	return nil
 }
 

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -141,25 +141,16 @@ func (cs *ConsensusSet) validateHeader(tx dbTx, h types.BlockHeader) error {
 // tip. An error will be returned if block verification fails or if the block
 // does not extend the longest fork.
 //
-// addBlockToTree must use its own database update because it might need to
-// modify the database while returning an error on the block. To prevent error
-// tracking complexity, the error is handled inside the function so that 'nil'
-// can be appropriately returned by the database and the transaction can be
-// committed. Switching to a managed tx through bolt will make this complexity
+// addBlockToTree might need to modify the database while returning an error
+// on the block. Such errors are handled outside of the transaction by the
+// caller. Switching to a managed tx through bolt will make this complexity
 // unneeded.
 func (cs *ConsensusSet) addBlockToTree(tx *bolt.Tx, b types.Block, parent *processedBlock) (ce changeEntry, err error) {
-	var nonExtending bool
 	err = func() error {
 		currentNode := currentProcessedBlock(tx)
 		newNode := cs.newChild(tx, parent, b)
-
-		// modules.ErrNonExtendingBlock should be returned if the block does
-		// not extend the current blockchain, however the changes from newChild
-		// should be committed (which means 'nil' must be returned). A flag is
-		// set to indicate that modules.ErrNonExtending should be returned.
-		nonExtending = !newNode.heavierThan(currentNode)
-		if nonExtending {
-			return nil
+		if !newNode.heavierThan(currentNode) {
+			return modules.ErrNonExtendingBlock
 		}
 		var revertedBlocks, appliedBlocks []*processedBlock
 		revertedBlocks, appliedBlocks, err = cs.forkBlockchain(tx, newNode)
@@ -190,9 +181,6 @@ func (cs *ConsensusSet) addBlockToTree(tx *bolt.Tx, b types.Block, parent *proce
 	if err != nil {
 		return changeEntry{}, err
 	}
-	if nonExtending {
-		return changeEntry{}, modules.ErrNonExtendingBlock
-	}
 	return ce, nil
 }
 
@@ -220,6 +208,7 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) error {
 	}
 
 	var changes changeEntry
+	var nonExtending bool
 
 	err := cs.db.Update(func(tx *bolt.Tx) error {
 		// Do not accept a block if the database is inconsistent.
@@ -267,7 +256,16 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) error {
 			// error is returned if verification fails or if the block does not extend
 			// the longest fork.
 			changeEntry, err := cs.addBlockToTree(tx, b, parent)
-			if err != nil {
+
+			// modules.ErrNonExtendingBlock should be returned if the block does
+			// not extend the current blockchain, however the changes from
+			// addBlockToTree should be committed (which means 'nil' must
+			// be returned). A flag is set to indicate that modules.ErrNonExtending
+			// should be returned.
+			if err == modules.ErrNonExtendingBlock {
+				nonExtending = true
+				return nil
+			} else if err != nil {
 				return err
 			}
 			// If appliedBlocks is 0, revertedBlocks will also be 0.
@@ -281,6 +279,9 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) error {
 	})
 	if err != nil {
 		return err
+	}
+	if nonExtending {
+		return modules.ErrNonExtendingBlock
 	}
 
 	// Updates complete, demote the lock.

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -192,9 +192,9 @@ func (cs *ConsensusSet) managedReceiveBlocks(conn modules.PeerConn) (returnErr e
 
 			// Call managedAcceptBlock instead of AcceptBlock so as not to broadcast
 			// every block.
-			acceptErr := cs.managedAcceptBlocks(newBlocks)
+			chainExtended2, acceptErr := cs.managedAcceptBlocks(newBlocks)
 			// Set a flag to indicate that we should broadcast the last block received.
-			if acceptErr == nil {
+			if chainExtended2 {
 				chainExtended = true
 			}
 			// ErrNonExtendingBlock must be ignored until headers-first block

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -187,11 +187,12 @@ func (cs *ConsensusSet) managedReceiveBlocks(conn modules.PeerConn) (returnErr e
 		}
 
 		// Integrate the blocks into the consensus set.
-		for _, block := range newBlocks {
+		if len(newBlocks) > 0 {
 			stalled = false
+
 			// Call managedAcceptBlock instead of AcceptBlock so as not to broadcast
 			// every block.
-			acceptErr := cs.managedAcceptBlock(block)
+			acceptErr := cs.managedAcceptBlocks(newBlocks)
 			// Set a flag to indicate that we should broadcast the last block received.
 			if acceptErr == nil {
 				chainExtended = true

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -192,9 +192,9 @@ func (cs *ConsensusSet) managedReceiveBlocks(conn modules.PeerConn) (returnErr e
 
 			// Call managedAcceptBlock instead of AcceptBlock so as not to broadcast
 			// every block.
-			chainExtended2, acceptErr := cs.managedAcceptBlocks(newBlocks)
+			acceptErr := cs.managedAcceptBlocks(newBlocks)
 			// Set a flag to indicate that we should broadcast the last block received.
-			if chainExtended2 {
+			if acceptErr == nil {
 				chainExtended = true
 			}
 			// ErrNonExtendingBlock must be ignored until headers-first block

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -166,7 +166,7 @@ func (cs *ConsensusSet) managedReceiveBlocks(conn modules.PeerConn) (returnErr e
 		cs.mu.RUnlock()
 		if chainExtended && synced {
 			// The last block received will be the current block since
-			// managedAcceptBlock only returns nil if a block extends the longest chain.
+			// managedAcceptBlocks only returns nil if a block extends the longest chain.
 			currentBlock := cs.managedCurrentBlock()
 			// broadcast the block header to all peers
 			go cs.gateway.Broadcast("RelayHeader", currentBlock.Header(), cs.gateway.Peers())


### PR DESCRIPTION
Bolt transaction involved fsync calls which are major time consumers during initial blocks download (IBD) according to trace tool. Applying many blocks (namely 10 - the size of newBlocks during IBD) in a single Bolt transaction results in a speedup.

Speedup numbers coming soon.