### PR TITLE
repair broken consensus change distribution

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -260,6 +260,7 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 			// Try adding the block to consnesus.
 			changeEntry, err := cs.addBlockToTree(tx, blocks[i], parent)
 			if err == nil {
+				changes = append(changes, changeEntry)
 				chainExtended = true
 			}
 			if err == modules.ErrNonExtendingBlock {
@@ -274,7 +275,6 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 				panic("after adding a change entry, there are no applied blocks but there are reverted blocks")
 			}
 			// Append to the set of changes, and append the valid block.
-			changes = append(changes, changeEntry)
 			validBlocks = append(validBlocks, blocks[i])
 			parents = append(parents, parent)
 		}
@@ -322,7 +322,7 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 	}
 
 	// Sanity check - if we get here, len(changes) should be non-zero.
-	if build.DEBUG && len(changes) == 0 || len(changes) != len(validBlocks) {
+	if build.DEBUG && len(changes) == 0 {
 		panic("changes is empty, but this code should not be reached if no blocks got added")
 	}
 

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -207,7 +207,7 @@ func (cs *ConsensusSet) ConsensusSetSubscribe(subscriber modules.ConsensusSetSub
 
 	// Add the module to the list of subscribers.
 	cs.mu.Lock()
-	// Check that this subscriber is not already subscribed.
+	// Sanity check - subscriber should not be already subscribed.
 	for _, s := range cs.subscribers {
 		if s == subscriber {
 			build.Critical("refusing to double-subscribe subscriber")


### PR DESCRIPTION
By combining consensus changes before distributing them when downloading multiple blocks at a time, we ended up providing subscribers with consensus change IDs that did not match the original consensus change ID. The result was a lot of the modules started resetting themselves.

This fixes that, I should have thought about it on the first pass, and I remember being skeptical that it was the right way to go.

Code has been simplified, and now it should be correct.

We need to replace RC3 with this code ASAP, it's a pretty massive usability fix.