### PR TITLE
WalletVerifyAddress response should be in lowercase to be consistent with other APIs

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -98,7 +98,7 @@ type (
 	// WalletVerifyAddressGET contains a bool indicating if the address passed to
 	// /wallet/verify/address/:addr is a valid address.
 	WalletVerifyAddressGET struct {
-		Valid bool
+		Valid bool `json:"valid"`
 	}
 )
 


### PR DESCRIPTION
This commit will change the response of /wallet/verify/address/:addr to lowercase. Right now, the documentation says:
```
{
	"valid": true
}
```

but the actual response is:
```
{
	"Valid": true
}
```

We should either change the documentation or fix the API to return a lowercase "valid". 
