### PR TITLE
Add txn size limit to hardfork

### DIFF
--- a/types/constants.go
+++ b/types/constants.go
@@ -42,11 +42,12 @@ var (
 
 	// Oak hardfork constants. Oak is the name of the difficulty algorithm for
 	// Sia following a hardfork at block 135e3.
-	OakHardforkBlock BlockHeight
-	OakDecayNum      int64
-	OakDecayDenom    int64
-	OakMaxRise       *big.Rat
-	OakMaxDrop       *big.Rat
+	OakHardforkBlock        BlockHeight
+	OakDecayNum             int64
+	OakDecayDenom           int64
+	OakMaxRise              *big.Rat
+	OakMaxDrop              *big.Rat
+	OakHardforkTxnSizeLimit = uint64(65536) // 64 KiB
 )
 
 // init checks which build constant is in place and initializes the variables

--- a/types/constants.go
+++ b/types/constants.go
@@ -47,7 +47,7 @@ var (
 	OakDecayDenom           int64
 	OakMaxRise              *big.Rat
 	OakMaxDrop              *big.Rat
-	OakHardforkTxnSizeLimit = uint64(65536) // 64 KiB
+	OakHardforkTxnSizeLimit = uint64(64e3) // 64 KB
 )
 
 // init checks which build constant is in place and initializes the variables

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -14,8 +14,35 @@ import (
 	"github.com/NebulousLabs/Sia/encoding"
 )
 
