### PR TITLE
add host interaction weight to the hostdb

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -630,6 +630,7 @@ overall.
     "ageadjustment":              0.1234,
     "burnadjustment":             0.1234,
     "collateraladjustment":       23.456,
+    "interactionadjustment":      0.1234,
     "priceadjustment":            0.1234,
     "storageremainingadjustment": 0.1234,
     "uptimeadjustment":           0.1234,

--- a/doc/api/HostDB.md
+++ b/doc/api/HostDB.md
@@ -277,6 +277,14 @@ overall.
     // a point it can be detrimental.
     "collateraladjustment":       23.456,
 
+    // The multipler that gets applied to a host based on previous interactions
+    // with the host. A high ratio of successful interactions will improve this
+    // hosts score, and a high ratio of failed interactions will hurt this
+    // hosts score. This adjustment helps account for hosts that are on
+    // unstable connections, don't keep their wallets unlocked, ran out of
+    // funds, etc.
+    "interactionadjustment":      0.1234,
+
     // The multiplier that gets applied to a host based on the host's price.
     // Lower prices are almost always better. Below a certain, very low price,
     // there is no advantage.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -98,10 +98,10 @@ type HostDBEntry struct {
 	HistoricUptime   time.Duration `json:"historicuptime"`
 	ScanHistory      HostDBScans   `json:"scanhistory"`
 
