### PR TITLE
add /renter/read and /renter/write APIs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -222,6 +222,8 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 		router.POST("/renter/delete/*siapath", RequirePassword(api.renterDeleteHandler, requiredPassword))
 		router.GET("/renter/download/*siapath", RequirePassword(api.renterDownloadHandler, requiredPassword))
 		router.GET("/renter/downloadasync/*siapath", RequirePassword(api.renterDownloadAsyncHandler, requiredPassword))
+		router.GET("/renter/read/:contractid/:sector_root", RequirePassword(api.renterReadHandler, requiredPassword))
+		router.POST("/renter/write/:contractid", RequirePassword(api.renterWriteHandler, requiredPassword))
 		router.POST("/renter/rename/*siapath", RequirePassword(api.renterRenameHandler, requiredPassword))
 		router.POST("/renter/upload/*siapath", RequirePassword(api.renterUploadHandler, requiredPassword))
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -272,6 +272,12 @@ type Renter interface {
 	// DownloadQueue lists all the files that have been scheduled for download.
 	DownloadQueue() []DownloadInfo
 
+	// Read returns data of a sector of a host.
+	Read(params RenterReadParameters) ([]byte, error)
+
+	// Write creates a sector in a host.
+	Write(params RenterWriteParameters) (crypto.Hash, error)
+
 	// FileList returns information on all of the files stored by the renter.
 	FileList() []FileInfo
 
@@ -326,4 +332,18 @@ type RenterDownloadParameters struct {
 	Offset      uint64
 	Siapath     string
 	Destination string
+}
+
+// RenterReadParameters defines the parameters passed to the Renter's
+// Read method.
+type RenterReadParameters struct {
+	ContractID types.FileContractID
+	SectorRoot crypto.Hash
+}
+
+// RenterWriteParameters defines the parameters passed to the Renter's
+// Write method.
+type RenterWriteParameters struct {
+	ContractID types.FileContractID
+	Data       []byte
 }

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -88,6 +88,37 @@ func (r *Renter) Download(p modules.RenterDownloadParameters) error {
 	}
 }
 
+// Read performs a sector download using the passed parameters.
+func (r *Renter) Read(p modules.RenterReadParameters) ([]byte, error) {
+	contractID := r.hostContractor.ResolveID(p.ContractID)
+	worker, has := r.workerPool[contractID]
+	if !has {
+		id := r.mu.Lock()
+		r.updateWorkerPool()
+		r.mu.Unlock(id)
+		worker, has = r.workerPool[contractID]
+	}
+	if !has {
+		return nil, errors.New("worker is not active")
+	}
+	rw := readWork{
+		sectorRoot: p.SectorRoot,
+		resultChan: make(chan finishedRead),
+	}
+	select {
+	case worker.priorityReadChan <- rw:
+	case <-r.tg.StopChan():
+		return nil, errors.New("read interrupted by shutdown")
+	}
+	// Block until the read has completed.
+	select {
+	case result := <-rw.resultChan:
+		return result.data, result.err
+	case <-r.tg.StopChan():
+		return nil, errors.New("read interrupted by shutdown")
+	}
+}
+
 // DownloadQueue returns the list of downloads in the queue.
 func (r *Renter) DownloadQueue() []modules.DownloadInfo {
 	lockID := r.mu.RLock()


### PR DESCRIPTION
This is the beginning of efforts to expose lowlevel renter features (uploading and downloading a single block) in the API.

Proof of concept example: https://gist.github.com/51c4a6116aed791147a2744d6cb290fa
File exchange site for files <4MB storing files directly in Sia without replication and/or encryption.
A file can be fetched using URL of format `site/contract_id/sector_root`.

Running instance with 3 contracts to real Sia hosts: http://redjohn.tk:4499/
This image is fed directly from Sia: http://redjohn.tk:4499/9bb5c0c456ecee0efb2d5179e37224586d4c04a00f2d26c5033bdf4c5bea83c9/f9144c418f516648295b6015454c2dce1b63755dc59327119238d874ed6dd002/cluster.png

(Two of three hosts are distant from the site and fetching a file from them takes 5 seconds, but third host is close (5ms ping) and the image is fetched in 1.2s. A random host is chosen to upload a file, so I did it multiple time to get fast URL.)

There is a large room for improvement (e.g. add RS, store primary blocks in close hosts and erasure codes on distant hosts; add encryption, support larger files, pack multiple small files to a single sector, download only needed part of a sector, produce shorter links, ...).