### PR TITLE
return local filepath in renter api

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -858,6 +858,7 @@ lists the status of all files.
   "files": [
     {
       "siapath":        "foo/bar.txt",
+      "localpath":      "/home/foo/bar.txt",
       "filesize":       8192, // bytes
       "available":      true,
       "renewing":       true,

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -190,6 +190,9 @@ lists the status of all files.
       // Path to the file in the renter on the network.
       "siapath": "foo/bar.txt",
 
+      // Path to the local file on disk.
+      "localpath": "/home/foo/bar.txt",
+
       // Size of the file in bytes.
       "filesize": 8192, // bytes
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -75,6 +75,7 @@ type FileUploadParams struct {
 // FileInfo provides information about a file.
 type FileInfo struct {
 	SiaPath        string            `json:"siapath"`
+	LocalPath      string            `json:"localpath"`
 	Filesize       uint64            `json:"filesize"`
 	Available      bool              `json:"available"`
 	Renewing       bool              `json:"renewing"`

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -229,8 +229,14 @@ func (r *Renter) FileList() []modules.FileInfo {
 	for _, f := range files {
 		f.mu.RLock()
 		renewing := true
+		var localPath string
+		tf, exists := r.tracking[f.name]
+		if exists {
+			localPath = tf.RepairPath
+		}
 		fileList = append(fileList, modules.FileInfo{
 			SiaPath:        f.name,
+			LocalPath:      localPath,
 			Filesize:       f.size,
 			Renewing:       renewing,
 			Available:      f.available(isOffline),

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -212,6 +212,34 @@ func TestFileExpiration(t *testing.T) {
 	}
 }
 
+// TestRenterFileListLocalPath verifies that FileList() returns the correct
+// local path information for an uploaded file.
+func TestRenterFileListLocalPath(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	rt, err := newRenterTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+	id := rt.renter.mu.Lock()
+	f := newTestingFile()
+	f.name = "testname"
+	rt.renter.files["test"] = f
+	rt.renter.tracking[f.name] = trackedFile{
+		RepairPath: "TestPath",
+	}
+	rt.renter.mu.Unlock(id)
+	files := rt.renter.FileList()
+	if len(files) != 1 {
+		t.Fatal("wrong number of files, got", len(files), "wanted one")
+	}
+	if files[0].LocalPath != "TestPath" {
+		t.Fatal("file had wrong LocalPath: got", files[0].LocalPath, "wanted TestPath")
+	}
+}
+
 // TestRenterDeleteFile probes the DeleteFile method of the renter type.
 func TestRenterDeleteFile(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
See #2428. Adds a new `localpath` string to `modules.FileInfo`.