### PR TITLE
accurately calculate renter spending

### DIFF
--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -668,9 +668,9 @@ func TestRenterHandlerContracts(t *testing.T) {
 	if err = st.getAPI("/renter", &get); err != nil {
 		t.Fatal(err)
 	}
-	expectedContractSpending := get.Settings.Allowance.Funds.Sub(get.FinancialMetrics.Unspent)
+	expectedContractSpending := types.ZeroCurrency
 	for _, contract := range contracts.Contracts {
-		expectedContractSpending = expectedContractSpending.Add(contract.RenterFunds)
+		expectedContractSpending = expectedContractSpending.Add(contract.TotalCost)
 	}
 	if got := get.FinancialMetrics.ContractSpending; got.Cmp(expectedContractSpending) != 0 {
 		t.Fatalf("expected contract spending to be %v; got %v", expectedContractSpending, got)

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -256,6 +256,16 @@ type RenterContract struct {
 	PreviousContracts []RenterContract
 }
 
+// ContractorSpending contains the metrics about how much the Contractor has
+// spent during the current billing period.
+type ContractorSpending struct {
+	ContractSpending types.Currency `json:"contractspending"`
+	UploadSpending   types.Currency `json:"uploadspending"`
+	DownloadSpending types.Currency `json:"downloadspending"`
+	StorageSpending  types.Currency `json:"storagespending"`
+	Unspent          types.Currency `json:"unspent"`
+}
+
 // EndHeight returns the height at which the host is no longer obligated to
 // store contract data.
 func (rc *RenterContract) EndHeight() types.BlockHeight {
@@ -291,6 +301,10 @@ type Renter interface {
 	// CurrentPeriod returns the height at which the current allowance period
 	// began.
 	CurrentPeriod() types.BlockHeight
+
+	// PeriodSpending returns the amount spent on contracts in the current
+	// billing period.
+	PeriodSpending() ContractorSpending
 
 	// DeleteFile deletes a file entry from the renter.
 	DeleteFile(path string) error

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -260,9 +260,9 @@ type RenterContract struct {
 // spent during the current billing period.
 type ContractorSpending struct {
 	ContractSpending types.Currency `json:"contractspending"`
-	UploadSpending   types.Currency `json:"uploadspending"`
 	DownloadSpending types.Currency `json:"downloadspending"`
 	StorageSpending  types.Currency `json:"storagespending"`
+	UploadSpending   types.Currency `json:"uploadspending"`
 	Unspent          types.Currency `json:"unspent"`
 }
 

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -108,7 +108,6 @@ func (c *Contractor) PeriodSpending() modules.ContractorSpending {
 	defer c.mu.RUnlock()
 
 	spending := modules.ContractorSpending{}
-	allSpending := types.ZeroCurrency
 	for _, contract := range c.contracts {
 		spending.ContractSpending = spending.ContractSpending.Add(contract.TotalCost)
 		spending.DownloadSpending = spending.DownloadSpending.Add(contract.DownloadSpending)
@@ -120,8 +119,8 @@ func (c *Contractor) PeriodSpending() modules.ContractorSpending {
 			spending.UploadSpending = spending.UploadSpending.Add(pre.UploadSpending)
 			spending.StorageSpending = spending.StorageSpending.Add(pre.StorageSpending)
 		}
-		allSpending = allSpending.Add(spending.ContractSpending).Add(spending.DownloadSpending).Add(spending.UploadSpending).Add(spending.StorageSpending)
 	}
+	allSpending := spending.ContractSpending.Add(spending.DownloadSpending).Add(spending.UploadSpending).Add(spending.StorageSpending)
 	spending.Unspent = c.allowance.Funds.Sub(allSpending)
 	return spending
 }

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -3,6 +3,7 @@ package contractor
 import (
 	"errors"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -199,7 +200,8 @@ func (stubHostDB) ScoreBreakdown(modules.HostDBEntry) modules.HostScoreBreakdown
 }
 
 // TestAllowanceSpending verifies that the contractor will not spend more or
-// less than the allowance if uploading causes repeated early renewal.
+// less than the allowance if uploading causes repeated early renewal, and that
+// correct spending metrics are returned, even across renewals.
 func TestAllowanceSpending(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -284,7 +286,6 @@ func TestAllowanceSpending(t *testing.T) {
 		}
 	}
 
-	// TODO: replace this logic with wallet contexts
 	var minerRewards types.Currency
 	w := c.wallet.(*walletBridge).w.(modules.Wallet)
 	txns, err := w.Transactions(0, 1000)
@@ -299,7 +300,7 @@ func TestAllowanceSpending(t *testing.T) {
 		}
 	}
 	balance, _, _ := w.ConfirmedBalance()
-	spent := minerRewards.Sub(balance).Add(h.FinancialMetrics().LockedStorageCollateral)
+	spent := minerRewards.Sub(balance)
 	if spent.Cmp(testAllowance.Funds) > 0 {
 		t.Fatal("contractor spent too much money: spent", spent.HumanString(), "allowance funds:", testAllowance.Funds.HumanString())
 	}
@@ -309,6 +310,31 @@ func TestAllowanceSpending(t *testing.T) {
 	expectedMinSpending := testAllowance.Funds.Sub(refreshCost)
 	if spent.Cmp(expectedMinSpending) < 0 {
 		t.Fatal("contractor spent to little money: spent", spent.HumanString(), "expected at least:", expectedMinSpending.HumanString())
+	}
+
+	// PeriodSpending should reflect the amount of spending accurately
+	reportedSpending := c.PeriodSpending()
+	if reportedSpending.ContractSpending.Cmp(spent) != 0 {
+		t.Fatal("reported incorrect spending for this billing cycle: got", reportedSpending.ContractSpending.HumanString(), "wanted", spent.HumanString())
+	}
+
+	// enter a new period. PeriodSpending should reset.
+	c.mu.Lock()
+	renewHeight := c.blockHeight + c.allowance.RenewWindow
+	blocksToMine := renewHeight - c.blockHeight
+	c.mu.Unlock()
+	for i := types.BlockHeight(0); i < blocksToMine; i++ {
+		_, err = m.AddBlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	newReportedSpending := c.PeriodSpending()
+	if reflect.DeepEqual(newReportedSpending, reportedSpending) {
+		t.Fatal("reported spending was identical after entering a renew period")
+	}
+	if newReportedSpending.Unspent.Cmp(reportedSpending.Unspent) <= 0 {
+		t.Fatal("expected newReportedSpending to have more unspent")
 	}
 }
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -120,6 +120,10 @@ type hostContractor interface {
 	// began.
 	CurrentPeriod() types.BlockHeight
 
+	// PeriodSpending returns the amount spent on contracts during the current
+	// billing period.
+	PeriodSpending() modules.ContractorSpending
+
 	// Editor creates an Editor from the specified contract ID, allowing the
 	// insertion, deletion, and modification of sectors.
 	Editor(types.FileContractID, <-chan struct{}) (contractor.Editor, error)
@@ -393,8 +397,9 @@ func (r *Renter) EstimateHostScore(e modules.HostDBEntry) modules.HostScoreBreak
 }
 
 // contractor passthroughs
-func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
-func (r *Renter) CurrentPeriod() types.BlockHeight    { return r.hostContractor.CurrentPeriod() }
+func (r *Renter) Contracts() []modules.RenterContract        { return r.hostContractor.Contracts() }
+func (r *Renter) CurrentPeriod() types.BlockHeight           { return r.hostContractor.CurrentPeriod() }
+func (r *Renter) PeriodSpending() modules.ContractorSpending { return r.hostContractor.PeriodSpending() }
 func (r *Renter) Settings() modules.RenterSettings {
 	return modules.RenterSettings{
 		Allowance: r.hostContractor.Allowance(),


### PR DESCRIPTION
This PR updates the renter to accurately reflect spending for the current billing period. The previous calculation did not take into account for all contracts in the billing line. This implementation provides a new contractor method, `PeriodSpending()`, which iterates through every contract _line_ in the current billing period to accurately calculate spending.