### PR TITLE
Add the packaging metadata to build the Sia snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   users to safely store their data with hosts that they do not know or trust.
 
 grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: strict #
+confinement: strict
 
 apps:
   daemon:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: sia
+version: git
+summary: Blockchain-based marketplace for file storage
+description: |
+  Sia is a new decentralized cloud storage platform that radically alters the
+  landscape of cloud storage. By leveraging smart contracts, client-side
+  encryption, and sophisticated redundancy (via Reed-Solomon codes), Sia allows
+  users to safely store their data with hosts that they do not know or trust.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict #
+
+apps:
+  siad:
+    command: siad
+    plugs: [network, network-bind]
+  client:
+    command: siac
+    plugs: [network]
+    aliases: [siac]
+
+parts:
+  sia:
+    source: .
+    plugin: go
+    go-importpath: github.com/NebulousLabs/Sia
+    after: [go]
+  go:
+    source-tag: go1.8

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
   siad:
     command: siad
     plugs: [network, network-bind]
+    daemon: simple
   client:
     command: siac
     plugs: [network]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,10 +11,10 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict #
 
 apps:
-  siad:
+  daemon:
     command: siad
     plugs: [network, network-bind]
-    daemon: simple
+    aliases: [siad]
   client:
     command: siac
     plugs: [network]


### PR DESCRIPTION
This package will let you publish the latest sia in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.