### PR TITLE
remove remoteAddr check

### DIFF
--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -163,12 +163,6 @@ func acceptableSessionHeader(ourHeader, remoteHeader sessionHeader, remoteAddr s
 	} else if err := remoteHeader.NetAddress.IsStdValid(); err != nil {
 		return fmt.Errorf("invalid remote address: %v", err)
 	}
-	// Check that claimed NetAddress matches remoteAddr
-	connHost, _, _ := net.SplitHostPort(remoteAddr)
-	claimedHost, _, _ := net.SplitHostPort(string(remoteHeader.NetAddress))
-	if connHost != claimedHost {
-		return fmt.Errorf("claimed hostname (%v) does not match conn.RemoteAddr (%v)", claimedHost, connHost)
-	}
 	return nil
 }
 


### PR DESCRIPTION
This fixes https://github.com/NebulousLabs/Sia/pull/2066#issuecomment-320294721

This shouldn't affect the threat model. Dropping this check makes it easier for a peer to make you ping an IP other than their own, but that was already possible via other means.

c.f. https://github.com/NebulousLabs/Sia/issues/1970