### PR TITLE
[WIP] add siac optional parameters hosts and renewwindow

### DIFF
--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -65,7 +65,7 @@ blocks, and a week is 1008 blocks.
 Note that setting the allowance will cause siad to immediately begin forming
 contracts! You should only set the allowance once you are fully synced and you
 have a reasonable number (>30) of hosts in your hostdb.`,
-		Run: wrap(rentersetallowancecmd),
+		Run: rentersetallowancecmd,
 	}
 
 	renterContractsCmd = &cobra.Command{
@@ -266,24 +266,45 @@ func renterallowancecancelcmd() {
 }
 
 // rentersetallowancecmd allows the user to set the allowance.
-func rentersetallowancecmd(amount, period, hosts, renewWindow string) {
-	hastings, err := parseCurrency(amount)
+// the first two parameters, amount and period, are required.
+// the second two parameters are optional:
+//    hosts                 integer number of hosts
+//    renewperiod           how many blocks between renewals
+func rentersetallowancecmd(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		die("Must supply amount (first) argument")
+	}
+	hastings, err := parseCurrency(args[0])
 	if err != nil {
 		die("Could not parse amount:", err)
 	}
-	blocks, err := parsePeriod(period)
+	if len(args) == 1 {
+		die("Must supply period (second) argument")
+	}
+	blocks, err := parsePeriod(args[1])
 	if err != nil {
 		die("Could not parse period")
 	}
-	_, err = strconv.Atoi(hosts)
-	if err != nil {
-		die("Count not parse host count")
+	queryString := fmt.Sprintf("funds=%s&period=%s", hastings, blocks)
+	if len(args) > 2 {
+		_, err = strconv.Atoi(args[2])
+		if err != nil {
+			die("Could not parse host count")
+		}
+		queryString += fmt.Sprintf("&hosts=%s", args[2])
 	}
-	_, err = parsePeriod(renewWindow)
-	if err != nil {
-		die("Could not parse renew window")
+	if len(args) > 3 {
+		renewWindow, err := parsePeriod(args[3])
+		if err != nil {
+			die("Could not parse renew window")
+		}
+		queryString += fmt.Sprintf("&renewwindow=%s", renewWindow)
 	}
-	err = post("/renter", fmt.Sprintf("funds=%s&period=%s&hosts=%s&renewwindow=%s", hastings, blocks, hosts, renewWindow))
+	if len(args) > 4 {
+		cmd.UsageFunc()(cmd)
+		os.Exit(exitCodeUsage)
+	}
+	err = post("/renter", queryString)
 	if err != nil {
 		die("Could not set allowance:", err)
 	}

--- a/siac/rentercmd.go
+++ b/siac/rentercmd.go
@@ -62,6 +62,14 @@ period is given in either blocks (b), hours (h), days (d), or weeks (w). A
 block is approximately 10 minutes, so one hour is six blocks, a day is 144
 blocks, and a week is 1008 blocks.
 
+The Sia renter module spreads data across more than one Sia server computer
+or "host". The "hosts" paramter for the setallowance command determines
+how many different hosts the renter will try to use to spread data out.
+
+Allowance can be automatically renewed periodically.  If the current
+blockheight + the renew window >= the end height the contract,
+then the contract is renewed automatically.
+
 Note that setting the allowance will cause siad to immediately begin forming
 contracts! You should only set the allowance once you are fully synced and you
 have a reasonable number (>30) of hosts in your hostdb.`,


### PR DESCRIPTION
compiles but not runtime tested yet for https://github.com/NebulousLabs/Sia/pull/2397

n.b. the decision to use the return value of parsePeriod in both places for consistency. we can switch that as appropriate. @DavidVorick   @lukechampine 