### PR TITLE
Add removeTransaction method to tpool

### DIFF
--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -458,6 +458,8 @@ func (tp *TransactionPool) findObjectLocations(oid ObjectID) ([]*objectLocation,
 	return locations, true
 }
 
+// removeTransaction removes a transaction and any transactions that spend its
+// outputs from the tpool.
 func (tp *TransactionPool) removeTransaction(txn types.Transaction, cc *modules.ConsensusChange) {
 	// removedTxnIndices is used to keep track of which need to be removed from
 	// which sets. Sets are changed (and a diff is created) once all changes


### PR DESCRIPTION
The `removeTransaction` method should be used in a new `ProcessConsensusChange` method for the tpool to remove any transaction that conflicts with the consensus set and all transactions that depend on its outputs. This PR still needs its own tests and should be tested with #2214 also. 

Right now this method can't actually be called anywhere usefully.