### PR TITLE
Split applyHistory into applyHistoryFromBlock

### DIFF
--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -10,6 +10,11 @@ import (
 	"github.com/NebulousLabs/bolt"
 )
 
+type (
+	spentSiacoinOutputSet map[types.SiacoinOutputID]types.SiacoinOutput
+	spentSiafundOutputSet map[types.SiafundOutputID]types.SiafundOutput
+)
+
 // threadedResetSubscriptions unsubscribes the wallet from the consensus set and transaction pool
 // and subscribes again.
 func (w *Wallet) threadedResetSubscriptions() error {
@@ -199,8 +204,8 @@ func (w *Wallet) revertHistory(tx *bolt.Tx, reverted []types.Block) error {
 
 // computeSpentSiacoinOutputSet scans a slice of Siacoin output diffs for spent
 // outputs and collects them in a map of SiacoinOutputID -> SiacoinOutput.
-func computeSpentSiacoinOutputSet(diffs []modules.SiacoinOutputDiff) map[types.SiacoinOutputID]types.SiacoinOutput {
-	outputs := make(map[types.SiacoinOutputID]types.SiacoinOutput)
+func computeSpentSiacoinOutputSet(diffs []modules.SiacoinOutputDiff) spentSiacoinOutputSet {
+	outputs := make(spentSiacoinOutputSet)
 	for _, diff := range diffs {
 		if diff.Direction == modules.DiffRevert {
 			// DiffRevert means spent.
@@ -212,8 +217,8 @@ func computeSpentSiacoinOutputSet(diffs []modules.SiacoinOutputDiff) map[types.S
 
 // computeSpentSiafundOutputSet scans a slice of Siafund output diffs for spent
 // outputs and collects them in a map of SiafundOutputID -> SiafundOutput.
-func computeSpentSiafundOutputSet(diffs []modules.SiafundOutputDiff) map[types.SiafundOutputID]types.SiafundOutput {
-	outputs := make(map[types.SiafundOutputID]types.SiafundOutput)
+func computeSpentSiafundOutputSet(diffs []modules.SiafundOutputDiff) spentSiafundOutputSet {
+	outputs := make(spentSiafundOutputSet)
 	for _, diff := range diffs {
 		if diff.Direction == modules.DiffRevert {
 			// DiffRevert means spent.
@@ -223,180 +228,189 @@ func computeSpentSiafundOutputSet(diffs []modules.SiafundOutputDiff) map[types.S
 	return outputs
 }
 
-// applyHistory applies any transaction history that was introduced by the
-// applied blocks.
+// applyHistoryFromBlock applies any transaction history that the given block
+// introduced.
+func (w *Wallet) applyHistoryFromBlock(tx *bolt.Tx, block types.Block, spentSiacoinOutputs spentSiacoinOutputSet, spentSiafundOutputs spentSiafundOutputSet) error {
+	consensusHeight, err := dbGetConsensusHeight(tx)
+	if err != nil {
+		return err
+	}
+	// increment the consensus height
+	if block.ID() != types.GenesisID {
+		consensusHeight++
+		err = dbPutConsensusHeight(tx, consensusHeight)
+		if err != nil {
+			return err
+		}
+	}
+
+	relevant := false
+	for _, mp := range block.MinerPayouts {
+		relevant = relevant || w.isWalletAddress(mp.UnlockHash)
+	}
+	if relevant {
+		w.log.Println("Wallet has received new miner payouts:", block.ID())
+		// Apply the miner payout transaction if applicable.
+		minerPT := modules.ProcessedTransaction{
+			Transaction:           types.Transaction{},
+			TransactionID:         types.TransactionID(block.ID()),
+			ConfirmationHeight:    consensusHeight,
+			ConfirmationTimestamp: block.Timestamp,
+		}
+		for i, mp := range block.MinerPayouts {
+			w.log.Println("\tminer payout:", block.MinerPayoutID(uint64(i)), "::", mp.Value.HumanString())
+			minerPT.Outputs = append(minerPT.Outputs, modules.ProcessedOutput{
+				ID:             types.OutputID(block.MinerPayoutID(uint64(i))),
+				FundType:       types.SpecifierMinerPayout,
+				MaturityHeight: consensusHeight + types.MaturityDelay,
+				WalletAddress:  w.isWalletAddress(mp.UnlockHash),
+				RelatedAddress: mp.UnlockHash,
+				Value:          mp.Value,
+			})
+		}
+		err := dbAppendProcessedTransaction(tx, minerPT)
+		if err != nil {
+			return fmt.Errorf("could not put processed miner transaction: %v", err)
+		}
+	}
+	for _, txn := range block.Transactions {
+		// determine if transaction is relevant
+		relevant := false
+		for _, sci := range txn.SiacoinInputs {
+			relevant = relevant || w.isWalletAddress(sci.UnlockConditions.UnlockHash())
+		}
+		for _, sco := range txn.SiacoinOutputs {
+			relevant = relevant || w.isWalletAddress(sco.UnlockHash)
+		}
+		for _, sfi := range txn.SiafundInputs {
+			relevant = relevant || w.isWalletAddress(sfi.UnlockConditions.UnlockHash())
+		}
+		for _, sfo := range txn.SiafundOutputs {
+			relevant = relevant || w.isWalletAddress(sfo.UnlockHash)
+		}
+
+		// only create a ProcessedTransaction if txn is relevant
+		if !relevant {
+			continue
+		}
+		w.log.Println("A transaction has been confirmed on the blockchain:", txn.ID())
+
+		pt := modules.ProcessedTransaction{
+			Transaction:           txn,
+			TransactionID:         txn.ID(),
+			ConfirmationHeight:    consensusHeight,
+			ConfirmationTimestamp: block.Timestamp,
+		}
+
+		for _, sci := range txn.SiacoinInputs {
+			pi := modules.ProcessedInput{
+				ParentID:       types.OutputID(sci.ParentID),
+				FundType:       types.SpecifierSiacoinInput,
+				WalletAddress:  w.isWalletAddress(sci.UnlockConditions.UnlockHash()),
+				RelatedAddress: sci.UnlockConditions.UnlockHash(),
+				Value:          spentSiacoinOutputs[sci.ParentID].Value,
+			}
+			pt.Inputs = append(pt.Inputs, pi)
+
+			// Log any wallet-relevant inputs.
+			if pi.WalletAddress {
+				w.log.Println("\tSiacoin Input:", pi.ParentID, "::", pi.Value.HumanString())
+			}
+
+		}
+
+		for i, sco := range txn.SiacoinOutputs {
+			po := modules.ProcessedOutput{
+				ID:             types.OutputID(txn.SiacoinOutputID(uint64(i))),
+				FundType:       types.SpecifierSiacoinOutput,
+				MaturityHeight: consensusHeight,
+				WalletAddress:  w.isWalletAddress(sco.UnlockHash),
+				RelatedAddress: sco.UnlockHash,
+				Value:          sco.Value,
+			}
+			pt.Outputs = append(pt.Outputs, po)
+
+			// Log any wallet-relevant outputs.
+			if po.WalletAddress {
+				w.log.Println("\tSiacoin Output:", po.ID, "::", po.Value.HumanString())
+			}
+		}
+
+		for _, sfi := range txn.SiafundInputs {
+			pi := modules.ProcessedInput{
+				ParentID:       types.OutputID(sfi.ParentID),
+				FundType:       types.SpecifierSiafundInput,
+				WalletAddress:  w.isWalletAddress(sfi.UnlockConditions.UnlockHash()),
+				RelatedAddress: sfi.UnlockConditions.UnlockHash(),
+				Value:          spentSiafundOutputs[sfi.ParentID].Value,
+			}
+			pt.Inputs = append(pt.Inputs, pi)
+			// Log any wallet-relevant inputs.
+			if pi.WalletAddress {
+				w.log.Println("\tSiafund Input:", pi.ParentID, "::", pi.Value.HumanString())
+			}
+
+			siafundPool, err := dbGetSiafundPool(w.dbTx)
+			if err != nil {
+				return fmt.Errorf("could not get siafund pool: %v", err)
+			}
+
+			sfo := spentSiafundOutputs[sfi.ParentID]
+			po := modules.ProcessedOutput{
+				ID:             types.OutputID(sfi.ParentID),
+				FundType:       types.SpecifierClaimOutput,
+				MaturityHeight: consensusHeight + types.MaturityDelay,
+				WalletAddress:  w.isWalletAddress(sfi.UnlockConditions.UnlockHash()),
+				RelatedAddress: sfi.ClaimUnlockHash,
+				Value:          siafundPool.Sub(sfo.ClaimStart).Mul(sfo.Value),
+			}
+			pt.Outputs = append(pt.Outputs, po)
+			// Log any wallet-relevant outputs.
+			if po.WalletAddress {
+				w.log.Println("\tClaim Output:", po.ID, "::", po.Value.HumanString())
+			}
+		}
+
+		for i, sfo := range txn.SiafundOutputs {
+			po := modules.ProcessedOutput{
+				ID:             types.OutputID(txn.SiafundOutputID(uint64(i))),
+				FundType:       types.SpecifierSiafundOutput,
+				MaturityHeight: consensusHeight,
+				WalletAddress:  w.isWalletAddress(sfo.UnlockHash),
+				RelatedAddress: sfo.UnlockHash,
+				Value:          sfo.Value,
+			}
+			pt.Outputs = append(pt.Outputs, po)
+			// Log any wallet-relevant outputs.
+			if po.WalletAddress {
+				w.log.Println("\tSiafund Output:", po.ID, "::", po.Value.HumanString())
+			}
+		}
+
+		for _, fee := range txn.MinerFees {
+			pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
+				FundType: types.SpecifierMinerFee,
+				Value:    fee,
+			})
+		}
+
+		err := dbAppendProcessedTransaction(tx, pt)
+		if err != nil {
+			return fmt.Errorf("could not put processed transaction: %v", err)
+		}
+	}
+	return nil
+}
+
+// applyHistory applies any transaction history that the applied blocks
+// introduced.
 func (w *Wallet) applyHistory(tx *bolt.Tx, cc modules.ConsensusChange) error {
 	spentSiacoinOutputs := computeSpentSiacoinOutputSet(cc.SiacoinOutputDiffs)
 	spentSiafundOutputs := computeSpentSiafundOutputSet(cc.SiafundOutputDiffs)
 
 	for _, block := range cc.AppliedBlocks {
-		consensusHeight, err := dbGetConsensusHeight(tx)
-		if err != nil {
+		if err := w.applyHistoryFromBlock(tx, block, spentSiacoinOutputs, spentSiafundOutputs); err != nil {
 			return err
-		}
-		// increment the consensus height
-		if block.ID() != types.GenesisID {
-			consensusHeight++
-			err = dbPutConsensusHeight(tx, consensusHeight)
-			if err != nil {
-				return err
-			}
-		}
-
-		relevant := false
-		for _, mp := range block.MinerPayouts {
-			relevant = relevant || w.isWalletAddress(mp.UnlockHash)
-		}
-		if relevant {
-			w.log.Println("Wallet has received new miner payouts:", block.ID())
-			// Apply the miner payout transaction if applicable.
-			minerPT := modules.ProcessedTransaction{
-				Transaction:           types.Transaction{},
-				TransactionID:         types.TransactionID(block.ID()),
-				ConfirmationHeight:    consensusHeight,
-				ConfirmationTimestamp: block.Timestamp,
-			}
-			for i, mp := range block.MinerPayouts {
-				w.log.Println("\tminer payout:", block.MinerPayoutID(uint64(i)), "::", mp.Value.HumanString())
-				minerPT.Outputs = append(minerPT.Outputs, modules.ProcessedOutput{
-					ID:             types.OutputID(block.MinerPayoutID(uint64(i))),
-					FundType:       types.SpecifierMinerPayout,
-					MaturityHeight: consensusHeight + types.MaturityDelay,
-					WalletAddress:  w.isWalletAddress(mp.UnlockHash),
-					RelatedAddress: mp.UnlockHash,
-					Value:          mp.Value,
-				})
-			}
-			err := dbAppendProcessedTransaction(tx, minerPT)
-			if err != nil {
-				return fmt.Errorf("could not put processed miner transaction: %v", err)
-			}
-		}
-		for _, txn := range block.Transactions {
-			// determine if transaction is relevant
-			relevant := false
-			for _, sci := range txn.SiacoinInputs {
-				relevant = relevant || w.isWalletAddress(sci.UnlockConditions.UnlockHash())
-			}
-			for _, sco := range txn.SiacoinOutputs {
-				relevant = relevant || w.isWalletAddress(sco.UnlockHash)
-			}
-			for _, sfi := range txn.SiafundInputs {
-				relevant = relevant || w.isWalletAddress(sfi.UnlockConditions.UnlockHash())
-			}
-			for _, sfo := range txn.SiafundOutputs {
-				relevant = relevant || w.isWalletAddress(sfo.UnlockHash)
-			}
-
-			// only create a ProcessedTransaction if txn is relevant
-			if !relevant {
-				continue
-			}
-			w.log.Println("A transaction has been confirmed on the blockchain:", txn.ID())
-
-			pt := modules.ProcessedTransaction{
-				Transaction:           txn,
-				TransactionID:         txn.ID(),
-				ConfirmationHeight:    consensusHeight,
-				ConfirmationTimestamp: block.Timestamp,
-			}
-
-			for _, sci := range txn.SiacoinInputs {
-				pi := modules.ProcessedInput{
-					ParentID:       types.OutputID(sci.ParentID),
-					FundType:       types.SpecifierSiacoinInput,
-					WalletAddress:  w.isWalletAddress(sci.UnlockConditions.UnlockHash()),
-					RelatedAddress: sci.UnlockConditions.UnlockHash(),
-					Value:          spentSiacoinOutputs[sci.ParentID].Value,
-				}
-				pt.Inputs = append(pt.Inputs, pi)
-
-				// Log any wallet-relevant inputs.
-				if pi.WalletAddress {
-					w.log.Println("\tSiacoin Input:", pi.ParentID, "::", pi.Value.HumanString())
-				}
-
-			}
-
-			for i, sco := range txn.SiacoinOutputs {
-				po := modules.ProcessedOutput{
-					ID:             types.OutputID(txn.SiacoinOutputID(uint64(i))),
-					FundType:       types.SpecifierSiacoinOutput,
-					MaturityHeight: consensusHeight,
-					WalletAddress:  w.isWalletAddress(sco.UnlockHash),
-					RelatedAddress: sco.UnlockHash,
-					Value:          sco.Value,
-				}
-				pt.Outputs = append(pt.Outputs, po)
-
-				// Log any wallet-relevant outputs.
-				if po.WalletAddress {
-					w.log.Println("\tSiacoin Output:", po.ID, "::", po.Value.HumanString())
-				}
-			}
-
-			for _, sfi := range txn.SiafundInputs {
-				pi := modules.ProcessedInput{
-					ParentID:       types.OutputID(sfi.ParentID),
-					FundType:       types.SpecifierSiafundInput,
-					WalletAddress:  w.isWalletAddress(sfi.UnlockConditions.UnlockHash()),
-					RelatedAddress: sfi.UnlockConditions.UnlockHash(),
-					Value:          spentSiafundOutputs[sfi.ParentID].Value,
-				}
-				pt.Inputs = append(pt.Inputs, pi)
-				// Log any wallet-relevant inputs.
-				if pi.WalletAddress {
-					w.log.Println("\tSiafund Input:", pi.ParentID, "::", pi.Value.HumanString())
-				}
-
-				siafundPool, err := dbGetSiafundPool(w.dbTx)
-				if err != nil {
-					return fmt.Errorf("could not get siafund pool: %v", err)
-				}
-
-				sfo := spentSiafundOutputs[sfi.ParentID]
-				po := modules.ProcessedOutput{
-					ID:             types.OutputID(sfi.ParentID),
-					FundType:       types.SpecifierClaimOutput,
-					MaturityHeight: consensusHeight + types.MaturityDelay,
-					WalletAddress:  w.isWalletAddress(sfi.UnlockConditions.UnlockHash()),
-					RelatedAddress: sfi.ClaimUnlockHash,
-					Value:          siafundPool.Sub(sfo.ClaimStart).Mul(sfo.Value),
-				}
-				pt.Outputs = append(pt.Outputs, po)
-				// Log any wallet-relevant outputs.
-				if po.WalletAddress {
-					w.log.Println("\tClaim Output:", po.ID, "::", po.Value.HumanString())
-				}
-			}
-
-			for i, sfo := range txn.SiafundOutputs {
-				po := modules.ProcessedOutput{
-					ID:             types.OutputID(txn.SiafundOutputID(uint64(i))),
-					FundType:       types.SpecifierSiafundOutput,
-					MaturityHeight: consensusHeight,
-					WalletAddress:  w.isWalletAddress(sfo.UnlockHash),
-					RelatedAddress: sfo.UnlockHash,
-					Value:          sfo.Value,
-				}
-				pt.Outputs = append(pt.Outputs, po)
-				// Log any wallet-relevant outputs.
-				if po.WalletAddress {
-					w.log.Println("\tSiafund Output:", po.ID, "::", po.Value.HumanString())
-				}
-			}
-
-			for _, fee := range txn.MinerFees {
-				pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
-					FundType: types.SpecifierMinerFee,
-					Value:    fee,
-				})
-			}
-
-			err := dbAppendProcessedTransaction(tx, pt)
-			if err != nil {
-				return fmt.Errorf("could not put processed transaction: %v", err)
-			}
 		}
 	}
 


### PR DESCRIPTION
Following #2456, this further refactors the Wallet.applyHistory function by splitting the body of the giant loop it contains into a separate method.

This reduces the 176 LOC method to 170 LOC and reduces the control flow nesting depth by 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nebulouslabs/sia/2459)
<!-- Reviewable:end -->
