### PR TITLE
run tpool tests with vlong flag

### DIFF
--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -213,9 +213,8 @@ func TestGetTransaction(t *testing.T) {
 // TestBlockFeeEstimation checks that the fee estimation algorithm is reasonably
 // on target when the tpool is relying on blockchain based fee estimation.
 func TestFeeEstimation(t *testing.T) {
-	t.Skip("Tpool is too slow to run this test regularly")
-	if testing.Short() {
-		t.SkipNow()
+	if testing.Short() || !build.VLONG {
+		t.Skip("Tpool is too slow to run this test regularly")
 	}
 	tpt, err := createTpoolTester(t.Name())
 	if err != nil {
@@ -344,9 +343,8 @@ func TestFeeEstimation(t *testing.T) {
 // up, and less than 250ms per mb to empty out - indicating linear scalability
 // and tolerance for a larger pool size.
 func TestTpoolScalability(t *testing.T) {
-	t.Skip("Tpool is too slow to run this test regularly")
-	if testing.Short() {
-		t.SkipNow()
+	if testing.Short() || !build.VLONG {
+		t.Skip("Tpool is too slow to run this test regularly")
 	}
 	tpt, err := createTpoolTester(t.Name())
 	if err != nil {


### PR DESCRIPTION
`make test-vlong` should only skip tests that are broken/buggy, but run all tests that are very long.