### PR TITLE
add /host/estimatescore to estimate the host's HostDB score

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -184,6 +184,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.GET("/host", api.hostHandlerGET)                                                   // Get the host status.
 		router.POST("/host", RequirePassword(api.hostHandlerPOST, requiredPassword))              // Change the settings of the host.
 		router.POST("/host/announce", RequirePassword(api.hostAnnounceHandler, requiredPassword)) // Announce the host to the network.
+		router.GET("/host/estimatescore", api.hostEstimateScoreGET)
 
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/host/storage", api.storageHandler)

--- a/api/api.go
+++ b/api/api.go
@@ -184,7 +184,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.GET("/host", api.hostHandlerGET)                                                   // Get the host status.
 		router.POST("/host", RequirePassword(api.hostHandlerPOST, requiredPassword))              // Change the settings of the host.
 		router.POST("/host/announce", RequirePassword(api.hostAnnounceHandler, requiredPassword)) // Announce the host to the network.
-		router.GET("/host/estimatescore", api.hostEstimateScoreGET)
+		router.POST("/host/estimatescore", api.hostEstimateScorePOST)
 
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/host/storage", api.storageHandler)

--- a/api/api.go
+++ b/api/api.go
@@ -184,7 +184,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.GET("/host", api.hostHandlerGET)                                                   // Get the host status.
 		router.POST("/host", RequirePassword(api.hostHandlerPOST, requiredPassword))              // Change the settings of the host.
 		router.POST("/host/announce", RequirePassword(api.hostAnnounceHandler, requiredPassword)) // Announce the host to the network.
-		router.POST("/host/estimatescore", api.hostEstimateScorePOST)
+		router.GET("/host/estimatescore", api.hostEstimateScoreGET)
 
 		// Calls pertaining to the storage manager that the host uses.
 		router.GET("/host/storage", api.storageHandler)

--- a/api/host.go
+++ b/api/host.go
@@ -35,9 +35,9 @@ type (
 		WorkingStatus        modules.HostWorkingStatus        `json:"workingstatus"`
 	}
 
-	// HostEstimateScorePOST contains the information that is returned from a
+	// HostEstimateScoreGET contains the information that is returned from a
 	// /host/estimatescore call.
