### PR TITLE
add string spellchecking to the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ dependencies:
 	go get -u github.com/spf13/cobra/...
 	# Developer Dependencies
 	go install -race std
+	go get -u github.com/client9/misspell/cmd/misspell
 	go get -u github.com/golang/lint/golint
 	go get -u github.com/NebulousLabs/glyphcheck
 
@@ -56,6 +57,10 @@ lint:
 		&& test -z $$(golint -min_confidence=1.0 $$package) ; \
 	done
 
+# spellcheck checks for misspelled words in comments or strings.
+spellcheck:
+	misspell -error -locale US -i "marshalled,marshalling,Marshalling,Marshalled" .
+
 # dev builds and installs developer binaries.
 dev:
 	go install -race -tags='dev debug profile' $(pkgs)
@@ -77,9 +82,9 @@ test:
 	go test -short -tags='debug testing' -timeout=5s $(pkgs) -run=$(run)
 test-v:
 	go test -race -v -short -tags='debug testing' -timeout=15s $(pkgs) -run=$(run)
-test-long: clean fmt vet lint
+test-long: clean fmt vet lint spellcheck
 	go test -v -race -tags='testing debug' -timeout=500s $(pkgs) -run=$(run)
-test-vlong: clean fmt vet lint
+test-vlong: clean fmt vet lint spellcheck
 	go test -v -race -tags='testing debug vlong' -timeout=5000s $(pkgs) -run=$(run)
 test-cpu:
 	go test -v -tags='testing debug' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ test:
 	go test -short -tags='debug testing' -timeout=5s $(pkgs) -run=$(run)
 test-v:
 	go test -race -v -short -tags='debug testing' -timeout=15s $(pkgs) -run=$(run)
-test-long: clean fmt vet lint spellcheck
+test-long: clean fmt vet lint
 	go test -v -race -tags='testing debug' -timeout=500s $(pkgs) -run=$(run)
-test-vlong: clean fmt vet lint spellcheck
+test-vlong: clean fmt vet lint
 	go test -v -race -tags='testing debug vlong' -timeout=5000s $(pkgs) -run=$(run)
 test-cpu:
 	go test -v -tags='testing debug' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ lint:
 
 # spellcheck checks for misspelled words in comments or strings.
 spellcheck:
-	misspell -error -locale US -i "marshalled,marshalling,Marshalling,Marshalled" .
+	misspell -error -i "marshalled,marshalling,Marshalling,Marshalled" .
 
 # dev builds and installs developer binaries.
 dev:

--- a/api/ecosystem_helpers_test.go
+++ b/api/ecosystem_helpers_test.go
@@ -44,7 +44,7 @@ func announceAllHosts(sts []*serverTester) error {
 		return err
 	}
 
