### PR TITLE
add missing error check to transactionpool test

### DIFF
--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -1021,6 +1021,9 @@ func TestBigTpool(t *testing.T) {
 	}
 
 	block, err = tpt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
 	totalFee4 := types.ZeroCurrency
 	maxFee4 := types.ZeroCurrency
 	for _, tx := range block.Transactions {


### PR DESCRIPTION
Adds a check for error after `AddBlock` call. This fixes a linter warning about ineffectual assignment of the `err` variable.