### PR TITLE
Add ContractSet type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 
 go:
-  - 1.8
+  - 1.9
 
 install:
   - make dependencies

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -1,0 +1,159 @@
+package proto
+
+import (
+	"sync"
+
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+// A safeContract protects a RenterContract with a mutex.
+type safeContract struct {
+	modules.RenterContract
+	mu sync.Mutex
+}
+
+// A ContractSet provides safe concurrent access to a set of contracts. Its
+// purpose is to serialize modifications to individual contracts, as well as
+// to provide operations on the set as a whole.
+type ContractSet struct {
+	contracts map[types.FileContractID]*safeContract
+	mu        sync.Mutex
+
+	// caches (initialized by initCache)
+	flatIDs       []types.FileContractID
+	flatContracts []modules.RenterContract
+	once          sync.Once
+}
+
+// initCache populates the flatIDs and flatContracts fields so that repeated
+// work can be avoided when calling the IDs and Contracts methods. It must be
+// called under lock. initCache should be called by IDs and Contracts if a
+// call to Insert, Return, or Delete has invalidated the cache. This is
+// managed via a sync.Once.
+func (cs *ContractSet) initCache() {
+	cs.flatIDs = make([]types.FileContractID, 0, len(cs.contracts))
+	for id := range cs.contracts {
+		cs.flatIDs = append(cs.flatIDs, id)
+	}
+	cs.flatContracts = make([]modules.RenterContract, 0, len(cs.contracts))
+	for _, sc := range cs.contracts {
+		// construct deep copy, sans MerkleRoots
+		c := sc.RenterContract
+		c.MerkleRoots = nil
+		var contractCopy modules.RenterContract
+		encoding.Unmarshal(encoding.Marshal(c), &contractCopy)
+		cs.flatContracts = append(cs.flatContracts, contractCopy)
+	}
+}
+
+// Len returns the number of contracts in the set.
+func (cs *ContractSet) Len() int {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return len(cs.contracts)
+}
+
+// IDs returns the FileContractID of each contract in the set. The contracts
+// are not locked. The returned slice must not be modified.
+func (cs *ContractSet) IDs() []types.FileContractID {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.once.Do(cs.initCache)
+	return cs.flatIDs
+}
+
+// Contracts returns a copy of each contract in the set. The contracts are not
+// locked, because modifying the copy does not modify the original. Certain
+// fields, such as the MerkleRoots, may be set to nil to prevent excess
+// copying. The returned slice must not be modified.
+func (cs *ContractSet) Contracts() []modules.RenterContract {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.once.Do(cs.initCache)
+	return cs.flatContracts
+}
+
+// Insert adds a new contract to the set. It panics if the contract is already
+// in the set.
+//
+// TODO: this behavior might not be ideal.
+func (cs *ContractSet) Insert(contract modules.RenterContract) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if _, ok := cs.contracts[contract.ID]; ok {
+		panic("contract already in set")
+	}
+	cs.contracts[contract.ID] = &safeContract{RenterContract: contract}
+	// reset sync.Once
+	cs.once = sync.Once{}
+}
+
+// Acquire looks up the contract with the specified FileContractID and locks
+// it before returning it. If the contract is not present in the set, Acquire
+// returns false and a zero-valued RenterContract.
+func (cs *ContractSet) Acquire(id types.FileContractID) (modules.RenterContract, bool) {
+	cs.mu.Lock()
+	sc, ok := cs.contracts[id]
+	cs.mu.Unlock()
+	if ok {
+		sc.mu.Lock()
+	}
+	return sc.RenterContract, ok
+}
+
+// MustAcquire is a convenience function for acquiring contracts that are
+// known to be in the set. It panics otherwise.
+func (cs *ContractSet) MustAcquire(id types.FileContractID) modules.RenterContract {
+	c, ok := cs.Acquire(id)
+	if !ok {
+		panic("no contract with that id")
+	}
+	return c
+}
+
+// Return returns a locked contract to the set and unlocks it. The contract
+// must have been previously acquired by Acquire. If the contract is not
+// present in the set, Return panics.
+func (cs *ContractSet) Return(contract modules.RenterContract) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	sc, ok := cs.contracts[contract.ID]
+	if !ok {
+		panic("no contract with that id")
+	}
+	sc.RenterContract = contract
+	cs.contracts[contract.ID] = sc
+	sc.mu.Unlock()
+	// reset sync.Once
+	cs.once = sync.Once{}
+}
+
+// Delete removes a contract from the set. The contract must have been
+// previously acquired by Acquire. If the contract is not present in the set,
+// Delete is a no-op.
+func (cs *ContractSet) Delete(contract modules.RenterContract) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	sc, ok := cs.contracts[contract.ID]
+	if !ok {
+		return
+	}
+	delete(cs.contracts, contract.ID)
+	sc.mu.Unlock()
+	// reset sync.Once
+	cs.once = sync.Once{}
+}
+
+// NewContractSet returns a ContractSet populated with the provided slice of
+// RenterContracts, which may be nil.
+func NewContractSet(contracts []modules.RenterContract) ContractSet {
+	cs := ContractSet{
+		contracts: make(map[types.FileContractID]*safeContract),
+	}
+	for _, c := range contracts {
+		cs.contracts[c.ID] = &safeContract{RenterContract: c}
+	}
+	return cs
+}

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -113,11 +113,11 @@ func (cs *ContractSet) Delete(contract modules.RenterContract) {
 // NewContractSet returns a ContractSet populated with the provided slice of
 // RenterContracts, which may be nil.
 func NewContractSet(contracts []modules.RenterContract) ContractSet {
-	cs := ContractSet{
-		contracts: make(map[types.FileContractID]*safeContract),
-	}
+	set := make(map[types.FileContractID]*safeContract)
 	for _, c := range contracts {
-		cs.contracts[c.ID] = &safeContract{RenterContract: c}
+		set[c.ID] = &safeContract{RenterContract: c}
 	}
-	return cs
+	return ContractSet{
+		contracts: set,
+	}
 }

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -58,8 +58,6 @@ func (cs *ContractSet) Contracts() []modules.RenterContract {
 
 // Insert adds a new contract to the set. It panics if the contract is already
 // in the set.
-//
-// TODO: this behavior might not be ideal.
 func (cs *ContractSet) Insert(contract modules.RenterContract) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -3,7 +3,6 @@ package proto
 import (
 	"sync"
 
-	"github.com/NebulousLabs/Sia/encoding"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -30,7 +29,7 @@ func (cs *ContractSet) Len() int {
 }
 
 // IDs returns the FileContractID of each contract in the set. The contracts
-// are not locked. The returned slice must not be modified.
+// are not locked.
 func (cs *ContractSet) IDs() []types.FileContractID {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
@@ -42,20 +41,17 @@ func (cs *ContractSet) IDs() []types.FileContractID {
 }
 
 // Contracts returns a copy of each contract in the set. The contracts are not
-// locked, because modifying the copy does not modify the original. Certain
-// fields, such as the MerkleRoots, may be set to nil to prevent excess
-// copying. The returned slice must not be modified.
+// locked. Certain fields, including the MerkleRoots, are set to nil for
+// safety reasons.
 func (cs *ContractSet) Contracts() []modules.RenterContract {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	contracts := make([]modules.RenterContract, 0, len(cs.contracts))
 	for _, sc := range cs.contracts {
-		// construct deep copy, sans MerkleRoots
+		// construct shallow copy, sans MerkleRoots
 		c := sc.RenterContract
 		c.MerkleRoots = nil
-		var contractCopy modules.RenterContract
-		encoding.Unmarshal(encoding.Marshal(c), &contractCopy)
-		contracts = append(contracts, contractCopy)
+		contracts = append(contracts, c)
 	}
 	return contracts
 }

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -81,16 +81,6 @@ func (cs *ContractSet) Acquire(id types.FileContractID) (modules.RenterContract,
 	return sc.RenterContract, ok
 }
 
-// MustAcquire is a convenience function for acquiring contracts that are
-// known to be in the set. It panics otherwise.
-func (cs *ContractSet) MustAcquire(id types.FileContractID) modules.RenterContract {
-	c, ok := cs.Acquire(id)
-	if !ok {
-		panic("no contract with that id")
-	}
-	return c
-}
-
 // Return returns a locked contract to the set and unlocks it. The contract
 // must have been previously acquired by Acquire. If the contract is not
 // present in the set, Return panics.

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -3,6 +3,7 @@ package proto
 import (
 	"sync"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 )
@@ -62,7 +63,7 @@ func (cs *ContractSet) Insert(contract modules.RenterContract) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	if _, ok := cs.contracts[contract.ID]; ok {
-		panic("contract already in set")
+		build.Critical("contract already in set")
 	}
 	cs.contracts[contract.ID] = &safeContract{RenterContract: contract}
 }
@@ -98,7 +99,7 @@ func (cs *ContractSet) Return(contract modules.RenterContract) {
 	defer cs.mu.Unlock()
 	sc, ok := cs.contracts[contract.ID]
 	if !ok {
-		panic("no contract with that id")
+		build.Critical("no contract with that id")
 	}
 	sc.RenterContract = contract
 	cs.contracts[contract.ID] = sc

--- a/modules/renter/proto/contractset_test.go
+++ b/modules/renter/proto/contractset_test.go
@@ -1,0 +1,86 @@
+package proto
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/fastrand"
+)
+
+// TestContractSet tests that the ContractSet type is safe for concurrent use.
+func TestContractSet(t *testing.T) {
+	// create contract set
+	id1 := types.FileContractID{1}
+	id2 := types.FileContractID{2}
+	cs := NewContractSet([]modules.RenterContract{
+		{ID: id1},
+		{ID: id2},
+	})
+
+	// uncontested acquire/release
+	c1 := cs.MustAcquire(id1)
+	cs.Return(c1)
+
+	// 100 concurrent serialized mutations
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c1 := cs.MustAcquire(id1)
+			c1.LastRevision.NewRevisionNumber++
+			time.Sleep(time.Duration(fastrand.Intn(100)))
+			cs.Return(c1)
+		}()
+	}
+	wg.Wait()
+	c1 = cs.MustAcquire(id1)
+	cs.Return(c1)
+	if c1.LastRevision.NewRevisionNumber != 100 {
+		t.Fatal("expected exactly 100 increments, got", c1.LastRevision.NewRevisionNumber)
+	}
+
+	// a blocked acquire shouldn't prevent a return
+	c1 = cs.MustAcquire(id1)
+	go func() {
+		time.Sleep(time.Millisecond)
+		cs.Return(c1)
+	}()
+	c1 = cs.MustAcquire(id1)
+	cs.Return(c1)
+
+	// delete and reinsert id2
+	c2 := cs.MustAcquire(id2)
+	cs.Delete(c2)
+	cs.Insert(c2)
+
+	// call all the methods in parallel haphazardly
+	funcs := []func(){
+		func() { cs.Len() },
+		func() { cs.IDs() },
+		func() { cs.Contracts() },
+		func() { cs.Return(cs.MustAcquire(id1)) },
+		func() { cs.Return(cs.MustAcquire(id2)) },
+		func() {
+			id3 := types.FileContractID{3}
+			cs.Insert(modules.RenterContract{ID: id3})
+			cs.Delete(cs.MustAcquire(id3))
+		},
+	}
+	wg = sync.WaitGroup{}
+	for _, fn := range funcs {
+		wg.Add(1)
+		go func(fn func()) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				time.Sleep(time.Duration(fastrand.Intn(100)))
+				fn()
+			}
+		}(fn)
+	}
+	wg.Wait()
+}

