### PR TITLE
release.sh: build with -tags 'netgo'

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ for os in darwin linux windows; do
 		if [ "$os" == "windows" ]; then
 			bin=${pkg}.exe
 		fi
-		GOOS=${os} go build -ldflags="-s -w" -o $folder/$bin ./$pkg
+		GOOS=${os} go build -tags 'netgo' -ldflags="-s -w" -o $folder/$bin ./$pkg
 		openssl dgst -sha256 -sign $keyfile -out $folder/${bin}.sig $folder/$bin
 		# verify signature
 		if [[ -n $pubkeyfile ]]; then


### PR DESCRIPTION
Sync it with what `make release-std` does. See https://github.com/NebulousLabs/Sia/pull/2357

Ideally release.sh should invoke `make release-std` but the former uses `go build` and specifies the output file while the later uses `go install` (and installs to `$GOPATH/bin`).