-	// Grab the inital transaction pool size to know how many total transactions
+	// Grab the initial transaction pool size to know how many total transactions
 	// there should be after announcement.
 	initialTpoolSize := len(sts[0].tpool.TransactionList())
 

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -1978,11 +1978,13 @@ func TestExhaustedContracts(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = build.Retry(100, time.Millisecond*500, func() error {
-		// mine blocks each iteration to trigger contract maintainence
+		// mine blocks each iteration to trigger contract maintenance
 		_, err = st.miner.AddBlock()
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		st.miner.AddBlock()
 		if !st.renter.FileList()[0].Available {
 			return errors.New("file did not complete uploading")
 		}
@@ -2076,7 +2078,7 @@ func TestAdversarialPriceRenewal(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = build.Retry(100, time.Millisecond*500, func() error {
-		// mine blocks each iteration to trigger contract maintainence
+		// mine blocks each iteration to trigger contract maintenance
 		_, err = st.miner.AddBlock()
 		if err != nil {
 			t.Fatal(err)

--- a/api/wallet_test.go
+++ b/api/wallet_test.go
@@ -678,7 +678,7 @@ func TestWalletTransactionGETid(t *testing.T) {
 			t.Fatal("transaction should have an input")
 		}
 		if len(txn.Outputs) < 1 {
-			t.Fatal("transaciton should have outputs")
+			t.Fatal("transactions should have outputs")
 		}
 		for _, input := range txn.Inputs {
 			if input.Value.IsZero() {
@@ -737,7 +737,7 @@ func TestWalletTransactionGETid(t *testing.T) {
 			t.Fatal("transaction should have an input")
 		}
 		if len(txn.Outputs) < 1 {
-			t.Fatal("transaciton should have outputs")
+			t.Fatal("transactions should have outputs")
 		}
 		for _, input := range txn.Inputs {
 			if input.Value.IsZero() {
@@ -775,7 +775,7 @@ func TestWalletTransactionGETid(t *testing.T) {
 			t.Fatal("transaction should have an input")
 		}
 		if len(txn.Outputs) < 1 {
-			t.Fatal("transaciton should have outputs")
+			t.Fatal("transactions should have outputs")
 		}
 		for _, input := range txn.Inputs {
 			if input.Value.IsZero() {

--- a/doc/api/Host.md
+++ b/doc/api/Host.md
@@ -559,7 +559,7 @@ combined with the provided settings.
 	// estimatedscore is the estimated HostDB score of the host given the
 	// settings passed to estimatescore.
 	"estimatedscore": "123456786786786786786786786742133",
-	// conversionrate is the likelyhood given the settings passed to
+	// conversionrate is the likelihood given the settings passed to
 	// estimatescore that the host will be selected by renters forming contracts.
 	"conversionrate": 95
 }

--- a/modules/consensus/database.go
+++ b/modules/consensus/database.go
@@ -87,7 +87,7 @@ func (cs *ConsensusSet) openDB(filename string) (err error) {
 // database with all the required buckets and sane initial values.
 func (cs *ConsensusSet) initDB(tx *bolt.Tx) error {
 	// If the database has already been initialized, there is nothing to do.
-	// Initialization can be detected by looking for the presense of the siafund
+	// Initialization can be detected by looking for the presence of the siafund
 	// pool bucket. (legacy design chioce - ultimately probably not the best way
 	// ot tell).
 	if tx.Bucket(SiafundPool) != nil {

--- a/modules/consensus/difficulty_test.go
+++ b/modules/consensus/difficulty_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/NebulousLabs/bolt"
 )
 
-// TestChildTargetOak checks the childTargetOak function, espeically for edge
+// TestChildTargetOak checks the childTargetOak function, especially for edge
 // cases like overflows and underflows.
 func TestChildTargetOak(t *testing.T) {
 	// NOTE: Test must not be run in parallel.

--- a/modules/host/network.go
+++ b/modules/host/network.go
@@ -108,7 +108,7 @@ func (h *Host) threadedTrackWorkingStatus(closeChan chan struct{}) {
 func (h *Host) threadedTrackConnectabilityStatus(closeChan chan struct{}) {
 	defer close(closeChan)
 
-	// Wait breifly before checking the first time. This gives time for any port
+	// Wait briefly before checking the first time. This gives time for any port
 	// forwarding to complete.
 	select {
 	case <-h.tg.StopChan():

--- a/modules/host/network_test.go
+++ b/modules/host/network_test.go
@@ -97,7 +97,7 @@ func TestHostWorkingStatus(t *testing.T) {
 			t.Fatal("expected working state to flip to HostWorkingStatusWorking after incrementing settings calls")
 		}
 
-		// make no settins calls, host should flip back to NotWorking
+		// make no settings calls, host should flip back to NotWorking
 		success = false
 		for start := time.Now(); time.Since(start) < 30*time.Second; time.Sleep(time.Millisecond * 10) {
 			if ht.host.WorkingStatus() == modules.HostWorkingStatusNotWorking {

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -48,7 +48,7 @@ var (
 	}).(time.Duration)
 )
 
-// splitSet defines a transaction set that can be added componenet-wise to a
+// splitSet defines a transaction set that can be added components-wise to a
 // block. It's split because it doesn't necessarily represent the full set
 // prpovided by the transaction pool. Splits can be sorted so that the largest
 // and most valuable sets can be selected when picking transactions.

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -122,7 +122,7 @@ type (
 	}
 )
 
-// newSectionDownload initialises and returns a download object for the specified chunk.
+// newSectionDownload initializes and returns a download object for the specified chunk.
 func (r *Renter) newSectionDownload(f *file, destination modules.DownloadWriter, offset, length uint64) *download {
 	d := newDownload(f, destination)
 
@@ -165,7 +165,7 @@ func newDownload(f *file, destination modules.DownloadWriter) *download {
 	}
 }
 
-// initPieceSet initialises the piece set, including calculations of the total download size.
+// initPieceSet initializes the piece set, including calculations of the total download size.
 func (d *download) initPieceSet(f *file, r *Renter) {
 	// Allocate the piece size and progress bar so that the download will
 	// finish at exactly 100%. Due to rounding error and padding, there is not
@@ -419,7 +419,7 @@ func (r *Renter) managedDownloadIteration(ds *downloadState) {
 
 // managedScheduleIncompleteChunks iterates through all of the incomplete
 // chunks and finds workers to complete the chunks.
-// managedScheduleIncompleteChunks also checks wheter a chunk is unable to be
+// managedScheduleIncompleteChunks also checks whether a chunk is unable to be
 // completed.
 func (r *Renter) managedScheduleIncompleteChunks(ds *downloadState) {
 	var newIncompleteChunks []*chunkDownload

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -72,7 +72,7 @@ type (
 	}
 
 	// UnconfirmedTransactionSet defines a new unconfirmed transaction that has
-	// been added to the transaction pool. ID is the ID of the set, IDs contians
+	// been added to the transaction pool. ID is the ID of the set, IDs contains
 	// an ID for each transaction, eliminating the need to recompute it (because
 	// that's an expensive operation).
 	UnconfirmedTransactionSet struct {

--- a/modules/transactionpool/consts.go
+++ b/modules/transactionpool/consts.go
@@ -67,7 +67,7 @@ var (
 // Variables related to the size and ease-of-entry of the transaction pool.
 var (
 	// minEstimation defines a sane minimum fee per byte for transactions.  This
-	// will typically be only suggested as a fee in the absense of congestion.
+	// will typically be only suggested as a fee in the absence of congestion.
 	minEstimation = types.SiacoinPrecision.Div64(100).Div64(1e3)
 )
 

--- a/modules/transactionpool/persist.go
+++ b/modules/transactionpool/persist.go
@@ -23,7 +23,7 @@ var (
 	errNilConsensusChange = errors.New("no consensus change found")
 
 	// errNilFeeMedian is the message returned if a database does not find fee
-	// median persistance.
+	// median persistence.
 	errNilFeeMedian = errors.New("no fee median found")
 )
 

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -184,7 +184,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 		}
 
 		// Pull the transactions out of the fee summary. For estimating only
-		// over 10 blocks, it is extermely likely that there will be more
+		// over 10 blocks, it is extremely likely that there will be more
 		// applied blocks than reverted blocks, and if there aren't (a height
 		// decreasing reorg), there will be more than 10 applied blocks.
 		if len(tp.recentMedians) > 0 {

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -259,9 +259,9 @@ func renterallowancecmd() {
 func renterallowancecancelcmd() {
 	err := post("/renter", "hosts=0&funds=0&period=0&renewwindow=0")
 	if err != nil {
-		die("error cancelling allowance:", err)
+		die("error canceling allowance:", err)
 	}
-	fmt.Println("Allowance cancelled.")
+	fmt.Println("Allowance canceled.")
 }
 
 // rentersetallowancecmd allows the user to set the allowance.

--- a/siac/walletcmd.go
+++ b/siac/walletcmd.go
@@ -214,7 +214,7 @@ func walletchangepasswordcmd() {
 	if err != nil {
 		die("Changing the password failed:", err)
 	}
-	fmt.Println("Password changed sucessfully.")
+	fmt.Println("Password changed successfully.")
 }
 
 // walletinitcmd encrypts the wallet with the given password

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -47,6 +47,6 @@ We welcome pull requests, bug fixes and issue reports. With that said, the bar f
 
 Before proposing a change, please discuss your change by raising an issue.
 
-## Licence
+## License
 
 BSD-2-Clause

--- a/vendor/github.com/pkg/errors/bench_test.go
+++ b/vendor/github.com/pkg/errors/bench_test.go
@@ -24,7 +24,7 @@ func yesErrors(at, depth int) error {
 }
 
 // GlobalE is an exported global to store the result of benchmark results,
-// preventing the compiler from optimizing the benchmark functions away.
+// preventing the compiler from optimising the benchmark functions away.
 var GlobalE error
 
 func BenchmarkErrors(b *testing.B) {

--- a/vendor/github.com/pkg/errors/bench_test.go
+++ b/vendor/github.com/pkg/errors/bench_test.go
@@ -24,7 +24,7 @@ func yesErrors(at, depth int) error {
 }
 
 // GlobalE is an exported global to store the result of benchmark results,
-// preventing the compiler from optimising the benchmark functions away.
+// preventing the compiler from optimizing the benchmark functions away.
 var GlobalE error
 
 func BenchmarkErrors(b *testing.B) {


### PR DESCRIPTION
Adding a spellcheck step to the build to catch misspelled words in comments and
output strings.

Fixing all of the existing spelling errors.