### PR TITLE
Delete .sia_temp files when .sia file is deleted. #1713

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -188,16 +188,12 @@ func (r *Renter) DeleteFile(nickname string) error {
 	}
 	delete(r.files, nickname)
 	delete(r.tracking, nickname)
-	err := os.RemoveAll(filepath.Join(r.persistDir, f.name+ShareExtension))
+
+	err := persist.RemoveFile(filepath.Join(r.persistDir, f.name+ShareExtension))
 	if err != nil {
-		r.log.Println("WARN: couldn't remove .sia file during delete:", err)
+		r.log.Println("WARN: couldn't remove file :", err)
 	}
 
-	// delete the temporary file
-	err := os.RemoveAll(filepath.Join(r.persistDir, f.name+ShareExtension+tempSuffix))
-	if err != nil {
-		r.log.Println("WARN: couldn't remove .sia_temp file during delete:", err)
-	}
 	r.saveSync()
 	r.mu.Unlock(lockID)
 

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -190,6 +191,12 @@ func (r *Renter) DeleteFile(nickname string) error {
 	err := os.RemoveAll(filepath.Join(r.persistDir, f.name+ShareExtension))
 	if err != nil {
 		r.log.Println("WARN: couldn't remove .sia file during delete:", err)
+	}
+
+	// delete the temporary file
+	err := os.RemoveAll(filepath.Join(r.persistDir, f.name+ShareExtension+tempSuffix))
+	if err != nil {
+		r.log.Println("WARN: couldn't remove .sia_temp file during delete:", err)
 	}
 	r.saveSync()
 	r.mu.Unlock(lockID)

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -89,7 +89,7 @@ func (sf *safeFile) CommitSync() error {
 // NewSafeFile returns a file that can atomically be written to disk,
 // minimizing the risk of corruption.
 func NewSafeFile(filename string) (*safeFile, error) {
-	file, err := os.Create(filename + "_temp")
+	file, err := os.Create(filename + tempSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -103,4 +103,18 @@ func NewSafeFile(filename string) (*safeFile, error) {
 	}
 
 	return &safeFile{file, absFilename}, nil
+}
+
+// RemoveFile removes an atomic file from disk, along with any uncommitted
+// or temporary files.
+func RemoveFile(filename string) error {
+	err := os.RemoveAll(filename)
+	if err != nil {
+		return err
+	}
+	err = os.RemoveAll(filename + tempSuffix)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
* Delete .sia_temp files when .sia file is deleted.

This PR fixes issue #1713.

1: Delete the .sia_temp file when it's matching .sia file is deleted.
2: Import the Sia/persist module to get the "tempSuffix" variable.