### PR TITLE
tweak make defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - make dependencies
   - test -z "$(go fmt ./...)"
   - glyphcheck ./...
-  - make
+  - make dev
 
 script: make test && make test-long && make cover && make bench
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # all will build and install developer binaries, which have debugging enabled
 # and much faster mining and block constants.
-all: install
+all: release-std
 
 # dependencies installs all of the dependencies that are required for building
 # Sia.
@@ -56,8 +56,8 @@ lint:
 		&& test -z $$(golint -min_confidence=1.0 $$package) ; \
 	done
 
-# install builds and installs developer binaries.
-install:
+# dev builds and installs developer binaries.
+dev:
 	go install -race -tags='dev debug profile' $(pkgs)
 
 # release builds and installs release binaries.


### PR DESCRIPTION
`make` now builds release binaries (std constants, no debug, no race detector). `make install` is now `make dev`, which builds dev binaries (dev constants, debug, race detector).