### PR TITLE
add ScoreBreakdown to ExtendedHostDBEntry

### DIFF
--- a/api/hostdb.go
+++ b/api/hostdb.go
@@ -13,10 +13,12 @@ import (
 type (
 	// ExtendedHostDBEntry is an extension to modules.HostDBEntry that includes
 	// the string representation of the public key, otherwise presented as two
-	// fields, a string and a base64 encoded byte slice.
+	// fields, a string and a base64 encoded byte slice, as well as the Score
+	// Breakdown for the host.
 	ExtendedHostDBEntry struct {
 		modules.HostDBEntry
 		PublicKeyString string `json:"publickeystring"`
+		ScoreBreakdown  modules.HostScoreBreakdown
 	}
 
 	// HostdbActiveGET lists active hosts on the network.
@@ -66,6 +68,7 @@ func (api *API) hostdbActiveHandler(w http.ResponseWriter, req *http.Request, _ 
 		extendedHosts = append(extendedHosts, ExtendedHostDBEntry{
 			HostDBEntry:     host,
 			PublicKeyString: host.PublicKey.String(),
+			ScoreBreakdown:  api.renter.ScoreBreakdown(host),
 		})
 	}
 

--- a/api/hostdb_test.go
+++ b/api/hostdb_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -107,6 +108,13 @@ func TestHostDBHostsActiveHandler(t *testing.T) {
 	}
 	if len(ah.Hosts) != 1 {
 		t.Fatal(len(ah.Hosts))
+	}
+	err = st.getAPI("/hostdb/active?numhosts=2", &ah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ah.Hosts[0].ScoreBreakdown, st.renter.ScoreBreakdown(ah.Hosts[0].HostDBEntry)) {
+		t.Fatal("score breakdown did not match")
 	}
 }
 


### PR DESCRIPTION
this PR adds a `ScoreBreakdown` field to the API's `ExtendedHostDBEntry` struct, removing the need to make multiple API requests to get a host's Score (/hostdb/active to get the list of active hosts, then /hostdb/host/[xxx] to get the host's scorebreakdown).
