### PR TITLE
fix DustThreshold usage

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -1077,7 +1077,7 @@ locked or unlocked.
   "siafundbalance":      "1",    // siafunds, big int
   "siacoinclaimbalance": "9001", // hastings, big int
 
-  "dustthreshold": "1234", // hastings, big int
+  "dustthreshold": "1234", // hastings / byte, big int
 }
 ```
 

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -104,9 +104,9 @@ locked or unlocked.
   // increase before any claim transaction is confirmed.
   "siacoinclaimbalance": "9001", // hastings, big int
 
-  // Number of siacoins, in hastings, below which a transaction output cannot
-  // be used because the wallet considers it a dust output
-  "dustthreshold": "1234", // hastings, big int
+  // Number of siacoins, in hastings per byte, below which a transaction output
+  // cannot be used because the wallet considers it a dust output
+  "dustthreshold": "1234", // hastings / byte, big int
 }
 ```
 

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -392,7 +392,8 @@ type (
 		// are also returned to the caller.
 		SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error)
 
-		// DustThreshold returns the quantity below which a Currency is considered to be Dust.
+		// DustThreshold returns the quantity per byte below which a Currency is
+		// considered to be Dust.
 		DustThreshold() types.Currency
 	}
 )

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -13,7 +13,8 @@ type sortedOutputs struct {
 	outputs []types.SiacoinOutput
 }
 
-// DustThreshold returns the quantity below which a Currency is considered to be Dust.
+// DustThreshold returns the quantity per byte below which a Currency is
+// considered to be Dust.
 func (w *Wallet) DustThreshold() types.Currency {
 	minFee, _ := w.tpool.FeeEstimation()
 	return minFee.Mul64(3)


### PR DESCRIPTION
I've now realized that `tpool.FeeEstimation()` returns hastings/byte and dustThreshold is/was used in a hastings/output context ([ex1](https://github.com/NebulousLabs/Sia/blob/master/modules/wallet/transactionbuilder.go#L97) and [ex2](https://github.com/NebulousLabs/Sia/blob/master/modules/wallet/money.go#L74)). I've used [this estimation](https://github.com/NebulousLabs/Sia/blob/master/modules/wallet/seed.go#L344) to get the consistent formula.