### PR TITLE
switch to diff-based updates for tpool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ test-v:
 	go test -race -v -short -tags='debug testing' -timeout=15s $(pkgs) -run=$(run)
 test-long: clean fmt vet lint
 	go test -v -race -tags='testing debug' -timeout=500s $(pkgs) -run=$(run)
+test-cpu:
+	go test -v -tags='testing debug' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)
+test-mem:
+	go test -v -tags='testing debug' -timeout=500s -memprofile mem.prof $(pkgs) -run=$(run)
 bench: clean fmt
 	go test -tags='debug testing' -timeout=500s -run=XXX -bench=$(run) $(pkgs)
 cover: clean

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -52,6 +52,8 @@ func validSiacoins(tx *bolt.Tx, t types.Transaction) error {
 		inputSum = inputSum.Add(sco.Value)
 	}
 	if !inputSum.Equals(t.SiacoinOutputSum()) {
+		println(inputSum.String())
+		println(t.SiacoinOutputSum().String())
 		return errSiacoinInputOutputMismatch
 	}
 	return nil

--- a/modules/consensus/validtransaction.go
+++ b/modules/consensus/validtransaction.go
@@ -52,8 +52,6 @@ func validSiacoins(tx *bolt.Tx, t types.Transaction) error {
 		inputSum = inputSum.Add(sco.Value)
 	}
 	if !inputSum.Equals(t.SiacoinOutputSum()) {
-		println(inputSum.String())
-		println(t.SiacoinOutputSum().String())
 		return errSiacoinInputOutputMismatch
 	}
 	return nil

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -48,6 +48,16 @@ var (
 	}).(time.Duration)
 )
 
