### PR TITLE
switch to ReconstructData

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -29,12 +29,11 @@ type ErasureCoder interface {
 	// containing parity data.
 	Encode(data []byte) ([][]byte, error)
 
-	// Recover recovers the original data from pieces (including parity) and
-	// writes it to w. pieces should be identical to the slice returned by
-	// Encode (length and order must be preserved), but with missing elements
-	// set to nil. n is the number of bytes to be written to w; this is
-	// necessary because pieces may have been padded with zeros during
-	// encoding.
+	// Recover recovers the original data from pieces and writes it to w.
+	// pieces should be identical to the slice returned by Encode (length and
+	// order must be preserved), but with missing elements set to nil. n is
+	// the number of bytes to be written to w; this is necessary because
+	// pieces may have been padded with zeros during encoding.
 	Recover(pieces [][]byte, n uint64, w io.Writer) error
 }
 

--- a/modules/renter/erasure.go
+++ b/modules/renter/erasure.go
@@ -40,12 +40,11 @@ func (rs *rsCode) Encode(data []byte) ([][]byte, error) {
 	return pieces, nil
 }
 
-// Recover recovers the original data from pieces (including parity) and
-// writes it to w. pieces should be identical to the slice returned by
-// Encode (length and order must be preserved), but with missing elements
-// set to nil.
+// Recover recovers the original data from pieces and writes it to w.
+// pieces should be identical to the slice returned by Encode (length and
+// order must be preserved), but with missing elements set to nil.
 func (rs *rsCode) Recover(pieces [][]byte, n uint64, w io.Writer) error {
-	err := rs.enc.Reconstruct(pieces)
+	err := rs.enc.ReconstructData(pieces)
 	if err != nil {
 		return err
 	}

--- a/modules/renter/erasure_test.go
+++ b/modules/renter/erasure_test.go
@@ -85,7 +85,9 @@ func BenchmarkRSRecover(b *testing.B) {
 	b.SetBytes(1 << 20)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		pieces[0] = nil
+		for j := 0; j < len(pieces)/2; j += 2 {
+			pieces[j] = nil
+		}
 		rsc.Recover(pieces, 1<<20, ioutil.Discard)
 	}
 }


### PR DESCRIPTION
In July, [a PR added a `ReconstructData` method reedsolomon package](https://github.com/klauspost/reedsolomon/pull/57). This method only recovers the data pieces, whereas `Reconstruct` recovers both data and parity pieces. Since we only care about the actual data, `ReconstructData` is the clear choice, since it is faster.

Benchmarks (recovering a 50-of-200 erasure code with every other piece missing):
```
with Reconstruct:
BenchmarkRSRecover-4      1000	   2033555 ns/op   515.64 MB/s

with ReconstructData:
BenchmarkRSRecover-4      2000	    692716 ns/op   1513.72 MB/s
```

NOTE: this does (indirectly) impact repairing. Currently, we repair by downloading pieces, recovering the original data via `Recover`, and then re-encoding to get the full set of data+parity pieces. We could optimize this by calling `Reconstruct` on the downloaded pieces directly. Obviously, `ReconstructData` would not be appropriate here, since we need to recover the parity pieces as well. So we just need to be aware of that if/when we switch to calling `Reconstruct` directly.