### PR TITLE
Add DustThreshold to /wallet API endpoint

### DIFF
--- a/api/wallet.go
+++ b/api/wallet.go
@@ -28,6 +28,8 @@ type (
 
 		SiafundBalance      types.Currency `json:"siafundbalance"`
 		SiacoinClaimBalance types.Currency `json:"siacoinclaimbalance"`
+
+		DustThreshold types.Currency `json:"dustthreshold"`
 	}
 
 	// WalletAddressGET contains an address returned by a GET call to
@@ -121,6 +123,7 @@ func encryptionKeys(seedStr string) (validKeys []crypto.TwofishKey) {
 func (api *API) walletHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	siacoinBal, siafundBal, siaclaimBal := api.wallet.ConfirmedBalance()
 	siacoinsOut, siacoinsIn := api.wallet.UnconfirmedBalance()
+	dustThreshold := api.wallet.DustThreshold()
 	WriteJSON(w, WalletGET{
 		Encrypted:  api.wallet.Encrypted(),
 		Unlocked:   api.wallet.Unlocked(),
@@ -132,6 +135,8 @@ func (api *API) walletHandler(w http.ResponseWriter, req *http.Request, _ httpro
 
 		SiafundBalance:      siafundBal,
 		SiacoinClaimBalance: siaclaimBal,
+
+		DustThreshold: dustThreshold,
 	})
 }
 

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -1451,3 +1451,26 @@ func TestWalletSiacoins(t *testing.T) {
 		}
 	}
 }
+
+// TestWalletGETDust tests the consistency of dustthreshold field in /wallet
+func TestWalletGETDust(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+	st, err := createServerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg WalletGET
+	err = st.getAPI("/wallet", &wg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dt := st.wallet.DustThreshold()
+	if !dt.Equals(wg.DustThreshold) {
+		t.Fatal("dustThreshold mismatch")
+	}
+}

--- a/doc/API.md
+++ b/doc/API.md
@@ -1076,6 +1076,8 @@ locked or unlocked.
 
   "siafundbalance":      "1",    // siafunds, big int
   "siacoinclaimbalance": "9001", // hastings, big int
+
+  "dustthreshold": "1234", // hastings, big int
 }
 ```
 

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -103,6 +103,10 @@ locked or unlocked.
   // time a file contract is created, it is possible that the balance will
   // increase before any claim transaction is confirmed.
   "siacoinclaimbalance": "9001", // hastings, big int
+
+  // Number of siacoins, in hastings, below which a transaction output cannot
+  // be used because the wallet considers it a dust output
+  "dustthreshold": "1234", // hastings, big int
 }
 ```
 

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -391,6 +391,9 @@ type (
 		// transactions are automatically given to the transaction pool, and
 		// are also returned to the caller.
 		SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
+
+		// DustThreshold returns the quantity below which a Currency is considered to be Dust.
+		DustThreshold() types.Currency
 	}
 )
 

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -16,7 +16,7 @@ var (
 // wallet outputs into a single new address.
 func (w *Wallet) managedCreateDefragTransaction() ([]types.Transaction, error) {
 	// dustThreshold and minFee have to be obtained separate from the lock
-	dustThreshold := w.managedDustThreshold()
+	dustThreshold := w.DustThreshold()
 	minFee, _ := w.tpool.FeeEstimation()
 
 	w.mu.Lock()

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -13,8 +13,8 @@ type sortedOutputs struct {
 	outputs []types.SiacoinOutput
 }
 
-// managedDustThreshold returns the quantity below which a Currency is considered to be Dust.
-func (w *Wallet) managedDustThreshold() types.Currency {
+// DustThreshold returns the quantity below which a Currency is considered to be Dust.
+func (w *Wallet) DustThreshold() types.Currency {
 	minFee, _ := w.tpool.FeeEstimation()
 	return minFee.Mul64(3)
 }
@@ -23,7 +23,7 @@ func (w *Wallet) managedDustThreshold() types.Currency {
 // confirmed transactions.
 func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalance types.Currency, siafundClaimBalance types.Currency) {
 	// dustThreshold has to be obtained separate from the lock
-	dustThreshold := w.managedDustThreshold()
+	dustThreshold := w.DustThreshold()
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -59,7 +59,7 @@ func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalan
 // reporting.
 func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency) {
 	// dustThreshold has to be obtained separate from the lock
-	dustThreshold := w.managedDustThreshold()
+	dustThreshold := w.DustThreshold()
 
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -118,7 +118,7 @@ func (w *Wallet) checkOutput(tx *bolt.Tx, currentHeight types.BlockHeight, id ty
 // on the transaction builder.
 func (tb *transactionBuilder) FundSiacoins(amount types.Currency) error {
 	// dustThreshold has to be obtained separate from the lock
-	dustThreshold := tb.wallet.managedDustThreshold()
+	dustThreshold := tb.wallet.DustThreshold()
 
 	tb.wallet.mu.Lock()
 	defer tb.wallet.mu.Unlock()


### PR DESCRIPTION
This PR fixes #2291. Two comments/questions:
- `TestWalletDustThreshold` is an adaptation of `TestTransactionPoolFee` to test the api endpoint like previous tests. It creates a simple test server and checks if the api endpoint result equals the direct call one but I am not sure if it clears the _sane value_ requirement that is said in the issue.
Is a different test needed or just to check its value in the real blockchain?
- Is adding this threshold value as an extra line in the `wallet balance` output of `siac` a good a idea? (after the estimated fee)