### PR TITLE
increase vlong test time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test-v:
 test-long: clean fmt vet lint
 	go test -v -race -tags='testing debug' -timeout=500s $(pkgs) -run=$(run)
 test-vlong: clean fmt vet lint
-	go test -v -race -tags='testing debug vlong' -timeout=1000s $(pkgs) -run=$(run)
+	go test -v -race -tags='testing debug vlong' -timeout=5000s $(pkgs) -run=$(run)
 test-cpu:
 	go test -v -tags='testing debug' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)
 test-mem:


### PR DESCRIPTION
The newly merged tpool test can push the whole suite over 1000 seconds.