### PR TITLE
Add API call to retrieve raw consensus change

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -162,6 +162,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 	if api.cs != nil {
 		router.GET("/consensus", api.consensusHandler)
 		router.POST("/consensus/validate/transactionset", api.consensusValidateTransactionsetHandler)
+		router.GET("/consensus/change/:id", api.consensusChange)
 	}
 
 	// Explorer API Calls

--- a/api/consensus.go
+++ b/api/consensus.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/NebulousLabs/Sia/types"
 
+	"fmt"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/julienschmidt/httprouter"
 )
 
@@ -17,6 +19,21 @@ type ConsensusGET struct {
 	CurrentBlock types.BlockID     `json:"currentblock"`
 	Target       types.Target      `json:"target"`
 	Difficulty   types.Currency    `json:"difficulty"`
+}
+
+// ConsensusChangeGet contains a raw consensus set with tags to support idiomatic json encodings.
+type ConsensusChangeGet struct {
+	ID                         string                             `json:"id"`
+	NextID                     string                             `json:"nextid"`
+	RevertedBlocks             []types.Block                      `json:"revertedblocks"`
+	AppliedBlocks              []types.Block                      `json:"appliedblocks"`
+	SiacoinOutputDiffs         []modules.SiacoinOutputDiff        `json:"siacoinoutputdiffs"`
+	FileContractDiffs          []modules.FileContractDiff         `json:"filecontractdiffs"`
+	SiafundOutputDiffs         []modules.SiafundOutputDiff        `json:"siafundoutputdiffs"`
+	DelayedSiacoinOutputDiffs  []modules.DelayedSiacoinOutputDiff `json:"delayedsiacoinoutputdiffs"`
+	SiafundPoolDiffs           []modules.SiafundPoolDiff          `json:"siafundpooldiffs"`
+	ChildTarget                types.Target                       `json:"childtarget"`
+	MinimumValidChildTimestamp types.Timestamp                    `json:"minimumvalidchildtimestamp"`
 }
 
 // consensusHandler handles the API calls to /consensus.
@@ -47,4 +64,40 @@ func (api *API) consensusValidateTransactionsetHandler(w http.ResponseWriter, re
 		return
 	}
 	WriteSuccess(w)
+}
+
+// consensusChange handles the API calls to /consensus/change
+func (api *API) consensusChange(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	// Parse the changeid that's being requested.
+	var idBytes []byte
+	var id modules.ConsensusChangeID
+
+	_, err := fmt.Sscanf(ps.ByName("id"), "%x", &idBytes)
+	if err != nil {
+		WriteError(w, Error{err.Error()}, http.StatusBadRequest)
+		return
+	}
+
+	// Get the consensus change
+	copy(id[:], idBytes)
+	cc, next, err := api.cs.GetConsensusChange(id)
+	if err != nil {
+		http.NotFound(w, req)
+		return
+	}
+
+	// Return the consensus change
+	WriteJSON(w, ConsensusChangeGet{
+		ID:                         fmt.Sprintf("%x", cc.ID[:]),
+		NextID:                     fmt.Sprintf("%x", next[:]),
+		RevertedBlocks:             cc.RevertedBlocks,
+		AppliedBlocks:              cc.AppliedBlocks,
+		SiacoinOutputDiffs:         cc.SiacoinOutputDiffs,
+		FileContractDiffs:          cc.FileContractDiffs,
+		SiafundOutputDiffs:         cc.SiafundOutputDiffs,
+		DelayedSiacoinOutputDiffs:  cc.DelayedSiacoinOutputDiffs,
+		SiafundPoolDiffs:           cc.SiafundPoolDiffs,
+		ChildTarget:                cc.ChildTarget,
+		MinimumValidChildTimestamp: cc.MinimumValidChildTimestamp,
+	})
 }

--- a/api/consensus_test.go
+++ b/api/consensus_test.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"testing"
 
+	"fmt"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -107,5 +109,76 @@ func TestConsensusValidateTransactionSet(t *testing.T) {
 	defer resp.Body.Close()
 	if !non2xx(resp.StatusCode) {
 		t.Fatal("expected validation error")
+	}
+}
+
+// TestConsensusChange probes the GET call to /consensus/change.
+func TestConsensusChange(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	st, err := createServerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.panicClose()
+
+	// Request the consensus change beginning
+	requestedID := modules.ConsensusChangeBeginning
+	cc, nextID, err := st.cs.GetConsensusChange(requestedID)
+
+	// Send the GET request
+	var ccg ConsensusChangeGet
+	err = st.getAPI(fmt.Sprintf("/consensus/change/%x", requestedID[:]), &ccg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare the values of the returned consensus change with the retrieved one
+	var replyIDBytes []byte
+	var replyNextIDBytes []byte
+	var replyID modules.ConsensusChangeID
+	var replyNextID modules.ConsensusChangeID
+
+	// Parse the ids of the request
+	_, err = fmt.Sscanf(ccg.ID, "%x", &replyIDBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = fmt.Sscanf(ccg.NextID, "%x", &replyNextIDBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	copy(replyID[:], replyIDBytes)
+	copy(replyNextID[:], replyNextIDBytes)
+
+	// Check if values match
+	if replyID != cc.ID {
+		t.Errorf("ID mismatch: expected %v but was %v", cc.ID, ccg.ID)
+	}
+	if replyNextID != nextID {
+		t.Errorf("NextID mismatch: expected %v but was %v", nextID, ccg.NextID)
+	}
+
+	// Request the next change
+	var ccg2 ConsensusChangeGet
+	err = st.getAPI("/consensus/change/"+ccg.NextID, &ccg2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check if the id of the next change matches the NextID of the previous change
+	var replyIDBytes2 []byte
+	var replyID2 modules.ConsensusChangeID
+
+	_, err = fmt.Sscanf(ccg2.ID, "%x", &replyIDBytes2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	copy(replyID2[:], replyIDBytes2)
+	if replyID2 != replyNextID {
+		t.Errorf("ID mismatch: expected %v but was %v", replyNextID, replyID2)
 	}
 }

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -243,6 +243,11 @@ type (
 		// allowing for garbage collection and rescanning. If the subscriber is
 		// not found in the subscriber database, no action is taken.
 		Unsubscribe(ConsensusSetSubscriber)
+
+		// GetConsensusChange returns the ConsensusChange that corresponds to
+		// a given ConsensusChangeID. Primarily used for API calls as modules
+		// should Subscribe to the Consensus Set instead
+		GetConsensusChange(id ConsensusChangeID) (ConsensusChange, ConsensusChangeID, error)
 	}
 )
 


### PR DESCRIPTION
This PR adds the `"/consensus/change/:id"` GET API call.
It takes a hex encoded consensus change id and returns a raw consensus change + the id of the next change if there is any. Otherwise it returns the 32 byte long zero id.
The first change can be retrieved providing the zero id.