### PR TITLE
use types.SiacoinOutput for /wallet/siacoins param

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -371,6 +371,11 @@ func (api *API) walletSiacoinsHandler(w http.ResponseWriter, req *http.Request, 
 	var txns []types.Transaction
 	if req.FormValue("outputs") != "" {
 		// multiple amounts + destinations
+		if req.FormValue("amount") != "" || req.FormValue("destination") != "" {
+			WriteError(w, Error{"cannot supply both 'outputs' and single amount+destination pair"}, http.StatusInternalServerError)
+			return
+		}
+
 		var outputs []types.SiacoinOutput
 		err := json.Unmarshal([]byte(req.FormValue("outputs")), &outputs)
 		if err != nil {

--- a/doc/API.md
+++ b/doc/API.md
@@ -1177,14 +1177,15 @@ dictionary
 
 #### /wallet/siacoins [POST]
 
-sends siacoins to a set of addresses. The outputs are arbitrarily selected
-from addresses in the wallet. The number of amounts must match the number of
-destinations.
+sends siacoins to an address or set of addresses. The outputs are arbitrarily
+selected from addresses in the wallet. If 'outputs' is supplied, 'amount' and
+'destination' must be empty.
 
 ###### Query String Parameters [(with comments)](/doc/api/Wallet.md#query-string-parameters-6)
 ```
-amount      // list of hastings (comma separated)
-destination // list of addresses (comma separated)
+amount      // hastings
+destination // address
+outputs     // JSON array of {unlockhash, value} pairs
 ```
 
 ###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response-5)

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -314,20 +314,24 @@ dictionary
 
 #### /wallet/siacoins [POST]
 
-Function: Send siacoins to a set of addresses. The outputs are arbitrarily
-selected from addresses in the wallet. Each address is paired with an amount;
-the number of amounts must match the number of addresses. The number of pairs
-should not exceed 250; this may result in a transaction too large to fit in
-the transaction pool.
+Function: Send siacoins to an address or set of addresses. The outputs are
+arbitrarily selected from addresses in the wallet. If 'outputs' is supplied,
+'amount' and 'destination' must be empty. The number of outputs should not
+exceed 250; this may result in a transaction too large to fit in the
+transaction pool.
 
 ###### Query String Parameters
 ```
-// Comma-separated list of hastings being sent to each address. A hasting is
-// the smallest unit in Sia. There are 10^24 hastings in a siacoin.
+// Number of hastings being sent. A hasting is the smallest unit in Sia. There
+// are 10^24 hastings in a siacoin.
 amount      // hastings
 
-// Comma-separated list of addresses that are receiving coins.
+// Address that is receiving the coins.
 destination // address
+
+// JSON array of outputs. The structure of each output is:
+// {"unlockhash": "<destination>", "value": "<amount>"}
+outputs
 ```
 
 ###### JSON Response

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -317,7 +317,7 @@ dictionary
 Function: Send siacoins to an address or set of addresses. The outputs are
 arbitrarily selected from addresses in the wallet. If 'outputs' is supplied,
 'amount' and 'destination' must be empty. The number of outputs should not
-exceed 250; this may result in a transaction too large to fit in the
+exceed 400; this may result in a transaction too large to fit in the
 transaction pool.
 
 ###### Query String Parameters

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -383,9 +383,8 @@ type (
 		// are also returned to the caller.
 		SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
 
-		// SendSiacoinsMulti sends coins to multiple addresses. The number of
-		// amounts and destinations must match.
-		SendSiacoinsMulti(amounts []types.Currency, dests []types.UnlockHash) ([]types.Transaction, error)
+		// SendSiacoinsMulti sends coins to multiple addresses.
+		SendSiacoinsMulti(outputs []types.SiacoinOutput) ([]types.Transaction, error)
 
 		// SendSiafunds is a tool for sending siafunds from the wallet to an
 		// address. Sending money usually results in multiple transactions. The


### PR DESCRIPTION
The (destination, amount) pairs are now encoded as a JSON array in the query string.
I realized that `types.SiacoinOutput` already has the desired structure, so I used it here. This also cleans up the `SendSiacoinsMulti` implementation.