### PR TITLE
Added missing property 'local' in Gateway's peer response

### DIFF
--- a/doc/api/Gateway.md
+++ b/doc/api/Gateway.md
@@ -55,7 +55,8 @@ returns information about the gateway, including the list of connected peers.
         // peers, as inbound peers are easily manipulated by an adversary.
         "inbound":    Boolean,
 
-        // what does local mean?
+        // local is true if the peer's IP address belongs to a local address
+        // range such as 192.168.x.x or 127.x.x.x
         "local":      Boolean
     }
 }

--- a/doc/api/Gateway.md
+++ b/doc/api/Gateway.md
@@ -53,7 +53,10 @@ returns information about the gateway, including the list of connected peers.
         // inbound is true when the peer initiated the connection. This field
         // is exposed as outbound peers are generally trusted more than inbound
         // peers, as inbound peers are easily manipulated by an adversary.
-        "inbound":    Boolean
+        "inbound":    Boolean,
+
+        // what does local mean?
+        "local":      Boolean
     }
 }
 ```


### PR DESCRIPTION
This commit will add the 'local' property in the /gateway's sample response. Although I don't know the description of it.