+// splitSet defines a transaction set that can be added componenet-wise to a
+// block. It's split because it doesn't necessarily represent the full set
+// prpovided by the transaction pool. Splits can be sorted so that the largest
+// and most valuable sets can be selected when picking transactions.
+type splitSet struct {
+	averageFee   types.Currency
+	size         int
+	transactions []types.Transaction
+}
+
 // Miner struct contains all variables the miner needs
 // in order to create and submit blocks.
 type Miner struct {
@@ -73,6 +83,11 @@ type Miner struct {
 	sourceBlock     *types.Block                                   // The block from which new headers for mining are created.
 	sourceBlockTime time.Time                                      // How long headers have been using the same block (different from 'recent block').
 	memProgress     int                                            // The index of the most recent header used in headerMem.
+
+	// Transaction pool variables.
+	fullSets   map[crypto.Hash][]int
+	setCounter int
+	splitSets  map[int]splitSet
 
 	// CPUMiner variables.
 	miningOn bool  // indicates if the miner is supposed to be running
@@ -148,6 +163,9 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 		blockMem:   make(map[types.BlockHeader]*types.Block),
 		arbDataMem: make(map[types.BlockHeader][crypto.EntropySize]byte),
 		headerMem:  make([]types.BlockHeader, HeaderMemory),
+
+		fullSets:  make(map[crypto.Hash][]int),
+		splitSets: make(map[int]splitSet),
 
 		persistDir: persistDir,
 	}

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -54,7 +54,7 @@ var (
 // and most valuable sets can be selected when picking transactions.
 type splitSet struct {
 	averageFee   types.Currency
-	size         int
+	size         uint64
 	transactions []types.Transaction
 }
 
@@ -85,7 +85,7 @@ type Miner struct {
 	memProgress     int                                            // The index of the most recent header used in headerMem.
 
 	// Transaction pool variables.
-	fullSets   map[crypto.Hash][]int
+	fullSets   map[modules.TransactionSetID][]int
 	setCounter int
 	splitSets  map[int]splitSet
 
@@ -164,7 +164,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 		arbDataMem: make(map[types.BlockHeader][crypto.EntropySize]byte),
 		headerMem:  make([]types.BlockHeader, HeaderMemory),
 
-		fullSets:  make(map[crypto.Hash][]int),
+		fullSets:  make(map[modules.TransactionSetID][]int),
 		splitSets: make(map[int]splitSet),
 
 		persistDir: persistDir,

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -87,7 +87,7 @@ type Miner struct {
 	// Transaction pool variables.
 	fullSets   map[modules.TransactionSetID][]int
 	setCounter int
-	splitSets  map[int]splitSet
+	splitSets  map[int]*splitSet
 
 	// CPUMiner variables.
 	miningOn bool  // indicates if the miner is supposed to be running
@@ -165,7 +165,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, w modules.Walle
 		headerMem:  make([]types.BlockHeader, HeaderMemory),
 
 		fullSets:  make(map[modules.TransactionSetID][]int),
-		splitSets: make(map[int]splitSet),
+		splitSets: make(map[int]*splitSet),
 
 		persistDir: persistDir,
 	}

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -7,6 +7,91 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// addNewTxns adds new unconfirmed transactions to the miner's transaction
+// selection.
+func (m *Miner) addNewTxns(diff *modules.TransactionPoolDiff) {
+	// Split the new sets and add the splits to the list of transactions we pull
+	// form.
+	for _, newSet := range diff.AppliedTransactions {
+		// Split the sets into smaller sets, and add them to the list of
+		// transactions the miner can draw from.
+		//
+		// TODO: Split the one set into a bunch of smaller sets using the cp4p
+		// splitter.
+		m.setCounter++
+		m.fullSets[newSet.ID] = []int{m.setCounter}
+		var size uint64
+		var totalFees types.Currency
+		for i := range newSet.IDs {
+			size += newSet.Sizes[i]
+			for _, fee := range newSet.Transactions[i].MinerFees {
+				totalFees = totalFees.Add(fee)
+			}
+		}
+		m.splitSets[m.setCounter] = &splitSet{
+			size:         size,
+			averageFee:   totalFees.Div64(size),
+			transactions: newSet.Transactions,
+		}
+	}
+}
+
+// deleteReverts deletes transactions from the miner's transaction selection
+// which are no longer in the transaction pool.
+func (m *Miner) deleteReverts(diff *modules.TransactionPoolDiff) {
+	// Delete the sets that are no longer useful. That means recognizing which
+	// of your splits belong to the missing sets.
+	for _, id := range diff.RevertedTransactions {
+		// Look up all of the split sets associated with the set being reverted,
+		// and delete them. Then delete the lookups from the list of full sets
+		// as well.
+		splitSetIndexes := m.fullSets[id]
+		for _, ss := range splitSetIndexes {
+			delete(m.splitSets, ss)
+		}
+		delete(m.fullSets, id)
+	}
+}
+
+// pickNewTransactions picks new transactions after the transaction pool has
+// presented more 
+func (m *Miner) pickNewTransactions(diff *modules.TransactionPoolDiff) {
+	// Sort the split sets and select the BlockSizeLimit most valueable sets.
+	sortedSets := make([]*splitSet, 0, len(m.splitSets))
+	for i := range m.splitSets {
+		sortedSets = append(sortedSets, m.splitSets[i])
+	}
+	sort.Slice(sortedSets, func(i, j int) bool {
+		return sortedSets[i].averageFee.Cmp(sortedSets[j].averageFee) < 0
+	})
+
+	// In a memory-efficient way, re-fill the block with the new transactions.
+	var totalSets int
+	var totalSize uint64
+	var numTxns int
+	for _, set := range sortedSets {
+		totalSize += set.size
+		if totalSize > types.BlockSizeLimit-5e3 {
+			break
+		}
+		totalSets++
+		numTxns += len(set.transactions)
+	}
+	if numTxns > cap(m.persist.UnsolvedBlock.Transactions) {
+		m.persist.UnsolvedBlock.Transactions = make([]types.Transaction, 0, numTxns)
+	} else {
+		m.persist.UnsolvedBlock.Transactions = m.persist.UnsolvedBlock.Transactions[:0]
+	}
+	totalSize = 0
+	for _, set := range sortedSets[:totalSets] {
+		totalSize += set.size
+		m.persist.UnsolvedBlock.Transactions = append(m.persist.UnsolvedBlock.Transactions, set.transactions...)
+		if totalSize > types.BlockSizeLimit-5e3 {
+			break
+		}
+	}
+}
+
 // ProcessConsensusDigest will update the miner's most recent block.
 func (m *Miner) ProcessConsensusChange(cc modules.ConsensusChange) {
 	m.mu.Lock()
@@ -57,61 +142,7 @@ func (m *Miner) ReceiveUpdatedUnconfirmedTransactions(diff *modules.TransactionP
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Delete the sets that are no longer useful. That means recognizing which
-	// of your splits belong to the missing sets.
-	for _, id := range diff.RevertedTransactions {
-		// Look up all of the split sets associated with the set being reverted,
-		// and delete them. Then delete the lookups from the list of full sets
-		// as well.
-		splitSetIndexes := m.fullSets[id]
-		for _, ss := range splitSetIndexes {
-			delete(m.splitSets, ss)
-		}
-		delete(m.fullSets, id)
-	}
-
-	// Split the new sets and add the splits to the list of transactions we pull
-	// form.
-	for _, newSet := range diff.AppliedTransactions {
-		// Split the sets into smaller sets, and add them to the list of
-		// transactions the miner can draw from.
-		//
-		// TODO: Split the one set into a bunch of smaller sets using the cp4p
-		// splitter.
-		m.setCounter++
-		m.fullSets[newSet.ID] = []int{m.setCounter}
-		var size uint64
-		var totalFees types.Currency
-		for i := range newSet.IDs {
-			size += newSet.Sizes[i]
-			for _, fee := range newSet.Transactions[i].MinerFees {
-				totalFees = totalFees.Add(fee)
-			}
-		}
-		m.splitSets[m.setCounter] = splitSet{
-			size:         size,
-			averageFee:   totalFees.Div64(size),
-			transactions: newSet.Transactions,
-		}
-	}
-
-	// Sort the split sets and select the BlockSizeLimit most valueable sets.
-	sortedSets := make([]splitSet, 0, len(m.splitSets))
-	for i := range m.splitSets {
-		sortedSets = append(sortedSets, m.splitSets[i])
-	}
-	sort.Slice(sortedSets, func(i, j int) bool {
-		return sortedSets[i].averageFee.Cmp(sortedSets[j].averageFee) < 0
-	})
-	var totalSize uint64
-	m.persist.UnsolvedBlock.Transactions = nil
-	for _, set := range m.splitSets {
-		totalSize += set.size
-		if totalSize > types.BlockSizeLimit-5e3 {
-			// There is no longer enough room to add this transction set. Stop
-			// here.
-			break
-		}
-		m.persist.UnsolvedBlock.Transactions = append(m.persist.UnsolvedBlock.Transactions, set.transactions...)
-	}
+	m.deleteReverts(diff)
+	m.addNewTxns(diff)
+	m.pickNewTransactions(diff)
 }

--- a/modules/miner/update.go
+++ b/modules/miner/update.go
@@ -54,7 +54,7 @@ func (m *Miner) deleteReverts(diff *modules.TransactionPoolDiff) {
 }
 
 // pickNewTransactions picks new transactions after the transaction pool has
-// presented more 
+// presented more
 func (m *Miner) pickNewTransactions(diff *modules.TransactionPoolDiff) {
 	// Sort the split sets and select the BlockSizeLimit most valueable sets.
 	sortedSets := make([]*splitSet, 0, len(m.splitSets))

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -52,83 +52,97 @@ var (
 	TransactionPoolDir = "transactionpool"
 )
 
-// A TransactionSetDiff indicates the adding or removal of a transaction set to
-// the transaction pool. The transactions in the pool are not persisted, so at
-// startup modules should assume an empty transaction pool.
-//
-// If 'Direction' is true, the transaction set has been added to the transaction
-// pool, and the transactions along with a complete consensus change will be
-// included. If 'Direction' is false, the transaction set has been removed, so
-// no transactions or consensus change will be provided.
-type TransactionSetDiff struct {
-	Change       ConsensusChange
-	Direction    DiffDirection
-	ID           crypto.Hash
-	Transactions []types.Transaction
-}
+type (
+	// ConsensusConflict implements the error interface, and indicates that a
+	// transaction was rejected due to being incompatible with the current
+	// consensus set, meaning either a double spend or a consensus rule violation -
+	// it is unlikely that the transaction will ever be valid.
+	ConsensusConflict string
 
-// A TransactionPoolSubscriber receives updates about the confirmed and
-// unconfirmed set from the transaction pool. Generally, there is no need to
-// subscribe to both the consensus set and the transaction pool.
-type TransactionPoolSubscriber interface {
-	// ReceiveTransactionPoolUpdate notifies subscribers of a change to the
-	// consensus set and/or unconfirmed set, and includes the consensus change
-	// that would result if all of the transactions made it into a block.
-	ReceiveUpdatedUnconfirmedTransactions([]*TransactionSetDiff)
-}
+	// TransactionSetID is a type-safe wrapper for a crypto.Hash that represents
+	// the ID of an entire transaction set.
+	TransactionSetID crypto.Hash
 
-// A TransactionPool manages unconfirmed transactions.
-type TransactionPool interface {
-	// AcceptTransactionSet accepts a set of potentially interdependent
-	// transactions.
-	AcceptTransactionSet([]types.Transaction) error
+	// A TransactionPoolDiff indicates the adding or removal of a transaction set to
+	// the transaction pool. The transactions in the pool are not persisted, so at
+	// startup modules should assume an empty transaction pool.
+	TransactionPoolDiff struct {
+		AppliedTransactions  []*UnconfirmedTransactionSet
+		RevertedTransactions []TransactionSetID
+	}
 
-	// Broadcast broadcasts a transaction set to all of the transaction pool's
-	// peers.
-	Broadcast(ts []types.Transaction)
+	// UnconfirmedTransactionSet defines a new unconfirmed transaction that has
+	// been added to the transaction pool. ID is the ID of the set, IDs contians
+	// an ID for each transaction, eliminating the need to recompute it (because
+	// that's an expensive operation).
+	UnconfirmedTransactionSet struct {
+		Change *ConsensusChange
+		ID     TransactionSetID
 
-	// Close is necessary for clean shutdown (e.g. during testing).
-	Close() error
+		IDs          []types.TransactionID
+		Sizes        []uint64
+		Transactions []types.Transaction
+	}
+)
 
-	// FeeEstimation returns an estimation for how high the transaction fee
-	// needs to be per byte. The minimum recommended targets getting accepted
-	// in ~3 blocks, and the maximum recommended targets getting accepted
-	// immediately. Taking the average has a moderate chance of being accepted
-	// within one block. The minimum has a strong chance of getting accepted
-	// within 10 blocks.
-	FeeEstimation() (minimumRecommended, maximumRecommended types.Currency)
+type (
+	// A TransactionPoolSubscriber receives updates about the confirmed and
+	// unconfirmed set from the transaction pool. Generally, there is no need to
+	// subscribe to both the consensus set and the transaction pool.
+	TransactionPoolSubscriber interface {
+		// ReceiveTransactionPoolUpdate notifies subscribers of a change to the
+		// consensus set and/or unconfirmed set, and includes the consensus change
+		// that would result if all of the transactions made it into a block.
+		ReceiveUpdatedUnconfirmedTransactions(*TransactionPoolDiff)
+	}
 
-	// PurgeTransactionPool is a temporary function available to the miner. In
-	// the event that a miner mines an unacceptable block, the transaction pool
-	// will be purged to clear out the transaction pool and get rid of the
-	// illegal transaction. This should never happen, however there are bugs
-	// that make this condition necessary.
-	PurgeTransactionPool()
+	// A TransactionPool manages unconfirmed transactions.
+	TransactionPool interface {
+		// AcceptTransactionSet accepts a set of potentially interdependent
+		// transactions.
+		AcceptTransactionSet([]types.Transaction) error
 
-	// TransactionList returns a list of all transactions in the transaction
-	// pool. The transactions are provided in an order that can acceptably be
-	// put into a block.
-	TransactionList() []types.Transaction
+		// Broadcast broadcasts a transaction set to all of the transaction pool's
+		// peers.
+		Broadcast(ts []types.Transaction)
 
-	// TransactionPoolSubscribe adds a subscriber to the transaction pool.
-	// Subscribers will receive all consensus set changes as well as
-	// transaction pool changes, and should not subscribe to both.
-	TransactionPoolSubscribe(TransactionPoolSubscriber)
+		// Close is necessary for clean shutdown (e.g. during testing).
+		Close() error
 
-	// Transaction returns the transaction and unconfirmed parents
-	// corresponding to the provided transaction id.
-	Transaction(id types.TransactionID) (txn types.Transaction, unconfirmedParents []types.Transaction, exists bool)
+		// FeeEstimation returns an estimation for how high the transaction fee
+		// needs to be per byte. The minimum recommended targets getting accepted
+		// in ~3 blocks, and the maximum recommended targets getting accepted
+		// immediately. Taking the average has a moderate chance of being accepted
+		// within one block. The minimum has a strong chance of getting accepted
+		// within 10 blocks.
+		FeeEstimation() (minimumRecommended, maximumRecommended types.Currency)
 
-	// Unsubscribe removes a subscriber from the transaction pool.
-	// This is necessary for clean shutdown of the miner.
-	Unsubscribe(TransactionPoolSubscriber)
-}
+		// PurgeTransactionPool is a temporary function available to the miner. In
+		// the event that a miner mines an unacceptable block, the transaction pool
+		// will be purged to clear out the transaction pool and get rid of the
+		// illegal transaction. This should never happen, however there are bugs
+		// that make this condition necessary.
+		PurgeTransactionPool()
 
-// ConsensusConflict implements the error interface, and indicates that a
-// transaction was rejected due to being incompatible with the current
-// consensus set, meaning either a double spend or a consensus rule violation -
-// it is unlikely that the transaction will ever be valid.
-type ConsensusConflict string
+		// TransactionList returns a list of all transactions in the transaction
+		// pool. The transactions are provided in an order that can acceptably be
+		// put into a block.
+		TransactionList() []types.Transaction
+
+		// TransactionPoolSubscribe adds a subscriber to the transaction pool.
+		// Subscribers will receive all consensus set changes as well as
+		// transaction pool changes, and should not subscribe to both.
+		TransactionPoolSubscribe(TransactionPoolSubscriber)
+
+		// Transaction returns the transaction and unconfirmed parents
+		// corresponding to the provided transaction id.
+		Transaction(id types.TransactionID) (txn types.Transaction, unconfirmedParents []types.Transaction, exists bool)
+
+		// Unsubscribe removes a subscriber from the transaction pool.
+		// This is necessary for clean shutdown of the miner.
+		Unsubscribe(TransactionPoolSubscriber)
+	}
+)
 
 // NewConsensusConflict returns a consensus conflict, which implements the
 // error interface.

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"errors"
 
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -51,6 +52,21 @@ var (
 	TransactionPoolDir = "transactionpool"
 )
 
+// A TransactionSetDiff indicates the adding or removal of a transaction set to
+// the transaction pool. The transactions in the pool are not persisted, so at
+// startup modules should assume an empty transaction pool.
+//
+// If 'Direction' is true, the transaction set has been added to the transaction
+// pool, and the transactions along with a complete consensus change will be
+// included. If 'Direction' is false, the transaction set has been removed, so
+// no transactions or consensus change will be provided.
+type TransactionSetDiff struct {
+	Change       ConsensusChange
+	Direction    DiffDirection
+	ID           crypto.Hash
+	Transactions []types.Transaction
+}
+
 // A TransactionPoolSubscriber receives updates about the confirmed and
 // unconfirmed set from the transaction pool. Generally, there is no need to
 // subscribe to both the consensus set and the transaction pool.
@@ -58,7 +74,7 @@ type TransactionPoolSubscriber interface {
 	// ReceiveTransactionPoolUpdate notifies subscribers of a change to the
 	// consensus set and/or unconfirmed set, and includes the consensus change
 	// that would result if all of the transactions made it into a block.
-	ReceiveUpdatedUnconfirmedTransactions([]types.Transaction, ConsensusChange)
+	ReceiveUpdatedUnconfirmedTransactions([]*TransactionSetDiff)
 }
 
 // A TransactionPool manages unconfirmed transactions.

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -212,7 +212,7 @@ func (tp *TransactionPool) handleConflicts(ts []types.Transaction, conflicts []T
 	for _, diff := range cc.SiafundOutputDiffs {
 		tp.knownObjects[ObjectID(diff.ID)] = setID
 	}
-	tp.transactionSetDiffs[setID] = cc
+	tp.transactionSetDiffs[setID] = &cc
 	tsetSize := len(encoding.Marshal(superset))
 	tp.transactionListSize += tsetSize
 
@@ -297,7 +297,7 @@ func (tp *TransactionPool) acceptTransactionSet(ts []types.Transaction, txnFn fu
 	for _, oid := range oids {
 		tp.knownObjects[oid] = setID
 	}
-	tp.transactionSetDiffs[setID] = cc
+	tp.transactionSetDiffs[setID] = &cc
 	tsetSize := len(encoding.Marshal(ts))
 	tp.transactionListSize += tsetSize
 	for _, txn := range ts {

--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -193,7 +193,7 @@ func (tp *TransactionPool) handleConflicts(ts []types.Transaction, conflicts []T
 	}
 
 	// Remove the conflicts from the transaction pool.
-	for _, conflict := range conflictMap {
+	for conflict := range supersetMap {
 		conflictSet := tp.transactionSets[conflict]
 		tp.transactionListSize -= len(encoding.Marshal(conflictSet))
 		delete(tp.transactionSets, conflict)

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -639,12 +639,6 @@ func TestPartialConfirmationWeave(t *testing.T) {
 	}
 	defer tpt.Close()
 
-	// Step 1: create an output to the empty address in a tx.
-	// Step 2: create a second output to the empty address in another tx.
-	// Step 3: create a transaction using both those outputs.
-	// Step 4: mine the txn set in step 2
-	// Step 5: Submit the complete set.
-
 	// Create a transaction with a single output to a fully controlled address.
 	emptyUH := types.UnlockConditions{}.UnlockHash()
 	builder1 := tpt.wallet.StartTransaction()

--- a/modules/transactionpool/consts.go
+++ b/modules/transactionpool/consts.go
@@ -30,7 +30,7 @@ const (
 
 	// TransactionPoolSizeTarget defines the target size of the pool when the
 	// transactions are paying 1 SC / kb in fees.
-	TransactionPoolSizeTarget = 2e6
+	TransactionPoolSizeTarget = 3e6
 
 	// TransactionPoolSizeForFee defines how large the transaction pool needs to
 	// be before it starts expecting fees to be on the transaction. This initial

--- a/modules/transactionpool/subscribe.go
+++ b/modules/transactionpool/subscribe.go
@@ -2,7 +2,6 @@ package transactionpool
 
 import (
 	"github.com/NebulousLabs/Sia/build"
-	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -45,7 +44,7 @@ func (tp *TransactionPool) updateSubscribersTransactions() {
 		for i := range set {
 			encodedTxn := encoding.Marshal(set[i])
 			sizes = append(sizes, uint64(len(encodedTxn)))
-			ids = append(ids, types.TransactionID(crypto.HashBytes(encodedTxn)))
+			ids = append(ids, set[i].ID())
 		}
 		ut := &modules.UnconfirmedTransactionSet{
 			Change: tp.transactionSetDiffs[id],

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -46,16 +46,13 @@ type (
 		// transactionSetDiffs map form a transaction set id to the set of
 		// diffs that resulted from the transaction set.
 		knownObjects        map[ObjectID]TransactionSetID
+		subscriberSets      map[TransactionSetID]*modules.TransactionSetDiff
 		transactionHeights  map[types.TransactionID]types.BlockHeight
 		transactionSets     map[TransactionSetID][]types.Transaction
 		transactionSetDiffs map[TransactionSetID]modules.ConsensusChange
 		transactionListSize int
-		// TODO: Write a consistency check comparing transactionSets,
-		// transactionSetDiffs.
-		//
-		// TODO: Write a consistency check making sure that all unconfirmedIDs
-		// point to the right place, and that all UnconfirmedIDs are accounted for.
 
+		// Variables related to the blockchain.
 		blockHeight     types.BlockHeight
 		recentMedians   []types.Currency
 		recentMedianFee types.Currency // SC per byte
@@ -92,6 +89,7 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string) (*Transa
 		gateway:      g,
 
 		knownObjects:        make(map[ObjectID]TransactionSetID),
+		subscriberSets:      make(map[TransactionSetID]*modules.TransactionSetDiff),
 		transactionHeights:  make(map[types.TransactionID]types.BlockHeight),
 		transactionSets:     make(map[TransactionSetID][]types.Transaction),
 		transactionSetDiffs: make(map[TransactionSetID]modules.ConsensusChange),

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -46,10 +46,10 @@ type (
 		// transactionSetDiffs map form a transaction set id to the set of
 		// diffs that resulted from the transaction set.
 		knownObjects        map[ObjectID]TransactionSetID
-		subscriberSets      map[TransactionSetID]*modules.TransactionSetDiff
+		subscriberSets      map[TransactionSetID]*modules.UnconfirmedTransactionSet
 		transactionHeights  map[types.TransactionID]types.BlockHeight
 		transactionSets     map[TransactionSetID][]types.Transaction
-		transactionSetDiffs map[TransactionSetID]modules.ConsensusChange
+		transactionSetDiffs map[TransactionSetID]*modules.ConsensusChange
 		transactionListSize int
 
 		// Variables related to the blockchain.
@@ -89,10 +89,10 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string) (*Transa
 		gateway:      g,
 
 		knownObjects:        make(map[ObjectID]TransactionSetID),
-		subscriberSets:      make(map[TransactionSetID]*modules.TransactionSetDiff),
+		subscriberSets:      make(map[TransactionSetID]*modules.UnconfirmedTransactionSet),
 		transactionHeights:  make(map[types.TransactionID]types.BlockHeight),
 		transactionSets:     make(map[TransactionSetID][]types.Transaction),
-		transactionSetDiffs: make(map[TransactionSetID]modules.ConsensusChange),
+		transactionSetDiffs: make(map[TransactionSetID]*modules.ConsensusChange),
 
 		persistDir: persistDir,
 	}

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -130,7 +130,7 @@ func findSets(ts []types.Transaction) [][]types.Transaction {
 func (tp *TransactionPool) purge() {
 	tp.knownObjects = make(map[ObjectID]TransactionSetID)
 	tp.transactionSets = make(map[TransactionSetID][]types.Transaction)
-	tp.transactionSetDiffs = make(map[TransactionSetID]modules.ConsensusChange)
+	tp.transactionSetDiffs = make(map[TransactionSetID]*modules.ConsensusChange)
 	tp.transactionListSize = 0
 }
 

--- a/modules/transactionpool/update_test.go
+++ b/modules/transactionpool/update_test.go
@@ -176,13 +176,11 @@ func TestValidRevertedTransaction(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-
 	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer tpt.Close()
-
 	tpt2, err := blankTpoolTester(t.Name() + "-tpt2")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -77,7 +77,7 @@ type Wallet struct {
 	// transaction set diff is provided, the entire array needs to be
 	// reallocated. Since this can happen tens of times per second, and the
 	// array can have tens of thousands of elements, it's a performance issue.
-	unconfirmedSets                  map[crypto.Hash][]types.TransactionID
+	unconfirmedSets                  map[modules.TransactionSetID][]types.TransactionID
 	unconfirmedProcessedTransactions []modules.ProcessedTransaction
 
 	// The wallet's database tracks its seeds, keys, outputs, and
@@ -120,7 +120,7 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 
 		keys: make(map[types.UnlockHash]spendableKey),
 
-		unconfirmedSets: make(map[crypto.Hash][]types.TransactionID),
+		unconfirmedSets: make(map[modules.TransactionSetID][]types.TransactionID),
 
 		persistDir: persistDir,
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -72,6 +72,12 @@ type Wallet struct {
 	keys  map[types.UnlockHash]spendableKey
 
 	// unconfirmedProcessedTransactions tracks unconfirmed transactions.
+	//
+	// TODO: Replace this field with a linked list. Currently when a new
+	// transaction set diff is provided, the entire array needs to be
+	// reallocated. Since this can happen tens of times per second, and the
+	// array can have tens of thousands of elements, it's a performance issue.
+	unconfirmedSets                  map[crypto.Hash][]types.TransactionID
 	unconfirmedProcessedTransactions []modules.ProcessedTransaction
 
 	// The wallet's database tracks its seeds, keys, outputs, and
@@ -113,6 +119,8 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		tpool: tpool,
 
 		keys: make(map[types.UnlockHash]spendableKey),
+
+		unconfirmedSets: make(map[crypto.Hash][]types.TransactionID),
 
 		persistDir: persistDir,
 	}


### PR DESCRIPTION
This PR builds off of #1910, and is an attempt to greatly improve the
performance of Sia when the transaction pool is full. These upgrades will help
to improve the stability of Sia, and also allow us to bump out the transaction
pool to 5mb or even 20mb if the optimizations are robust enough. I'm
continuing to boost performance and test edge cases before we increase the
size of the transaction pool, but this should be ready soon. Even a jump to 5mb
would really help the transaction pool pressure that's on our network, but really
I'm targeting 20mb.

Transaction pool was previously updating subscribers on the new state of the
transaction pool by sending the entire transaction pool to them every single
time a new transaction got added. This was incredibly slow, especially
considering all of the IDs and stuff that was happening behind the scenes.

Now only the diffs are sent whenever there's a transaction pool update, instead
of sending everything. This has resulted in huge speedups that should allow us
to safely increase the transaction pool from 2mb to something larger.