### PR TITLE
add sanity check subscriber to tpool

### DIFF
--- a/modules/transactionpool/accept.go
+++ b/modules/transactionpool/accept.go
@@ -341,6 +341,7 @@ func (tp *TransactionPool) AcceptTransactionSet(ts []types.Transaction) error {
 		go tp.gateway.Broadcast("RelayTransactionSet", ts, tp.gateway.Peers())
 		// Notify subscribers of an accepted transaction set
 		tp.updateSubscribersTransactions()
+		tp.subscriberSanityCheck(tp.sanitycheck) // Probabilistic sanity check.
 		return nil
 	})
 }

--- a/modules/transactionpool/sanitychecksubscriber.go
+++ b/modules/transactionpool/sanitychecksubscriber.go
@@ -1,0 +1,70 @@
+package transactionpool
+
+import (
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+	"github.com/NebulousLabs/fastrand"
+)
+
+type sanityCheckSubscriber struct {
+	transactionSets map[TransactionSetID][]types.Transaction
+}
+
+// newSanityCheckSubscriber returns a new sanityCheckSubscriber with no
+// transaction sets.
+func newSanityCheckSubscriber() *sanityCheckSubscriber {
+	return &sanityCheckSubscriber{
+		transactionSets: make(map[TransactionSetID][]types.Transaction),
+	}
+}
+
+// ReceiveUpdatedUnconfirmedTransactions updates the sanityCheckSubscriber's
+// transactionSets using the diff sent from the tpool. It is needed to satisfy
+// the TransactionPoolSubscriber interface.
+func (s *sanityCheckSubscriber) ReceiveUpdatedUnconfirmedTransactions(diff *modules.TransactionPoolDiff) {
+	for _, setID := range diff.RevertedTransactions {
+		delete(s.transactionSets, TransactionSetID(setID))
+	}
+	for _, unconfirmedTxnSet := range diff.AppliedTransactions {
+		s.transactionSets[TransactionSetID(unconfirmedTxnSet.ID)] = unconfirmedTxnSet.Transactions
+	}
+}
+
+// subscriberSanityCheck performs a sanity check on the transaction pool. It
+// panics if the map of transaction sets in the subscriber's state is not
+// exactly the same as the map of transaction sets in the transaction pool.
+func (tp *TransactionPool) subscriberSanityCheck(s *sanityCheckSubscriber) {
+	// 1/30 chance of running this check because it is expensive
+	if fastrand.Intn(30) != 0 {
+		return
+	}
+
+	if len(tp.transactionSets) != len(s.transactionSets) {
+		panic("length of tp transactions sets different from sanityCheckSubscriber's ")
+	}
+
+	for tpoolSetID, tpoolSet := range tp.transactionSets {
+		subscriberSet, ok := s.transactionSets[tpoolSetID]
+		if !ok {
+			// Doesn't contain a set the tpool contains.
+			panic("sanityCheckSubscriber doesn't contain same transaction set as tpool")
+		}
+
+		if len(tpoolSet) != len(subscriberSet) {
+			panic("sanityCheckSubscriber txn set has different size than corresponding set in tpool")
+		}
+		// Check that both sets contain the exact same transactions
+
+		tpoolTxns := make(map[types.TransactionID]struct{})
+		for _, txn := range tpoolSet {
+			tpoolTxns[txn.ID()] = struct{}{}
+		}
+		for _, txn := range subscriberSet {
+			_, ok := tpoolTxns[txn.ID()]
+			if !ok {
+				// Doesn't contain a transacion the tpool contains.
+				panic("sanityCheckSubscriber doesn't contain the same transaction in the same set as tpool")
+			}
+		}
+	}
+}

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NebulousLabs/bolt"
 	"github.com/NebulousLabs/demotemutex"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/persist"
@@ -62,6 +63,7 @@ type (
 		// transaction pool, all prior consensus changes are sent to the new
 		// subscriber.
 		subscribers []modules.TransactionPoolSubscriber
+		sanitycheck *sanityCheckSubscriber
 
 		// Utilities.
 		db         *persist.BoltDatabase
@@ -95,6 +97,12 @@ func New(cs modules.ConsensusSet, g modules.Gateway, persistDir string) (*Transa
 		transactionSetDiffs: make(map[TransactionSetID]*modules.ConsensusChange),
 
 		persistDir: persistDir,
+	}
+
+	if build.DEBUG {
+		sub := newSanityCheckSubscriber()
+		tp.subscribers = append(tp.subscribers, sub)
+		tp.sanitycheck = sub
 	}
 
 	// Open the tpool database.

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -378,6 +378,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// Inform subscribers that an update has executed.
 	tp.mu.Demote()
 	tp.updateSubscribersTransactions()
+	tp.subscriberSanityCheck(tp.sanitycheck) // Probabilistic sanity check.
 	tp.mu.DemotedUnlock()
 }
 


### PR DESCRIPTION
This PR adds a new subscriber to the tpool which creates and maintains a map of `transactionSets` from subscriber diffs. This confirms that the transaction pool is correctly altering its own internal state consistently the the diffs it sends out to subscribers.