### PR TITLE
Reduce encoding allocations

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -113,13 +113,14 @@ func (b Block) ID() BlockID {
 func (b Block) MerkleRoot() crypto.Hash {
 	tree := crypto.NewTree()
 	var buf bytes.Buffer
+	e := encoder(&buf)
 	for _, payout := range b.MinerPayouts {
-		payout.MarshalSia(&buf)
+		payout.MarshalSia(e)
 		tree.Push(buf.Bytes())
 		buf.Reset()
 	}
 	for _, txn := range b.Transactions {
-		txn.MarshalSia(&buf)
+		txn.MarshalSia(e)
 		tree.Push(buf.Bytes())
 		buf.Reset()
 	}

--- a/types/block_bench_test.go
+++ b/types/block_bench_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/encoding"
@@ -15,7 +16,7 @@ func BenchmarkEncodeEmptyBlock(b *testing.B) {
 	b.SetBytes(int64(len(encoding.Marshal(block))))
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		encoding.Marshal(block)
+		block.MarshalSia(ioutil.Discard)
 	}
 }
 
@@ -45,7 +46,7 @@ func BenchmarkEncodeHeavyBlock(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		encoding.Marshal(heavyBlock)
+		heavyBlock.MarshalSia(ioutil.Discard)
 	}
 }
 

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -96,9 +96,8 @@ func encoder(w io.Writer) *encHelper {
 		return e
 	}
 	return &encHelper{
-		w: w,
-		// 32 bytes is large enough for everything except StorageProof.Segment
-		buf: make([]byte, 32),
+		w:   w,
+		buf: make([]byte, 64), // large enough for everything but ArbitraryData
 	}
 }
 


### PR DESCRIPTION
Follow up to #2282, implementing a similar strategy for reducing allocations. This should have a huge effect on our total number of allocations, and the resulting amount of time we spend in GC. The reason for this is that we hash lots of data, and hashing requires encoding, and encoding requires allocations. The two biggest offenders are `encoding.WriteUint64` (for writing length prefixes) and `Currency.MarshalSia` (which makes a copy of the bytes before writing them). I was able to nullify both of these by writing length prefixes to a reusable buffer and by doing some bitmath on the raw Currency bytes to avoid the copy. The end result is that most encodings require only a single allocation, even for very complex objects.

Microbenchmark:
```
old:

BenchmarkEncodeEmptyBlock-4	10000000    127 ns/op   500.19 MB/s     4 allocs/op
BenchmarkEncodeHeavyBlock-4	  500000   3330 ns/op   455.85 MB/s   102 allocs/op

new:

BenchmarkEncodeEmptyBlock-4	10000000    127 ns/op   501.06 MB/s     2 allocs/op
BenchmarkEncodeHeavyBlock-4	 1000000   1812 ns/op   837.71 MB/s     3 allocs/op
```

And a more realistic benchmark, unlocking a fresh wallet:

Master branch: 50.0 GB GB allocated (640 million objects)
PR branch: 43.6 GB allocated (470 million objects)

This wasn't as dramatic as I was hoping, but I think it's because rescanning is mostly a decode-heavy operation.

The block encoding already includes sanity checks, and it hasn't complained during testing or during the unlocks. I can sync a full node again just to be sure, though.