### PR TITLE
Update docs to use Discord

### DIFF
--- a/doc/Guide to Contributing to Sia.md
+++ b/doc/Guide to Contributing to Sia.md
@@ -248,7 +248,7 @@ tests is a good way to get your feet wet.  See [doc/Running and Writing Tests fo
 
 ## Contact us
 
-Feel free to ask for help on the #dev channel on [Slack][slack].
+Feel free to ask for help on the #core-dev channel on [discord][discord].
 
 [cross]: http://dave.cheney.net/2015/08/22/cross-compilation-with-go-1-5
 [binary]: https://golang.org/dl/
@@ -266,7 +266,7 @@ Feel free to ask for help on the #dev channel on [Slack][slack].
 [developers.md]: https://github.com/NebulousLabs/Sia/blob/master/doc/Developers.md
 [gofmt]: https://golang.org/cmd/gofmt/
 [nutshell]: https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell
-[slack]: http://slackin.siacoin.com
+[discord]: https://discordapp.com/channels/341359001797132308/347026783750717450
 [install-git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 [test-doc]: https://github.com/NebulousLabs/Sia/blob/master/doc/Testing.md
 [stashing]: https://git-scm.com/book/en/v2/Git-Tools-Stashing-and-Cleaning

--- a/doc/Guide to Contributing to Sia.md
+++ b/doc/Guide to Contributing to Sia.md
@@ -266,7 +266,7 @@ Feel free to ask for help on the #core-dev channel on [discord][discord].
 [developers.md]: https://github.com/NebulousLabs/Sia/blob/master/doc/Developers.md
 [gofmt]: https://golang.org/cmd/gofmt/
 [nutshell]: https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell
-[discord]: https://discordapp.com/channels/341359001797132308/347026783750717450
+[discord]: https://discord.gg/sia
 [install-git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 [test-doc]: https://github.com/NebulousLabs/Sia/blob/master/doc/Testing.md
 [stashing]: https://git-scm.com/book/en/v2/Git-Tools-Stashing-and-Cleaning

--- a/doc/Running and Writing Tests for Sia.md
+++ b/doc/Running and Writing Tests for Sia.md
@@ -251,6 +251,6 @@ Odds are, someone else is wondering the same thing.
 [boltdb_test.go]: https://github.com/NebulousLabs/Sia/blob/master/persist/boltdb_test.go
 [cheney-benchmarks]: http://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go
 [pkg/testing]: https://golang.org/pkg/testing/
-[discord]: https://discordapp.com/channels/341359001797132308/347026783750717450
+[discord]: https://discord.gg/sia
 [parse_test]: https://github.com/NebulousLabs/Sia/blob/master/siac/parse_test.go
 [global]: http://c2.com/cgi/wiki?GlobalVariablesAreBad

--- a/doc/Running and Writing Tests for Sia.md
+++ b/doc/Running and Writing Tests for Sia.md
@@ -239,7 +239,7 @@ Some other useful resources, some of which have been linked to already:
 * [How to Write Benchmarks in Go][cheney-benchmarks]
 * [How to into git and GitHub][luke]: an essential introduction to git
 
-And feel free to ask questions on the [#dev channel][slack] on the Sia Slack. 
+And feel free to ask questions on the [#core-dev channel][discord] on the Sia Discord. 
 Odds are, someone else is wondering the same thing.
 
 [pkg/testing]: https://golang.org/pkg/testing/
@@ -251,6 +251,6 @@ Odds are, someone else is wondering the same thing.
 [boltdb_test.go]: https://github.com/NebulousLabs/Sia/blob/master/persist/boltdb_test.go
 [cheney-benchmarks]: http://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go
 [pkg/testing]: https://golang.org/pkg/testing/
-[slack]: https://siatalk.slack.com/messages/dev/
+[discord]: https://discordapp.com/channels/341359001797132308/347026783750717450
 [parse_test]: https://github.com/NebulousLabs/Sia/blob/master/siac/parse_test.go
 [global]: http://c2.com/cgi/wiki?GlobalVariablesAreBad


### PR DESCRIPTION
Updated the documentation to point to the #core-dev discord channel instead of Slack.