### PR TITLE
fix host settings reset bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,14 @@ dependencies:
 	go get -u github.com/NebulousLabs/errors
 	go get -u github.com/NebulousLabs/go-upnp
 	go get -u github.com/NebulousLabs/muxado
+	go get -u github.com/NebulousLabs/threadgroup
 	go get -u github.com/klauspost/reedsolomon
 	go get -u github.com/julienschmidt/httprouter
 	go get -u github.com/inconshreveable/go-update
 	go get -u github.com/kardianos/osext
 	go get -u github.com/inconshreveable/mousetrap
 	# Frontend Dependencies
-	go get -u github.com/bgentry/speakeasy
+	go get -u golang.org/x/crypto/ssh/terminal
 	go get -u github.com/spf13/cobra/...
 	# Developer Dependencies
 	go install -race std
@@ -37,8 +38,8 @@ run = .
 pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/consensus                                  \
        ./modules/explorer ./modules/gateway ./modules/host ./modules/host/contractmanager                               \
        ./modules/renter ./modules/renter/contractor ./modules/renter/hostdb ./modules/renter/hostdb/hosttree            \
-       ./modules/renter/proto ./modules/miner ./modules/wallet ./modules/transactionpool ./persist ./cmd/siac               \
-       ./cmd/siad ./sync ./types
+       ./modules/renter/proto ./modules/miner ./modules/wallet ./modules/transactionpool ./persist                      \
+       ./cmd/siad ./cmd/siac ./sync ./types
 
 # fmt calls go fmt on all packages.
 fmt:
@@ -63,15 +64,15 @@ spellcheck:
 
 # dev builds and installs developer binaries.
 dev:
-	go install -race -tags='dev debug profile' $(pkgs)
+	go install -race -tags='dev debug profile netgo' $(pkgs)
 
 # release builds and installs release binaries.
 release:
-	go install -tags='debug profile' $(pkgs)
+	go install -tags='debug profile netgo' $(pkgs)
 release-race:
-	go install -race -tags='debug profile' $(pkgs)
+	go install -race -tags='debug profile netgo' $(pkgs)
 release-std:
-	go install -tags '' -ldflags='-s -w' $(pkgs)
+	go install -tags 'netgo' -a -ldflags='-s -w' $(pkgs)
 
 # clean removes all directories that get automatically created during
 # development.
@@ -79,19 +80,19 @@ clean:
 	rm -rf release doc/whitepaper.aux doc/whitepaper.log doc/whitepaper.pdf
 
 test:
-	go test -short -tags='debug testing' -timeout=5s $(pkgs) -run=$(run)
+	go test -short -tags='debug testing netgo' -timeout=5s $(pkgs) -run=$(run)
 test-v:
-	go test -race -v -short -tags='debug testing' -timeout=15s $(pkgs) -run=$(run)
+	go test -race -v -short -tags='debug testing netgo' -timeout=15s $(pkgs) -run=$(run)
 test-long: clean fmt vet lint
-	go test -v -race -tags='testing debug' -timeout=500s $(pkgs) -run=$(run)
+	go test -v -race -tags='testing debug netgo' -timeout=500s $(pkgs) -run=$(run)
 test-vlong: clean fmt vet lint
-	go test -v -race -tags='testing debug vlong' -timeout=5000s $(pkgs) -run=$(run)
+	go test -v -race -tags='testing debug vlong netgo' -timeout=5000s $(pkgs) -run=$(run)
 test-cpu:
-	go test -v -tags='testing debug' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)
+	go test -v -tags='testing debug netgo' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)
 test-mem:
-	go test -v -tags='testing debug' -timeout=500s -memprofile mem.prof $(pkgs) -run=$(run)
+	go test -v -tags='testing debug netgo' -timeout=500s -memprofile mem.prof $(pkgs) -run=$(run)
 bench: clean fmt
-	go test -tags='debug testing' -timeout=500s -run=XXX -bench=$(run) $(pkgs)
+	go test -tags='debug testing netgo' -timeout=500s -run=XXX -bench=$(run) $(pkgs)
 cover: clean
 	@mkdir -p cover/modules
 	@mkdir -p cover/modules/renter

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,13 @@ dependencies:
 	go get -u github.com/NebulousLabs/errors
 	go get -u github.com/NebulousLabs/go-upnp
 	go get -u github.com/NebulousLabs/muxado