-	HostEstimateScorePOST struct {
+	HostEstimateScoreGET struct {
 		EstimatedScore types.Currency `json:"estimatedscore"`
 		ConversionRate float64        `json:"conversionrate"`
 	}
@@ -199,7 +199,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 
 // hostEstimateScoreGET handles the POST request to /host/estimatescore and
 // computes an estimated HostDB score for the provided settings.
-func (api *API) hostEstimateScorePOST(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+func (api *API) hostEstimateScoreGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	settings, err := api.parseHostSettings(req)
 	if err != nil {
 		WriteError(w, Error{"error parsing host settings: " + err.Error()}, http.StatusBadRequest)
@@ -234,7 +234,7 @@ func (api *API) hostEstimateScorePOST(w http.ResponseWriter, req *http.Request, 
 	entry.PublicKey = api.host.PublicKey()
 	entry.HostExternalSettings = mergedSettings
 	estimatedScoreBreakdown := api.renter.EstimateHostScore(entry)
-	e := HostEstimateScorePOST{
+	e := HostEstimateScoreGET{
 		EstimatedScore: estimatedScoreBreakdown.Score,
 		ConversionRate: estimatedScoreBreakdown.ConversionRate,
 	}

--- a/api/host.go
+++ b/api/host.go
@@ -199,6 +199,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 // hostEstimateScoreGET handles the POST request to /host/estimatescore and
 // computes an estimated HostDB score for the provided settings.
 func (api *API) hostEstimateScorePOST(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	entry, _ := api.renter.Host(api.host.PublicKey())
 	settings, err := api.parseHostSettings(req)
 	if err != nil {
 		WriteError(w, Error{"error parsing host settings: " + err.Error()}, http.StatusBadRequest)
@@ -209,8 +210,7 @@ func (api *API) hostEstimateScorePOST(w http.ResponseWriter, req *http.Request, 
 		totalStorage += sf.Capacity
 		remainingStorage += sf.CapacityRemaining
 	}
-	dbe := modules.HostDBEntry{}
-	dbe.HostExternalSettings = modules.HostExternalSettings{
+	entry.HostExternalSettings = modules.HostExternalSettings{
 		AcceptingContracts:   settings.AcceptingContracts,
 		MaxDownloadBatchSize: settings.MaxDownloadBatchSize,
 		MaxDuration:          settings.MaxDuration,
@@ -231,7 +231,7 @@ func (api *API) hostEstimateScorePOST(w http.ResponseWriter, req *http.Request, 
 		Version: build.Version,
 	}
 	e := HostEstimateScorePOST{
-		EstimatedScore: api.renter.ScoreBreakdown(dbe).Score,
+		EstimatedScore: api.renter.ScoreBreakdown(entry).Score,
 	}
 	WriteJSON(w, e)
 }

--- a/api/host.go
+++ b/api/host.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 
@@ -242,15 +243,15 @@ func (api *API) hostEstimateScorePOST(w http.ResponseWriter, req *http.Request, 
 		hosts = append(hosts, entry)
 	}
 	sort.Slice(hosts, func(i, j int) bool {
-		return api.renter.ScoreBreakdown(hosts[i]).Score.Cmp(api.renter.ScoreBreakdown(hosts[j]).Score) == -1
+		return api.renter.ScoreBreakdown(hosts[i]).Score.Cmp(api.renter.ScoreBreakdown(hosts[j]).Score) == 1
 	})
-	var position float64
+	var rank float64
 	for i, host := range hosts {
 		if host.PublicKey.String() == entry.PublicKey.String() {
-			position = float64(i)
+			rank = float64(i)
 		}
 	}
-	conversionRate := 100 - ((position / 50) * 100)
+	conversionRate := math.Max(100-((rank/50)*100), 0)
 
 	e := HostEstimateScorePOST{
 		EstimatedScore: api.renter.ScoreBreakdown(entry).Score,

--- a/api/host.go
+++ b/api/host.go
@@ -34,6 +34,12 @@ type (
 		WorkingStatus        modules.HostWorkingStatus        `json:"workingstatus"`
 	}
 
+	// HostEstimateScoreGET contains the information that is returned from a
+	// /host/estimatescore call, currently only the EstimatedScore.
+	HostEstimateScoreGET struct {
+		EstimatedScore types.Currency
+	}
+
 	// StorageGET contains the information that is returned after a GET request
 	// to /host/storage - a bunch of information about the status of storage
 	// management on the host.
@@ -71,6 +77,17 @@ func (api *API) hostHandlerGET(w http.ResponseWriter, req *http.Request, _ httpr
 		WorkingStatus:        ws,
 	}
 	WriteJSON(w, hg)
+}
+
+// hostEstimateScoreGET handles the GET request to /host/estimatescore and
+// computes an estimated HostDB score for the host's current settings.
+func (api *API) hostEstimateScoreGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	dbe := modules.HostDBEntry{}
+	dbe.HostExternalSettings = api.host.ExternalSettings()
+	e := HostEstimateScoreGET{
+		EstimatedScore: api.renter.ScoreBreakdown(dbe).Score,
+	}
+	WriteJSON(w, e)
 }
 
 // hostHandlerPOST handles POST request to the /host API endpoint, which sets

--- a/api/host.go
+++ b/api/host.go
@@ -37,7 +37,7 @@ type (
 	// HostEstimateScoreGET contains the information that is returned from a
 	// /host/estimatescore call, currently only the EstimatedScore.
 	HostEstimateScoreGET struct {
-		EstimatedScore types.Currency
+		EstimatedScore types.Currency `json:"estimatedscore"`
 	}
 
 	// StorageGET contains the information that is returned after a GET request

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -74,8 +75,8 @@ func TestEstimateWeight(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var eg HostEstimateScorePOST
-	if err := st.postAPI("/host/estimatescore", url.Values{}, &eg); err != nil {
+	var eg HostEstimateScoreGET
+	if err := st.getAPI("/host/estimatescore", &eg); err != nil {
 		t.Fatal(err)
 	}
 	originalEstimate := eg.EstimatedScore
@@ -87,7 +88,7 @@ func TestEstimateWeight(t *testing.T) {
 	if err := st.host.SetInternalSettings(is); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.postAPI("/host/estimatescore", url.Values{}, &eg); err != nil {
+	if err := st.getAPI("/host/estimatescore", &eg); err != nil {
 		t.Fatal(err)
 	}
 	if eg.EstimatedScore.Cmp(originalEstimate) != -1 {
@@ -147,9 +148,7 @@ func TestEstimateWeight(t *testing.T) {
 		{types.SiacoinPrecision.Mul64(60000000), 94},
 	}
 	for _, test := range tests {
-		values := url.Values{}
-		values.Set("mincontractprice", test.price.String())
-		err = st.postAPI("/host/estimatescore", values, &eg)
+		err = st.getAPI(fmt.Sprintf("/host/estimatescore?mincontractprice=%v", test.price.String()), &eg)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -79,7 +79,6 @@ func TestEstimateWeight(t *testing.T) {
 		t.Fatal(err)
 	}
 	originalEstimate := eg.EstimatedScore
-	t.Log(originalEstimate)
 
 	// verify that the estimate is being correctly updated by setting a massively
 	// increased min contract price and verifying that the score decreases.

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -79,6 +79,7 @@ func TestEstimateWeight(t *testing.T) {
 		t.Fatal(err)
 	}
 	originalEstimate := eg.EstimatedScore
+	t.Log(originalEstimate)
 
 	// verify that the estimate is being correctly updated by setting a massively
 	// increased min contract price and verifying that the score decreases.

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -74,8 +74,8 @@ func TestEstimateWeight(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var eg HostEstimateScoreGET
-	if err := st.getAPI("/host/estimatescore", &eg); err != nil {
+	var eg HostEstimateScorePOST
+	if err := st.postAPI("/host/estimatescore", url.Values{}, &eg); err != nil {
 		t.Fatal(err)
 	}
 	originalEstimate := eg.EstimatedScore
@@ -87,7 +87,7 @@ func TestEstimateWeight(t *testing.T) {
 	if err := st.host.SetInternalSettings(is); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.getAPI("/host/estimatescore", &eg); err != nil {
+	if err := st.postAPI("/host/estimatescore", url.Values{}, &eg); err != nil {
 		t.Fatal(err)
 	}
 	if eg.EstimatedScore.Cmp(originalEstimate) != -1 {

--- a/doc/API.md
+++ b/doc/API.md
@@ -490,7 +490,8 @@ combined with the provided settings.
 ###### JSON Response [(with comments)](/doc/api/Host.md#json-response-2)
 ```javascript
 {
-	"estimatedscore": "123456786786786786786786786742133"
+	"estimatedscore": "123456786786786786786786786742133",
+	"conversionrate": 95
 }
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -257,7 +257,7 @@ Host
 | [/host](#host-get)                                                                         | GET       |
 | [/host](#host-post)                                                                        | POST      |
 | [/host/announce](#hostannounce-post)                                                       | POST      |
-| [/host/estimatescore](#hostestimatescore-get)                                              | GET       |
+| [/host/estimatescore](#hostestimatescore-post)                                             | POST      |
 | [/host/storage](#hoststorage-get)                                                          | GET       |
 | [/host/storage/folders/add](#hoststoragefoldersadd-post)                                   | POST      |
 | [/host/storage/folders/remove](#hoststoragefoldersremove-post)                             | POST      |
@@ -482,15 +482,35 @@ data.
 standard success or error response. See
 [#standard-responses](#standard-responses).
 
-#### /host/estimatescore [GET]
+#### /host/estimatescore [POST]
 
-returns the estimated HostDB score of the host using its current settings.
+returns the estimated HostDB score of the host using its current settings,
+combined with the provided settings.
 
 ###### JSON Response [(with comments)](/doc/api/Host.md#json-response-2)
 ```javascript
 {
 	"estimatedscore": "123456786786786786786786786742133"
 }
+```
+
+###### Query String Parameters [(with comments)](/doc/api/Host.md#query-string-parameters-5)
+```
+acceptingcontracts   // Optional, true / false
+maxdownloadbatchsize // Optional, bytes
+maxduration          // Optional, blocks
+maxrevisebatchsize   // Optional, bytes
+netaddress           // Optional
+windowsize           // Optional, blocks
+
+collateral       // Optional, hastings / byte / block
+collateralbudget // Optional, hastings
+maxcollateral    // Optional, hastings
+
+mincontractprice          // Optional, hastings
+mindownloadbandwidthprice // Optional, hastings / byte
+minstorageprice           // Optional, hastings / byte / block
+minuploadbandwidthprice   // Optional, hastings / byte
 ```
 
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -257,7 +257,7 @@ Host
 | [/host](#host-get)                                                                         | GET       |
 | [/host](#host-post)                                                                        | POST      |
 | [/host/announce](#hostannounce-post)                                                       | POST      |
-| [/host/estimatescore](#hostestimatescore-post)                                             | POST      |
+| [/host/estimatescore](#hostestimatescore-get)                                              | GET       |
 | [/host/storage](#hoststorage-get)                                                          | GET       |
 | [/host/storage/folders/add](#hoststoragefoldersadd-post)                                   | POST      |
 | [/host/storage/folders/remove](#hoststoragefoldersremove-post)                             | POST      |
@@ -482,7 +482,7 @@ data.
 standard success or error response. See
 [#standard-responses](#standard-responses).
 
-#### /host/estimatescore [POST]
+#### /host/estimatescore [GET]
 
 returns the estimated HostDB score of the host using its current settings,
 combined with the provided settings.

--- a/doc/API.md
+++ b/doc/API.md
@@ -252,15 +252,16 @@ standard success or error response. See
 Host
 ----
 
-| Route                                                                                 | HTTP verb |
-| ------------------------------------------------------------------------------------- | --------- |
-| [/host](#host-get)                                                                    | GET       |
-| [/host](#host-post)                                                                   | POST      |
-| [/host/announce](#hostannounce-post)                                                  | POST      |
-| [/host/storage](#hoststorage-get)                                                     | GET       |
-| [/host/storage/folders/add](#hoststoragefoldersadd-post)                              | POST      |
-| [/host/storage/folders/remove](#hoststoragefoldersremove-post)                        | POST      |
-| [/host/storage/folders/resize](#hoststoragefoldersresize-post)                        | POST      |
+| Route                                                                                      | HTTP verb |
+| ------------------------------------------------------------------------------------------ | --------- |
+| [/host](#host-get)                                                                         | GET       |
+| [/host](#host-post)                                                                        | POST      |
+| [/host/announce](#hostannounce-post)                                                       | POST      |
+| [/host/estimatescore](#hostestimatescore-get)                                              | GET       |
+| [/host/storage](#hoststorage-get)                                                          | GET       |
+| [/host/storage/folders/add](#hoststoragefoldersadd-post)                                   | POST      |
+| [/host/storage/folders/remove](#hoststoragefoldersremove-post)                             | POST      |
+| [/host/storage/folders/resize](#hoststoragefoldersresize-post)                             | POST      |
 | [/host/storage/sectors/delete/:___merkleroot___](#hoststoragesectorsdeletemerkleroot-post) | POST      |
 
 For examples and detailed descriptions of request and response parameters,
@@ -480,6 +481,17 @@ data.
 ###### Response
 standard success or error response. See
 [#standard-responses](#standard-responses).
+
+#### /host/estimatescore [GET]
+
+returns the estimated HostDB score of the host using its current settings.
+
+###### JSON Response [(with comments)](/doc/api/Host.md#json-response-2)
+```javascript
+{
+	"estimatedscore": "123456786786786786786786786742133"
+}
+```
 
 
 Host DB

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -25,7 +25,7 @@ Index
 | [/host](#host-get)                                                                         | GET       |
 | [/host](#host-post)                                                                        | POST      |
 | [/host/announce](#hostannounce-post)                                                       | POST      |
-| [/host/estimatescore](#hostestimatescore-post)                                             | POST      |
+| [/host/estimatescore](#hostestimatescore-get)                                              | GET       |
 | [/host/storage](#hoststorage-get)                                                          | GET       |
 | [/host/storage/folders/add](#hoststoragefoldersadd-post)                                   | POST      |
 | [/host/storage/folders/remove](#hoststoragefoldersremove-post)                             | POST      |
@@ -548,7 +548,7 @@ data.
 standard success or error response. See
 [#standard-responses](#standard-responses).
 
-#### /host/estimatescore [POST]
+#### /host/estimatescore [GET]
 
 returns the estimated HostDB score of the host using its current settings,
 combined with the provided settings.

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -556,7 +556,12 @@ combined with the provided settings.
 ###### JSON Response
 ```javascript
 {
-	"estimatedscore": "123456786786786786786786786742133"
+	// estimatedscore is the estimated HostDB score of the host given the
+	// settings passed to estimatescore.
+	"estimatedscore": "123456786786786786786786786742133",
+	// conversionrate is the likelyhood given the settings passed to
+	// estimatescore that the host will be selected by renters forming contracts.
+	"conversionrate": 95
 }
 ```
 

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -25,7 +25,7 @@ Index
 | [/host](#host-get)                                                                         | GET       |
 | [/host](#host-post)                                                                        | POST      |
 | [/host/announce](#hostannounce-post)                                                       | POST      |
-| [/host/estimatescore](#hostestimatescore-get)                                              | GET       |
+| [/host/estimatescore](#hostestimatescore-post)                                             | POST      |
 | [/host/storage](#hoststorage-get)                                                          | GET       |
 | [/host/storage/folders/add](#hoststoragefoldersadd-post)                                   | POST      |
 | [/host/storage/folders/remove](#hoststoragefoldersremove-post)                             | POST      |
@@ -548,16 +548,34 @@ data.
 standard success or error response. See
 [#standard-responses](#standard-responses).
 
-#### /host/estimatescore [GET]
+#### /host/estimatescore [POST]
 
-returns the estimated HostDB score of the host using its current settings.
+returns the estimated HostDB score of the host using its current settings,
+combined with the provided settings.
 
-###### JSON Response [(with comments)](/doc/api/Host.md#json-response-2)
+###### JSON Response
 ```javascript
 {
-	// estimatedscore is the estimated hostdb score of the host with its current
-  // settings. This does not factor in age or uptime.
 	"estimatedscore": "123456786786786786786786786742133"
 }
+```
+
+###### Query String Parameters
+```
+acceptingcontracts   // Optional, true / false
+maxdownloadbatchsize // Optional, bytes
+maxduration          // Optional, blocks
+maxrevisebatchsize   // Optional, bytes
+netaddress           // Optional
+windowsize           // Optional, blocks
+
+collateral       // Optional, hastings / byte / block
+collateralbudget // Optional, hastings
+maxcollateral    // Optional, hastings
+
+mincontractprice          // Optional, hastings
+mindownloadbandwidthprice // Optional, hastings / byte
+minstorageprice           // Optional, hastings / byte / block
+minuploadbandwidthprice   // Optional, hastings / byte
 ```
 

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -20,16 +20,18 @@ settings, announcing to the network, and managing how files are stored on disk.
 Index
 -----
 
-| Route                                                                                 | HTTP verb |
-| ------------------------------------------------------------------------------------- | --------- |
-| [/host](#host-get)                                                                    | GET       |
-| [/host](#host-post)                                                                   | POST      |
-| [/host/announce](#hostannounce-post)                                                  | POST      |
-| [/host/storage](#hoststorage-get)                                                     | GET       |
-| [/host/storage/folders/add](#hoststoragefoldersadd-post)                              | POST      |
-| [/host/storage/folders/remove](#hoststoragefoldersremove-post)                        | POST      |
-| [/host/storage/folders/resize](#hoststoragefoldersresize-post)                        | POST      |
-| [/host/storage/sectors/delete/___:merkleroot___](#hoststoragesectorsdeletemerkleroot) | POST      |
+| Route                                                                                      | HTTP verb |
+| ------------------------------------------------------------------------------------------ | --------- |
+| [/host](#host-get)                                                                         | GET       |
+| [/host](#host-post)                                                                        | POST      |
+| [/host/announce](#hostannounce-post)                                                       | POST      |
+| [/host/estimatescore](#hostestimatescore-get)                                              | GET       |
+| [/host/storage](#hoststorage-get)                                                          | GET       |
+| [/host/storage/folders/add](#hoststoragefoldersadd-post)                                   | POST      |
+| [/host/storage/folders/remove](#hoststoragefoldersremove-post)                             | POST      |
+| [/host/storage/folders/resize](#hoststoragefoldersresize-post)                             | POST      |
+| [/host/storage/sectors/delete/:___merkleroot___](#hoststoragesectorsdeletemerkleroot-post) | POST      |
+
 
 #### /host [GET]
 
@@ -545,3 +547,17 @@ data.
 ###### Response
 standard success or error response. See
 [#standard-responses](#standard-responses).
+
+#### /host/estimatescore [GET]
+
+returns the estimated HostDB score of the host using its current settings.
+
+###### JSON Response [(with comments)](/doc/api/Host.md#json-response-2)
+```javascript
+{
+	// estimatedscore is the estimated hostdb score of the host with its current
+  // settings. This does not factor in age or uptime.
+	"estimatedscore": "123456786786786786786786786742133"
+}
+```
+

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -117,7 +117,8 @@ type HostDBScan struct {
 // results provided by this struct can only be used as a guide, and may vary
 // significantly from machine to machine.
 type HostScoreBreakdown struct {
-	Score types.Currency `json:"score"`
+	Score          types.Currency `json:"score"`
+	ConversionRate float64        `json:"conversionrate"`
 
 	AgeAdjustment              float64 `json:"ageadjustment"`
 	BurnAdjustment             float64 `json:"burnadjustment"`
@@ -284,6 +285,10 @@ type Renter interface {
 
 	// RenameFile changes the path of a file.
 	RenameFile(path, newPath string) error
+
+	// EstimateHostScore will return the score for a host with the provided
+	// settings, assuming perfect age and uptime adjustments
+	EstimateHostScore(entry HostDBEntry) HostScoreBreakdown
 
 	// ScoreBreakdown will return the score for a host db entry using the
 	// hostdb's weighting algorithm.

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -3,6 +3,7 @@ package hostdb
 import (
 	"math"
 	"math/big"
+	"sort"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -358,6 +359,64 @@ func (hdb *HostDB) calculateHostWeight(entry modules.HostDBEntry) types.Currency
 		return types.NewCurrency64(1)
 	}
 	return weight
+}
+
+// EstimateHostScore takes a HostExternalSettings and returns the estimated
+// score of that host in the hostdb, assuming no penalties for age or uptime.
+func (hdb *HostDB) EstimateHostScore(entry modules.HostDBEntry) modules.HostScoreBreakdown {
+	collateralReward := hdb.collateralAdjustments(entry)
+	pricePenalty := hdb.priceAdjustments(entry)
+	storageRemainingPenalty := storageRemainingAdjustments(entry)
+	versionPenalty := versionAdjustments(entry)
+	fullPenalty := collateralReward * pricePenalty * storageRemainingPenalty * versionPenalty
+
+	estimatedScore := baseWeight.MulFloat(fullPenalty)
+	if estimatedScore.IsZero() {
+		estimatedScore = types.NewCurrency64(1)
+	}
+
+	// compute the host's conversion rate, that is, how likely it is to be
+	// selected by renters for use in contracts, by finding its position in the
+	// sorted list of active hosts
+	rankedHosts := []struct {
+		pk    string
+		score types.Currency
+	}{}
+	for _, h := range hdb.ActiveHosts() {
+		var score types.Currency
+		if h.PublicKey.String() == entry.PublicKey.String() {
+			score = estimatedScore
+		} else {
+			score = hdb.ScoreBreakdown(h).Score
+		}
+		rankedHosts = append(rankedHosts, struct {
+			pk    string
+			score types.Currency
+		}{h.PublicKey.String(), score})
+	}
+	sort.Slice(rankedHosts, func(i, j int) bool {
+		return rankedHosts[i].score.Cmp(rankedHosts[j].score) >= 0
+	})
+	var rank float64
+	for i, host := range rankedHosts {
+		if host.pk == entry.PublicKey.String() {
+			rank = float64(i)
+		}
+	}
+	conversionRate := math.Max(100-((rank/50)*100), 0)
+
+	return modules.HostScoreBreakdown{
+		Score:          estimatedScore,
+		ConversionRate: conversionRate,
+
+		AgeAdjustment:              1,
+		BurnAdjustment:             1,
+		CollateralAdjustment:       collateralReward,
+		PriceAdjustment:            pricePenalty,
+		StorageRemainingAdjustment: storageRemainingPenalty,
+		UptimeAdjustment:           1,
+		VersionAdjustment:          versionPenalty,
+	}
 }
 
 // ScoreBreakdown provdes a detailed set of scalars and bools indicating

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -66,6 +66,10 @@ type hostDB interface {
 	// ScoreBreakdown returns a detailed explanation of the various properties
 	// of the host.
 	ScoreBreakdown(modules.HostDBEntry) modules.HostScoreBreakdown
+
+	// EstimateHostScore returns the estimated score breakdown of a host with the
+	// provided settings.
+	EstimateHostScore(modules.HostDBEntry) modules.HostScoreBreakdown
 }
 
 // A hostContractor negotiates, revises, renews, and provides access to file
@@ -303,6 +307,9 @@ func (r *Renter) AllHosts() []modules.HostDBEntry                         { retu
 func (r *Renter) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) { return r.hostDB.Host(spk) }
 func (r *Renter) ScoreBreakdown(e modules.HostDBEntry) modules.HostScoreBreakdown {
 	return r.hostDB.ScoreBreakdown(e)
+}
+func (r *Renter) EstimateHostScore(e modules.HostDBEntry) modules.HostScoreBreakdown {
+	return r.hostDB.EstimateHostScore(e)
 }
 
 // contractor passthroughs


### PR DESCRIPTION
This PR adds a new endpoint to the API, `/host/estimatescore`, enabling API consumers to get an idea of their estimated HostDB score with their host's current settings.

