### PR TITLE
Optimize Block.MerkleRoot by replacing tree.PushObject calls

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -3,7 +3,11 @@ package types
 // block.go defines the Block type for Sia, and provides some helper functions
 // for working with blocks.
 
-import "github.com/NebulousLabs/Sia/crypto"
+import (
+	"bytes"
+
+	"github.com/NebulousLabs/Sia/crypto"
+)
 
 const (
 	// BlockHeaderSize is the size, in bytes, of a block header.
@@ -108,10 +112,14 @@ func (b Block) ID() BlockID {
 func (b Block) MerkleRoot() crypto.Hash {
 	tree := crypto.NewTree()
 	for _, payout := range b.MinerPayouts {
-		tree.PushObject(payout)
+		var b bytes.Buffer
+		payout.MarshalSia(&b)
+		tree.Push(b.Bytes())
 	}
 	for _, txn := range b.Transactions {
-		tree.PushObject(txn)
+		var b bytes.Buffer
+		txn.MarshalSia(&b)
+		tree.Push(b.Bytes())
 	}
 	return tree.Root()
 }

--- a/types/block.go
+++ b/types/block.go
@@ -111,15 +111,16 @@ func (b Block) ID() BlockID {
 // transactions (one leaf per transaction).
 func (b Block) MerkleRoot() crypto.Hash {
 	tree := crypto.NewTree()
+	var buf bytes.Buffer
 	for _, payout := range b.MinerPayouts {
-		var b bytes.Buffer
-		payout.MarshalSia(&b)
-		tree.Push(b.Bytes())
+		payout.MarshalSia(&buf)
+		tree.Push(buf.Bytes())
+		buf.Reset()
 	}
 	for _, txn := range b.Transactions {
-		var b bytes.Buffer
-		txn.MarshalSia(&b)
-		tree.Push(b.Bytes())
+		txn.MarshalSia(&buf)
+		tree.Push(buf.Bytes())
+		buf.Reset()
 	}
 	return tree.Root()
 }


### PR DESCRIPTION
Optimized MerkleRoot computation for transactionpool tests. Specifically running the profiler for TestFeeEstimation shows ~900 MB used for runtime.convT2E which can be reduced to ~415 MB with the changes.

Before: 
![before](https://user-images.githubusercontent.com/12243734/26994227-bd73053c-4d34-11e7-8599-9a09497b996d.png)

After:
![after](https://user-images.githubusercontent.com/12243734/26994228-bd743ccc-4d34-11e7-9170-207ebf8219d3.png)


