### PR TITLE
Reduce decoding allocations

### DIFF
--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	maxDecodeLen = 12e6 // 12 MB
-	maxSliceLen  = 5e6  // 5 MB
+	MaxDecodeSize = 12e6 // 12 MB
+	MaxSliceSize  = 5e6  // 5 MB
 )
 
 var (
@@ -185,7 +185,7 @@ type Decoder struct {
 func (d *Decoder) Read(p []byte) (int, error) {
 	n, err := d.r.Read(p)
 	// enforce an absolute maximum size limit
-	if d.n += n; d.n > maxDecodeLen {
+	if d.n += n; d.n > MaxDecodeSize {
 		panic("encoded type exceeds size limit")
 	}
 	return n, err
@@ -233,7 +233,7 @@ func (d *Decoder) readN(n int) []byte {
 		if len(b) != n {
 			panic(io.ErrUnexpectedEOF)
 		}
-		if d.n += n; d.n > maxDecodeLen {
+		if d.n += n; d.n > MaxDecodeSize {
 			panic("encoded type exceeds size limit")
 		}
 		return b
@@ -286,7 +286,7 @@ func (d *Decoder) decode(val reflect.Value) {
 		val.SetUint(DecUint64(d.readN(8)))
 	case reflect.String:
 		strLen := DecUint64(d.readN(8))
-		if strLen > maxSliceLen {
+		if strLen > MaxSliceSize {
 			panic("string is too large")
 		}
 		val.SetString(string(d.readN(int(strLen))))
@@ -296,7 +296,7 @@ func (d *Decoder) decode(val reflect.Value) {
 		sliceLen := DecUint64(d.readN(8))
 		// sanity-check the sliceLen, otherwise you can crash a peer by making
 		// them allocate a massive slice
-		if sliceLen > 1<<31-1 || sliceLen*uint64(val.Type().Elem().Size()) > maxSliceLen {
+		if sliceLen > 1<<31-1 || sliceLen*uint64(val.Type().Elem().Size()) > MaxSliceSize {
 			panic("slice is too large")
 		} else if sliceLen == 0 {
 			return

--- a/encoding/marshal.go
+++ b/encoding/marshal.go
@@ -253,7 +253,7 @@ func (d *Decoder) decode(val reflect.Value) {
 	// check for UnmarshalSia interface first
 	if val.CanAddr() && val.Addr().CanInterface() {
 		if u, ok := val.Addr().Interface().(SiaUnmarshaler); ok {
-			err := u.UnmarshalSia(d)
+			err := u.UnmarshalSia(d.r)
 			if err != nil {
 				panic(err)
 			}

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -146,22 +146,22 @@ func TestDecode(t *testing.T) {
 		t.Error("expected unknown type error, got", err)
 	}
 
-	// big slice (larger than maxSliceLen)
-	err = Unmarshal(EncUint64(maxSliceLen+1), new([]byte))
-	if err == nil || err.Error() != "could not decode type []uint8: slice is too large" {
+	// big slice (larger than MaxSliceSize)
+	err = Unmarshal(EncUint64(MaxSliceSize+1), new([]byte))
+	if err == nil || err.Error() != "could not decode type []uint8: encoded slice is too large" {
 		t.Error("expected large slice error, got", err)
 	}
 
 	// massive slice (larger than MaxInt32)
 	err = Unmarshal(EncUint64(1<<32), new([]byte))
-	if err == nil || err.Error() != "could not decode type []uint8: slice is too large" {
+	if err == nil || err.Error() != "could not decode type []uint8: encoded slice is too large" {
 		t.Error("expected large slice error, got", err)
 	}
 
 	// many small slices (total larger than maxDecodeLen)
-	bigSlice := strings.Split(strings.Repeat("0123456789abcdefghijklmnopqrstuvwxyz", (maxSliceLen/16)-1), "0")
+	bigSlice := strings.Split(strings.Repeat("0123456789abcdefghijklmnopqrstuvwxyz", (MaxSliceSize/16)-1), "0")
 	err = Unmarshal(Marshal(bigSlice), new([]string))
-	if err == nil || err.Error() != "could not decode type []string: encoded type exceeds size limit" {
+	if err == nil || err.Error() != "could not decode type []string: encoded object exceeds size limit" {
 		t.Error("expected size limit error, got", err)
 	}
 

--- a/types/block_bench_test.go
+++ b/types/block_bench_test.go
@@ -9,9 +9,11 @@ import (
 // BenchmarkEncodeEmptyBlock benchmarks encoding an empty block.
 //
 // i5-4670K, 9a90f86: 48 MB/s
-func BenchmarkEncodeBlock(b *testing.B) {
+// i5-4670K, f8f2df2: 211 MB/s
+func BenchmarkEncodeEmptyBlock(b *testing.B) {
 	var block Block
 	b.SetBytes(int64(len(encoding.Marshal(block))))
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		encoding.Marshal(block)
 	}
@@ -21,10 +23,41 @@ func BenchmarkEncodeBlock(b *testing.B) {
 //
 // i7-4770,  b0b162d: 38 MB/s
 // i5-4670K, 9a90f86: 55 MB/s
+// i5-4670K, f8f2df2: 166 MB/s
 func BenchmarkDecodeEmptyBlock(b *testing.B) {
 	var block Block
 	encodedBlock := encoding.Marshal(block)
 	b.SetBytes(int64(len(encodedBlock)))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		err := encoding.Unmarshal(encodedBlock, &block)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEncodeHeavyBlock benchmarks encoding a "heavy" block.
+//
+// i5-4670K, f8f2df2: 250 MB/s
+func BenchmarkEncodeHeavyBlock(b *testing.B) {
+	b.SetBytes(int64(len(encoding.Marshal(heavyBlock))))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoding.Marshal(heavyBlock)
+	}
+}
+
+// BenchmarkDecodeHeavyBlock benchmarks decoding a "heavy" block.
+//
+// i5-4670K, f8f2df2: 326 MB/s
+func BenchmarkDecodeHeavyBlock(b *testing.B) {
+	var block Block
+	encodedBlock := encoding.Marshal(heavyBlock)
+	b.SetBytes(int64(len(encodedBlock)))
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		err := encoding.Unmarshal(encodedBlock, &block)
 		if err != nil {

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -34,23 +34,38 @@ type decHelper struct {
 	err error
 }
 
-func (d *decHelper) Read(p []byte) (n int, _ error) {
-	n, d.err = d.Reader.Read(p)
-	return n, d.err
+func (d *decHelper) Read(p []byte) (int, error) {
+	if d.err != nil {
+		return 0, d.err
+	}
+	n, err := d.Reader.Read(p)
+	if d.err == nil {
+		d.err = err
+	}
+	return n, err
 }
 
 func (d *decHelper) ReadFull(p []byte) {
-	_, d.err = io.ReadFull(d, p)
+	if d.err != nil {
+		return
+	}
+	io.ReadFull(d, p)
 }
 
 func (d *decHelper) ReadPrefix() []byte {
+	if d.err != nil {
+		return nil
+	}
 	b := make([]byte, d.NextUint64())
 	d.ReadFull(b)
 	return b
 }
 
 func (d *decHelper) NextUint64() uint64 {
-	_, d.err = d.Read(d.buf[:])
+	if d.err != nil {
+		return 0
+	}
+	d.Read(d.buf[:])
 	return encoding.DecUint64(d.buf[:])
 }
 

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -28,6 +28,43 @@ func (s sanityCheckWriter) Write(p []byte) (int, error) {
 	return s.w.Write(p)
 }
 
+type decHelper struct {
+	io.Reader
+	buf [8]byte
+	err error
+}
+
+func (d *decHelper) Read(p []byte) (n int, _ error) {
+	n, d.err = d.Reader.Read(p)
+	return n, d.err
+}
+
+func (d *decHelper) ReadFull(p []byte) {
+	_, d.err = io.ReadFull(d, p)
+}
+
+func (d *decHelper) ReadPrefix() []byte {
+	b := make([]byte, d.NextUint64())
+	d.ReadFull(b)
+	return b
+}
+
+func (d *decHelper) NextUint64() uint64 {
+	_, d.err = d.Read(d.buf[:])
+	return encoding.DecUint64(d.buf[:])
+}
+
+func (d *decHelper) Err() error {
+	return d.err
+}
+
+func decoder(r io.Reader) *decHelper {
+	if d, ok := r.(*decHelper); ok {
+		return d
+	}
+	return &decHelper{Reader: r}
+}
+
 // MarshalSia implements the encoding.SiaMarshaler interface.
 func (b Block) MarshalSia(w io.Writer) error {
 	if build.DEBUG {
@@ -61,12 +98,21 @@ func (b Block) MarshalSia(w io.Writer) error {
 
 // UnmarshalSia implements the encoding.SiaUnmarshaler interface.
 func (b *Block) UnmarshalSia(r io.Reader) error {
-	io.ReadFull(r, b.ParentID[:])
-	io.ReadFull(r, b.Nonce[:])
-	tsBytes := make([]byte, 8)
-	io.ReadFull(r, tsBytes)
-	b.Timestamp = Timestamp(encoding.DecUint64(tsBytes))
-	return encoding.NewDecoder(r).DecodeAll(&b.MinerPayouts, &b.Transactions)
+	d := decoder(r)
+	d.ReadFull(b.ParentID[:])
+	d.ReadFull(b.Nonce[:])
+	b.Timestamp = Timestamp(d.NextUint64())
+	// MinerPayouts
+	b.MinerPayouts = make([]SiacoinOutput, d.NextUint64())
+	for i := range b.MinerPayouts {
+		b.MinerPayouts[i].UnmarshalSia(d)
+	}
+	// Transactions
+	b.Transactions = make([]Transaction, d.NextUint64())
+	for i := range b.Transactions {
+		b.Transactions[i].UnmarshalSia(d)
+	}
+	return d.Err()
 }
 
 // MarshalJSON marshales a block id as a hex string.
@@ -130,6 +176,34 @@ func (cf CoveredFields) MarshalSiaSize() (size int) {
 	return
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (cf *CoveredFields) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	buf := make([]byte, 1)
+	d.ReadFull(buf)
+	cf.WholeTransaction = (buf[0] == 1)
+	fields := []*[]uint64{
+		&cf.SiacoinInputs,
+		&cf.SiacoinOutputs,
+		&cf.FileContracts,
+		&cf.FileContractRevisions,
+		&cf.StorageProofs,
+		&cf.SiafundInputs,
+		&cf.SiafundOutputs,
+		&cf.MinerFees,
+		&cf.ArbitraryData,
+		&cf.TransactionSignatures,
+	}
+	for i := range fields {
+		f := make([]uint64, d.NextUint64())
+		for i := range f {
+			f[i] = d.NextUint64()
+		}
+		*fields[i] = f
+	}
+	return d.Err()
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (c Currency) MarshalJSON() ([]byte, error) {
 	// Must enclosed the value in quotes; otherwise JS will convert it to a
@@ -188,14 +262,11 @@ zeros:
 
 // UnmarshalSia implements the encoding.SiaUnmarshaler interface.
 func (c *Currency) UnmarshalSia(r io.Reader) error {
-	b, err := encoding.ReadPrefix(r, 256)
-	if err != nil {
-		return err
-	}
+	d := decoder(r)
 	var dec Currency
-	dec.i.SetBytes(b)
+	dec.i.SetBytes(d.ReadPrefix())
 	*c = dec
-	return nil
+	return d.Err()
 }
 
 // HumanString prints the Currency using human readable units. The unit used
@@ -287,6 +358,27 @@ func (fc FileContract) MarshalSiaSize() (size int) {
 	return
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (fc *FileContract) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	fc.FileSize = d.NextUint64()
+	d.ReadFull(fc.FileMerkleRoot[:])
+	fc.WindowStart = BlockHeight(d.NextUint64())
+	fc.WindowEnd = BlockHeight(d.NextUint64())
+	fc.Payout.UnmarshalSia(d)
+	fc.ValidProofOutputs = make([]SiacoinOutput, d.NextUint64())
+	for i := range fc.ValidProofOutputs {
+		fc.ValidProofOutputs[i].UnmarshalSia(d)
+	}
+	fc.MissedProofOutputs = make([]SiacoinOutput, d.NextUint64())
+	for i := range fc.MissedProofOutputs {
+		fc.MissedProofOutputs[i].UnmarshalSia(d)
+	}
+	d.ReadFull(fc.UnlockHash[:])
+	fc.RevisionNumber = d.NextUint64()
+	return d.Err()
+}
+
 // MarshalSia implements the encoding.SiaMarshaler interface.
 func (fcr FileContractRevision) MarshalSia(w io.Writer) error {
 	w.Write(fcr.ParentID[:])
@@ -330,6 +422,28 @@ func (fcr FileContractRevision) MarshalSiaSize() (size int) {
 	return
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (fcr *FileContractRevision) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	d.ReadFull(fcr.ParentID[:])
+	fcr.UnlockConditions.UnmarshalSia(d)
+	fcr.NewRevisionNumber = d.NextUint64()
+	fcr.NewFileSize = d.NextUint64()
+	d.ReadFull(fcr.NewFileMerkleRoot[:])
+	fcr.NewWindowStart = BlockHeight(d.NextUint64())
+	fcr.NewWindowEnd = BlockHeight(d.NextUint64())
+	fcr.NewValidProofOutputs = make([]SiacoinOutput, d.NextUint64())
+	for i := range fcr.NewValidProofOutputs {
+		fcr.NewValidProofOutputs[i].UnmarshalSia(d)
+	}
+	fcr.NewMissedProofOutputs = make([]SiacoinOutput, d.NextUint64())
+	for i := range fcr.NewMissedProofOutputs {
+		fcr.NewMissedProofOutputs[i].UnmarshalSia(d)
+	}
+	d.ReadFull(fcr.NewUnlockHash[:])
+	return d.Err()
+}
+
 // MarshalJSON marshals an id as a hex string.
 func (fcid FileContractID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(fcid.String())
@@ -366,11 +480,27 @@ func (sci SiacoinInput) MarshalSia(w io.Writer) error {
 	return sci.UnlockConditions.MarshalSia(w)
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (sci *SiacoinInput) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	d.ReadFull(sci.ParentID[:])
+	sci.UnlockConditions.UnmarshalSia(d)
+	return d.Err()
+}
+
 // MarshalSia implements the encoding.SiaMarshaler interface.
 func (sco SiacoinOutput) MarshalSia(w io.Writer) error {
 	sco.Value.MarshalSia(w)
 	_, err := w.Write(sco.UnlockHash[:])
 	return err
+}
+
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (sco *SiacoinOutput) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	sco.Value.UnmarshalSia(d)
+	d.ReadFull(sco.UnlockHash[:])
+	return d.Err()
 }
 
 // MarshalJSON marshals an id as a hex string.
@@ -396,11 +526,29 @@ func (sfi SiafundInput) MarshalSia(w io.Writer) error {
 	return err
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (sfi *SiafundInput) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	d.ReadFull(sfi.ParentID[:])
+	sfi.UnlockConditions.UnmarshalSia(d)
+	d.ReadFull(sfi.ClaimUnlockHash[:])
+	return d.Err()
+}
+
 // MarshalSia implements the encoding.SiaMarshaler interface.
 func (sfo SiafundOutput) MarshalSia(w io.Writer) error {
 	sfo.Value.MarshalSia(w)
 	w.Write(sfo.UnlockHash[:])
 	return sfo.ClaimStart.MarshalSia(w)
+}
+
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (sfo *SiafundOutput) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	sfo.Value.UnmarshalSia(d)
+	d.ReadFull(sfo.UnlockHash[:])
+	sfo.ClaimStart.UnmarshalSia(d)
+	return d.Err()
 }
 
 // MarshalJSON marshals an id as a hex string.
@@ -422,6 +570,14 @@ func (sfoid *SiafundOutputID) UnmarshalJSON(b []byte) error {
 func (spk SiaPublicKey) MarshalSia(w io.Writer) error {
 	w.Write(spk.Algorithm[:])
 	return encoding.WritePrefix(w, spk.Key)
+}
+
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (spk *SiaPublicKey) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	d.ReadFull(spk.Algorithm[:])
+	spk.Key = d.ReadPrefix()
+	return d.Err()
 }
 
 // LoadString is the inverse of SiaPublicKey.String().
@@ -483,6 +639,18 @@ func (sp *StorageProof) MarshalSia(w io.Writer) error {
 		}
 	}
 	return nil
+}
+
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (sp *StorageProof) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	d.ReadFull(sp.ParentID[:])
+	d.ReadFull(sp.Segment[:])
+	sp.HashSet = make([]crypto.Hash, d.NextUint64())
+	for i := range sp.HashSet {
+		d.ReadFull(sp.HashSet[i][:])
+	}
+	return d.Err()
 }
 
 // MarshalSia implements the encoding.SiaMarshaler interface.
@@ -622,6 +790,52 @@ func (t Transaction) MarshalSiaSize() (size int) {
 	return
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (t *Transaction) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	t.SiacoinInputs = make([]SiacoinInput, d.NextUint64())
+	for i := range t.SiacoinInputs {
+		t.SiacoinInputs[i].UnmarshalSia(d)
+	}
+	t.SiacoinOutputs = make([]SiacoinOutput, d.NextUint64())
+	for i := range t.SiacoinOutputs {
+		t.SiacoinOutputs[i].UnmarshalSia(d)
+	}
+	t.FileContracts = make([]FileContract, d.NextUint64())
+	for i := range t.FileContracts {
+		t.FileContracts[i].UnmarshalSia(d)
+	}
+	t.FileContractRevisions = make([]FileContractRevision, d.NextUint64())
+	for i := range t.FileContractRevisions {
+		t.FileContractRevisions[i].UnmarshalSia(d)
+	}
+	t.StorageProofs = make([]StorageProof, d.NextUint64())
+	for i := range t.StorageProofs {
+		t.StorageProofs[i].UnmarshalSia(d)
+	}
+	t.SiafundInputs = make([]SiafundInput, d.NextUint64())
+	for i := range t.SiafundInputs {
+		t.SiafundInputs[i].UnmarshalSia(d)
+	}
+	t.SiafundOutputs = make([]SiafundOutput, d.NextUint64())
+	for i := range t.SiafundOutputs {
+		t.SiafundOutputs[i].UnmarshalSia(d)
+	}
+	t.MinerFees = make([]Currency, d.NextUint64())
+	for i := range t.MinerFees {
+		t.MinerFees[i].UnmarshalSia(d)
+	}
+	t.ArbitraryData = make([][]byte, d.NextUint64())
+	for i := range t.ArbitraryData {
+		t.ArbitraryData[i] = d.ReadPrefix()
+	}
+	t.TransactionSignatures = make([]TransactionSignature, d.NextUint64())
+	for i := range t.TransactionSignatures {
+		t.TransactionSignatures[i].UnmarshalSia(d)
+	}
+	return d.Err()
+}
+
 // MarshalJSON marshals an id as a hex string.
 func (tid TransactionID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tid.String())
@@ -646,6 +860,17 @@ func (ts TransactionSignature) MarshalSia(w io.Writer) error {
 	return encoding.WritePrefix(w, ts.Signature)
 }
 
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (ts *TransactionSignature) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	d.ReadFull(ts.ParentID[:])
+	ts.PublicKeyIndex = d.NextUint64()
+	ts.Timelock = BlockHeight(d.NextUint64())
+	ts.CoveredFields.UnmarshalSia(d)
+	ts.Signature = d.ReadPrefix()
+	return d.Err()
+}
+
 // MarshalSia implements the encoding.SiaMarshaler interface.
 func (uc UnlockConditions) MarshalSia(w io.Writer) error {
 	encoding.WriteUint64(w, uint64(uc.Timelock))
@@ -666,6 +891,18 @@ func (uc UnlockConditions) MarshalSiaSize() (size int) {
 	}
 	size += 8 // SignaturesRequired
 	return
+}
+
+// UnmarshalSia implements the encoding.SiaUnmarshaler interface.
+func (uc *UnlockConditions) UnmarshalSia(r io.Reader) error {
+	d := decoder(r)
+	uc.Timelock = BlockHeight(d.NextUint64())
+	uc.PublicKeys = make([]SiaPublicKey, d.NextUint64())
+	for i := range uc.PublicKeys {
+		uc.PublicKeys[i].UnmarshalSia(d)
+	}
+	uc.SignaturesRequired = d.NextUint64()
+	return d.Err()
 }
 
 // MarshalJSON is implemented on the unlock hash to always produce a hex string

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -18,24 +18,121 @@ func hashStr(v interface{}) string {
 	return fmt.Sprintf("%x", h[:])
 }
 
-// TestBlockEncodes probes the MarshalSia and UnmarshalSia methods of the
-// Block type.
-func TestBlockEncoding(t *testing.T) {
+// heavyBlock is a complex block that fills every possible field with data.
+var heavyBlock = func() Block {
 	b := Block{
 		MinerPayouts: []SiacoinOutput{
 			{Value: CalculateCoinbase(0)},
-			{Value: CalculateCoinbase(0)},
+			{Value: CalculateCoinbase(1)},
+		},
+		Transactions: []Transaction{
+			{
+				SiacoinInputs: []SiacoinInput{{
+					UnlockConditions: UnlockConditions{
+						PublicKeys: []SiaPublicKey{{
+							Algorithm: SignatureEd25519,
+							Key:       fastrand.Bytes(32),
+						}},
+						SignaturesRequired: 6,
+					},
+				}},
+				SiacoinOutputs: []SiacoinOutput{{
+					Value: NewCurrency64(20),
+				}},
+				FileContracts: []FileContract{{
+					FileSize:       12,
+					Payout:         NewCurrency64(100),
+					RevisionNumber: 8,
+					ValidProofOutputs: []SiacoinOutput{{
+						Value: NewCurrency64(2),
+					}},
+					MissedProofOutputs: []SiacoinOutput{{
+						Value: NewCurrency64(3),
+					}},
+				}},
+				FileContractRevisions: []FileContractRevision{{
+					NewFileSize:       13,
+					NewRevisionNumber: 9,
+					UnlockConditions: UnlockConditions{
+						PublicKeys: []SiaPublicKey{{
+							Algorithm: SignatureEd25519,
+							Key:       fastrand.Bytes(32),
+						}},
+					},
+					NewValidProofOutputs: []SiacoinOutput{{
+						Value: NewCurrency64(4),
+					}},
+					NewMissedProofOutputs: []SiacoinOutput{{
+						Value: NewCurrency64(5),
+					}},
+				}},
+				StorageProofs: []StorageProof{{
+					HashSet: []crypto.Hash{{}},
+				}},
+				SiafundInputs: []SiafundInput{{
+					UnlockConditions: UnlockConditions{
+						PublicKeys: []SiaPublicKey{{
+							Algorithm: SignatureEd25519,
+							Key:       fastrand.Bytes(32),
+						}},
+					},
+				}},
+				SiafundOutputs: []SiafundOutput{{
+					ClaimStart: NewCurrency64(99),
+					Value:      NewCurrency64(25),
+				}},
+				MinerFees:     []Currency{NewCurrency64(215)},
+				ArbitraryData: [][]byte{fastrand.Bytes(10)},
+				TransactionSignatures: []TransactionSignature{{
+					PublicKeyIndex: 5,
+					Timelock:       80,
+					CoveredFields: CoveredFields{
+						WholeTransaction:      true,
+						SiacoinInputs:         []uint64{0},
+						SiacoinOutputs:        []uint64{1},
+						FileContracts:         []uint64{2},
+						FileContractRevisions: []uint64{3},
+						StorageProofs:         []uint64{4},
+						SiafundInputs:         []uint64{5},
+						SiafundOutputs:        []uint64{6},
+						MinerFees:             []uint64{7},
+						ArbitraryData:         []uint64{8},
+						TransactionSignatures: []uint64{9},
+					},
+					Signature: fastrand.Bytes(32),
+				}},
+			},
 		},
 	}
+	fastrand.Read(b.Transactions[0].SiacoinInputs[0].ParentID[:])
+	fastrand.Read(b.Transactions[0].SiacoinOutputs[0].UnlockHash[:])
+	fastrand.Read(b.Transactions[0].FileContracts[0].FileMerkleRoot[:])
+	fastrand.Read(b.Transactions[0].FileContracts[0].ValidProofOutputs[0].UnlockHash[:])
+	fastrand.Read(b.Transactions[0].FileContracts[0].MissedProofOutputs[0].UnlockHash[:])
+	fastrand.Read(b.Transactions[0].FileContractRevisions[0].ParentID[:])
+	fastrand.Read(b.Transactions[0].FileContractRevisions[0].NewFileMerkleRoot[:])
+	fastrand.Read(b.Transactions[0].FileContractRevisions[0].NewValidProofOutputs[0].UnlockHash[:])
+	fastrand.Read(b.Transactions[0].FileContractRevisions[0].NewMissedProofOutputs[0].UnlockHash[:])
+	fastrand.Read(b.Transactions[0].StorageProofs[0].ParentID[:])
+	fastrand.Read(b.Transactions[0].StorageProofs[0].HashSet[0][:])
+	fastrand.Read(b.Transactions[0].StorageProofs[0].Segment[:])
+	fastrand.Read(b.Transactions[0].SiafundInputs[0].ParentID[:])
+	fastrand.Read(b.Transactions[0].SiafundInputs[0].ClaimUnlockHash[:])
+	fastrand.Read(b.Transactions[0].SiafundOutputs[0].UnlockHash[:])
+	fastrand.Read(b.Transactions[0].TransactionSignatures[0].ParentID[:])
+	return b
+}()
+
+// TestBlockEncodes probes the MarshalSia and UnmarshalSia methods of the
+// Block type.
+func TestBlockEncoding(t *testing.T) {
 	var decB Block
-	err := encoding.Unmarshal(encoding.Marshal(b), &decB)
+	err := encoding.Unmarshal(encoding.Marshal(heavyBlock), &decB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(decB.MinerPayouts) != len(b.MinerPayouts) ||
-		decB.MinerPayouts[0].Value.Cmp(b.MinerPayouts[0].Value) != 0 ||
-		decB.MinerPayouts[1].Value.Cmp(b.MinerPayouts[1].Value) != 0 {
-		t.Fatal("block changed after encode/decode:", b, decB)
+	if hashStr(heavyBlock) != hashStr(decB) {
+		t.Fatal("block changed after encode/decode:", heavyBlock, decB)
 	}
 }
 

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -136,6 +136,19 @@ func TestBlockEncoding(t *testing.T) {
 	}
 }
 
+// TestTooLargeDecoder tests that the decoder catches allocations that are too
+// large.
+func TestTooLargeDecoder(t *testing.T) {
+	enc := encoding.Marshal(Block{})
+	// change number of transactions to large number
+	copy(enc[len(enc)-8:], encoding.EncUint64(^uint64(0)))
+	var block Block
+	err := encoding.Unmarshal(enc, &block)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
 // TestCurrencyMarshalJSON probes the MarshalJSON and UnmarshalJSON functions
 // of the currency type.
 func TestCurrencyMarshalJSON(t *testing.T) {


### PR DESCRIPTION
The decoder operates using the `io.Reader` abstraction, which means that if it e.g. wants to decode a length prefix, it must allocate 8 bytes, read into the byte slice, and decode the result. This is unavoidable if the underlying `io.Reader` is an `*os.File` or a `net.Conn`. However, in the majority of cases, we are decoding a byte slice that has already been allocated, as in `Unmarshal`:
```go
func Unmarshal(b []byte, v interface{}) error {
	r := bytes.NewReader(b)
	return NewDecoder(r).Decode(v)
}
```
In this case, we should be able to skip the `Read` call and work directly with the data present in `b`.

To implement this, I added a type assertion that checks if the underlying `io.Reader` is a `bytes.Buffer`. If it is, we can call the `Next` method to return the next `n` bytes without allocating. Otherwise, we fallback to the allocation-based code.

Profiling suggests that this saves a few GB of allocations per rescan. At some point we should fully implement `UnmarshalSia` for `types.Block` so that it's fast, reflection-free, and keeps allocations to a minimum.