### PR TITLE
Convert last 3-4 inconsistent API document styles to dominant style

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -75,7 +75,7 @@ type (
 	}
 
 	// WalletTransactionGETid contains the transaction returned by a call to
-	// /wallet/transaction/$(id)
+	// /wallet/transaction/:id
 	WalletTransactionGETid struct {
 		Transaction modules.ProcessedTransaction `json:"transaction"`
 	}
@@ -89,7 +89,7 @@ type (
 
 	// WalletTransactionsGETaddr contains the set of wallet transactions
 	// relevant to the input address provided in the call to
-	// /wallet/transaction/$(addr)
+	// /wallet/transaction/:addr
 	WalletTransactionsGETaddr struct {
 		ConfirmedTransactions   []modules.ProcessedTransaction `json:"confirmedtransactions"`
 		UnconfirmedTransactions []modules.ProcessedTransaction `json:"unconfirmedtransactions"`
@@ -481,7 +481,7 @@ func (api *API) walletTransactionHandler(w http.ResponseWriter, req *http.Reques
 
 	txn, ok := api.wallet.Transaction(id)
 	if !ok {
-		WriteError(w, Error{"error when calling /wallet/transaction/$(id): transaction not found"}, http.StatusBadRequest)
+		WriteError(w, Error{"error when calling /wallet/transaction/:id  :  transaction not found"}, http.StatusBadRequest)
 		return
 	}
 	WriteJSON(w, WalletTransactionGETid{

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -526,7 +526,7 @@ func TestIntegrationWalletLoadSeedPOST(t *testing.T) {
 	}
 }
 
-// TestWalletTransactionGETid queries the /wallet/transaction/$(id)
+// TestWalletTransactionGETid queries the /wallet/transaction/:id
 // api call.
 func TestWalletTransactionGETid(t *testing.T) {
 	if testing.Short() {
@@ -560,7 +560,7 @@ func TestWalletTransactionGETid(t *testing.T) {
 	}
 
 	// Query the details of the first transaction using
-	// /wallet/transaction/$(id)
+	// /wallet/transaction/:id
 	var wtgid WalletTransactionGETid
 	wtgidQuery := fmt.Sprintf("/wallet/transaction/%s", wtg.ConfirmedTransactions[0].TransactionID)
 	err = st.getAPI(wtgidQuery, &wtgid)


### PR DESCRIPTION
seems like these few are the last ones
```➜  
Sia git:(rudi-fix-siac-readme) grep '/[a-z][a-z]*/' **/*.go |grep -v post  | grep '/[$][(]'
api/wallet.go:	// /wallet/transaction/$(id)
api/wallet.go:	// /wallet/transaction/$(addr)
api/wallet.go:		WriteError(w, Error{"error when calling /wallet/transaction/$(id): transaction not found"}, http.StatusBadRequest)
api/wallet_test.go:// TestWalletTransactionGETid queries the /wallet/transaction/$(id)
api/wallet_test.go:	// /wallet/transaction/$(id)
➜  Sia git:(rudi-fix-api-comment-style) ✗ 
```