### PR TITLE
Update the way host feedback works

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -98,6 +98,11 @@ type HostDBEntry struct {
 	HistoricUptime   time.Duration `json:"historicuptime"`
 	ScanHistory      HostDBScans   `json:"scanhistory"`
 
+	HistoricSuccessfulInteractions uint64 `json:"historicSuccessfulInteractions"`
+	HistoricFailedInteractions     uint64 `json:"historicFailedInteractions"`
+	RecentSuccessfulInteractions   uint64 `json:"recentSuccessfulInteractions"`
+	RecentFailedInteractions       uint64 `json:"recentFailedInteractions"`
+
 	// The public key of the host, stored separately to minimize risk of certain
 	// MitM based vulnerabilities.
 	PublicKey types.SiaPublicKey `json:"publickey"`

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -103,6 +103,8 @@ type HostDBEntry struct {
 	RecentSuccessfulInteractions   uint64 `json:"recentSuccessfulInteractions"`
 	RecentFailedInteractions       uint64 `json:"recentFailedInteractions"`
 
+	LastHistoricUpdate types.BlockHeight
+
 	// The public key of the host, stored separately to minimize risk of certain
 	// MitM based vulnerabilities.
 	PublicKey types.SiaPublicKey `json:"publickey"`

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -34,6 +34,8 @@ func (newStub) AllHosts() []modules.HostDBEntry                                 
 func (newStub) ActiveHosts() []modules.HostDBEntry                              { return nil }
 func (newStub) Host(types.SiaPublicKey) (settings modules.HostDBEntry, ok bool) { return }
 func (newStub) RandomHosts(int, []types.SiaPublicKey) []modules.HostDBEntry     { return nil }
+func (newStub) IncrementSuccessfulInteractions(key types.SiaPublicKey)          {}
+func (newStub) IncrementFailedInteractions(key types.SiaPublicKey)              {}
 
 // TestNew tests the New function.
 func TestNew(t *testing.T) {
@@ -186,6 +188,8 @@ func (stubHostDB) ActiveHosts() (hs []modules.HostDBEntry)                      
 func (stubHostDB) Host(types.SiaPublicKey) (h modules.HostDBEntry, ok bool)         { return }
 func (stubHostDB) PublicKey() (spk types.SiaPublicKey)                              { return }
 func (stubHostDB) RandomHosts(int, []types.SiaPublicKey) (hs []modules.HostDBEntry) { return }
+func (stubHostDB) IncrementSuccessfulInteractions(key types.SiaPublicKey)           {}
+func (stubHostDB) IncrementFailedInteractions(key types.SiaPublicKey)               {}
 
 // TestIntegrationSetAllowance tests the SetAllowance method.
 func TestIntegrationSetAllowance(t *testing.T) {

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -34,8 +34,8 @@ func (newStub) AllHosts() []modules.HostDBEntry                                 
 func (newStub) ActiveHosts() []modules.HostDBEntry                              { return nil }
 func (newStub) Host(types.SiaPublicKey) (settings modules.HostDBEntry, ok bool) { return }
 func (newStub) RandomHosts(int, []types.SiaPublicKey) []modules.HostDBEntry     { return nil }
-func (newStub) IncrementSuccessfulInteractions(key types.SiaPublicKey)          {}
-func (newStub) IncrementFailedInteractions(key types.SiaPublicKey)              {}
+func (newStub) IncrementSuccessfulInteractions(key types.SiaPublicKey)          { return }
+func (newStub) IncrementFailedInteractions(key types.SiaPublicKey)              { return }
 
 // TestNew tests the New function.
 func TestNew(t *testing.T) {
@@ -188,8 +188,8 @@ func (stubHostDB) ActiveHosts() (hs []modules.HostDBEntry)                      
 func (stubHostDB) Host(types.SiaPublicKey) (h modules.HostDBEntry, ok bool)         { return }
 func (stubHostDB) PublicKey() (spk types.SiaPublicKey)                              { return }
 func (stubHostDB) RandomHosts(int, []types.SiaPublicKey) (hs []modules.HostDBEntry) { return }
-func (stubHostDB) IncrementSuccessfulInteractions(key types.SiaPublicKey)           {}
-func (stubHostDB) IncrementFailedInteractions(key types.SiaPublicKey)               {}
+func (stubHostDB) IncrementSuccessfulInteractions(key types.SiaPublicKey)           { return }
+func (stubHostDB) IncrementFailedInteractions(key types.SiaPublicKey)               { return }
 
 // TestIntegrationSetAllowance tests the SetAllowance method.
 func TestIntegrationSetAllowance(t *testing.T) {

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -50,6 +50,8 @@ type (
 		ActiveHosts() []modules.HostDBEntry
 		Host(types.SiaPublicKey) (modules.HostDBEntry, bool)
 		RandomHosts(n int, exclude []types.SiaPublicKey) []modules.HostDBEntry
+		IncrementSuccessfulInteractions(key types.SiaPublicKey)
+		IncrementFailedInteractions(key types.SiaPublicKey)
 	}
 
 	persister interface {

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -175,6 +175,15 @@ func (c *Contractor) Downloader(id types.FileContractID, cancel <-chan struct{})
 		}
 	}
 
+	// Increase Successful/Failed interactions accordingly
+	defer func() {
+		if err != nil {
+			c.hdb.IncrementFailedInteractions(contract.HostPublicKey)
+		} else {
+			c.hdb.IncrementSuccessfulInteractions(contract.HostPublicKey)
+		}
+	}()
+
 	// create downloader
 	d, err := proto.NewDownloader(host, contract, cancel)
 	if proto.IsRevisionMismatch(err) {

--- a/modules/renter/contractor/downloader.go
+++ b/modules/renter/contractor/downloader.go
@@ -175,17 +175,8 @@ func (c *Contractor) Downloader(id types.FileContractID, cancel <-chan struct{})
 		}
 	}
 
-	// Increase Successful/Failed interactions accordingly
-	defer func() {
-		if err != nil {
-			c.hdb.IncrementFailedInteractions(contract.HostPublicKey)
-		} else {
-			c.hdb.IncrementSuccessfulInteractions(contract.HostPublicKey)
-		}
-	}()
-
 	// create downloader
-	d, err := proto.NewDownloader(host, contract, cancel)
+	d, err := proto.NewDownloader(host, contract, c.hdb, cancel)
 	if proto.IsRevisionMismatch(err) {
 		// try again with the cached revision
 		c.mu.RLock()
@@ -198,7 +189,11 @@ func (c *Contractor) Downloader(id types.FileContractID, cancel <-chan struct{})
 		}
 		c.log.Printf("host %v has different revision for %v; retrying with cached revision", contract.NetAddress, contract.ID)
 		contract.LastRevision = cached.Revision
-		d, err = proto.NewDownloader(host, contract, cancel)
+		d, err = proto.NewDownloader(host, contract, c.hdb, cancel)
+		// needs to be handled separately since a revision mismatch is not automatically a failed interaction
+		if proto.IsRevisionMismatch(err) {
+			c.hdb.IncrementFailedInteractions(host.PublicKey)
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/modules/renter/contractor/editor.go
+++ b/modules/renter/contractor/editor.go
@@ -108,6 +108,10 @@ func (he *hostEditor) Upload(data []byte) (_ crypto.Hash, err error) {
 	he.mu.Lock()
 	defer he.mu.Unlock()
 
+	if he.invalid {
+		return crypto.Hash{}, errInvalidEditor
+	}
+
 	// Increase Successful/Failed interactions accordingly
 	defer func() {
 		if err != nil {
@@ -117,9 +121,6 @@ func (he *hostEditor) Upload(data []byte) (_ crypto.Hash, err error) {
 		}
 	}()
 
-	if he.invalid {
-		return crypto.Hash{}, errInvalidEditor
-	}
 	contract, sectorRoot, err := he.editor.Upload(data)
 	if err != nil {
 		return crypto.Hash{}, err
@@ -144,6 +145,10 @@ func (he *hostEditor) Delete(root crypto.Hash) (err error) {
 	he.mu.Lock()
 	defer he.mu.Unlock()
 
+	if he.invalid {
+		return errInvalidEditor
+	}
+
 	// Increase Successful/Failed interactions accordingly
 	defer func() {
 		if err != nil {
@@ -152,10 +157,6 @@ func (he *hostEditor) Delete(root crypto.Hash) (err error) {
 			he.contractor.hdb.IncrementSuccessfulInteractions(he.contract.HostPublicKey)
 		}
 	}()
-
-	if he.invalid {
-		return errInvalidEditor
-	}
 
 	contract, err := he.editor.Delete(root)
 	if err != nil {
@@ -176,6 +177,10 @@ func (he *hostEditor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newDat
 	he.mu.Lock()
 	defer he.mu.Unlock()
 
+	if he.invalid {
+		return errInvalidEditor
+	}
+
 	// Increase Successful/Failed interactions accordingly
 	defer func() {
 		if err != nil {
@@ -185,9 +190,6 @@ func (he *hostEditor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newDat
 		}
 	}()
 
-	if he.invalid {
-		return errInvalidEditor
-	}
 	contract, err := he.editor.Modify(oldRoot, newRoot, offset, newData)
 	if err != nil {
 		return err

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -67,7 +67,16 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 
 // managedNewContract negotiates an initial file contract with the specified
 // host, saves it, and returns it.
-func (c *Contractor) managedNewContract(host modules.HostDBEntry, numSectors uint64, endHeight types.BlockHeight) (modules.RenterContract, error) {
+func (c *Contractor) managedNewContract(host modules.HostDBEntry, numSectors uint64, endHeight types.BlockHeight) (_ modules.RenterContract, err error) {
+	// Increase Successful/Failed interactions accordingly
+	defer func() {
+		if err != nil {
+			c.hdb.IncrementFailedInteractions(host.PublicKey)
+		} else {
+			c.hdb.IncrementSuccessfulInteractions(host.PublicKey)
+		}
+	}()
+
 	// reject hosts that are too expensive
 	if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
 		return modules.RenterContract{}, errTooExpensive

--- a/modules/renter/contractor/formcontract.go
+++ b/modules/renter/contractor/formcontract.go
@@ -68,15 +68,6 @@ func maxSectors(a modules.Allowance, hdb hostDB, tp transactionPool) (uint64, er
 // managedNewContract negotiates an initial file contract with the specified
 // host, saves it, and returns it.
 func (c *Contractor) managedNewContract(host modules.HostDBEntry, numSectors uint64, endHeight types.BlockHeight) (_ modules.RenterContract, err error) {
-	// Increase Successful/Failed interactions accordingly
-	defer func() {
-		if err != nil {
-			c.hdb.IncrementFailedInteractions(host.PublicKey)
-		} else {
-			c.hdb.IncrementSuccessfulInteractions(host.PublicKey)
-		}
-	}()
-
 	// reject hosts that are too expensive
 	if host.StoragePrice.Cmp(maxStoragePrice) > 0 {
 		return modules.RenterContract{}, errTooExpensive
@@ -106,7 +97,7 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, numSectors uin
 	// create transaction builder
 	txnBuilder := c.wallet.StartTransaction()
 
-	contract, err := proto.FormContract(params, txnBuilder, c.tpool, c.tg.StopChan())
+	contract, err := proto.FormContract(params, txnBuilder, c.tpool, c.hdb, c.tg.StopChan())
 	if err != nil {
 		txnBuilder.Drop()
 		return modules.RenterContract{}, err

--- a/modules/renter/contractor/renew.go
+++ b/modules/renter/contractor/renew.go
@@ -13,15 +13,6 @@ import (
 // It returns the new contract. This is a blocking call that performs network
 // I/O.
 func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors uint64, newEndHeight types.BlockHeight) (_ modules.RenterContract, err error) {
-	// Increase Successful/Failed interactions accordingly
-	defer func() {
-		if err != nil {
-			c.hdb.IncrementFailedInteractions(contract.HostPublicKey)
-		} else {
-			c.hdb.IncrementSuccessfulInteractions(contract.HostPublicKey)
-		}
-	}()
-
 	host, ok := c.hdb.Host(contract.HostPublicKey)
 	if !ok {
 		return modules.RenterContract{}, errors.New("no record of that host")
@@ -55,7 +46,7 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 
 	// execute negotiation protocol
 	txnBuilder := c.wallet.StartTransaction()
-	newContract, err := proto.Renew(contract, params, txnBuilder, c.tpool, c.tg.StopChan())
+	newContract, err := proto.Renew(contract, params, txnBuilder, c.tpool, c.hdb, c.tg.StopChan())
 	if proto.IsRevisionMismatch(err) {
 		// return unused outputs to wallet
 		txnBuilder.Drop()
@@ -72,7 +63,11 @@ func (c *Contractor) managedRenew(contract modules.RenterContract, numSectors ui
 		contract.LastRevision = cached.Revision
 		// need to start a new transaction
 		txnBuilder = c.wallet.StartTransaction()
-		newContract, err = proto.Renew(contract, params, txnBuilder, c.tpool, c.tg.StopChan())
+		newContract, err = proto.Renew(contract, params, txnBuilder, c.tpool, c.hdb, c.tg.StopChan())
+		// needs to be handled separately since a revision mismatch is not automatically a failed interaction
+		if proto.IsRevisionMismatch(err) {
+			c.hdb.IncrementFailedInteractions(host.PublicKey)
+		}
 	}
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet

--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -29,6 +29,10 @@ const (
 	// saveFrequency defines how frequently the hostdb will save to disk. Hostdb
 	// will also save immediately prior to shutdown.
 	saveFrequency = 2 * time.Minute
+
+	// historicInteractionDecay defines the decay of the HistoricSuccessfulInteractions
+	// and HistoricFailedInteractions after every block
+	historicInteractionDecay = 0.997
 )
 
 var (

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -307,7 +307,8 @@ func (hdb *HostDB) IncrementFailedInteractions(key types.SiaPublicKey) {
 	defer hdb.mu.Unlock()
 
 	host, haveHost := hdb.hostTree.Select(key)
-	if !haveHost {
+	if !haveHost || !hdb.online {
+		// If we are offline it probably wasn't the host's fault
 		return
 	}
 

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -238,3 +238,31 @@ func (hdb *HostDB) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) {
 func (hdb *HostDB) RandomHosts(n int, excludeKeys []types.SiaPublicKey) []modules.HostDBEntry {
 	return hdb.hostTree.SelectRandom(n, excludeKeys)
 }
+
+// IncrementSuccessfulInteractions increments the number of successful interactions with a host for a given key
+func (hdb *HostDB) IncrementSuccessfulInteractions(key types.SiaPublicKey) {
+	hdb.mu.Lock()
+	defer hdb.mu.Unlock()
+
+	host, haveHost := hdb.hostTree.Select(key)
+	if !haveHost {
+		return
+	}
+
+	host.RecentSuccessfulInteractions++
+	hdb.hostTree.Modify(host)
+}
+
+// IncrementFailedInteractions increments the number of failed interactions with a host for a given key
+func (hdb *HostDB) IncrementFailedInteractions(key types.SiaPublicKey) {
+	hdb.mu.Lock()
+	defer hdb.mu.Unlock()
+
+	host, haveHost := hdb.hostTree.Select(key)
+	if !haveHost {
+		return
+	}
+
+	host.RecentFailedInteractions++
+	hdb.hostTree.Modify(host)
+}

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -7,6 +7,7 @@ package hostdb
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -17,7 +18,6 @@ import (
 	"github.com/NebulousLabs/Sia/persist"
 	siasync "github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
-	"math"
 )
 
 var (

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -2,6 +2,7 @@ package hostdb
 
 import (
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,6 @@ import (
 	"github.com/NebulousLabs/Sia/modules/wallet"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
-	"math"
 )
 
 // hdbTester contains a hostdb and all dependencies.

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules/wallet"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
+	"math"
 )
 
 // hdbTester contains a hostdb and all dependencies.
@@ -409,5 +410,103 @@ func TestRemoveNonexistingHostFromHostTree(t *testing.T) {
 	err = hdbt.hdb.hostTree.Remove(types.SiaPublicKey{})
 	if err == nil {
 		t.Fatal("There should be an error, but not a panic:", err)
+	}
+}
+
+// TestUpdateHistoricInteractions is a simple check to ensure that incrementing
+// the recent and historic host interactions works
+func TestUpdateHistoricInteractions(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// create a HostDB tester without scanloop to be able to manually increment
+	// the interactions without interference.
+	hdbt, err := newHDBTesterDeps(t.Name(), disableScanLoopDeps{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a HostDBEntry and add it to the tree
+	host := makeHostDBEntry()
+	err = hdbt.hdb.hostTree.Insert(host)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// increment successful and failed interactions by 100
+	interactions := uint64(100)
+	for i := uint64(0); i < interactions; i++ {
+		hdbt.hdb.IncrementSuccessfulInteractions(host.PublicKey)
+		hdbt.hdb.IncrementFailedInteractions(host.PublicKey)
+	}
+
+	// get updated host from hostdb
+	host, ok := hdbt.hdb.Host(host.PublicKey)
+	if !ok {
+		t.Fatal("Modified host not found in hostdb")
+	}
+
+	// check that recent interactions are exactly 100 and historic interactions are 0
+	if host.RecentFailedInteractions != interactions || host.RecentSuccessfulInteractions != interactions {
+		t.Errorf("Interactions should be %v but were %v and %v", interactions,
+			host.RecentFailedInteractions, host.RecentSuccessfulInteractions)
+	}
+	if host.HistoricFailedInteractions != 0 || host.HistoricSuccessfulInteractions != 0 {
+		t.Errorf("Historic Interactions should be %v but were %v and %v", 0,
+			host.HistoricFailedInteractions, host.HistoricSuccessfulInteractions)
+	}
+
+	// add single block to consensus
+	hdbt.miner.AddBlock()
+
+	// increment interactions again by 100
+	for i := uint64(0); i < interactions; i++ {
+		hdbt.hdb.IncrementSuccessfulInteractions(host.PublicKey)
+		hdbt.hdb.IncrementFailedInteractions(host.PublicKey)
+	}
+
+	// get updated host from hostdb
+	host, ok = hdbt.hdb.Host(host.PublicKey)
+	if !ok {
+		t.Fatal("Modified host not found in hostdb")
+	}
+
+	// check that recent interactions are exactly 100 again and historic interactions are also exactly 100
+	if host.RecentFailedInteractions != interactions || host.RecentSuccessfulInteractions != interactions {
+		t.Errorf("Interactions should be %v but were %v and %v", interactions,
+			host.RecentFailedInteractions, host.RecentSuccessfulInteractions)
+	}
+	if host.HistoricFailedInteractions != interactions || host.HistoricSuccessfulInteractions != interactions {
+		t.Errorf("Historic Interactions should be %v but were %v and %v", interactions,
+			host.HistoricFailedInteractions, host.HistoricSuccessfulInteractions)
+	}
+
+	// add 10 blocks to consensus
+	for i := 0; i < 10; i++ {
+		hdbt.miner.AddBlock()
+	}
+
+	// add a single interaction
+	hdbt.hdb.IncrementSuccessfulInteractions(host.PublicKey)
+	hdbt.hdb.IncrementFailedInteractions(host.PublicKey)
+
+	// get updated host from hostdb
+	host, ok = hdbt.hdb.Host(host.PublicKey)
+	if !ok {
+		t.Fatal("Modified host not found in hostdb")
+	}
+
+	// check that recent interactions are exactly 1 and historic interactions are (100*0.997 + 100)*0.997^9
+	if host.RecentFailedInteractions != 1 || host.RecentSuccessfulInteractions != 1 {
+		t.Errorf("Interactions should be %v but were %v and %v", interactions,
+			host.RecentFailedInteractions, host.RecentSuccessfulInteractions)
+	}
+
+	// Those two lines need to be split because
+	expected := uint64((100.0*historicInteractionDecay + 100.0) * math.Pow(historicInteractionDecay, 9))
+	if host.HistoricFailedInteractions != expected || host.HistoricSuccessfulInteractions != expected {
+		t.Errorf("Historic Interactions should be %v but were %v and %v", expected,
+			host.HistoricFailedInteractions, host.HistoricSuccessfulInteractions)
 	}
 }

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -230,9 +230,14 @@ func (hdb *HostDB) managedScanHost(entry modules.HostDBEntry) {
 	}()
 	if err != nil {
 		hdb.log.Debugf("Scan of host at %v failed: %v", netAddr, err)
+		// Increment failed host interactions
+		entry.RecentFailedInteractions++
 	} else {
 		hdb.log.Debugf("Scan of host at %v succeeded.", netAddr)
 		entry.HostExternalSettings = settings
+
+		// Increment successful host interactions
+		entry.RecentSuccessfulInteractions++
 	}
 
 	// Update the host tree to have a new entry, including the new error. Then

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -228,6 +228,9 @@ func (hdb *HostDB) managedScanHost(entry modules.HostDBEntry) {
 		copy(pubkey[:], pubKey.Key)
 		return crypto.ReadSignedObject(conn, &settings, maxSettingsLen, pubkey)
 	}()
+	// Update historic interactions of entry if necessary
+	updateHostsHistoricInteractions(&entry, hdb.cs.Height())
+
 	if err != nil {
 		hdb.log.Debugf("Scan of host at %v failed: %v", netAddr, err)
 		// Increment failed host interactions

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -233,8 +233,11 @@ func (hdb *HostDB) managedScanHost(entry modules.HostDBEntry) {
 
 	if err != nil {
 		hdb.log.Debugf("Scan of host at %v failed: %v", netAddr, err)
-		// Increment failed host interactions
-		entry.RecentFailedInteractions++
+		if hdb.online {
+			// Increment failed host interactions
+			entry.RecentFailedInteractions++
+		}
+
 	} else {
 		hdb.log.Debugf("Scan of host at %v succeeded.", netAddr)
 		entry.HostExternalSettings = settings

--- a/modules/renter/hostdb/update.go
+++ b/modules/renter/hostdb/update.go
@@ -29,23 +29,6 @@ func findHostAnnouncements(b types.Block) (announcements []modules.HostDBEntry) 
 	return
 }
 
-// updateHistoricInteractions adds the recent interactions to the historic interactions
-// and progresses the decay
-func (hdb *HostDB) updateHistoricInteractions() {
-	hosts := hdb.hostTree.All()
-	for _, host := range hosts {
-		host.HistoricSuccessfulInteractions = uint64(float64(host.HistoricSuccessfulInteractions) * historicInteractionDecay)
-		host.HistoricSuccessfulInteractions += host.RecentSuccessfulInteractions
-		host.RecentSuccessfulInteractions = 0
-
-		host.HistoricFailedInteractions = uint64(float64(host.HistoricFailedInteractions) * historicInteractionDecay)
-		host.HistoricFailedInteractions += host.RecentFailedInteractions
-		host.RecentFailedInteractions = 0
-
-		hdb.hostTree.Modify(host)
-	}
-}
-
 // insertBlockchainHost adds a host entry to the state. The host will be inserted
 // into the set of all hosts, and if it is online and responding to requests it
 // will be put into the list of active hosts.
@@ -128,9 +111,6 @@ func (hdb *HostDB) ProcessConsensusChange(cc modules.ConsensusChange) {
 			hdb.insertBlockchainHost(host)
 		}
 	}
-
-	// Update historic interactions
-	hdb.updateHistoricInteractions()
 
 	hdb.lastChange = cc.ID
 }

--- a/modules/renter/hostdb/update.go
+++ b/modules/renter/hostdb/update.go
@@ -29,6 +29,23 @@ func findHostAnnouncements(b types.Block) (announcements []modules.HostDBEntry) 
 	return
 }
 
+// updateHistoricInteractions adds the recent interactions to the historic interactions
+// and progresses the decay
+func (hdb *HostDB) updateHistoricInteractions() {
+	hosts := hdb.hostTree.All()
+	for _, host := range hosts {
+		host.HistoricSuccessfulInteractions = uint64(float64(host.HistoricSuccessfulInteractions) * historicInteractionDecay)
+		host.HistoricSuccessfulInteractions += host.RecentSuccessfulInteractions
+		host.RecentSuccessfulInteractions = 0
+
+		host.HistoricFailedInteractions = uint64(float64(host.HistoricFailedInteractions) * historicInteractionDecay)
+		host.HistoricFailedInteractions += host.RecentFailedInteractions
+		host.RecentFailedInteractions = 0
+
+		hdb.hostTree.Modify(host)
+	}
+}
+
 // insertBlockchainHost adds a host entry to the state. The host will be inserted
 // into the set of all hosts, and if it is online and responding to requests it
 // will be put into the list of active hosts.
@@ -111,6 +128,9 @@ func (hdb *HostDB) ProcessConsensusChange(cc modules.ConsensusChange) {
 			hdb.insertBlockchainHost(host)
 		}
 	}
+
+	// Update historic interactions
+	hdb.updateHistoricInteractions()
 
 	hdb.lastChange = cc.ID
 }

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -47,6 +47,7 @@ type Editor struct {
 	closeChan chan struct{}
 	once      sync.Once
 	host      modules.HostDBEntry
+	hdb       hostDB
 
 	height   types.BlockHeight
 	contract modules.RenterContract // updated after each revision
@@ -75,7 +76,16 @@ func (he *Editor) Close() error {
 // runRevisionIteration submits actions and their accompanying revision to the
 // host for approval. If negotiation is successful, it updates the underlying
 // Contract.
-func (he *Editor) runRevisionIteration(actions []modules.RevisionAction, rev types.FileContractRevision, newRoots []crypto.Hash) error {
+func (he *Editor) runRevisionIteration(actions []modules.RevisionAction, rev types.FileContractRevision, newRoots []crypto.Hash) (err error) {
+	// Increase Successful/Failed interactions accordingly
+	defer func() {
+		if err != nil {
+			he.hdb.IncrementFailedInteractions(he.contract.HostPublicKey)
+		} else {
+			he.hdb.IncrementSuccessfulInteractions(he.contract.HostPublicKey)
+		}
+	}()
+
 	// initiate revision
 	if err := startRevision(he.conn, he.host); err != nil {
 		return err
@@ -255,11 +265,21 @@ func (he *Editor) Modify(oldRoot, newRoot crypto.Hash, offset uint64, newData []
 
 // NewEditor initiates the contract revision process with a host, and returns
 // an Editor.
-func NewEditor(host modules.HostDBEntry, contract modules.RenterContract, currentHeight types.BlockHeight, cancel <-chan struct{}) (*Editor, error) {
+func NewEditor(host modules.HostDBEntry, contract modules.RenterContract, currentHeight types.BlockHeight, hdb hostDB, cancel <-chan struct{}) (_ *Editor, err error) {
 	// check that contract has enough value to support an upload
 	if len(contract.LastRevision.NewValidProofOutputs) != 2 {
 		return nil, errors.New("invalid contract")
 	}
+
+	// Increase Successful/Failed interactions accordingly
+	defer func() {
+		// a revision mismatch is not necessarily the host's fault
+		if err != nil && !IsRevisionMismatch(err) {
+			hdb.IncrementFailedInteractions(contract.HostPublicKey)
+		} else if err == nil {
+			hdb.IncrementSuccessfulInteractions(contract.HostPublicKey)
+		}
+	}()
 
 	// initiate revision loop
 	conn, err := (&net.Dialer{
@@ -294,6 +314,7 @@ func NewEditor(host modules.HostDBEntry, contract modules.RenterContract, curren
 	// the host is now ready to accept revisions
 	return &Editor{
 		host:      host,
+		hdb:       hdb,
 		height:    currentHeight,
 		contract:  contract,
 		conn:      conn,

--- a/modules/renter/proto/proto.go
+++ b/modules/renter/proto/proto.go
@@ -27,6 +27,11 @@ type (
 		AcceptTransactionSet([]types.Transaction) error
 		FeeEstimation() (min types.Currency, max types.Currency)
 	}
+
+	hostDB interface {
+		IncrementSuccessfulInteractions(key types.SiaPublicKey)
+		IncrementFailedInteractions(key types.SiaPublicKey)
+	}
 )
 
 // ContractParams are supplied as an argument to FormContract.


### PR DESCRIPTION
This PR is meant to improve existing measurements and add new ones like latency, speed and responsiveness to requests.

The first step is to add "InteractionReliability" by counting all the successful and failed interactions with a host (upload, download, delete, modify, form new contract, renew contract and scan) and adding them up to historic values which decay at a certain rate after each new block. 