-	HistoricFailedInteractions     uint64 `json:"historicFailedInteractions"`
-	HistoricSuccessfulInteractions uint64 `json:"historicSuccessfulInteractions"`
-	RecentFailedInteractions       uint64 `json:"recentFailedInteractions"`
-	RecentSuccessfulInteractions   uint64 `json:"recentSuccessfulInteractions"`
+	HistoricFailedInteractions     uint64 `json:"historicfailedinteractions"`
+	HistoricSuccessfulInteractions uint64 `json:"historicsuccessfulinteractions"`
+	RecentFailedInteractions       uint64 `json:"recentfailedinteractions"`
+	RecentSuccessfulInteractions   uint64 `json:"recentsuccessfulinteractions"`
 
 	LastHistoricUpdate types.BlockHeight
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -98,10 +98,10 @@ type HostDBEntry struct {
 	HistoricUptime   time.Duration `json:"historicuptime"`
 	ScanHistory      HostDBScans   `json:"scanhistory"`
 
-	HistoricSuccessfulInteractions uint64 `json:"historicSuccessfulInteractions"`
 	HistoricFailedInteractions     uint64 `json:"historicFailedInteractions"`
-	RecentSuccessfulInteractions   uint64 `json:"recentSuccessfulInteractions"`
+	HistoricSuccessfulInteractions uint64 `json:"historicSuccessfulInteractions"`
 	RecentFailedInteractions       uint64 `json:"recentFailedInteractions"`
+	RecentSuccessfulInteractions   uint64 `json:"recentSuccessfulInteractions"`
 
 	LastHistoricUpdate types.BlockHeight
 
@@ -130,6 +130,7 @@ type HostScoreBreakdown struct {
 	AgeAdjustment              float64 `json:"ageadjustment"`
 	BurnAdjustment             float64 `json:"burnadjustment"`
 	CollateralAdjustment       float64 `json:"collateraladjustment"`
+	InteractionAdjustment      float64 `json:"interactionadjustment"`
 	PriceAdjustment            float64 `json:"pricesmultiplier"`
 	StorageRemainingAdjustment float64 `json:"storageremainingadjustment"`
 	UptimeAdjustment           float64 `json:"uptimeadjustment"`

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -98,10 +98,10 @@ type HostDBEntry struct {
 	HistoricUptime   time.Duration `json:"historicuptime"`
 	ScanHistory      HostDBScans   `json:"scanhistory"`
 
-	HistoricFailedInteractions     uint64 `json:"historicfailedinteractions"`
-	HistoricSuccessfulInteractions uint64 `json:"historicsuccessfulinteractions"`
-	RecentFailedInteractions       uint64 `json:"recentfailedinteractions"`
-	RecentSuccessfulInteractions   uint64 `json:"recentsuccessfulinteractions"`
+	HistoricFailedInteractions     float64 `json:"historicfailedinteractions"`
+	HistoricSuccessfulInteractions float64 `json:"historicsuccessfulinteractions"`
+	RecentFailedInteractions       float64 `json:"recentfailedinteractions"`
+	RecentSuccessfulInteractions   float64 `json:"recentsuccessfulinteractions"`
 
 	LastHistoricUpdate types.BlockHeight
 

--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -7,17 +7,13 @@ import (
 )
 
 const (
-	// maxHostDowntime specifies the maximum amount of time that a host is
-	// allowed to be offline while still being in the hostdb.
-	maxHostDowntime = 10 * 24 * time.Hour
+	// historicInteractionDecay defines the decay of the HistoricSuccessfulInteractions
+	// and HistoricFailedInteractions after every block for a host entry.
+	historicInteractionDecay = 0.9995
 
-	// minScans specifies the number of scans that a host should have before the
-	// scans start getting compressed.
-	minScans = 12
-
-	// maxSettingsLen indicates how long in bytes the host settings field is
-	// allowed to be before being ignored as a DoS attempt.
-	maxSettingsLen = 10e3
+	// historicInteractionDecalLimit defines the number of historic
+	// interactions required before decay is applied.
+	historicInteractionDecayLimit = 500
 
 	// hostRequestTimeout indicates how long a host has to respond to a dial.
 	hostRequestTimeout = 2 * time.Minute
@@ -26,13 +22,30 @@ const (
 	// scan.
 	hostScanDeadline = 4 * time.Minute
 
+	// maxHostDowntime specifies the maximum amount of time that a host is
+	// allowed to be offline while still being in the hostdb.
+	maxHostDowntime = 10 * 24 * time.Hour
+
+	// maxSettingsLen indicates how long in bytes the host settings field is
+	// allowed to be before being ignored as a DoS attempt.
+	maxSettingsLen = 10e3
+
+	// minScans specifies the number of scans that a host should have before the
+	// scans start getting compressed.
+	minScans = 12
+
+	// recentInteractionWeightLimit caps the number of recent interactions as a
+	// percentage of the historic interactions, to be certain that a large
+	// amount of activity in a short period of time does not overwhelm the
+	// score for a host.
+	//
+	// Non-stop heavy interactions for half a day can result in gaining more
+	// than half the total weight at this limit.
+	recentInteractionWeightLimit = 0.01
+
 	// saveFrequency defines how frequently the hostdb will save to disk. Hostdb
 	// will also save immediately prior to shutdown.
 	saveFrequency = 2 * time.Minute
-
-	// historicInteractionDecay defines the decay of the HistoricSuccessfulInteractions
-	// and HistoricFailedInteractions after every block
-	historicInteractionDecay = 0.999
 )
 
 var (

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -229,7 +229,14 @@ func (hdb *HostDB) Close() error {
 // Host returns the HostSettings associated with the specified NetAddress. If
 // no matching host is found, Host returns false.
 func (hdb *HostDB) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) {
-	return hdb.hostTree.Select(spk)
+	host, exists := hdb.hostTree.Select(spk)
+	if !exists {
+		return host, exists
+	}
+	hdb.mu.RLock()
+	updateHostHistoricInteractions(&host, hdb.blockHeight)
+	hdb.mu.RUnlock()
+	return host, exists
 }
 
 // RandomHosts implements the HostDB interface's RandomHosts() method. It takes

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -7,7 +7,6 @@ package hostdb
 import (
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -184,50 +183,6 @@ func newHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir string, de
 	return hdb, nil
 }
 
-// updateHostDBEntry updates a HostDBEntries's historic interactions if more
-// than one block passed since the last update. This should be called every time
-// before the recent interactions are updated.  if passedTime is e.g. 10, this
-// means that the recent interactions were updated 10 blocks ago but never
-// since. So we need to apply the decay of 1 block before we append the recent
-// interactions from 10 blocks ago and then apply the decay of 9 more blocks in
-// which the recent interactions have been 0
-func updateHostHistoricInteractions(host *modules.HostDBEntry, bh types.BlockHeight) {
-	passedTime := bh - host.LastHistoricUpdate
-	if passedTime == 0 {
-		// no time passed. nothing to do.
-		return
-	}
-
-	// tmp float64 values for more accurate decay
-	hsi := float64(host.HistoricSuccessfulInteractions)
-	hfi := float64(host.HistoricFailedInteractions)
-
-	// Apply the decay of a single block
-	decay := historicInteractionDecay
-	hsi *= decay
-	hfi *= decay
-
-	// Apply the recent interactions of that single block
-	hsi += float64(host.RecentSuccessfulInteractions)
-	hfi += float64(host.RecentFailedInteractions)
-
-	// Apply the decay of the rest of the blocks
-	if passedTime > 1 {
-		decay = math.Pow(historicInteractionDecay, float64(passedTime-1))
-		hsi *= decay
-		hfi *= decay
-	}
-
-	// Set new values
-	host.HistoricSuccessfulInteractions = uint64(hsi)
-	host.HistoricFailedInteractions = uint64(hfi)
-	host.RecentSuccessfulInteractions = 0
-	host.RecentFailedInteractions = 0
-
-	// Update the time of the last update
-	host.LastHistoricUpdate = bh
-}
-
 // ActiveHosts returns a list of hosts that are currently online, sorted by
 // weight.
 func (hdb *HostDB) ActiveHosts() (activeHosts []modules.HostDBEntry) {
@@ -282,45 +237,4 @@ func (hdb *HostDB) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) {
 // returns a slice of entries.
 func (hdb *HostDB) RandomHosts(n int, excludeKeys []types.SiaPublicKey) []modules.HostDBEntry {
 	return hdb.hostTree.SelectRandom(n, excludeKeys)
-}
-
-// IncrementSuccessfulInteractions increments the number of successful
-// interactions with a host for a given key
-func (hdb *HostDB) IncrementSuccessfulInteractions(key types.SiaPublicKey) {
-	hdb.mu.Lock()
-	defer hdb.mu.Unlock()
-
-	// Fetch the host.
-	host, haveHost := hdb.hostTree.Select(key)
-	if !haveHost {
-		return
-	}
-
-	// Update historic values if necessary
-	updateHostHistoricInteractions(&host, hdb.blockHeight)
-
-	// Increment the successful interactions
-	host.RecentSuccessfulInteractions++
-	hdb.hostTree.Modify(host)
-}
-
-// IncrementFailedInteractions increments the number of failed interactions with
-// a host for a given key
-func (hdb *HostDB) IncrementFailedInteractions(key types.SiaPublicKey) {
-	hdb.mu.Lock()
-	defer hdb.mu.Unlock()
-
-	// Fetch the host.
-	host, haveHost := hdb.hostTree.Select(key)
-	if !haveHost || !hdb.online {
-		// If we are offline it probably wasn't the host's fault
-		return
-	}
-
-	// Update historic values if necessary
-	updateHostHistoricInteractions(&host, hdb.blockHeight)
-
-	// Increment the failed interactions
-	host.RecentFailedInteractions++
-	hdb.hostTree.Modify(host)
 }

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -15,11 +15,13 @@ import (
 // interactions from 10 blocks ago and then apply the decay of 9 more blocks in
 // which the recent interactions have been 0
 func updateHostHistoricInteractions(host *modules.HostDBEntry, bh types.BlockHeight) {
-	passedTime := bh - host.LastHistoricUpdate
-	if passedTime == 0 {
-		// no time passed. nothing to do.
+	// Check that the last historic update was not in the future.
+	if host.LastHistoricUpdate >= bh {
+		// The hostdb may be performing a rescan, or maybe no time has passed
+		// since the last update, so there is nothing to do.
 		return
 	}
+	passedTime := bh - host.LastHistoricUpdate
 
 	// tmp float64 values for more accurate decay
 	hsi := float64(host.HistoricSuccessfulInteractions)

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -24,16 +24,13 @@ func updateHostHistoricInteractions(host *modules.HostDBEntry, bh types.BlockHei
 	passedTime := bh - host.LastHistoricUpdate
 
 	// tmp float64 values for more accurate decay
-	hsi := float64(host.HistoricSuccessfulInteractions)
-	hfi := float64(host.HistoricFailedInteractions)
+	hsi := host.HistoricSuccessfulInteractions
+	hfi := host.HistoricFailedInteractions
 
-	// Apply the decay of a single block, but only if there are more than
-	// historicInteractionDecalyLimit datapoints total.
-	if hsi+hfi > historicInteractionDecayLimit {
-		decay := historicInteractionDecay
-		hsi *= decay
-		hfi *= decay
-	}
+	// Apply the decay of a single block.
+	decay := historicInteractionDecay
+	hsi *= decay
+	hfi *= decay
 
 	// Apply the recent interactions of that single block. Recent interactions
 	// cannot represent more than recentInteractionWeightLimit of historic
@@ -66,8 +63,8 @@ func updateHostHistoricInteractions(host *modules.HostDBEntry, bh types.BlockHei
 	}
 
 	// Set new values
-	host.HistoricSuccessfulInteractions = uint64(hsi)
-	host.HistoricFailedInteractions = uint64(hfi)
+	host.HistoricSuccessfulInteractions = hsi
+	host.HistoricFailedInteractions = hfi
 	host.RecentSuccessfulInteractions = 0
 	host.RecentFailedInteractions = 0
 

--- a/modules/renter/hostdb/hostentry.go
+++ b/modules/renter/hostdb/hostentry.go
@@ -1,0 +1,115 @@
+package hostdb
+
+import (
+	"math"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// updateHostDBEntry updates a HostDBEntries's historic interactions if more
+// than one block passed since the last update. This should be called every time
+// before the recent interactions are updated.  if passedTime is e.g. 10, this
+// means that the recent interactions were updated 10 blocks ago but never
+// since. So we need to apply the decay of 1 block before we append the recent
+// interactions from 10 blocks ago and then apply the decay of 9 more blocks in
+// which the recent interactions have been 0
+func updateHostHistoricInteractions(host *modules.HostDBEntry, bh types.BlockHeight) {
+	passedTime := bh - host.LastHistoricUpdate
+	if passedTime == 0 {
+		// no time passed. nothing to do.
+		return
+	}
+
+	// tmp float64 values for more accurate decay
+	hsi := float64(host.HistoricSuccessfulInteractions)
+	hfi := float64(host.HistoricFailedInteractions)
+
+	// Apply the decay of a single block, but only if there are more than
+	// historicInteractionDecalyLimit datapoints total.
+	if hsi+hfi > historicInteractionDecayLimit {
+		decay := historicInteractionDecay
+		hsi *= decay
+		hfi *= decay
+	}
+
+	// Apply the recent interactions of that single block. Recent interactions
+	// cannot represent more than recentInteractionWeightLimit of historic
+	// interactions, unless there are less than historicInteractionDecayLimit
+	// total interactions, and then the recent interactions cannot count for
+	// more than recentInteractionWeightLimit of the decay limit.
+	rsi := float64(host.RecentSuccessfulInteractions)
+	rfi := float64(host.RecentFailedInteractions)
+	if hsi+hfi > historicInteractionDecayLimit {
+		if rsi+rfi > recentInteractionWeightLimit*(hsi+hfi) {
+			adjustment := recentInteractionWeightLimit * (hsi + hfi) / (rsi + rfi)
+			rsi *= adjustment
+			rfi *= adjustment
+		}
+	} else {
+		if rsi+rfi > recentInteractionWeightLimit*historicInteractionDecayLimit {
+			adjustment := recentInteractionWeightLimit * historicInteractionDecayLimit / (rsi + rfi)
+			rsi *= adjustment
+			rfi *= adjustment
+		}
+	}
+	hsi += rsi
+	hfi += rfi
+
+	// Apply the decay of the rest of the blocks
+	if passedTime > 1 && hsi+hfi > historicInteractionDecayLimit {
+		decay := math.Pow(historicInteractionDecay, float64(passedTime-1))
+		hsi *= decay
+		hfi *= decay
+	}
+
+	// Set new values
+	host.HistoricSuccessfulInteractions = uint64(hsi)
+	host.HistoricFailedInteractions = uint64(hfi)
+	host.RecentSuccessfulInteractions = 0
+	host.RecentFailedInteractions = 0
+
+	// Update the time of the last update
+	host.LastHistoricUpdate = bh
+}
+
+// IncrementSuccessfulInteractions increments the number of successful
+// interactions with a host for a given key
+func (hdb *HostDB) IncrementSuccessfulInteractions(key types.SiaPublicKey) {
+	hdb.mu.Lock()
+	defer hdb.mu.Unlock()
+
+	// Fetch the host.
+	host, haveHost := hdb.hostTree.Select(key)
+	if !haveHost {
+		return
+	}
+
+	// Update historic values if necessary
+	updateHostHistoricInteractions(&host, hdb.blockHeight)
+
+	// Increment the successful interactions
+	host.RecentSuccessfulInteractions++
+	hdb.hostTree.Modify(host)
+}
+
+// IncrementFailedInteractions increments the number of failed interactions with
+// a host for a given key
+func (hdb *HostDB) IncrementFailedInteractions(key types.SiaPublicKey) {
+	hdb.mu.Lock()
+	defer hdb.mu.Unlock()
+
+	// Fetch the host.
+	host, haveHost := hdb.hostTree.Select(key)
+	if !haveHost || !hdb.online {
+		// If we are offline it probably wasn't the host's fault
+		return
+	}
+
+	// Update historic values if necessary
+	updateHostHistoricInteractions(&host, hdb.blockHeight)
+
+	// Increment the failed interactions
+	host.RecentFailedInteractions++
+	hdb.hostTree.Modify(host)
+}

--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -101,22 +101,17 @@ func (hdb *HostDB) interactionAdjustments(entry modules.HostDBEntry) float64 {
 	// interactions with them. The two failed interactions will become
 	// irrelevant after sufficient interactions with the host.
 	hsi := entry.HistoricSuccessfulInteractions + 30
-	hfi := entry.HistoricFailedInteractions + 2
+	hfi := entry.HistoricFailedInteractions + 1
 
 	// Determine the intraction ratio based off of the historic interactions.
 	ratio := float64(hsi) / float64(hsi+hfi)
 
-	// Raise the ratio to the 6th power and return that.
-	//
-	// 98% = 0.885
-	// 95% = 0.735
-	// 93% = 0.646 - this is roughly the penalty applied to fresh hosts
-	// 90% = 0.531
-	// 85% = 0.377
-	// 75% = 0.177
-	// 60% = 0.046
-	// 50% = 0.015
-	return math.Pow(ratio, 6)
+	// Raise the ratio to the 15th power and return that. The exponentiation is
+	// very high because the renter will already intentionally avoid hosts that
+	// do not have many successful interactions, meaning that the bad points do
+	// not rack up very quickly. We want to signal a bad score for the host
+	// nonetheless.
+	return math.Pow(ratio, 15)
 }
 
 // priceAdjustments will adjust the weight of the entry according to the prices

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -35,6 +35,21 @@ var (
 	}
 )
 
+// printScoreBreakdown prints the score breakdown of a host, provided the info.
+func printScoreBreakdown(info *api.HostdbHostsGET) {
+	fmt.Println("\n  Score Breakdown:")
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "\t\tAge:\t %.3f\n", info.ScoreBreakdown.AgeAdjustment)
+	fmt.Fprintf(w, "\t\tBurn:\t %.3f\n", info.ScoreBreakdown.BurnAdjustment)
+	fmt.Fprintf(w, "\t\tCollateral:\t %.3f\n", info.ScoreBreakdown.CollateralAdjustment)
+	fmt.Fprintf(w, "\t\tInteraction:\t %.3f\n", info.ScoreBreakdown.InteractionAdjustment)
+	fmt.Fprintf(w, "\t\tPrice:\t %.3f\n", info.ScoreBreakdown.PriceAdjustment*1e6)
+	fmt.Fprintf(w, "\t\tStorage:\t %.3f\n", info.ScoreBreakdown.StorageRemainingAdjustment)
+	fmt.Fprintf(w, "\t\tUptime:\t %.3f\n", info.ScoreBreakdown.UptimeAdjustment)
+	fmt.Fprintf(w, "\t\tVersion:\t %.3f\n", info.ScoreBreakdown.VersionAdjustment)
+	w.Flush()
+}
+
 func hostdbcmd() {
 	if !hostdbVerbose {
 		info := new(api.HostdbActiveGET)
@@ -285,17 +300,7 @@ func hostdbviewcmd(pubkey string) {
 	fmt.Fprintln(w, "\t\tVersion:\t", info.Entry.Version)
 	w.Flush()
 
-	fmt.Println("\n  Score Breakdown:")
-	w = tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "\t\tAge:\t %.3f\n", info.ScoreBreakdown.AgeAdjustment)
-	fmt.Fprintf(w, "\t\tBurn:\t %.3f\n", info.ScoreBreakdown.BurnAdjustment)
-	fmt.Fprintf(w, "\t\tCollateral:\t %.3f\n", info.ScoreBreakdown.CollateralAdjustment)
-	fmt.Fprintf(w, "\t\tInteraction:\t %.3f\n", info.ScoreBreakdown.InteractionAdjustment)
-	fmt.Fprintf(w, "\t\tPrice:\t %.3f\n", info.ScoreBreakdown.PriceAdjustment*1e6)
-	fmt.Fprintf(w, "\t\tStorage:\t %.3f\n", info.ScoreBreakdown.StorageRemainingAdjustment)
-	fmt.Fprintf(w, "\t\tUptime:\t %.3f\n", info.ScoreBreakdown.UptimeAdjustment)
-	fmt.Fprintf(w, "\t\tVersion:\t %.3f\n", info.ScoreBreakdown.VersionAdjustment)
-	w.Flush()
+	printScoreBreakdown(info)
 
 	// Compute the total measured uptime and total measured downtime for this
 	// host.

--- a/siac/hostdbcmd.go
+++ b/siac/hostdbcmd.go
@@ -290,6 +290,7 @@ func hostdbviewcmd(pubkey string) {
 	fmt.Fprintf(w, "\t\tAge:\t %.3f\n", info.ScoreBreakdown.AgeAdjustment)
 	fmt.Fprintf(w, "\t\tBurn:\t %.3f\n", info.ScoreBreakdown.BurnAdjustment)
 	fmt.Fprintf(w, "\t\tCollateral:\t %.3f\n", info.ScoreBreakdown.CollateralAdjustment)
+	fmt.Fprintf(w, "\t\tInteraction:\t %.3f\n", info.ScoreBreakdown.InteractionAdjustment)
 	fmt.Fprintf(w, "\t\tPrice:\t %.3f\n", info.ScoreBreakdown.PriceAdjustment*1e6)
 	fmt.Fprintf(w, "\t\tStorage:\t %.3f\n", info.ScoreBreakdown.StorageRemainingAdjustment)
 	fmt.Fprintf(w, "\t\tUptime:\t %.3f\n", info.ScoreBreakdown.UptimeAdjustment)

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -335,22 +335,27 @@ func rentercontractsviewcmd(cid string) {
 
 	for _, rc := range rc.Contracts {
 		if rc.ID.String() == cid {
-			fmt.Printf(`
+			var hostInfo api.HostdbHostsGET
+			err = getAPI("/hostdb/hosts/"+rc.HostPublicKey.String(), &hostInfo)
+			if err != nil {
+				die("Could not fetch details of host: ", err)
+			}
+      fmt.Printf(`
 Contract %v
-Host: %v (Public Key: %v)
+  Host: %v (Public Key: %v)
 
-Start Height: %v
-End Height:   %v
+  Start Height: %v
+  End Height:   %v
 
-Total cost:        %v (Fees: %v)
-Funds Allocated:   %v
-Upload Spending:   %v
-Storage Spending:  %v
-Download Spending: %v
-Remaining Funds:   %v
+  Total cost:        %v (Fees: %v)
+  Funds Allocated:   %v
+  Upload Spending:   %v
+  Storage Spending:  %v
+  Download Spending: %v
+  Remaining Funds:   %v
 
-File Size: %v
-`, rc.ID, rc.NetAddress, rc.HostPublicKey, rc.StartHeight, rc.EndHeight,
+  File Size: %v
+`, rc.ID, rc.NetAddress, rc.HostPublicKey.String(), rc.StartHeight, rc.EndHeight,
 				currencyUnits(rc.TotalCost),
 				currencyUnits(rc.Fees),
 				currencyUnits(rc.TotalCost.Sub(rc.Fees)),
@@ -359,6 +364,8 @@ File Size: %v
 				currencyUnits(rc.DownloadSpending),
 				currencyUnits(rc.RenterFunds),
 				filesizeUnits(int64(rc.Size)))
+
+				printScoreBreakdown(&hostInfo)
 			return
 		}
 	}

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -340,7 +340,7 @@ func rentercontractsviewcmd(cid string) {
 			if err != nil {
 				die("Could not fetch details of host: ", err)
 			}
-      fmt.Printf(`
+			fmt.Printf(`
 Contract %v
   Host: %v (Public Key: %v)
 
@@ -365,7 +365,7 @@ Contract %v
 				currencyUnits(rc.RenterFunds),
 				filesizeUnits(int64(rc.Size)))
 
-				printScoreBreakdown(&hostInfo)
+			printScoreBreakdown(&hostInfo)
 			return
 		}
 	}


### PR DESCRIPTION
This was originally several nicer commits, but my .git folder corrupted somehow :/

The hostdb was already tracking the reliability of hosts, but this reliability was not actually being factored into the scores of the hosts.

Now it is factored in, although siac doesn't display it in the score breakdown I believe, still need a commit to extend siac.