### PR TITLE
add reasonable timeouts to the API server

### DIFF
--- a/siad/server.go
+++ b/siad/server.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/NebulousLabs/Sia/api"
 	"github.com/NebulousLabs/Sia/build"
@@ -382,6 +383,23 @@ func NewServer(bindAddr, requiredUserAgent, requiredPassword string) (*Server, e
 		listener: l,
 		httpServer: &http.Server{
 			Handler: mux,
+
+			// set reasonable timeout windows for requests, to prevent the Sia API
+			// server from leaking file descriptors due to slow, disappearing, or
+			// unreliable API clients.
+
+			// ReadTimeout defines the maximum amount of time allowed to fully read
+			// the request body. This timeout is applied to every handler in the
+			// server.
+			ReadTimeout: time.Minute,
+
+			// ReadHeaderTimeout defines the amount of time allowed to fully read the
+			// request headers.
+			ReadHeaderTimeout: time.Second * 15,
+
+			// IdleTimeout defines the maximum duration a HTTP Keep-Alive connection
+			// the API is kept open with no activity before closing.
+			IdleTimeout: time.Minute * 5,
 		},
 	}
 

--- a/siad/server.go
+++ b/siad/server.go
@@ -399,7 +399,7 @@ func NewServer(bindAddr, requiredUserAgent, requiredPassword string) (*Server, e
 
 			// IdleTimeout defines the maximum duration a HTTP Keep-Alive connection
 			// the API is kept open with no activity before closing.
-			IdleTimeout: time.Minute * 5,
+			IdleTimeout: time.Second * 20,
 		},
 	}
 


### PR DESCRIPTION
Previously, `siad`'s API server was missing [timeouts](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) for its HTTP connections. This could lead to it leaking conns if clients are slow, disappearing, or unreliable and is a plausible cause for the `too many open files` errors users have been reporting.