### PR TITLE
New Block Fee Estimation Algo

### DIFF
--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -50,9 +50,11 @@ func (g *Gateway) managedRPC(addr modules.NetAddress, name string, fn modules.RP
 	defer conn.Close()
 
 	// write header
+	conn.SetDeadline(time.Now().Add(rpcStdDeadline))
 	if err := encoding.WriteObject(conn, handlerName(name)); err != nil {
 		return err
 	}
+	conn.SetDeadline(time.Time{})
 	// call fn
 	return fn(conn)
 }

--- a/modules/transactionpool/database.go
+++ b/modules/transactionpool/database.go
@@ -51,18 +51,11 @@ var (
 
 // Complex objects that get stored in database fields.
 type (
-	// feeSummary desribes the fee structure of a transaction.
-	feeSummary struct {
-		Fee  types.Currency // SC per byte
-		Size uint64
-	}
-
 	// medianPersist is the json object that gets stored in the database so that
 	// the transaction pool can persist its block based fee estimations.
 	medianPersist struct {
-		RecentConfirmedFees []feeSummary
-		TxnsPerBlock        []uint64
-		RecentMedianFee     types.Currency
+		RecentMedians   []types.Currency
+		RecentMedianFee types.Currency
 	}
 )
 

--- a/modules/transactionpool/persist.go
+++ b/modules/transactionpool/persist.go
@@ -169,8 +169,7 @@ func (tp *TransactionPool) initPersist() error {
 	// Just leave the fields empty if no fee median was found. They will be
 	// filled out.
 	if err != errNilFeeMedian {
-		tp.recentConfirmedFees = mp.RecentConfirmedFees
-		tp.txnsPerBlock = mp.TxnsPerBlock
+		tp.recentMedians = mp.RecentMedians
 		tp.recentMedianFee = mp.RecentMedianFee
 	}
 

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -56,10 +56,9 @@ type (
 		// TODO: Write a consistency check making sure that all unconfirmedIDs
 		// point to the right place, and that all UnconfirmedIDs are accounted for.
 
-		blockHeight         types.BlockHeight
-		recentConfirmedFees []feeSummary
-		txnsPerBlock        []uint64       // the number of txns in each of the blocks
-		recentMedianFee     types.Currency // SC per byte
+		blockHeight     types.BlockHeight
+		recentMedians   []types.Currency
+		recentMedianFee types.Currency // SC per byte
 
 		// The consensus change index tracks how many consensus changes have
 		// been sent to the transaction pool. When a new subscriber joins the

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -253,7 +253,7 @@ func TestFeeEstimation(t *testing.T) {
 		var edges []types.TransactionGraphEdge
 		var cumFee types.Currency
 		for j := 0; j < graphLens; j++ {
-			fee := types.SiacoinPrecision.Mul64(uint64(j + 1)).Div64(100)
+			fee := types.SiacoinPrecision.Mul64(uint64(j + i + 1)).Div64(200)
 			cumFee = cumFee.Add(fee)
 			edges = append(edges, types.TransactionGraphEdge{
 				Dest:   j + 1,

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -1,9 +1,9 @@
 package transactionpool
 
 import (
+	"bytes"
 	"sort"
 
-	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -215,8 +215,11 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 			// Compile the fees for this set.
 			var feeSum types.Currency
 			var sizeSum int
+			b := new(bytes.Buffer)
 			for _, txn := range set {
-				sizeSum += len(encoding.Marshal(txn))
+				txn.MarshalSia(b)
+				sizeSum += b.Len()
+				b.Reset()
 				for _, fee := range txn.MinerFees {
 					feeSum = feeSum.Add(fee)
 				}

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -8,6 +8,134 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// TestFindSets checks that the findSets functions is properly parsing and
+// combining transactions into their minimal sets.
+func TestFindSets(t *testing.T) {
+	// Graph a graph which is a chain. Graph will be invalid, but we don't need
+	// the consensus set, so no worries.
+	graph1Size := 5
+	edges := make([]types.TransactionGraphEdge, 0, graph1Size)
+	for i := 0; i < graph1Size; i++ {
+		edges = append(edges, types.TransactionGraphEdge{
+			Dest:   i + 1,
+			Fee:    types.NewCurrency64(5),
+			Source: i,
+			Value:  types.NewCurrency64(100),
+		})
+	}
+	graph1, err := types.TransactionGraph(types.SiacoinOutputID{}, edges)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Split the graph using findSets. Result should be a single set with 5
+	// transactions.
+	sets := findSets(graph1)
+	if len(sets) != 1 {
+		t.Fatal("there should be only one set")
+	}
+	if len(sets[0]) != graph1Size {
+		t.Error("findSets is not grouping the transactions correctly")
+	}
+
+	// Create a second graph to check it can handle two graphs.
+	graph2Size := 6
+	edges = make([]types.TransactionGraphEdge, 0, graph2Size)
+	for i := 0; i < graph2Size; i++ {
+		edges = append(edges, types.TransactionGraphEdge{
+			Dest:   i + 1,
+			Fee:    types.NewCurrency64(5),
+			Source: i,
+			Value:  types.NewCurrency64(100),
+		})
+	}
+	graph2, err := types.TransactionGraph(types.SiacoinOutputID{1}, edges)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sets = findSets(append(graph1, graph2...))
+	if len(sets) != 2 {
+		t.Fatal("there should be two sets")
+	}
+	lens := make(map[int]struct{})
+	lens[len(sets[0])] = struct{}{}
+	lens[len(sets[1])] = struct{}{}
+	_, exists1 := lens[graph1Size]
+	_, exists2 := lens[graph2Size]
+	if !exists1 || !exists2 {
+		t.Fatal("there should be five transactions in each set")
+	}
+
+	// Create a diamond graph to make sure it can handle diamond graph.
+	edges = make([]types.TransactionGraphEdge, 0, 5)
+	sources := []int{0, 0, 1, 2, 3}
+	dests := []int{1, 2, 3, 3, 4}
+	for i := 0; i < 5; i++ {
+		edges = append(edges, types.TransactionGraphEdge{
+			Dest:   dests[i],
+			Fee:    types.NewCurrency64(5),
+			Source: sources[i],
+			Value:  types.NewCurrency64(100),
+		})
+	}
+	graph3, err := types.TransactionGraph(types.SiacoinOutputID{2}, edges)
+	graph3Size := len(graph3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sets = findSets(append(graph1, append(graph2, graph3...)...))
+	if len(sets) != 3 {
+		t.Fatal("there should be two sets")
+	}
+	lens = make(map[int]struct{})
+	lens[len(sets[0])] = struct{}{}
+	lens[len(sets[1])] = struct{}{}
+	lens[len(sets[2])] = struct{}{}
+	_, exists1 = lens[graph1Size]
+	_, exists2 = lens[graph2Size]
+	_, exists3 := lens[graph3Size]
+	if !exists1 || !exists2 || !exists3 {
+		t.Fatal("sets have wrong counts", exists1, exists2, exists3)
+	}
+
+	// Sporadically weave the transactions and make sure the set finder still
+	// parses the sets correctly (sets can assumed to be ordered, but not all in
+	// a row).
+	var sporadic []types.Transaction
+	for len(graph1) > 0 || len(graph2) > 0 || len(graph3) > 0 {
+		if len(graph1) > 0 {
+			sporadic = append(sporadic, graph1[0])
+			graph1 = graph1[1:]
+		}
+		if len(graph2) > 0 {
+			sporadic = append(sporadic, graph2[0])
+			graph2 = graph2[1:]
+		}
+		if len(graph3) > 0 {
+			sporadic = append(sporadic, graph3[0])
+			graph3 = graph3[1:]
+		}
+	}
+	if len(sporadic) != graph1Size+graph2Size+graph3Size {
+		t.Error("sporadic block creation failed")
+	}
+	// Result of findSets should match previous result.
+	sets = findSets(sporadic)
+	if len(sets) != 3 {
+		t.Fatal("there should be two sets")
+	}
+	lens = make(map[int]struct{})
+	lens[len(sets[0])] = struct{}{}
+	lens[len(sets[1])] = struct{}{}
+	lens[len(sets[2])] = struct{}{}
+	_, exists1 = lens[graph1Size]
+	_, exists2 = lens[graph2Size]
+	_, exists3 = lens[graph3Size]
+	if !exists1 || !exists2 || !exists3 {
+		t.Fatal("sets have wrong counts", exists1, exists2, exists3)
+	}
+}
+
 // TestArbDataOnly tries submitting a transaction with only arbitrary data to
 // the transaction pool. Then a block is mined, putting the transaction on the
 // blockchain. The arb data transaction should no longer be in the transaction

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -1,6 +1,7 @@
 package transactionpool
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -57,13 +58,12 @@ func TestFindSets(t *testing.T) {
 	if len(sets) != 2 {
 		t.Fatal("there should be two sets")
 	}
-	lens := make(map[int]struct{})
-	lens[len(sets[0])] = struct{}{}
-	lens[len(sets[1])] = struct{}{}
-	_, exists1 := lens[graph1Size]
-	_, exists2 := lens[graph2Size]
-	if !exists1 || !exists2 {
-		t.Fatal("there should be five transactions in each set")
+	lens := []int{len(sets[0]), len(sets[1])}
+	sort.Ints(lens)
+	expected := []int{graph1Size, graph2Size}
+	sort.Ints(expected)
+	if lens[0] != expected[0] || lens[1] != expected[1] {
+		t.Error("Resulting sets do not have the right lengths")
 	}
 
 	// Create a diamond graph to make sure it can handle diamond graph.
@@ -87,15 +87,12 @@ func TestFindSets(t *testing.T) {
 	if len(sets) != 3 {
 		t.Fatal("there should be two sets")
 	}
-	lens = make(map[int]struct{})
-	lens[len(sets[0])] = struct{}{}
-	lens[len(sets[1])] = struct{}{}
-	lens[len(sets[2])] = struct{}{}
-	_, exists1 = lens[graph1Size]
-	_, exists2 = lens[graph2Size]
-	_, exists3 := lens[graph3Size]
-	if !exists1 || !exists2 || !exists3 {
-		t.Fatal("sets have wrong counts", exists1, exists2, exists3)
+	lens = []int{len(sets[0]), len(sets[1]), len(sets[2])}
+	sort.Ints(lens)
+	expected = []int{graph1Size, graph2Size, graph3Size}
+	sort.Ints(expected)
+	if lens[0] != expected[0] || lens[1] != expected[1] || lens[2] != expected[2] {
+		t.Error("Resulting sets do not have the right lengths")
 	}
 
 	// Sporadically weave the transactions and make sure the set finder still
@@ -124,15 +121,12 @@ func TestFindSets(t *testing.T) {
 	if len(sets) != 3 {
 		t.Fatal("there should be two sets")
 	}
-	lens = make(map[int]struct{})
-	lens[len(sets[0])] = struct{}{}
-	lens[len(sets[1])] = struct{}{}
-	lens[len(sets[2])] = struct{}{}
-	_, exists1 = lens[graph1Size]
-	_, exists2 = lens[graph2Size]
-	_, exists3 = lens[graph3Size]
-	if !exists1 || !exists2 || !exists3 {
-		t.Fatal("sets have wrong counts", exists1, exists2, exists3)
+	lens = []int{len(sets[0]), len(sets[1]), len(sets[2])}
+	sort.Ints(lens)
+	expected = []int{graph1Size, graph2Size, graph3Size}
+	sort.Ints(expected)
+	if lens[0] != expected[0] || lens[1] != expected[1] || lens[2] != expected[2] {
+		t.Error("Resulting sets do not have the right lengths")
 	}
 }
 


### PR DESCRIPTION
Bunch of insight while writing up our new transaction fee mechanism for review.

1. There's no point in considering the highest-value fees in each block when guessing the required fee. The ~lowest value fee in each block was enough to get in that block, so that's pretty much all you should be considering. Of course, lowest is a bit dangerous, so we grab the fee located in the 75%-ile for each block, meaning there are about 500kb of transactions with lower fees, and about 1.5mb of transactions with higher fees in the block. This makes malice harder, while also not getting you an unneeded value.

2. Sia makes very heavy use of the child-pays-for-parent scheme. This means that for any set of transactions, the naive median fee is rather likely to be '0', which is not very helpful because it's not actually 0. So this PR includes a scheme that lumps transaction sets together and appropriately considers cp4p.

The result is a new block-based fee estimation that is way better than the one we merged yesterday.