### PR TITLE
Add look ahead safety to wallet

### DIFF
--- a/modules/wallet/consts.go
+++ b/modules/wallet/consts.go
@@ -16,10 +16,24 @@ const (
 	// defragStartIndex is the number of outputs to skip over when performing a
 	// defrag.
 	defragStartIndex = 10
+)
 
+var (
 	// lookaheadRescanThreshold is the number of keys in the lookahead that will be
 	// generated before a complete wallet rescan is initialized.
-	lookaheadRescanThreshold = 1000
+	lookaheadRescanThreshold = build.Select(build.Var{
+		Dev:      uint64(100),
+		Standard: uint64(1000),
+		Testing:  uint64(10),
+	}).(uint64)
+
+	// lookaheadBuffer together with lookaheadRescanThreshold defines the constant part
+	// of the maxLookahead
+	lookaheadBuffer = build.Select(build.Var{
+		Dev:      uint64(400),
+		Standard: uint64(4000),
+		Testing:  uint64(40),
+	}).(uint64)
 )
 
 // dustValue is the quantity below which a Currency is considered to be Dust.
@@ -53,5 +67,5 @@ func init() {
 // maxLookahead returns the size of the lookahead for a given seed progress
 // which usually is the current primarySeedProgress
 func maxLookahead(start uint64) uint64 {
-	return start + lookaheadRescanThreshold + 4000 + start/10
+	return start + lookaheadRescanThreshold + lookaheadBuffer + start/10
 }

--- a/modules/wallet/consts.go
+++ b/modules/wallet/consts.go
@@ -16,6 +16,10 @@ const (
 	// defragStartIndex is the number of outputs to skip over when performing a
 	// defrag.
 	defragStartIndex = 10
+
+	// lookaheadRescanThreshold is the number of keys in the lookahead that will be
+	// generated before a complete wallet rescan is initialized.
+	lookaheadRescanThreshold = 1000
 )
 
 // dustValue is the quantity below which a Currency is considered to be Dust.
@@ -49,5 +53,5 @@ func init() {
 // maxLookahead returns the size of the lookahead for a given seed progress
 // which usually is the current primarySeedProgress
 func maxLookahead(start uint64) uint64 {
-	return start + 5000 + start/10
+	return start + lookaheadRescanThreshold + 4000 + start/10
 }

--- a/modules/wallet/consts.go
+++ b/modules/wallet/consts.go
@@ -45,3 +45,9 @@ func init() {
 		panic("constants are incorrect, defragThreshold needs to be larger than the sum of defragBatchSize and defragStartIndex")
 	}
 }
+
+// maxLookahead returns the size of the lookahead for a given seed progress
+// which usually is the current primarySeedProgress
+func maxLookahead(start uint64) uint64 {
+	return start + 5000 + start/10
+}

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -163,6 +163,7 @@ func (w *Wallet) managedUnlock(masterKey crypto.TwofishKey) error {
 		}
 		w.integrateSeed(primarySeed, primarySeedProgress)
 		w.primarySeed = primarySeed
+		w.updateFutureKeys(primarySeedProgress)
 
 		// auxiliarySeedFiles
 		for _, sf := range auxiliarySeedFiles {
@@ -335,6 +336,7 @@ func (w *Wallet) Reset() error {
 	}
 	w.wipeSecrets()
 	w.keys = make(map[types.UnlockHash]spendableKey)
+	w.futureKeys = make(map[types.UnlockHash]bool)
 	w.seeds = []modules.Seed{}
 	w.unconfirmedProcessedTransactions = []modules.ProcessedTransaction{}
 	w.unlocked = false

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -163,7 +163,7 @@ func (w *Wallet) managedUnlock(masterKey crypto.TwofishKey) error {
 		}
 		w.integrateSeed(primarySeed, primarySeedProgress)
 		w.primarySeed = primarySeed
-		w.updateFutureKeys(primarySeedProgress)
+		w.regenerateLookahead(primarySeedProgress)
 
 		// auxiliarySeedFiles
 		for _, sf := range auxiliarySeedFiles {
@@ -336,7 +336,7 @@ func (w *Wallet) Reset() error {
 	}
 	w.wipeSecrets()
 	w.keys = make(map[types.UnlockHash]spendableKey)
-	w.futureKeys = make(map[types.UnlockHash]bool)
+	w.lookahead = make(map[types.UnlockHash]uint64)
 	w.seeds = []modules.Seed{}
 	w.unconfirmedProcessedTransactions = []modules.ProcessedTransaction{}
 	w.unlocked = false

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -431,6 +431,8 @@ func TestReset(t *testing.T) {
 	postEncryptionTesting(wt.miner, wt.wallet, newKey)
 }
 
+// TestChangeKey tests that a wallet can only be unlocked with the new key
+// after changing it and that it shows the same balance as before
 func TestChangeKey(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -93,6 +93,23 @@ func decryptSeedFile(masterKey crypto.TwofishKey, sf seedFile) (seed modules.See
 	return seed, nil
 }
 
+// maxFutureKeys is a helper function from a given start index
+// which usually is the current primarySeedProgress
+func maxFutureKeys(start uint64) uint64 {
+	return start + 5000 + start/10
+}
+
+// updateFutureKeys creates future keys up to a maximum of maxKeys keys
+func (w *Wallet) updateFutureKeys(start uint64) {
+	// Check how many keys need to be generated
+	maxKeys := maxFutureKeys(start)
+	existingKeys := uint64(len(w.futureKeys))
+
+	for _, k := range generateKeys(w.primarySeed, start+existingKeys, maxKeys-existingKeys) {
+		w.futureKeys[k.UnlockConditions.UnlockHash()] = true
+	}
+}
+
 // integrateSeed generates n spendableKeys from the seed and loads them into
 // the wallet.
 func (w *Wallet) integrateSeed(seed modules.Seed, n uint64) {
@@ -120,6 +137,11 @@ func (w *Wallet) nextPrimarySeedAddress(tx *bolt.Tx) (types.UnlockConditions, er
 	// conditions.
 	spendableKey := generateSpendableKey(w.primarySeed, progress)
 	w.keys[spendableKey.UnlockConditions.UnlockHash()] = spendableKey
+
+	// Remove new key from the future keys and update them according to new progress
+	delete(w.futureKeys, spendableKey.UnlockConditions.UnlockHash())
+	w.updateFutureKeys(progress + 1)
+
 	return spendableKey.UnlockConditions, nil
 }
 

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -217,10 +217,10 @@ func (w *Wallet) LoadSeed(masterKey crypto.TwofishKey, seed modules.Seed) error 
 	if err := s.scan(w.cs); err != nil {
 		return err
 	}
-	// Add 10% as a buffer because the seed may have addresses in the wild
+	// Add 4% as a buffer because the seed may have addresses in the wild
 	// that have not appeared in the blockchain yet.
-	seedProgress := s.largestIndexSeen + 1
-	seedProgress += seedProgress / 10
+	seedProgress := s.largestIndexSeen + 500
+	seedProgress += seedProgress / 25
 	w.log.Printf("INFO: found key index %v in blockchain. Setting auxiliary seed progress to %v", s.largestIndexSeen, seedProgress)
 
 	err := func() error {

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -18,59 +18,46 @@ type historicOutput struct {
 	val types.Currency
 }
 
-// isFutureWalletAddress is a helper function that checks if an UnlockHash is
-// derived from one of the wallet's future keys. If it is all future keys up to
-// this one will be added to the spendable keys or a blockhain rescan will be
-// initiated
-func (w *Wallet) isFutureWalletAddress(uh types.UnlockHash) bool {
-	if _, exists := w.futureKeys[uh]; !exists {
-		return false
+// advanceSeedLookahead is a helper function that checks if an UnlockHash is
+// derived from one of the wallet's lookahead keys. If it is all lookahead keys up to
+// this one will be added to the spendable keys
+func (w *Wallet) advanceSeedLookahead(index uint64) {
+	progress, err := dbGetPrimarySeedProgress(w.dbTx)
+	if err != nil {
+		return
 	}
 
-	// generate and add spendable keys until the future key is present in w.keys
-	foundKey := false
-	for i := 0; i < 1000; i++ {
-		_, err := w.nextPrimarySeedAddress(w.dbTx)
-		if err != nil {
-			return false
-		}
-
-		if _, exists := w.keys[uh]; exists {
-			foundKey = true
-			break
-		}
+	// Add spendable keys and remove them from lookahead
+	spendableKeys := generateKeys(w.primarySeed, progress, index-progress+1)
+	for _, key := range spendableKeys {
+		w.keys[key.UnlockConditions.UnlockHash()] = key
+		delete(w.lookahead, key.UnlockConditions.UnlockHash())
 	}
 
-	// if future key was not among the next 1000 keys rescan the blockchain
-	if !foundKey {
-		// TODO: rescan blockchain
-		/*
-			w.cs.Unsubscribe(w)
-			w.tpool.Unsubscribe(w)
-
-			done := make(chan struct{})
-			go w.rescanMessage(done)
-			defer close(done)
-
-			err := w.cs.ConsensusSetSubscribe(w, modules.ConsensusChangeBeginning)
-			if err != nil {
-				// TODO: error handling
-			}
-			w.tpool.TransactionPoolSubscribe(w)
-
-		*/
-		return false
+	// Update the primarySeedProgress
+	newProgress := progress + uint64(len(spendableKeys))
+	dbPutPrimarySeedProgress(w.dbTx, newProgress)
+	if err != nil {
+		return
 	}
 
-	return true
+	// Regenerate lookahead
+	w.regenerateLookahead(newProgress)
 }
 
 // isWalletAddress is a helper function that checks if an UnlockHash is
 // derived from one of the wallet's spendable keys or future keys.
 func (w *Wallet) isWalletAddress(uh types.UnlockHash) bool {
 	_, exists := w.keys[uh]
-	if !exists {
-		exists = w.isFutureWalletAddress(uh)
+	if exists {
+		return true
+	}
+
+	// check keys in lookahead
+	index, exists := w.lookahead[uh]
+	if exists {
+		// advance the lookahead accordingly
+		w.advanceSeedLookahead(index)
 	}
 	return exists
 }

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -18,9 +18,10 @@ type historicOutput struct {
 	val types.Currency
 }
 
-// advanceSeedLookahead is a helper function that checks if an UnlockHash is
-// derived from one of the wallet's lookahead keys. If it is all lookahead keys up to
-// this one will be added to the spendable keys
+// advanceSeedLookahead generates all keys from the current primary seed
+// progress up to index and adds them to the set of spendable keys.
+// Therefore the new primary seed progress will be index+1 and new
+// lookahead keys will be generated starting from index+1
 func (w *Wallet) advanceSeedLookahead(index uint64) {
 	progress, err := dbGetPrimarySeedProgress(w.dbTx)
 	if err != nil {

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -64,7 +64,7 @@ func (w *Wallet) advanceSeedLookahead(index uint64) error {
 
 	// If more than lookaheadRescanThreshold keys were generated
 	// also initialize a rescan just to be safe.
-	if len(spendableKeys) > lookaheadRescanThreshold {
+	if uint64(len(spendableKeys)) > lookaheadRescanThreshold {
 		go w.threadedResetSubscriptions()
 	}
 

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -68,9 +68,9 @@ type Wallet struct {
 	// from the seeds, when checking new outputs or spending outputs, the seeds
 	// are not referenced at all. The seeds are only stored so that the user
 	// may access them.
-	seeds      []modules.Seed
-	keys       map[types.UnlockHash]spendableKey
-	futureKeys map[types.UnlockHash]bool
+	seeds     []modules.Seed
+	keys      map[types.UnlockHash]spendableKey
+	lookahead map[types.UnlockHash]uint64
 
 	// unconfirmedProcessedTransactions tracks unconfirmed transactions.
 	unconfirmedProcessedTransactions []modules.ProcessedTransaction
@@ -113,8 +113,8 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		cs:    cs,
 		tpool: tpool,
 
-		keys:       make(map[types.UnlockHash]spendableKey),
-		futureKeys: make(map[types.UnlockHash]bool),
+		keys:      make(map[types.UnlockHash]spendableKey),
+		lookahead: make(map[types.UnlockHash]uint64),
 
 		persistDir: persistDir,
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -68,8 +68,9 @@ type Wallet struct {
 	// from the seeds, when checking new outputs or spending outputs, the seeds
 	// are not referenced at all. The seeds are only stored so that the user
 	// may access them.
-	seeds []modules.Seed
-	keys  map[types.UnlockHash]spendableKey
+	seeds      []modules.Seed
+	keys       map[types.UnlockHash]spendableKey
+	futureKeys map[types.UnlockHash]bool
 
 	// unconfirmedProcessedTransactions tracks unconfirmed transactions.
 	unconfirmedProcessedTransactions []modules.ProcessedTransaction
@@ -112,7 +113,8 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		cs:    cs,
 		tpool: tpool,
 
-		keys: make(map[types.UnlockHash]spendableKey),
+		keys:       make(map[types.UnlockHash]spendableKey),
+		futureKeys: make(map[types.UnlockHash]bool),
 
 		persistDir: persistDir,
 	}

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -318,13 +318,13 @@ func TestLookaheadGeneration(t *testing.T) {
 	}
 
 	wt.wallet.mu.RLock()
+	defer wt.wallet.mu.RUnlock()
 	for i := range wt.wallet.keys {
 		_, exists := wt.wallet.lookahead[i]
 		if exists {
-			t.Fatal("wallet.keys contained a key which is also present in wallet.futurekeys")
+			t.Fatal("wallet keys contained a key which is also present in lookahead")
 		}
 	}
-	wt.wallet.mu.RUnlock()
 }
 
 // TestAdvanceLookaheadNoRescan tests if a transaction to multiple lookahead addresses
@@ -385,10 +385,11 @@ func TestAdvanceLookaheadNoRescan(t *testing.T) {
 
 	// Check if the receiving addresses were moved from future keys to keys
 	wt.wallet.mu.RLock()
+	defer wt.wallet.mu.RUnlock()
 	for _, uh := range receivingAddresses {
 		_, exists := wt.wallet.lookahead[uh]
 		if exists {
-			t.Fatal("UnlockHash still exists in wallet.lookahead")
+			t.Fatal("UnlockHash still exists in wallet lookahead")
 		}
 
 		_, exists = wt.wallet.keys[uh]
@@ -396,7 +397,6 @@ func TestAdvanceLookaheadNoRescan(t *testing.T) {
 			t.Fatal("UnlockHash not in map of spendable keys")
 		}
 	}
-	wt.wallet.mu.RUnlock()
 }
 
 // TestAdvanceLookaheadNoRescan tests if a transaction to multiple lookahead addresses
@@ -411,36 +411,71 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 	}
 	defer wt.closeWt()
 
-	builder := wt.wallet.StartTransaction()
-	payout := types.ZeroCurrency
+	// Mine blocks without payouts so that the balance stabilizes
+	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
+		wt.addBlockNoPayout()
+	}
 
-	// Get the current progress
+	// Get the current progress and balance
 	wt.wallet.mu.RLock()
 	progress, err := dbGetPrimarySeedProgress(wt.wallet.dbTx)
 	wt.wallet.mu.RUnlock()
 	if err != nil {
 		t.Fatal("Couldn't fetch primary seed from db")
 	}
+	startBal, _, _ := wt.wallet.ConfirmedBalance()
+
+	// Send coins to an address with a high seed index, just outside the
+	// lookahead range. It will not be initially detected, but later the
+	// rescan should find it.
+	highIndex := progress + uint64(len(wt.wallet.lookahead)) + 5
+	farAddr := generateSpendableKey(wt.wallet.primarySeed, highIndex).UnlockConditions.UnlockHash()
+	farPayout := types.SiacoinPrecision.Mul64(8888)
+
+	builder := wt.wallet.StartTransaction()
+	builder.AddSiacoinOutput(types.SiacoinOutput{
+		UnlockHash: farAddr,
+		Value:      farPayout,
+	})
+	err = builder.FundSiacoins(farPayout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txnSet, err := builder.Sign(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = wt.tpool.AcceptTransactionSet(txnSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt.addBlockNoPayout()
+	newBal, _, _ := wt.wallet.ConfirmedBalance()
+	if !startBal.Sub(newBal).Equals(farPayout) {
+		t.Fatal("wallet should not recognize coins sent to very high seed index")
+	}
+
+	builder = wt.wallet.StartTransaction()
+	var payout types.Currency
 
 	// choose 10 keys in the lookahead and remember them
 	var receivingAddresses []types.UnlockHash
 	for uh, index := range wt.wallet.lookahead {
-
 		// Only choose keys that force a rescan
 		if index < progress+lookaheadRescanThreshold {
 			continue
 		}
-
 		sco := types.SiacoinOutput{
 			UnlockHash: uh,
-			Value:      types.NewCurrency64(1e3),
+			Value:      types.SiacoinPrecision.Mul64(1000),
 		}
-
 		builder.AddSiacoinOutput(sco)
 		payout = payout.Add(sco.Value)
 		receivingAddresses = append(receivingAddresses, uh)
 
-		if len(receivingAddresses) > 10 {
+		if len(receivingAddresses) >= 10 {
 			break
 		}
 	}
@@ -450,30 +485,33 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tSet, err := builder.Sign(true)
+	txnSet, err = builder.Sign(true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = wt.tpool.AcceptTransactionSet(tSet)
+	err = wt.tpool.AcceptTransactionSet(txnSet)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = wt.miner.AddBlock()
-	if err != nil {
-		t.Fatal(err)
-	}
+	wt.addBlockNoPayout()
 
 	// Allow the wallet rescan to finish
-	time.Sleep(time.Second * 5)
+	time.Sleep(time.Second * 2)
+
+	// Check that high seed index txn was discovered in the rescan
+	rescanBal, _, _ := wt.wallet.ConfirmedBalance()
+	if !rescanBal.Equals(startBal) {
+		t.Fatal("wallet did not discover txn after rescan")
+	}
 
 	// Check if the receiving addresses were moved from future keys to keys
 	wt.wallet.mu.RLock()
+	defer wt.wallet.mu.RUnlock()
 	for _, uh := range receivingAddresses {
 		_, exists := wt.wallet.lookahead[uh]
 		if exists {
-			t.Fatal("UnlockHash still exists in wallet.lookahead")
+			t.Fatal("UnlockHash still exists in wallet lookahead")
 		}
 
 		_, exists = wt.wallet.keys[uh]
@@ -481,5 +519,75 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 			t.Fatal("UnlockHash not in map of spendable keys")
 		}
 	}
-	wt.wallet.mu.RUnlock()
+}
+
+// TestDistantWallets tests if two wallets that use the same seed stay
+// synchronized.
+func TestDistantWallets(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	wt, err := createWalletTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	// Create another wallet with the same seed.
+	w2, err := New(wt.cs, wt.tpool, build.TempDir(modules.WalletDir, t.Name()+"2", modules.WalletDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w2.InitFromSeed(crypto.TwofishKey{}, wt.wallet.primarySeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w2.Unlock(crypto.TwofishKey(crypto.HashObject(wt.wallet.primarySeed)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use the first wallet.
+	for i := uint64(0); i < lookaheadBuffer/2; i++ {
+		_, err = wt.wallet.SendSiacoins(types.SiacoinPrecision, types.UnlockHash{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wt.addBlockNoPayout()
+	}
+
+	// The second wallet's balance should update accordingly.
+	w1bal, _, _ := wt.wallet.ConfirmedBalance()
+	w2bal, _, _ := w2.ConfirmedBalance()
+
+	if !w1bal.Equals(w2bal) {
+		t.Fatal("balances do not match:", w1bal, w2bal)
+	}
+
+	// Send coins to an address with a very high seed index, outside the
+	// lookahead range. w2 should not detect it.
+	tbuilder := wt.wallet.StartTransaction()
+	farAddr := generateSpendableKey(wt.wallet.primarySeed, lookaheadBuffer*10).UnlockConditions.UnlockHash()
+	value := types.SiacoinPrecision.Mul64(1e3)
+	tbuilder.AddSiacoinOutput(types.SiacoinOutput{
+		UnlockHash: farAddr,
+		Value:      value,
+	})
+	err = tbuilder.FundSiacoins(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txnSet, err := tbuilder.Sign(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = wt.tpool.AcceptTransactionSet(txnSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt.addBlockNoPayout()
+
+	if newBal, _, _ := w2.ConfirmedBalance(); !newBal.Equals(w2bal.Sub(value)) {
+		t.Fatal("wallet should not recognize coins sent to very high seed index")
+	}
 }

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -289,10 +289,10 @@ func TestFutureAddressGeneration(t *testing.T) {
 		t.Fatal("Couldn't fetch primary seed from db")
 	}
 
-	actualKeys := uint64(len(wt.wallet.futureKeys))
-	expectedKeys := maxFutureKeys(progress)
+	actualKeys := uint64(len(wt.wallet.lookahead))
+	expectedKeys := maxLookahead(progress)
 	if actualKeys != expectedKeys {
-		t.Errorf("expected len(futureKeys) == %d but was %d", actualKeys, expectedKeys)
+		t.Errorf("expected len(lookahead) == %d but was %d", actualKeys, expectedKeys)
 	}
 
 	// Generate some more keys
@@ -311,15 +311,15 @@ func TestFutureAddressGeneration(t *testing.T) {
 		t.Fatal("Couldn't fetch primary seed from db")
 	}
 
-	actualKeys = uint64(len(wt.wallet.futureKeys))
-	expectedKeys = maxFutureKeys(progress)
+	actualKeys = uint64(len(wt.wallet.lookahead))
+	expectedKeys = maxLookahead(progress)
 	if actualKeys != expectedKeys {
-		t.Errorf("expected len(futureKeys) == %d but was %d", actualKeys, expectedKeys)
+		t.Errorf("expected len(lookahead) == %d but was %d", actualKeys, expectedKeys)
 	}
 
 	wt.wallet.mu.RLock()
 	for i := range wt.wallet.keys {
-		_, exists := wt.wallet.futureKeys[i]
+		_, exists := wt.wallet.lookahead[i]
 		if exists {
 			t.Fatal("wallet.keys contained a key which is also present in wallet.futurekeys")
 		}
@@ -343,7 +343,7 @@ func TestFutureAddressReceive(t *testing.T) {
 
 	// choose 10 of the future keys and remember them
 	var receivingAddresses []types.UnlockHash
-	for uh := range wt.wallet.futureKeys {
+	for uh := range wt.wallet.lookahead {
 		sco := types.SiacoinOutput{
 			UnlockHash: uh,
 			Value:      types.NewCurrency64(1e3),
@@ -381,9 +381,9 @@ func TestFutureAddressReceive(t *testing.T) {
 	// Check if the receiving addresses were moved from future keys to keys
 	wt.wallet.mu.RLock()
 	for _, uh := range receivingAddresses {
-		_, exists := wt.wallet.futureKeys[uh]
+		_, exists := wt.wallet.lookahead[uh]
 		if exists {
-			t.Fatal("UnlockHash still exists in wallet.futureKeys")
+			t.Fatal("UnlockHash still exists in wallet.lookahead")
 		}
 
 		_, exists = wt.wallet.keys[uh]

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -352,25 +352,15 @@ func TestAdvanceLookaheadNoRescan(t *testing.T) {
 
 	// choose 10 keys in the lookahead and remember them
 	var receivingAddresses []types.UnlockHash
-	for uh, index := range wt.wallet.lookahead {
-
-		// Ignore keys that would force a rescan
-		if index > progress+lookaheadRescanThreshold {
-			continue
-		}
-
+	for _, sk := range generateKeys(wt.wallet.primarySeed, progress, 10) {
 		sco := types.SiacoinOutput{
-			UnlockHash: uh,
+			UnlockHash: sk.UnlockConditions.UnlockHash(),
 			Value:      types.NewCurrency64(1e3),
 		}
 
 		builder.AddSiacoinOutput(sco)
 		payout = payout.Add(sco.Value)
-		receivingAddresses = append(receivingAddresses, uh)
-
-		if len(receivingAddresses) > 10 {
-			break
-		}
+		receivingAddresses = append(receivingAddresses, sk.UnlockConditions.UnlockHash())
 	}
 
 	err = builder.FundSiacoins(payout)


### PR DESCRIPTION
Add look ahead safety to wallet by generating 5000 + 10% more addresses than the current "SeedProgress" and looking for transactions on those addresses. If one of those addresses receives coins the SeedProgress and buffer will be updated accordingly. If one address past the first 1000 in the buffer receives coins a full rescan will be initiated. 