### PR TITLE
Fix re-open journal if rename fails

### DIFF
--- a/modules/renter/contractor/journal.go
+++ b/modules/renter/contractor/journal.go
@@ -19,7 +19,6 @@ package contractor
 // simply ignored when reading the journal.
 
 import (
-	"build"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,6 +26,7 @@ import (
 	"os"
 	"reflect"
 	"syscall"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
@@ -117,7 +117,9 @@ func (j *journal) checkpoint(data contractorPersist) error {
 	}
 
 	// Attempt rename up to 5 times to prevent issues with anti-virus software
-	err = build.Retry(5, 1000*Millisecond, func() error { return os.Rename(tmp.Name(), j.filename) })
+	err = build.Retry(5, 100*time.Millisecond, func() error {
+		return os.Rename(tmp.Name(), j.filename)
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If journal rename fails, the fd becomes invalid and journal processing will never recover. Antivirus software on Windows causes the rename to intermittently fail.
- Added 5 retry attempts on failed rename
- Check for invalid handle before trying to close