### PR TITLE
add second void output to file contracts

### DIFF
--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -150,7 +150,7 @@ func (h *Host) managedDownloadIteration(conn net.Conn, so *storageObligation) er
 // host.
 func verifyPaymentRevision(existingRevision, paymentRevision types.FileContractRevision, blockHeight types.BlockHeight, expectedTransfer types.Currency) error {
 	// Check that the revision is well-formed.
-	if len(paymentRevision.NewValidProofOutputs) != 2 || len(paymentRevision.NewMissedProofOutputs) != 3 {
+	if len(paymentRevision.NewValidProofOutputs) != 2 || (len(paymentRevision.NewMissedProofOutputs) != 3 && len(paymentRevision.NewMissedProofOutputs) != 4) {
 		return errBadContractOutputCounts
 	}
 

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -242,14 +242,16 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	}
 
 	// ValidProofOutputs shoud have 2 outputs (renter + host) and missed
-	// outputs should have 3 (renter + host + void)
-	if len(fc.ValidProofOutputs) != 2 || len(fc.MissedProofOutputs) != 3 {
+	// outputs should have either 3 or 4 (renter + host + void [+ void])
+	if len(fc.ValidProofOutputs) != 2 || (len(fc.MissedProofOutputs) != 3 && len(fc.MissedProofOutputs) != 4) {
 		return errBadContractOutputCounts
 	}
 	// The unlock hashes of the valid and missed proof outputs for the host
-	// must match the host's unlock hash. The third missed output should point
-	// to the void.
-	if fc.ValidProofOutputs[1].UnlockHash != unlockHash || fc.MissedProofOutputs[1].UnlockHash != unlockHash || fc.MissedProofOutputs[2].UnlockHash != (types.UnlockHash{}) {
+	// must match the host's unlock hash. The third (and possibly fourth)
+	// missed output(s) should point to the void.
+	if fc.ValidProofOutputs[1].UnlockHash != unlockHash || fc.MissedProofOutputs[1].UnlockHash != unlockHash ||
+		fc.MissedProofOutputs[2].UnlockHash != (types.UnlockHash{}) ||
+		(len(fc.MissedProofOutputs) == 4 && fc.MissedProofOutputs[2].UnlockHash != (types.UnlockHash{})) {
 		return errBadPayoutUnlockHashes
 	}
 	// Check that the payouts for the valid proof outputs and the missed proof

--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -250,14 +250,17 @@ func (h *Host) managedVerifyRenewedContract(so storageObligation, txnSet []types
 	}
 
 	// ValidProofOutputs shoud have 2 outputs (renter + host) and missed
-	// outputs should have 3 (renter + host + void)
-	if len(fc.ValidProofOutputs) != 2 || len(fc.MissedProofOutputs) != 3 {
+	// outputs should have either 3 or 4 (renter + host + void [+ void])
+	if len(fc.ValidProofOutputs) != 2 || (len(fc.MissedProofOutputs) != 3 && len(fc.MissedProofOutputs) != 4) {
 		return errBadContractOutputCounts
 	}
+
 	// The unlock hashes of the valid and missed proof outputs for the host
-	// must match the host's unlock hash. The third missed output should point
-	// to the void.
-	if fc.ValidProofOutputs[1].UnlockHash != unlockHash || fc.MissedProofOutputs[1].UnlockHash != unlockHash || fc.MissedProofOutputs[2].UnlockHash != (types.UnlockHash{}) {
+	// must match the host's unlock hash. The third (and possibly fourth)
+	// missed output(s) should point to the void.
+	if fc.ValidProofOutputs[1].UnlockHash != unlockHash || fc.MissedProofOutputs[1].UnlockHash != unlockHash ||
+		fc.MissedProofOutputs[2].UnlockHash != (types.UnlockHash{}) ||
+		(len(fc.MissedProofOutputs) == 4 && fc.MissedProofOutputs[2].UnlockHash != (types.UnlockHash{})) {
 		return errBadPayoutUnlockHashes
 	}
 

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -228,7 +228,7 @@ func (h *Host) managedRPCReviseContract(conn net.Conn) error {
 // the revision does not attempt any malicious or unexpected changes.
 func verifyRevision(so storageObligation, revision types.FileContractRevision, blockHeight types.BlockHeight, expectedExchange, expectedCollateral types.Currency) error {
 	// Check that the revision is well-formed.
-	if len(revision.NewValidProofOutputs) != 2 || len(revision.NewMissedProofOutputs) != 3 {
+	if len(revision.NewValidProofOutputs) != 2 || (len(revision.NewMissedProofOutputs) != 3 && len(revision.NewMissedProofOutputs) != 4) {
 		return errBadContractOutputCounts
 	}
 

--- a/modules/renter/proto/formcontract.go
+++ b/modules/renter/proto/formcontract.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
@@ -73,6 +74,16 @@ func FormContract(params ContractParams, txnBuilder transactionBuilder, tpool tr
 			// Once we start doing revisions, we'll move some coins to the host and some to the void.
 			{Value: types.ZeroCurrency, UnlockHash: types.UnlockHash{}},
 		},
+	}
+	if build.VersionCmp(host.Version, "1.3.0") >= 0 {
+		// After version 1.3.1, file contracts will have an extra void output
+		// in MissedProofOutputs. The renter moves voided coins to
+		// MissedProofOutputs[2], and the host moves voided coins to
+		// MissedProofOutputs[3]. This allows us to calculate the original
+		// amount of funds paid into the contract by the renter and host.
+		fc.MissedProofOutputs = append(fc.MissedProofOutputs, types.SiacoinOutput{
+			Value: types.ZeroCurrency, UnlockHash: types.UnlockHash{},
+		})
 	}
 
 	// Calculate transaction fee.

--- a/modules/renter/proto/negotiate.go
+++ b/modules/renter/proto/negotiate.go
@@ -173,10 +173,8 @@ func newRevision(current types.FileContractRevision, cost types.Currency) types.
 	rev := current
 
 	// need to manually copy slice memory
-	rev.NewValidProofOutputs = make([]types.SiacoinOutput, 2)
-	rev.NewMissedProofOutputs = make([]types.SiacoinOutput, 3)
-	copy(rev.NewValidProofOutputs, current.NewValidProofOutputs)
-	copy(rev.NewMissedProofOutputs, current.NewMissedProofOutputs)
+	rev.NewValidProofOutputs = append([]types.SiacoinOutput(nil), current.NewValidProofOutputs...)
+	rev.NewMissedProofOutputs = append([]types.SiacoinOutput(nil), current.NewMissedProofOutputs...)
 
 	// move valid payout from renter to host
 	rev.NewValidProofOutputs[0].Value = current.NewValidProofOutputs[0].Value.Sub(cost)
@@ -204,8 +202,10 @@ func newUploadRevision(current types.FileContractRevision, merkleRoot crypto.Has
 	rev := newRevision(current, price)
 
 	// move collateral from host to void
+	// NOTE: as of v1.3.1, there are 2 void outputs; the host's is the latter.
+	i := len(rev.NewMissedProofOutputs) - 1
 	rev.NewMissedProofOutputs[1].Value = rev.NewMissedProofOutputs[1].Value.Sub(collateral)
-	rev.NewMissedProofOutputs[2].Value = rev.NewMissedProofOutputs[2].Value.Add(collateral)
+	rev.NewMissedProofOutputs[i].Value = rev.NewMissedProofOutputs[i].Value.Add(collateral)
 
 	// set new filesize and Merkle root
 	rev.NewFileSize += modules.SectorSize


### PR DESCRIPTION
Currently, file contracts have a single "void" output, where coins are burnt to prevent certain misaligned-incentive attacks (e.g. the renter DoS'ing the host). During a revision, missed payout funds are moved from the renter to void, and missed payout collateral is moved from the host to the void. This works perfectly well, but it has one unfortunate side-effect: the void output contains a mixture of renter and host coins. The reason this is unfortunate is that, were the coins cleanly separated, we could trivially compute the original number of coins paid in by the renter and the host (i.e. the original values of `ValidProofOutputs`). If we separate the coins by adding a new void output to `MissedProofOutputs`, and specify that index 2 is the "renter void" and index 3 is the "host void", then we can calculate the original funds via:

```go
missed := contract.LastRevision.NewMissedProofOutputs
origRenterFunds := missed[0] + missed[2]
origHostFunds := missed[1] + missed[3]
```

For reporting purposes, it's important that we know how much the renter originally paid into a contract, so currently we track this via separate metadata in the `modules.RenterContract` object. But there is no way to determine this value simply by looking at the most recent revision of the contract. You would have to lookup the parent ID in the blockchain.

This doesn't help Sia in the short-term, since we'll need to maintain compatibility for a while with hosts that don't support 2 void payouts. But down the road, I think it will be a useful property to have.

---

This code is passing tests despite making only small changes to the host, which I find somewhat surprising. It's possible that the host is not fully validating the missed proof outputs when accepting contract revisions. This warrants further investigation.