### PR TITLE
add -a flag when building release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ release:
 release-race:
 	go install -race -tags='debug profile netgo' $(pkgs)
 release-std:
-	go install -tags 'netgo' -ldflags='-s -w' $(pkgs)
+	go install -tags 'netgo' -a -ldflags='-s -w' $(pkgs)
 
 # clean removes all directories that get automatically created during
 # development.

--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ for os in darwin linux windows; do
 		if [ "$os" == "windows" ]; then
 			bin=${pkg}.exe
 		fi
-		GOOS=${os} go build -ldflags="-s -w" -o $folder/$bin ./$pkg
+		GOOS=${os} go build -a -ldflags="-s -w" -o $folder/$bin ./$pkg
 		openssl dgst -sha256 -sign $keyfile -out $folder/${bin}.sig $folder/$bin
 		# verify signature
 		if [[ -n $pubkeyfile ]]; then


### PR DESCRIPTION
One more step towards byte-perfect reproducibility.

The option -a tells Go to rebuild everything. Libraries in `$GOROOT/pkg/$GOOS_$GOARCH` could be (and are likely to) build with other toolchain, leaking build directory of that other toolchain into resulting binaries.

See https://github.com/NebulousLabs/Sia/issues/2410