### PR TITLE
Seed sweep considers transaction size limit

### DIFF
--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -332,6 +332,12 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 		return
 	}
 
+	if len(s.siacoinOutputs) == 0 && len(s.siafundOutputs) == 0 {
+		// if we aren't sweeping any coins or funds, then just return an
+		// error; no reason to proceed
+		return types.Currency{}, types.Currency{}, errors.New("nothing to sweep")
+	}
+
 	for len(s.siacoinOutputs) > 0 || len(s.siafundOutputs) > 0 {
 		// Create temporary maps and var for the current transaction
 		siacoinOutputs := make(map[types.SiacoinOutputID]scannedOutput)

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -326,123 +326,155 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 	s := newSeedScanner(seed, w.log)
 	_, maxFee := w.tpool.FeeEstimation()
 	const outputSize = 350 // approx. size in bytes of an output and accompanying signature
+	const maxOutputs = 50  // approx. number of outputs that a transaction can handle
 	s.dustThreshold = maxFee.Mul64(outputSize)
 	if err = s.scan(w.cs); err != nil {
 		return
 	}
 
-	// construct a transaction that spends the outputs
-	// TODO: this may result in transactions that are too large.
-	tb := w.StartTransaction()
-	var sweptCoins, sweptFunds types.Currency // total values of swept outputs
-	for _, output := range s.siacoinOutputs {
-		// construct a siacoin input that spends the output
-		sk := generateSpendableKey(seed, output.seedIndex)
-		tb.AddSiacoinInput(types.SiacoinInput{
-			ParentID:         types.SiacoinOutputID(output.id),
-			UnlockConditions: sk.UnlockConditions,
-		})
-		// add a signature for the input
-		sweptCoins = sweptCoins.Add(output.value)
-	}
-	for _, output := range s.siafundOutputs {
-		// construct a siafund input that spends the output
-		sk := generateSpendableKey(seed, output.seedIndex)
-		tb.AddSiafundInput(types.SiafundInput{
-			ParentID:         types.SiafundOutputID(output.id),
-			UnlockConditions: sk.UnlockConditions,
-		})
-		// add a signature for the input
-		sweptFunds = sweptFunds.Add(output.value)
-	}
+	for len(s.siacoinOutputs) > 0 || len(s.siafundOutputs) > 0 {
+		// Create temporary maps and var for the current transaction
+		siacoinOutputs := make(map[types.SiacoinOutputID]scannedOutput)
+		siafundOutputs := make(map[types.SiafundOutputID]scannedOutput)
+		var currentCoins, currentFunds types.Currency
 
-	// estimate the transaction size and fee. NOTE: this equation doesn't
-	// account for other fields in the transaction, but since we are
-	// multiplying by maxFee, lowballing is ok
-	estTxnSize := (len(s.siacoinOutputs) + len(s.siafundOutputs)) * outputSize
-	estFee := maxFee.Mul64(uint64(estTxnSize))
-	tb.AddMinerFee(estFee)
+		// Fill those maps with up to maxOutputs outputs from the scanner
+		counter := 0
+		for id, output := range s.siacoinOutputs {
+			if counter == maxOutputs {
+				break
+			}
+			siacoinOutputs[id] = output
+			delete(s.siacoinOutputs, id)
+			counter++
+		}
+		for id, output := range s.siafundOutputs {
+			if counter == maxOutputs {
+				break
+			}
+			siafundOutputs[id] = output
+			delete(s.siafundOutputs, id)
+			counter++
+		}
 
-	// calculate total siacoin payout
-	if sweptCoins.Cmp(estFee) > 0 {
-		coins = sweptCoins.Sub(estFee)
-	}
-	funds = sweptFunds
+		// construct a transaction that spends the outputs
+		tb := w.StartTransaction()
+		var sweptCoins, sweptFunds types.Currency // total values of swept outputs
+		for _, output := range siacoinOutputs {
+			// construct a siacoin input that spends the output
+			sk := generateSpendableKey(seed, output.seedIndex)
+			tb.AddSiacoinInput(types.SiacoinInput{
+				ParentID:         types.SiacoinOutputID(output.id),
+				UnlockConditions: sk.UnlockConditions,
+			})
+			// add a signature for the input
+			sweptCoins = sweptCoins.Add(output.value)
+		}
+		for _, output := range siafundOutputs {
+			// construct a siafund input that spends the output
+			sk := generateSpendableKey(seed, output.seedIndex)
+			tb.AddSiafundInput(types.SiafundInput{
+				ParentID:         types.SiafundOutputID(output.id),
+				UnlockConditions: sk.UnlockConditions,
+			})
+			// add a signature for the input
+			sweptFunds = sweptFunds.Add(output.value)
+		}
 
-	switch {
-	case coins.IsZero() && funds.IsZero():
-		// if we aren't sweeping any coins or funds, then just return an
-		// error; no reason to proceed
-		return types.Currency{}, types.Currency{}, errors.New("transaction fee exceeds value of swept outputs")
+		// estimate the transaction size and fee. NOTE: this equation doesn't
+		// account for other fields in the transaction, but since we are
+		// multiplying by maxFee, lowballing is ok
+		estTxnSize := (len(siacoinOutputs) + len(siafundOutputs)) * outputSize
+		estFee := maxFee.Mul64(uint64(estTxnSize))
+		tb.AddMinerFee(estFee)
 
-	case !coins.IsZero() && funds.IsZero():
-		// if we're sweeping coins but not funds, add a siacoin output for
-		// them
-		tb.AddSiacoinOutput(types.SiacoinOutput{
-			Value:      coins,
-			UnlockHash: uc.UnlockHash(),
-		})
+		// calculate total siacoin payout
+		if sweptCoins.Cmp(estFee) > 0 {
+			currentCoins = sweptCoins.Sub(estFee)
+		}
+		currentFunds = sweptFunds
 
-	case coins.IsZero() && !funds.IsZero():
-		// if we're sweeping funds but not coins, add a siafund output for
-		// them. This is tricky because we still need to pay for the
-		// transaction fee, but we can't simply subtract the fee from the
-		// output value like we can with swept coins. Instead, we need to fund
-		// the fee using the existing wallet balance.
-		tb.AddSiafundOutput(types.SiafundOutput{
-			Value:      funds,
-			UnlockHash: uc.UnlockHash(),
-		})
-		err = tb.FundSiacoins(estFee)
+		switch {
+		case currentCoins.IsZero() && currentFunds.IsZero():
+			// if we aren't sweeping any coins or funds, then just return an
+			// error; no reason to proceed
+			return types.Currency{}, types.Currency{}, errors.New("transaction fee exceeds value of swept outputs")
+
+		case !currentCoins.IsZero() && currentFunds.IsZero():
+			// if we're sweeping coins but not funds, add a siacoin output for
+			// them
+			tb.AddSiacoinOutput(types.SiacoinOutput{
+				Value:      currentCoins,
+				UnlockHash: uc.UnlockHash(),
+			})
+
+		case currentCoins.IsZero() && !currentFunds.IsZero():
+			// if we're sweeping funds but not coins, add a siafund output for
+			// them. This is tricky because we still need to pay for the
+			// transaction fee, but we can't simply subtract the fee from the
+			// output value like we can with swept coins. Instead, we need to fund
+			// the fee using the existing wallet balance.
+			tb.AddSiafundOutput(types.SiafundOutput{
+				Value:      currentFunds,
+				UnlockHash: uc.UnlockHash(),
+			})
+			err = tb.FundSiacoins(estFee)
+			if err != nil {
+				return types.Currency{}, types.Currency{}, errors.New("couldn't pay transaction fee on swept funds: " + err.Error())
+			}
+
+		case !currentCoins.IsZero() && !currentFunds.IsZero():
+			// if we're sweeping both coins and funds, add a siacoin output and a
+			// siafund output
+			tb.AddSiacoinOutput(types.SiacoinOutput{
+				Value:      currentCoins,
+				UnlockHash: uc.UnlockHash(),
+			})
+			tb.AddSiafundOutput(types.SiafundOutput{
+				Value:      currentFunds,
+				UnlockHash: uc.UnlockHash(),
+			})
+		}
+
+		// add signatures for all coins and funds (manually, since tb doesn't have
+		// access to the signing keys)
+		txn, parents := tb.View()
+		for _, output := range siacoinOutputs {
+			sk := generateSpendableKey(seed, output.seedIndex)
+			addSignatures(&txn, types.FullCoveredFields, sk.UnlockConditions, crypto.Hash(output.id), sk)
+		}
+		for _, sfo := range siafundOutputs {
+			sk := generateSpendableKey(seed, sfo.seedIndex)
+			addSignatures(&txn, types.FullCoveredFields, sk.UnlockConditions, crypto.Hash(sfo.id), sk)
+		}
+		// Usually, all the inputs will come from swept outputs. However, there is
+		// an edge case in which inputs will be added from the wallet. To cover
+		// this case, we iterate through the SiacoinInputs and add a signature for
+		// any input that belongs to the wallet.
+		w.mu.RLock()
+		for _, input := range txn.SiacoinInputs {
+			if key, ok := w.keys[input.UnlockConditions.UnlockHash()]; ok {
+				addSignatures(&txn, types.FullCoveredFields, input.UnlockConditions, crypto.Hash(input.ParentID), key)
+			}
+		}
+		w.mu.RUnlock()
+
+		// Append transaction to txnSet
+		txnSet := append(parents, txn)
+
+		// submit the transactions
+		err = w.tpool.AcceptTransactionSet(txnSet)
 		if err != nil {
-			return types.Currency{}, types.Currency{}, errors.New("couldn't pay transaction fee on swept funds: " + err.Error())
+			return
 		}
 
-	case !coins.IsZero() && !funds.IsZero():
-		// if we're sweeping both coins and funds, add a siacoin output and a
-		// siafund output
-		tb.AddSiacoinOutput(types.SiacoinOutput{
-			Value:      coins,
-			UnlockHash: uc.UnlockHash(),
-		})
-		tb.AddSiafundOutput(types.SiafundOutput{
-			Value:      funds,
-			UnlockHash: uc.UnlockHash(),
-		})
-	}
-
-	// add signatures for all coins and funds (manually, since tb doesn't have
-	// access to the signing keys)
-	txn, parents := tb.View()
-	for _, output := range s.siacoinOutputs {
-		sk := generateSpendableKey(seed, output.seedIndex)
-		addSignatures(&txn, types.FullCoveredFields, sk.UnlockConditions, crypto.Hash(output.id), sk)
-	}
-	for _, sfo := range s.siafundOutputs {
-		sk := generateSpendableKey(seed, sfo.seedIndex)
-		addSignatures(&txn, types.FullCoveredFields, sk.UnlockConditions, crypto.Hash(sfo.id), sk)
-	}
-	// Usually, all the inputs will come from swept outputs. However, there is
-	// an edge case in which inputs will be added from the wallet. To cover
-	// this case, we iterate through the SiacoinInputs and add a signature for
-	// any input that belongs to the wallet.
-	w.mu.RLock()
-	for _, input := range txn.SiacoinInputs {
-		if key, ok := w.keys[input.UnlockConditions.UnlockHash()]; ok {
-			addSignatures(&txn, types.FullCoveredFields, input.UnlockConditions, crypto.Hash(input.ParentID), key)
+		w.log.Println("Creating a transaction set to sweep a seed, IDs:")
+		for _, txn := range txnSet {
+			w.log.Println("\t", txn.ID())
 		}
-	}
-	w.mu.RUnlock()
 
-	// submit the transaction
-	txnSet := append(parents, txn)
-	err = w.tpool.AcceptTransactionSet(txnSet)
-	if err != nil {
-		return
-	}
-	w.log.Println("Creating a transaction set to sweep a seed, IDs:")
-	for _, txn := range txnSet {
-		w.log.Println("\t", txn.ID())
+		coins = coins.Add(currentCoins)
+		funds = funds.Add(currentFunds)
 	}
 	return
 }

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -419,15 +419,21 @@ func TestSweepSeedCoinsAndFunds(t *testing.T) {
 	sk := generateSpendableKey(seed, 1)
 
 	// Send some siafunds to the address.
-	_, err = wt.wallet.SendSiafunds(types.NewCurrency64(12), sk.UnlockConditions.UnlockHash())
-	if err != nil {
-		t.Fatal(err)
+	for i := 0; i < 12; i++ {
+		_, err = wt.wallet.SendSiafunds(types.NewCurrency64(1), sk.UnlockConditions.UnlockHash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		wt.addBlockNoPayout()
 	}
 	// Send some siacoins to the address -- must be more than the transaction
 	// fee.
-	_, err = wt.wallet.SendSiacoins(types.SiacoinPrecision.Mul64(1000), sk.UnlockConditions.UnlockHash())
-	if err != nil {
-		t.Fatal(err)
+	for i := 0; i < 100; i++ {
+		_, err = wt.wallet.SendSiacoins(types.SiacoinPrecision.Mul64(10), sk.UnlockConditions.UnlockHash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		wt.addBlockNoPayout()
 	}
 	// mine blocks without earning payout until our balance is stable
 	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {


### PR DESCRIPTION
If seed sweep is done on a seed with too many outputs it fails due to the sweep not considering the transaction size limit. This PR should fix that.