### PR TITLE
Host Scalability Update

### DIFF
--- a/modules/host/contractmanager/consts.go
+++ b/modules/host/contractmanager/consts.go
@@ -33,11 +33,6 @@ const (
 	// walFile is the name of the file that is used to save the write ahead log
 	// for the contract manager.
 	walFile = "contractmanager.wal"
-
-	// walFileTmp is used for incomplete writes to the WAL. Data could be
-	// interrupted by power outages, etc., and is therefore written to a
-	// temporary file before being atomically renamed to the correct name.
-	walFileTmp = "contractmanager.wal_temp"
 )
 
 const (

--- a/modules/host/contractmanager/contractmanager_test.go
+++ b/modules/host/contractmanager/contractmanager_test.go
@@ -145,13 +145,8 @@ func TestNewContractManagerErroredStartup(t *testing.T) {
 	// Verify that shutdown was triggered correctly - tmp files should be gone,
 	// WAL file should also be gone.
 	walFileName := filepath.Join(cmd, walFile)
-	walFileTmpName := filepath.Join(cmd, walFileTmp)
 	settingsFileTmpName := filepath.Join(cmd, settingsFileTmp)
 	_, err = os.Stat(walFileName)
-	if !os.IsNotExist(err) {
-		t.Error("file should have been removed:", err)
-	}
-	_, err = os.Stat(walFileTmpName)
 	if !os.IsNotExist(err) {
 		t.Error("file should have been removed:", err)
 	}

--- a/modules/host/contractmanager/sector.go
+++ b/modules/host/contractmanager/sector.go
@@ -113,7 +113,7 @@ func writeSectorMetadata(f file, sectorIndex uint32, id sectorID, count uint16) 
 // when an attacker can perform orders of magnitude more than a billion trials
 // per second. When attacking the host sector ids though, the attacker can only
 // do one trial per sector upload, and even then has minimal means to learn
-// whether or not a collision was successfully achieved. Hash length can safely
+// whether or not a collision was successfully achieved. Hash changeLength can safely
 // be reduced from 32 bytes to 12 bytes, which has a collision resistance of
 // 2^48. The host however is unlikely to be storing 2^48 sectors, which would
 // be an exabyte of data.


### PR DESCRIPTION
This PR is meant to increase the scalability of the host to achieve 1TB file contracts. The first step is to modify the contractmanager WAL to not rely on a tmp log since `os.Rename` is not atomic. Once the WAL is fixed the two host databases need to be merged into a single one.
