### PR TITLE
Add automatic non-interactive wallet unlock command

### DIFF
--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math/big"
+	"os"
 
 	"github.com/bgentry/speakeasy"
 	"github.com/spf13/cobra"
@@ -489,6 +490,19 @@ func wallettransactionscmd() {
 
 // walletunlockcmd unlocks a saved wallet
 func walletunlockcmd() {
+	env_password := os.Getenv("SIA_WALLET_PASSWORD")
+	if len(env_password) > 0 {
+		qs := fmt.Sprintf("encryptionpassword=%s&dictonary=%s",
+			env_password, "english")
+		err := post("/wallet/unlock", qs)
+		if err != nil {
+			fmt.Println("Warning: SIA_WALLET_PASSWORD unlock failed")
+			fmt.Println("Trying interactive console input method next...")
+		} else {
+			fmt.Println("Wallet unlocked")
+			return
+		}
+	}
 	password, err := speakeasy.Ask("Wallet password: ")
 	if err != nil {
 		die("Reading password failed:", err)

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -491,7 +491,7 @@ func wallettransactionscmd() {
 // walletunlockcmd unlocks a saved wallet
 func walletunlockcmd() {
 	env_password := os.Getenv("SIA_WALLET_PASSWORD")
-	if len(env_password) > 0 {
+	if env_password != "" {
 		qs := fmt.Sprintf("encryptionpassword=%s&dictonary=%s",
 			env_password, "english")
 		err := post("/wallet/unlock", qs)


### PR DESCRIPTION
Wallet unlock with SIA_WALLET_PASSWORD environment variable non-interactively

Addresses trello public road map feature

https://trello.com/c/yRFaIgLb/65-enable-the-wallet-to-unlock-at-startup-without-user-intervention-advanced-less-secure-feature-primarily-for-hosts

See attached manual transcripts before and after patch showing positive test results.
[notes-02.txt](https://github.com/NebulousLabs/Sia/files/1268435/notes-02.txt)
[notes-01.txt](https://github.com/NebulousLabs/Sia/files/1268436/notes-01.txt)
