### PR TITLE
make AddressTransactions faster for large wallets

### DIFF
--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -19,6 +19,9 @@ var (
 	// chronological order. Only transactions relevant to the wallet are
 	// stored. The key of this bucket is an autoincrementing integer.
 	bucketProcessedTransactions = []byte("bucketProcessedTransactions")
+	// bucketAddrTransactions maps an UnlockHash to the
+	// ProcessedTransactions that it appears in.
+	bucketAddrTransactions = []byte("bucketAddrTransactions")
 	// bucketSiacoinOutputs maps a SiacoinOutputID to its SiacoinOutput. Only
 	// outputs that the wallet controls are stored. The wallet uses these
 	// outputs to fund transactions.
@@ -38,6 +41,7 @@ var (
 
 	dbBuckets = [][]byte{
 		bucketProcessedTransactions,
+		bucketAddrTransactions,
 		bucketSiacoinOutputs,
 		bucketSiafundOutputs,
 		bucketSpentOutputs,
@@ -204,6 +208,47 @@ func dbDeleteSpentOutput(tx *bolt.Tx, id types.OutputID) error {
 	return dbDelete(tx.Bucket(bucketSpentOutputs), id)
 }
 
+// bucketAddrTransactions is special: it's okay if the key doesn't exist, and
+// we need to avoid inserting duplicate slice elements.
+
+func dbPutAddrTransactions(tx *bolt.Tx, addr types.UnlockHash, txns []uint64) error {
+	return dbPut(tx.Bucket(bucketAddrTransactions), addr, txns)
+}
+func dbGetAddrTransactions(tx *bolt.Tx, addr types.UnlockHash) (txns []uint64, err error) {
+	err = dbGet(tx.Bucket(bucketAddrTransactions), addr, &txns)
+	if err == errNoKey {
+		err = nil // no key means no transactions associated yet
+	}
+	return
+}
+func dbAddAddrTransaction(tx *bolt.Tx, addr types.UnlockHash, txn uint64) error {
+	txns, err := dbGetAddrTransactions(tx, addr)
+	if err != nil {
+		return err
+	}
+	for _, i := range txns {
+		if i == txn {
+			return nil
+		}
+	}
+	return dbPutAddrTransactions(tx, addr, append(txns, txn))
+}
+func dbAddProcessedTransactionAddrs(tx *bolt.Tx, pt modules.ProcessedTransaction, txn uint64) error {
+	addrs := make(map[types.UnlockHash]struct{})
+	for _, input := range pt.Inputs {
+		addrs[input.RelatedAddress] = struct{}{}
+	}
+	for _, output := range pt.Outputs {
+		addrs[output.RelatedAddress] = struct{}{}
+	}
+	for addr := range addrs {
+		if err := dbAddAddrTransaction(tx, addr, txn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // bucketProcessedTransactions works a little differently: the key is
 // meaningless, only used to order the transactions chronologically.
 
@@ -216,7 +261,11 @@ func dbAppendProcessedTransaction(tx *bolt.Tx, pt modules.ProcessedTransaction) 
 	// big-endian is used so that the keys are properly sorted
 	keyBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(keyBytes, key)
-	return b.Put(keyBytes, encoding.Marshal(pt))
+	if err = b.Put(keyBytes, encoding.Marshal(pt)); err != nil {
+		return err
+	}
+	// also add this txid to the bucketAddrTransactions
+	return dbAddProcessedTransactionAddrs(tx, pt, key)
 }
 func dbGetLastProcessedTransaction(tx *bolt.Tx) (pt modules.ProcessedTransaction, err error) {
 	_, val := tx.Bucket(bucketProcessedTransactions).Cursor().Last()
@@ -237,29 +286,43 @@ func dbDeleteLastProcessedTransaction(tx *bolt.Tx) error {
 	key, _ := b.Cursor().Last()
 	return b.Delete(key)
 }
-func dbForEachProcessedTransaction(tx *bolt.Tx, fn func(modules.ProcessedTransaction)) error {
-	return dbForEach(tx.Bucket(bucketProcessedTransactions), func(_ uint64, pt modules.ProcessedTransaction) {
-		fn(pt)
-	})
+func dbGetProcessedTransaction(tx *bolt.Tx, index uint64) (pt modules.ProcessedTransaction, err error) {
+	// big-endian is used so that the keys are properly sorted
+	indexBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(indexBytes, index)
+	val := tx.Bucket(bucketProcessedTransactions).Get(indexBytes)
+	err = encoding.Unmarshal(val, &pt)
+	if err != nil {
+		// COMPATv1.2.1: try decoding into old transaction type
+		var oldpt v121ProcessedTransaction
+		err = encoding.Unmarshal(val, &oldpt)
+		pt = convertProcessedTransaction(oldpt)
+	}
+	return
 }
 
 // A processedTransactionsIter iterates through the ProcessedTransactions bucket.
 type processedTransactionsIter struct {
-	c  *bolt.Cursor
-	pt modules.ProcessedTransaction
+	c   *bolt.Cursor
+	seq uint64
+	pt  modules.ProcessedTransaction
 }
 
 // next decodes the next ProcessedTransaction, returning false if the end of
 // the bucket has been reached.
 func (it *processedTransactionsIter) next() bool {
-	var ptBytes []byte
+	var seqBytes, ptBytes []byte
 	if it.pt.TransactionID == (types.TransactionID{}) {
 		// this is the first time next has been called, so cursor is not
 		// initialized yet
-		_, ptBytes = it.c.First()
+		seqBytes, ptBytes = it.c.First()
 	} else {
-		_, ptBytes = it.c.Next()
+		seqBytes, ptBytes = it.c.Next()
 	}
+	if seqBytes == nil {
+		return false
+	}
+	it.seq = binary.BigEndian.Uint64(seqBytes)
 	err := encoding.Unmarshal(ptBytes, &it.pt)
 	if err != nil {
 		// COMPATv1.2.1: try decoding into old transaction type
@@ -268,6 +331,11 @@ func (it *processedTransactionsIter) next() bool {
 		it.pt = convertProcessedTransaction(oldpt)
 	}
 	return err == nil
+}
+
+// key returns the key for the most recently decoded ProcessedTransaction.
+func (it *processedTransactionsIter) key() uint64 {
+	return it.seq
 }
 
 // value returns the most recently decoded ProcessedTransaction.

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -19,21 +19,14 @@ func (w *Wallet) AddressTransactions(uh types.UnlockHash) (pts []modules.Process
 	defer w.mu.Unlock()
 	w.syncDB()
 
-	it := dbProcessedTransactionsIterator(w.dbTx)
-	for it.next() {
-		pt := it.value()
-		relevant := false
-		for _, input := range pt.Inputs {
-			relevant = relevant || input.RelatedAddress == uh
+	txnIndices, _ := dbGetAddrTransactions(w.dbTx, uh)
+	for _, i := range txnIndices {
+		pt, err := dbGetProcessedTransaction(w.dbTx, i)
+		if err != nil {
+			continue
 		}
-		for _, output := range pt.Outputs {
-			relevant = relevant || output.RelatedAddress == uh
-		}
-		if relevant {
-			pts = append(pts, pt)
-		}
+		pts = append(pts, pt)
 	}
-
 	return pts
 }
 

--- a/modules/wallet/transactions_test.go
+++ b/modules/wallet/transactions_test.go
@@ -60,7 +60,7 @@ func TestIntegrationTransactions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(txns) != int(types.MaturityDelay+2+2) {
-		t.Error("unexpected transaction history length")
+		t.Errorf("unexpected transaction history length: expected %v, got %v", types.MaturityDelay+2+2, len(txns))
 	}
 
 	// Try getting a partial history for just the previous block.
@@ -71,7 +71,7 @@ func TestIntegrationTransactions(t *testing.T) {
 	// The partial should include one transaction for a block, and 2 for the
 	// send that occurred.
 	if len(txns) != 3 {
-		t.Error(len(txns))
+		t.Errorf("unexpected transaction history length: expected %v, got %v", 3, len(txns))
 	}
 }
 


### PR DESCRIPTION
Previously, `AddressTransactions` iterated through all the transactions tracked by the wallet in order to find those associated with a given address. After this PR, the wallet builds a separate index (`bucketAddrTransactions`) that maps each address seen to the transactions it was seen in. These transactions are then looked up in the existing `bucketProcessedTransactions` bucket. This dramatically improves performance when the address is only associated with a few transactions, which is typically the case. The downside is increased wallet.db size: if the wallet has 1M transactions associated with it, and we assume there are 5 unique addresses in each transaction, with each address associated with 10 transactions, then this new index consumes about 5 * 1M * (32 + 10 * 8) = 2 GB. In reality, the average transaction only contains 3 addresses, and the average address appears in 2 transactions; so a wallet with 1M transactions is more likely to consume 3/2 * 1M * (32 + 2 * 8) = 72MB. (That math needs double-checking, but I'm pretty sure I'm not off by more than one order of magnitude, and even 720MB seems acceptable for such a large wallet.)

This optimization is difficult to benchmark, mostly because the setup (generating thousands transactions) takes a long time. I could fake it by manually generating the transactions (instead of calling `SendSiacoins`), but that risks skewing the results. However, I did perform a manual benchmark of 10,000 transactions, all involving a specific address. When searching for that address, the performance is more or less identical, since you still have to iterate through every transaction. But when searching for an address that is not present in any of the 10k transactions, this PR improves performance by a factor of 134,000. Part of the reason is that, even if you could iterate through all the transactions really quickly, you still need to _decode_ them in order to determine whether they are relevant to an address, and decoding is slow. Using a separate index minimizes the amount of decoding required (you only decode transactions that you care about).