### PR TITLE
Optimize Transaction.ID() by adding direct calls to MarshalSia.

### DIFF
--- a/types/transactions.go
+++ b/types/transactions.go
@@ -144,7 +144,7 @@ type (
 // ID returns the id of a transaction, which is taken by marshalling all of the
 // fields except for the signatures and taking the hash of the result.
 func (t Transaction) ID() TransactionID {
-	var hash crypto.Hash
+	var txid TransactionID
 	h := crypto.NewHash()
 	enc := encoding.NewEncoder(h)
 
@@ -187,8 +187,8 @@ func (t Transaction) ID() TransactionID {
 	for i := range t.TransactionSignatures {
 		t.TransactionSignatures[i].MarshalSia(h)
 	}
-	h.Sum(hash[:0])
-	return TransactionID(hash)
+	h.Sum(txid[:0])
+	return txid
 }
 
 // SiacoinOutputID returns the ID of a siacoin output at the given index,


### PR DESCRIPTION
Reduces runtime.convT2E memory usage to by ~90MB

With PR #1905 it goes down to ~300MB.

Before:
![before](https://user-images.githubusercontent.com/12243734/26997552-ca434e52-4d48-11e7-8f5c-e9b37801ad15.png)
![correct-before](https://user-images.githubusercontent.com/12243734/26997553-ca43bf4a-4d48-11e7-8464-5d0e1b81a272.png)

After:
![txid-after](https://user-images.githubusercontent.com/12243734/26997426-8e53424a-4d47-11e7-90f0-b051cafe6f7b.png)
![txid-after-t25](https://user-images.githubusercontent.com/12243734/26997489-2a3b9504-4d48-11e7-8713-272da00012a4.png)



