### PR TITLE
make renter prices estimation less volatile

### DIFF
--- a/modules/renter/consts.go
+++ b/modules/renter/consts.go
@@ -56,11 +56,4 @@ var (
 		Standard: time.Second * 61,
 		Testing:  time.Second,
 	}).(time.Duration)
-
-	// estimationTimeout defines how long a renter price estimation is cached.
-	estimationTimeout = build.Select(build.Var{
-		Dev:      time.Minute,
-		Standard: time.Minute,
-		Testing:  time.Second * 5,
-	}).(time.Duration)
 )

--- a/modules/renter/consts.go
+++ b/modules/renter/consts.go
@@ -56,4 +56,11 @@ var (
 		Standard: time.Second * 61,
 		Testing:  time.Second,
 	}).(time.Duration)
+
+	// estimationTimeout defines how long a renter price estimation is cached.
+	estimationTimeout = build.Select(build.Var{
+		Dev:      time.Minute,
+		Standard: time.Minute,
+		Testing:  time.Second * 5,
+	}).(time.Duration)
 )

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -27,6 +27,7 @@ package renter
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -196,6 +197,9 @@ type Renter struct {
 	heapWG         sync.WaitGroup // in-progress chunks join this waitgroup
 	tg             threadgroup.ThreadGroup
 	tpool          modules.TransactionPool
+
+	lastEstimation          modules.RenterPriceEstimation // used to cache the last price estimation result
+	lastEstimationTimestamp time.Time                     // used to determine if we need to re-sample hosts for price estimation
 }
 
 // New returns an initialized renter.
@@ -323,6 +327,15 @@ func (r *Renter) Close() error {
 // TODO: Make this function line up with the actual settings in the renter.
 // Perhaps even make it so it uses the renter's actual contracts if it has any.
 func (r *Renter) PriceEstimation() modules.RenterPriceEstimation {
+	id := r.mu.RLock()
+	lastEstimationTimestamp := r.lastEstimationTimestamp
+	lastEstimation := r.lastEstimation
+	r.mu.RUnlock(id)
+
+	if time.Since(lastEstimationTimestamp) < estimationTimeout {
+		return lastEstimation
+	}
+
 	// Grab hosts to perform the estimation.
 	hosts := r.hostDB.RandomHosts(priceEstimationScope, nil)
 
@@ -366,12 +379,18 @@ func (r *Renter) PriceEstimation() modules.RenterPriceEstimation {
 	_, feePerByte := r.tpool.FeeEstimation()
 	totalContractCost = totalContractCost.Add(feePerByte.Mul64(1000).Mul64(uint64(priceEstimationScope)))
 
-	return modules.RenterPriceEstimation{
+	est := modules.RenterPriceEstimation{
 		FormContracts:        totalContractCost,
 		DownloadTerabyte:     totalDownloadCost,
 		StorageTerabyteMonth: totalStorageCost,
 		UploadTerabyte:       totalUploadCost,
 	}
+	id = r.mu.Lock()
+	r.lastEstimationTimestamp = time.Now()
+	r.lastEstimation = est
+	r.mu.Unlock(id)
+
+	return est
 }
 
 // SetSettings will update the settings for the renter.

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
@@ -241,9 +240,12 @@ func TestRenterPricesVolatility(t *testing.T) {
 		t.Log(after)
 		t.Fatal("expected renter price estimation to be constant")
 	}
-	time.Sleep(estimationTimeout)
+	_, err = rt.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
 	after = rt.renter.PriceEstimation()
 	if reflect.DeepEqual(initial, after) {
-		t.Fatal("expected renter price estimation to change after waiting timeout")
+		t.Fatal("expected renter price estimation to change after mining a block")
 	}
 }

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -2,6 +2,9 @@ package renter
 
 import (
 	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
@@ -165,6 +168,18 @@ func (stubHostDB) AllHosts() []modules.HostDBEntry      { return nil }
 func (stubHostDB) AverageContractPrice() types.Currency { return types.Currency{} }
 func (stubHostDB) Close() error                         { return nil }
 func (stubHostDB) IsOffline(modules.NetAddress) bool    { return true }
+func (stubHostDB) RandomHosts(int, []types.SiaPublicKey) []modules.HostDBEntry {
+	return []modules.HostDBEntry{}
+}
+func (stubHostDB) EstimateHostScore(modules.HostDBEntry) modules.HostScoreBreakdown {
+	return modules.HostScoreBreakdown{}
+}
+func (stubHostDB) Host(types.SiaPublicKey) (modules.HostDBEntry, bool) {
+	return modules.HostDBEntry{}, false
+}
+func (stubHostDB) ScoreBreakdown(modules.HostDBEntry) modules.HostScoreBreakdown {
+	return modules.HostScoreBreakdown{}
+}
 
 // stubContractor is the minimal implementation of the hostContractor
 // interface.
@@ -181,4 +196,54 @@ func (stubContractor) IsOffline(modules.NetAddress) bool                      { 
 func (stubContractor) Editor(types.FileContractID) (contractor.Editor, error) { return nil, nil }
 func (stubContractor) Downloader(types.FileContractID) (contractor.Downloader, error) {
 	return nil, nil
+}
+
+type pricesStub struct {
+	stubHostDB
+
+	dbEntries []modules.HostDBEntry
+}
+
+func (ps pricesStub) RandomHosts(n int, exclude []types.SiaPublicKey) []modules.HostDBEntry {
+	return ps.dbEntries
+}
+
+// TestRenterPricesVolatility verifies that the renter caches its price
+// estimation, and subsequent calls result in non-volatile results.
+func TestRenterPricesVolatility(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	rt, err := newRenterTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Close()
+
+	// create a stubbed hostdb, query it with one contract, add another, verify
+	// the price estimation remains constant until the timeout has passed.
+	hdb := &pricesStub{}
+	id := rt.renter.mu.Lock()
+	rt.renter.hostDB = hdb
+	rt.renter.mu.Unlock(id)
+	dbe := modules.HostDBEntry{}
+	dbe.ContractPrice = types.SiacoinPrecision
+	dbe.DownloadBandwidthPrice = types.SiacoinPrecision
+	dbe.StoragePrice = types.SiacoinPrecision
+	dbe.UploadBandwidthPrice = types.SiacoinPrecision
+	hdb.dbEntries = append(hdb.dbEntries, dbe)
+	initial := rt.renter.PriceEstimation()
+	dbe.ContractPrice = dbe.ContractPrice.Mul64(2)
+	hdb.dbEntries = append(hdb.dbEntries, dbe)
+	after := rt.renter.PriceEstimation()
+	if !reflect.DeepEqual(initial, after) {
+		t.Log(initial)
+		t.Log(after)
+		t.Fatal("expected renter price estimation to be constant")
+	}
+	time.Sleep(estimationTimeout)
+	after = rt.renter.PriceEstimation()
+	if reflect.DeepEqual(initial, after) {
+		t.Fatal("expected renter price estimation to change after waiting timeout")
+	}
 }


### PR DESCRIPTION
This PR addresses the UX concerns noted in #2364. Previously, hosts would be re-sampled on each call, causing confusing volatility. Now, the renter will cache renter price estimations, only resampling if more than a minute has passed since the last price estimation call.