-	go get -u github.com/NebulousLabs/threadgroup
 	go get -u github.com/klauspost/reedsolomon
 	go get -u github.com/julienschmidt/httprouter
 	go get -u github.com/inconshreveable/go-update
 	go get -u github.com/kardianos/osext
 	go get -u github.com/inconshreveable/mousetrap
 	# Frontend Dependencies
-	go get -u golang.org/x/crypto/ssh/terminal
+	go get -u github.com/bgentry/speakeasy
 	go get -u github.com/spf13/cobra/...
 	# Developer Dependencies
 	go install -race std
@@ -38,8 +37,8 @@ run = .
 pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/consensus                                  \
        ./modules/explorer ./modules/gateway ./modules/host ./modules/host/contractmanager                               \
        ./modules/renter ./modules/renter/contractor ./modules/renter/hostdb ./modules/renter/hostdb/hosttree            \
-       ./modules/renter/proto ./modules/miner ./modules/wallet ./modules/transactionpool ./persist                      \
-       ./cmd/siad ./cmd/siac ./sync ./types
+       ./modules/renter/proto ./modules/miner ./modules/wallet ./modules/transactionpool ./persist ./cmd/siac               \
+       ./cmd/siad ./sync ./types
 
 # fmt calls go fmt on all packages.
 fmt:
@@ -64,15 +63,15 @@ spellcheck:
 
 # dev builds and installs developer binaries.
 dev:
-	go install -race -tags='dev debug profile netgo' $(pkgs)
+	go install -race -tags='dev debug profile' $(pkgs)
 
 # release builds and installs release binaries.
 release:
-	go install -tags='debug profile netgo' $(pkgs)
+	go install -tags='debug profile' $(pkgs)
 release-race:
-	go install -race -tags='debug profile netgo' $(pkgs)
+	go install -race -tags='debug profile' $(pkgs)
 release-std:
-	go install -tags 'netgo' -a -ldflags='-s -w' $(pkgs)
+	go install -tags '' -ldflags='-s -w' $(pkgs)
 
 # clean removes all directories that get automatically created during
 # development.
@@ -80,19 +79,19 @@ clean:
 	rm -rf release doc/whitepaper.aux doc/whitepaper.log doc/whitepaper.pdf
 
 test:
-	go test -short -tags='debug testing netgo' -timeout=5s $(pkgs) -run=$(run)
+	go test -short -tags='debug testing' -timeout=5s $(pkgs) -run=$(run)
 test-v:
-	go test -race -v -short -tags='debug testing netgo' -timeout=15s $(pkgs) -run=$(run)
+	go test -race -v -short -tags='debug testing' -timeout=15s $(pkgs) -run=$(run)
 test-long: clean fmt vet lint
-	go test -v -race -tags='testing debug netgo' -timeout=500s $(pkgs) -run=$(run)
+	go test -v -race -tags='testing debug' -timeout=500s $(pkgs) -run=$(run)
 test-vlong: clean fmt vet lint
-	go test -v -race -tags='testing debug vlong netgo' -timeout=5000s $(pkgs) -run=$(run)
+	go test -v -race -tags='testing debug vlong' -timeout=5000s $(pkgs) -run=$(run)
 test-cpu:
-	go test -v -tags='testing debug netgo' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)
+	go test -v -tags='testing debug' -timeout=500s -cpuprofile cpu.prof $(pkgs) -run=$(run)
 test-mem:
-	go test -v -tags='testing debug netgo' -timeout=500s -memprofile mem.prof $(pkgs) -run=$(run)
+	go test -v -tags='testing debug' -timeout=500s -memprofile mem.prof $(pkgs) -run=$(run)
 bench: clean fmt
-	go test -tags='debug testing netgo' -timeout=500s -run=XXX -bench=$(run) $(pkgs)
+	go test -tags='debug testing' -timeout=500s -run=XXX -bench=$(run) $(pkgs)
 cover: clean
 	@mkdir -p cover/modules
 	@mkdir -p cover/modules/renter