--- a/modules/renter/proto/contractset_test.go
+++ b/modules/renter/proto/contractset_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/NebulousLabs/fastrand"
 )
 
+// mustAcquire is a convenience function for acquiring contracts that are
+// known to be in the set.
+func (cs *ContractSet) mustAcquire(t *testing.T, id types.FileContractID) modules.RenterContract {
+	t.Helper()
+	c, ok := cs.Acquire(id)
+	if !ok {
+		t.Fatal("no contract with that id")
+	}
+	return c
+}
+
 // TestContractSet tests that the ContractSet type is safe for concurrent use.
 func TestContractSet(t *testing.T) {
 	// create contract set
@@ -22,7 +33,7 @@ func TestContractSet(t *testing.T) {
 	})
 
 	// uncontested acquire/release
-	c1 := cs.MustAcquire(id1)
+	c1 := cs.mustAcquire(t, id1)
 	cs.Return(c1)
 
 	// 100 concurrent serialized mutations
@@ -31,30 +42,30 @@ func TestContractSet(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c1 := cs.MustAcquire(id1)
+			c1 := cs.mustAcquire(t, id1)
 			c1.LastRevision.NewRevisionNumber++
 			time.Sleep(time.Duration(fastrand.Intn(100)))
 			cs.Return(c1)
 		}()
 	}
 	wg.Wait()