+// sanityCheckWriter checks that the bytes written to w exactly match the
+// bytes in buf.
+type sanityCheckWriter struct {
+	w   io.Writer
+	buf *bytes.Buffer
+}
+
+func (s sanityCheckWriter) Write(p []byte) (int, error) {
+	if !bytes.Equal(p, s.buf.Next(len(p))) {
+		panic("encoding mismatch")
+	}
+	return s.w.Write(p)
+}
+
 // MarshalSia implements the encoding.SiaMarshaler interface.
 func (b Block) MarshalSia(w io.Writer) error {
+	if build.DEBUG {
+		// Sanity check: compare against the old encoding
+		buf := new(bytes.Buffer)
+		encoding.NewEncoder(buf).EncodeAll(
+			b.ParentID,
+			b.Nonce,
+			b.Timestamp,
+			b.MinerPayouts,
+			b.Transactions,
+		)
+		w = sanityCheckWriter{w, buf}
+	}
+
 	w.Write(b.ParentID[:])
 	w.Write(b.Nonce[:])
 	encoding.WriteUint64(w, uint64(b.Timestamp))

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -487,42 +487,25 @@ func (sp *StorageProof) MarshalSia(w io.Writer) error {
 
 // MarshalSia implements the encoding.SiaMarshaler interface.
 func (t Transaction) MarshalSia(w io.Writer) error {
-	encoding.WriteInt(w, len((t.SiacoinInputs)))
-	for i := range t.SiacoinInputs {
-		t.SiacoinInputs[i].MarshalSia(w)
+	if build.DEBUG {
+		// Sanity check: compare against the old encoding
+		buf := new(bytes.Buffer)
+		encoding.NewEncoder(buf).EncodeAll(
+			t.SiacoinInputs,
+			t.SiacoinOutputs,
+			t.FileContracts,
+			t.FileContractRevisions,
+			t.StorageProofs,
+			t.SiafundInputs,
+			t.SiafundOutputs,
+			t.MinerFees,
+			t.ArbitraryData,
+			t.TransactionSignatures,
+		)
+		w = sanityCheckWriter{w, buf}
 	}
-	encoding.WriteInt(w, len((t.SiacoinOutputs)))
-	for i := range t.SiacoinOutputs {
-		t.SiacoinOutputs[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.FileContracts)))
-	for i := range t.FileContracts {
-		t.FileContracts[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.FileContractRevisions)))
-	for i := range t.FileContractRevisions {
-		t.FileContractRevisions[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.StorageProofs)))
-	for i := range t.StorageProofs {
-		t.StorageProofs[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.SiafundInputs)))
-	for i := range t.SiafundInputs {
-		t.SiafundInputs[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.SiafundOutputs)))
-	for i := range t.SiafundOutputs {
-		t.SiafundOutputs[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.MinerFees)))
-	for i := range t.MinerFees {
-		t.MinerFees[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.ArbitraryData)))
-	for i := range t.ArbitraryData {
-		encoding.WritePrefix(w, t.ArbitraryData[i])
-	}
+
+	t.marshalSiaNoSignatures(w)
 	encoding.WriteInt(w, len((t.TransactionSignatures)))
 	for i := range t.TransactionSignatures {
 		err := t.TransactionSignatures[i].MarshalSia(w)

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -154,54 +154,43 @@ func (uc UnlockConditions) UnlockHash() UnlockHash {
 func (t Transaction) SigHash(i int) (hash crypto.Hash) {
 	cf := t.TransactionSignatures[i].CoveredFields
 	h := crypto.NewHash()
-	enc := encoding.NewEncoder(h)
 	if cf.WholeTransaction {
-		enc.EncodeAll(
-			t.SiacoinInputs,
-			t.SiacoinOutputs,
-			t.FileContracts,
-			t.FileContractRevisions,
-			t.StorageProofs,
-			t.SiafundInputs,
-			t.SiafundOutputs,
-			t.MinerFees,
-			t.ArbitraryData,
-			t.TransactionSignatures[i].ParentID,
-			t.TransactionSignatures[i].PublicKeyIndex,
-			t.TransactionSignatures[i].Timelock,
-		)
+		t.marshalSiaNoSignatures(h)
+		h.Write(t.TransactionSignatures[i].ParentID[:])
+		encoding.WriteUint64(h, t.TransactionSignatures[i].PublicKeyIndex)
+		encoding.WriteUint64(h, uint64(t.TransactionSignatures[i].Timelock))
 	} else {
 		for _, input := range cf.SiacoinInputs {
-			enc.Encode(t.SiacoinInputs[input])
+			t.SiacoinInputs[input].MarshalSia(h)
 		}
 		for _, output := range cf.SiacoinOutputs {
-			enc.Encode(t.SiacoinOutputs[output])
+			t.SiacoinOutputs[output].MarshalSia(h)
 		}
 		for _, contract := range cf.FileContracts {
-			enc.Encode(t.FileContracts[contract])
+			t.FileContracts[contract].MarshalSia(h)
 		}
 		for _, revision := range cf.FileContractRevisions {
-			enc.Encode(t.FileContractRevisions[revision])
+			t.FileContractRevisions[revision].MarshalSia(h)
 		}
 		for _, storageProof := range cf.StorageProofs {
-			enc.Encode(t.StorageProofs[storageProof])
+			t.StorageProofs[storageProof].MarshalSia(h)
 		}
 		for _, siafundInput := range cf.SiafundInputs {
-			enc.Encode(t.SiafundInputs[siafundInput])
+			t.SiafundInputs[siafundInput].MarshalSia(h)
 		}
 		for _, siafundOutput := range cf.SiafundOutputs {
-			enc.Encode(t.SiafundOutputs[siafundOutput])
+			t.SiafundOutputs[siafundOutput].MarshalSia(h)
 		}
 		for _, minerFee := range cf.MinerFees {
-			enc.Encode(t.MinerFees[minerFee])
+			t.MinerFees[minerFee].MarshalSia(h)
 		}
 		for _, arbData := range cf.ArbitraryData {
-			enc.Encode(t.ArbitraryData[arbData])
+			encoding.WritePrefix(h, t.ArbitraryData[arbData])
 		}
 	}
 
 	for _, sig := range cf.TransactionSignatures {
-		enc.Encode(t.TransactionSignatures[sig])
+		t.TransactionSignatures[sig].MarshalSia(h)
 	}
 
 	h.Sum(hash[:0])

--- a/types/transactions.go
+++ b/types/transactions.go
@@ -7,7 +7,6 @@ package types
 
 import (
 	"errors"
-	"io"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
@@ -142,47 +141,6 @@ type (
 	// UnlockHash is constructed.
 	UnlockHash crypto.Hash
 )
-
-func (t Transaction) marshalSiaNoSignatures(w io.Writer) {
-	enc := encoding.NewEncoder(w)
-
-	encoding.WriteInt(w, len((t.SiacoinInputs)))
-	for i := range t.SiacoinInputs {
-		t.SiacoinInputs[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.SiacoinOutputs)))
-	for i := range t.SiacoinOutputs {
-		t.SiacoinOutputs[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.FileContracts)))
-	for i := range t.FileContracts {
-		enc.Encode(t.FileContracts[i])
-	}
-	encoding.WriteInt(w, len((t.FileContractRevisions)))
-	for i := range t.FileContractRevisions {
-		enc.Encode(t.FileContractRevisions[i])
-	}
-	encoding.WriteInt(w, len((t.StorageProofs)))
-	for i := range t.StorageProofs {
-		enc.Encode(t.StorageProofs[i])
-	}
-	encoding.WriteInt(w, len((t.SiafundInputs)))
-	for i := range t.SiafundInputs {
-		enc.Encode(t.SiafundInputs[i])
-	}
-	encoding.WriteInt(w, len((t.SiafundOutputs)))
-	for i := range t.SiafundOutputs {
-		t.SiafundOutputs[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.MinerFees)))
-	for i := range t.MinerFees {
-		t.MinerFees[i].MarshalSia(w)
-	}
-	encoding.WriteInt(w, len((t.ArbitraryData)))
-	for i := range t.ArbitraryData {
-		encoding.WritePrefix(w, t.ArbitraryData[i])
-	}
-}
 
 // ID returns the id of a transaction, which is taken by marshalling all of the
 // fields except for the signatures and taking the hash of the result.

--- a/types/validtransaction_test.go
+++ b/types/validtransaction_test.go
@@ -142,13 +142,25 @@ func TestTransactionFitsInABlock(t *testing.T) {
 	// Try a transaction that will fit in a block, followed by one that won't.
 	data := make([]byte, BlockSizeLimit/2)
 	txn := Transaction{ArbitraryData: [][]byte{data}}
-	err := txn.fitsInABlock()
+	err := txn.fitsInABlock(0)
 	if err != nil {
 		t.Error(err)
 	}
 	data = make([]byte, BlockSizeLimit)
 	txn.ArbitraryData[0] = data
-	err = txn.fitsInABlock()
+	err = txn.fitsInABlock(0)
+	if err != ErrTransactionTooLarge {
+		t.Error(err)
+	}
+
+	// Try a too-large transaction before and after the hardfork height.
+	data = make([]byte, OakHardforkTxnSizeLimit+1)
+	txn.ArbitraryData[0] = data
+	err = txn.fitsInABlock(0)
+	if err != nil {
+		t.Error(err)
+	}
+	err = txn.fitsInABlock(OakHardforkBlock)
 	if err != ErrTransactionTooLarge {
 		t.Error(err)
 	}


### PR DESCRIPTION
I also snuck some encoding optimizations in. Mostly just calling `MarshalSia` methods directly where we weren't before.

Regrettably, `MarshalSiaSize` had a bug; it was 8 bytes short for each `TransactionSignature`. This was fixed on my local `txn-size` branch but was not pushed before that PR was merged. Good call on adding the sanity check during debug mode, otherwise I wouldn't have caught this.