### PR TITLE
set LocalAddr in outbound gateway conns

### DIFF
--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -26,6 +26,9 @@ func (g *Gateway) dial(addr modules.NetAddress) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Cancel:  g.threads.StopChan(),
 		Timeout: dialTimeout,
+		LocalAddr: &net.TCPAddr{
+			IP: g.listener.Addr().(*net.TCPAddr).IP,
+		},
 	}
 	conn, err := dialer.Dial("tcp", string(addr))
 	if err != nil {


### PR DESCRIPTION
This means that the IP you dial from is the same IP that you listen on. As a consequence, when you manually bind to an IP, as in:
```
siad --rpc-addr 123.456.789.0:1234
```
peers that you connect to will see your RemoteAddr as `123.456.789.0`.

This should (hopefully) fix #1970. I'm not sure how to test it though; the best confirmation would be for @D4rk4 or another contributor with this sort of networking setup to test that it works for them.