### PR TITLE
requestNodes: only save if new nodes were added

### DIFF
--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -173,15 +173,21 @@ func (g *Gateway) requestNodes(conn modules.PeerConn) error {
 	}
 
 	g.mu.Lock()
+	changed := false
 	for _, node := range nodes {
 		err := g.addNode(node)
 		if err != nil && err != errNodeExists && err != errOurAddress {
 			g.log.Printf("WARN: peer '%v' sent the invalid addr '%v'", conn.RPCAddr(), node)
 		}
+		if err == nil {
+			changed = true
+		}
 	}
-	err := g.saveSync()
-	if err != nil {
-		g.log.Println("ERROR: unable to save new nodes added to the gateway:", err)
+	if changed {
+		err := g.saveSync()
+		if err != nil {
+			g.log.Println("ERROR: unable to save new nodes added to the gateway:", err)
+		}
 	}
 	g.mu.Unlock()
 	return nil


### PR DESCRIPTION
this is mostly relevant to antfarm setups, where you have a small number of nodes that repeatedly bounce their addresses back and forth to each other. After a few minutes, none of the nodes will ever receive another unique address, but they still save the node list over and over again, incurring needless IO.
This was discovered using the `inotifywait` command mentioned in #2362.