### PR TITLE
close file handle in DownloadFileWriter

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -62,6 +62,7 @@ type DownloadInfo struct {
 type DownloadWriter interface {
 	WriteAt(b []byte, off int64) (int, error)
 	Destination() string
+	Close() error
 }
 
 // FileUploadParams contains the information used by the Renter to upload a

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -707,12 +707,15 @@ func (dw *DownloadFileWriter) Destination() string {
 
 // WriteAt writes the passed bytes at the specified offset.
 func (dw *DownloadFileWriter) WriteAt(b []byte, off int64) (int, error) {
+	if dw.written+uint64(len(b)) > dw.length {
+		build.Critical("DownloadFileWriter write exceeds file length")
+	}
 	n, err := dw.f.WriteAt(b, off-int64(dw.offset))
 	if err != nil {
 		return n, err
 	}
 	dw.written += uint64(n)
-	if dw.written == dw.length {
+	if dw.written >= dw.length {
 		return n, dw.f.Close()
 	}
 	return n, err
@@ -743,7 +746,7 @@ func NewDownloadHttpWriter(w io.Writer, offset, length uint64) *DownloadHttpWrit
 	}
 }
 
-// Destination implements the Location method of the DownloadWriter
+// Destination implements the Destination method of the DownloadWriter
 // interface and informs callers where this download writer is
 // being written to.
 func (dw *DownloadHttpWriter) Destination() string {

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -217,6 +217,7 @@ func (d *download) fail(err error) {
 	d.downloadComplete = true
 	d.downloadErr = err
 	close(d.downloadFinished)
+	// TODO: log the error from Close().
 	d.destination.Close()
 }
 
@@ -318,7 +319,10 @@ func (cd *chunkDownload) recoverChunk() error {
 		// Signal that the download is complete.
 		cd.download.downloadComplete = true
 		close(cd.download.downloadFinished)
-		cd.download.destination.Close()
+		err = cd.download.destination.Close()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/modules/renter/download_test.go
+++ b/modules/renter/download_test.go
@@ -1,0 +1,43 @@
+package renter
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRenterDownloadFileWriterClose verifies that the renter's
+// DownloadFileWriter closes the underlying file handle when the entire file
+// has been written.
+func TestRenterDownloadFileWriterClose(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	testPath, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testPath = filepath.Join(testPath, "testfile")
+	defer os.RemoveAll(testPath)
+	df, err := NewDownloadFileWriter(testPath, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := make([]byte, 100)
+	_, err = df.WriteAt(b, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = df.f.Read(b)
+	if err == nil {
+		t.Fatal("expected read to fail after writing full length")
+	}
+	if !strings.Contains(err.Error(), "file already closed") {
+		t.Fatal("expected read to return file already closed, got", err, "instead.")
+	}
+}

--- a/modules/renter/download_test.go
+++ b/modules/renter/download_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 )
 
-// TestRenterDownloadFileWriterClose verifies that the renter's
-// DownloadFileWriter closes the underlying file handle when the entire file
-// has been written.
-func TestRenterDownloadFileWriterClose(t *testing.T) {
+// TestRenterDownloadFileWriter verifies that the renter's DownloadFileWriter
+// has the correct behavior.
+func TestRenterDownloadFileWriter(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -28,6 +27,18 @@ func TestRenterDownloadFileWriterClose(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// writing a too-large slice should fail
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected too-large slice to error")
+			}
+		}()
+		df.WriteAt(make([]byte, 200), 0)
+	}()
+
+	// underlying file handle should be closed if we write the entirety of the
+	// file
 	b := make([]byte, 100)
 	_, err = df.WriteAt(b, 0)
 	if err != nil {

--- a/modules/renter/download_test.go
+++ b/modules/renter/download_test.go
@@ -37,14 +37,12 @@ func TestRenterDownloadFileWriter(t *testing.T) {
 		df.WriteAt(make([]byte, 200), 0)
 	}()
 
-	// underlying file handle should be closed if we write the entirety of the
-	// file
-	b := make([]byte, 100)
-	_, err = df.WriteAt(b, 0)
+	// Close should close the file handle
+	err = df.f.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = df.f.Read(b)
+	_, err = df.f.Read(make([]byte, 100))
 	if err == nil {
 		t.Fatal("expected read to fail after writing full length")
 	}

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -37,6 +37,14 @@ func (r *Renter) Download(p modules.RenterDownloadParameters) error {
 	if p.Offset == file.size {
 		return errors.New("offset equals filesize")
 	}
+	// sentinel: if length == 0, download the entire file
+	if p.Length == 0 {
+		p.Length = file.size - p.Offset
+	}
+	// Check whether offset and length is valid.
+	if p.Offset < 0 || p.Offset+p.Length > file.size {
+		return fmt.Errorf("offset and length combination invalid, max byte is at index %d", file.size-1)
+	}
 
 	// Instantiate the correct DownloadWriter implementation
 	// (e.g. content written to file or response body).
@@ -49,15 +57,6 @@ func (r *Renter) Download(p modules.RenterDownloadParameters) error {
 			return err
 		}
 		dw = dfw
-	}
-
-	// sentinel: if length == 0, download the entire file
-	if p.Length == 0 {
-		p.Length = file.size - p.Offset
-	}
-	// Check whether offset and length is valid.
-	if p.Offset < 0 || p.Offset+p.Length > file.size {
-		return fmt.Errorf("offset and length combination invalid, max byte is at index %d", file.size-1)
 	}
 
 	// Create the download object and add it to the queue.

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -44,7 +44,11 @@ func (r *Renter) Download(p modules.RenterDownloadParameters) error {
 	if isHttpResp {
 		dw = NewDownloadHttpWriter(p.Httpwriter, p.Offset, p.Length)
 	} else {
-		dw = NewDownloadFileWriter(p.Destination, p.Offset, p.Length)
+		dfw, err := NewDownloadFileWriter(p.Destination, p.Offset, p.Length)
+		if err != nil {
+			return err
+		}
+		dw = dfw
 	}
 
 	// sentinel: if length == 0, download the entire file


### PR DESCRIPTION
Fixes #2279. Also fixes a case where we didn't check the error when opening a file handle for a download.