### PR TITLE
compute diff in acceptTransactionSet more efficiently.

### DIFF
--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -164,6 +164,7 @@ func (tp *TransactionPool) purge() {
 	tp.transactionSets = make(map[TransactionSetID][]types.Transaction)
 	tp.transactionSetDiffs = make(map[TransactionSetID]*modules.ConsensusChange)
 	tp.transactionListSize = 0
+	tp.updateSubscribersTransactions()
 }
 
 // ProcessConsensusChange gets called to inform the transaction pool of changes


### PR DESCRIPTION
Computes the diff in `acceptTransactionSet` directly rather than by iterating through the whole transaction pool like in `updateSubscribersTransactions`. Working on a similar change for `ProcessConsensusChange` so that the entire transaction pool doesn't have to be remade after every consensus change.