### PR TITLE
fix goroutine/download leak in renter

### DIFF
--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -274,7 +274,8 @@ func (cd *chunkDownload) recoverChunk() error {
 		lowerBound = int(offsetInBlock) // If the offset is within the block, part of the block will be ignored
 	}
 
-	// Truncate b if writing the whole buffer at the specified offset would exceed the maximum file size.
+	// Truncate b if writing the whole buffer at the specified offset would
+	// exceed the maximum file size.
 	upperBound := cd.download.chunkSize
 	if chunkTopAddress > cd.download.length+cd.download.offset {
 		diff := chunkTopAddress - (cd.download.length + cd.download.offset)

--- a/modules/renter/repair.go
+++ b/modules/renter/repair.go
@@ -337,8 +337,13 @@ func (r *Renter) managedGetChunkData(rs *repairState, file *file, trackedFile tr
 
 		// create the download object and push it on to the download queue
 		d := r.newSectionDownload(file, buf, currentContracts, offset, downloadSize)
+		done := make(chan struct{})
+		defer close(done)
 		go func() {
-			r.newDownloads <- d
+			select {
+			case r.newDownloads <- d:
+			case <-done:
+			}
 		}()
 
 		// wait for the download to complete and return the data


### PR DESCRIPTION
This PR fixes a case where the renter's `chunkDownloadTimeout` would elapse before the download gets pulled out of the `newDownloads` chan, resulting in a goroutine leak and failing to cancel the download.

