### PR TITLE
spellcheck: remove ignored corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ lint:
 
 # spellcheck checks for misspelled words in comments or strings.
 spellcheck:
-	misspell -error -i "marshalled,marshalling,Marshalling,Marshalled" .
+	misspell -error .
 
 # dev builds and installs developer binaries.
 dev:


### PR DESCRIPTION
They are not needed after removing `-locale US` option in e506ac755f5ac8eccbab28e8d5ff3a32fbe80d30.