### PR TITLE
fix TestHostDBAndRenterDownloadDynamicIPs

### DIFF
--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -607,7 +607,6 @@ func TestHostDBAndRenterDownloadDynamicIPs(t *testing.T) {
 	// Mine enough blocks that multiple renew cylces happen. After the renewing
 	// happens, the file should still be downloadable. This is to check that the
 	// renewal doesn't throw things off.
-	t.Skip("renew cycle seems to be having trouble. Re-enable after contractor upgrade")
 	for i := 0; i < testPeriodInt; i++ {
 		_, err = st.miner.AddBlock()
 		if err != nil {
@@ -617,26 +616,25 @@ func TestHostDBAndRenterDownloadDynamicIPs(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Give time for the upgrade to happen.
-		err = retry(100, time.Millisecond*100, func() error {
-			err = st.stdGetAPI("/renter/download/test?destination=" + downpath)
-			if err != nil {
-				return err
-			}
-			// Try downloading the file.
-			// Check that the download has the right contents.
-			download, err = ioutil.ReadFile(downpath)
-			if err != nil {
-				return err
-			}
-			if !bytes.Equal(orig, download) {
-				return errors.New("downloaded file does not equal the original")
-			}
-			return nil
-		})
+	}
+	err = retry(100, time.Millisecond*100, func() error {
+		err = st.stdGetAPI("/renter/download/test?destination=" + downpath)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
+		// Try downloading the file.
+		// Check that the download has the right contents.
+		download, err = ioutil.ReadFile(downpath)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(orig, download) {
+			return errors.New("downloaded file does not equal the original")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
previously, this test would close and bring back a host, then mine `period` blocks and try to download after each block. The test now mines `period` blocks and tries to download after `period` block have been mined.