### PR TITLE
add fee estimation to 'siac wallet'

### DIFF
--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -403,6 +403,15 @@ Siafunds:            %v SF
 Siafund Claims:      %v H
 `, encStatus, currencyUnits(status.ConfirmedSiacoinBalance), delta,
 		status.ConfirmedSiacoinBalance, status.SiafundBalance, status.SiacoinClaimBalance)
+
+	var fees api.TpoolFeeGET
+	err = getAPI("/tpool/fee", &fees)
+	if err != nil {
+		die("Could not get fee estimation:", err)
+	}
+	fmt.Printf(`
+Estimated Fee        %v / KB
+`, fees.Maximum.Mul64(1e3).HumanString())
 }
 
 // walletsweepcmd sweeps coins and funds from a seed.


### PR DESCRIPTION
sample output:
```
Wallet status:
Encrypted, Unlocked
Confirmed Balance:   100 SC
Unconfirmed Delta:  +0 H
Exact:               100000000000000000000000000 H
Siafunds:            0 SF
Siafund Claims:      0 H

Estimated Fee:       150 mS / KB
```