--- a/api/host.go
+++ b/api/host.go
@@ -91,7 +91,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x bool
 		_, err := fmt.Sscan(req.FormValue("acceptingcontracts"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.AcceptingContracts = x
 	}
@@ -99,7 +99,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x uint64
 		_, err := fmt.Sscan(req.FormValue("maxdownloadbatchsize"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MaxDownloadBatchSize = x
 	}
@@ -107,7 +107,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.BlockHeight
 		_, err := fmt.Sscan(req.FormValue("maxduration"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MaxDuration = x
 	}
@@ -115,7 +115,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x uint64
 		_, err := fmt.Sscan(req.FormValue("maxrevisebatchsize"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MaxReviseBatchSize = x
 	}
@@ -123,7 +123,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x modules.NetAddress
 		_, err := fmt.Sscan(req.FormValue("netaddress"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.NetAddress = x
 	}
@@ -131,7 +131,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.BlockHeight
 		_, err := fmt.Sscan(req.FormValue("windowsize"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.WindowSize = x
 	}
@@ -140,7 +140,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.Currency
 		_, err := fmt.Sscan(req.FormValue("collateral"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.Collateral = x
 	}
@@ -148,7 +148,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.Currency
 		_, err := fmt.Sscan(req.FormValue("collateralbudget"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.CollateralBudget = x
 	}
@@ -156,7 +156,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.Currency
 		_, err := fmt.Sscan(req.FormValue("maxcollateral"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MaxCollateral = x
 	}
@@ -165,7 +165,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.Currency
 		_, err := fmt.Sscan(req.FormValue("mincontractprice"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MinContractPrice = x
 	}
@@ -173,7 +173,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.Currency
 		_, err := fmt.Sscan(req.FormValue("mindownloadbandwidthprice"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MinDownloadBandwidthPrice = x
 	}
@@ -181,7 +181,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.Currency
 		_, err := fmt.Sscan(req.FormValue("minstorageprice"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MinStoragePrice = x
 	}
@@ -189,7 +189,7 @@ func (api *API) parseHostSettings(req *http.Request) (modules.HostInternalSettin
 		var x types.Currency
 		_, err := fmt.Sscan(req.FormValue("minuploadbandwidthprice"), &x)
 		if err != nil {
-			return modules.HostInternalSettings{}, nil
+			return modules.HostInternalSettings{}, err
 		}
 		settings.MinUploadBandwidthPrice = x
 	}

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -153,6 +154,34 @@ func TestEstimateWeight(t *testing.T) {
 		if eg.ConversionRate < test.minConversionRate {
 			t.Fatalf("test %v: incorrect conversion rate: got %v wanted %v\n", i, eg.ConversionRate, test.minConversionRate)
 		}
+	}
+}
+
+// TestHostSettingsHandlerParsing verifies that providing invalid host settings
+// doesn't reset the host's settings.
+func TestHostSettingsHandlerParsing(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	st, err := createServerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.panicClose()
+
+	settings := st.host.InternalSettings()
+	t.Log(settings)
+	settingsValues := url.Values{}
+	settingsValues.Set("maxdownloadbatchsize", "foo")
+	err = st.stdPostAPI("/host", settingsValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSettings := st.host.InternalSettings()
+	if !reflect.DeepEqual(newSettings, settings) {
+		t.Fatal("invalid acceptingcontracts value changed host settings! got", newSettings, "wanted", settings)
 	}
 }
 

--- a/api/host_test.go
+++ b/api/host_test.go
@@ -172,13 +172,9 @@ func TestHostSettingsHandlerParsing(t *testing.T) {
 	defer st.server.panicClose()
 
 	settings := st.host.InternalSettings()
-	t.Log(settings)
 	settingsValues := url.Values{}
 	settingsValues.Set("maxdownloadbatchsize", "foo")
-	err = st.stdPostAPI("/host", settingsValues)
-	if err != nil {
-		t.Fatal(err)
-	}
+	st.stdPostAPI("/host", settingsValues)
 	newSettings := st.host.InternalSettings()
 	if !reflect.DeepEqual(newSettings, settings) {
 		t.Fatal("invalid acceptingcontracts value changed host settings! got", newSettings, "wanted", settings)


### PR DESCRIPTION
This PR fixes a bug where if a user supplies an invalid host parameter to the `/host` API endpoint, all of the host's internal settings will be reset to zero-values.