-	c1 = cs.MustAcquire(id1)
+	c1 = cs.mustAcquire(t, id1)
 	cs.Return(c1)
 	if c1.LastRevision.NewRevisionNumber != 100 {
 		t.Fatal("expected exactly 100 increments, got", c1.LastRevision.NewRevisionNumber)
 	}
 
 	// a blocked acquire shouldn't prevent a return
-	c1 = cs.MustAcquire(id1)
+	c1 = cs.mustAcquire(t, id1)
 	go func() {
 		time.Sleep(time.Millisecond)
 		cs.Return(c1)
 	}()
-	c1 = cs.MustAcquire(id1)
+	c1 = cs.mustAcquire(t, id1)
 	cs.Return(c1)
 
 	// delete and reinsert id2
-	c2 := cs.MustAcquire(id2)
+	c2 := cs.mustAcquire(t, id2)
 	cs.Delete(c2)
 	cs.Insert(c2)
 
@@ -63,12 +74,12 @@ func TestContractSet(t *testing.T) {
 		func() { cs.Len() },
 		func() { cs.IDs() },
 		func() { cs.Contracts() },
-		func() { cs.Return(cs.MustAcquire(id1)) },
-		func() { cs.Return(cs.MustAcquire(id2)) },
+		func() { cs.Return(cs.mustAcquire(t, id1)) },
+		func() { cs.Return(cs.mustAcquire(t, id2)) },
 		func() {
 			id3 := types.FileContractID{3}
 			cs.Insert(modules.RenterContract{ID: id3})
-			cs.Delete(cs.MustAcquire(id3))
+			cs.Delete(cs.mustAcquire(t, id3))
 		},
 	}
 	wg = sync.WaitGroup{}


