### PR TITLE
fix AddSectorBatch on large contracts

### DIFF
--- a/modules/host/contractmanager/consts.go
+++ b/modules/host/contractmanager/consts.go
@@ -60,6 +60,10 @@ const (
 	// which is a high granluarity relative the to the TiBs of storage that
 	// hosts are expected to provide.
 	storageFolderGranularity = 64
+
+	// maxAddSectorBatchThreads is the maximum number of threads updating
+	// sector counters on disk in AddSectorBatch.
+	maxAddSectorBatchThreads = 100
 )
 
 var (


### PR DESCRIPTION
AddSectorBatch is applied to the whole list of sectors of a contract being
renewed. The function started a goroutine per sector before. Each goroutine
made disk access to update the sector's reference counter. This resulted
is thousands of goroutines and potentially OS threads.
The tool crashed when a large contract was renewed:
https://github.com/NebulousLabs/Sia/issues/1775#issuecomment-330666550

This commit sets a cap for maximum parallel running goroutines in that group.

This PR is the mitigation to stop bleeding. Another PR which is more long term
and will take more time is https://github.com/NebulousLabs/Sia/pull/2361