### PR DESCRIPTION
This is an initial design for the new `ContractSet` type, which will live in the `proto` package and provide safe concurrent access to contracts. Once we settle on the design, I can replace all contract manipulation in the `contractor` package with safe `ContractSet` methods.

Previously @DavidVorick and I ran into trouble when trying to design an access pattern that did not lead to deadlocks. As I recall, there were two classes of deadlocks:

1. After `Acquire`ing a contract, code may call out to a helper function that needs to modify the contract, thus calling `Acquire` again, causing deadlock. This was addressed by modifying the helper functions to take the contract as an argument, rather than independently acquiring it.
2. Concurrently trying to `Acquire` a contract while `Return`ing it in a separate goroutine caused a deadlock, because `Acquire` grabs the "outer" lock, which `Return` also needs in order to unlock the "inner" lock. This is addressed in this PR by altering the design so that `Acquire` doesn't hold the outer lock while waiting for the inner lock.

I've added tests to check that all the methods can be called concurrently without deadlocking, but I may have missed an edge case, so please check thoroughly.

Lastly: this code implements an optimization wherein a slice of contracts is cached so that it does not need to be rebuilt in each `Contracts` call. This may be overkill. I implemented it only because rebuilding the slice requires making a deep copy via the (slow) encoding package. Implementing the deep copy manually could make it fast enough that this is not needed. Additionally, `Contracts` should not be called too frequently, so performance isn't critical.