### PR TITLE
Implement GitHub template files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+Interested in contributing to SIA?
+==================================
+
+Please review the contributing guidelines in the following pages:
+- [Guide to Contributing to Sia](https://github.com/NebulousLabs/Sia/blob/master/doc/Guide%20to%20Contributing%20to%20Sia.md)
+- [Developers](https://github.com/NebulousLabs/Sia/blob/master/doc/Developers.md)
+- [All Documentation](https://github.com/NebulousLabs/Sia/tree/master/doc)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Interested in contributing to SIA?
+Interested in contributing to Sia?
 ==================================
 
 Please review the contributing guidelines in the following pages:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+Bug Report
+==========
+
+### Stack Trace or error message
+
+### Environment
+* Sia version:
+* OS:
+
+### Any useful logs
+
+
+Feature Request
+===============
+
+Clearly descibe your feature request and why it would benefit {{.RepoName}}

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,6 +16,6 @@ Check to see if a bug report already exists.  If you still want to create a new 
 
 Feature Request
 ===============
-Check to see if the feature is on the roadmap.  If it is not on the roadmap then clearly describe your feature request and why it would benefit {{.RepoName}}
+Check to see if the feature is on the roadmap.  If it is not on the roadmap then clearly describe your feature request and why it would benefit Sia.
 
 [Sia roadmap](https://trello.com/b/Io1dDyuI/sia-public-roadmap)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,5 +16,6 @@ Check to see if a bug report already exists.  If you still want to create a new 
 
 Feature Request
 ===============
+Check to see if the feature is on the roadmap.  If it is not on the roadmap then clearly describe your feature request and why it would benefit {{.RepoName}}
 
-Clearly describe your feature request and why it would benefit {{.RepoName}}
+[Sia roadmap](https://trello.com/b/Io1dDyuI/sia-public-roadmap)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,20 @@
 Bug Report
 ==========
+Check to see if a bug report already exists.  If you still want to create a new issue please include the information below.
 
-### Stack Trace or error message
+**Stack Trace or error message**
 
-### Environment
+
+**Environment**
 * Sia version:
 * OS:
 
-### Any useful logs
+
+**Any useful logs**
+
 
 
 Feature Request
 ===============
 
-Clearly descibe your feature request and why it would benefit {{.RepoName}}
+Clearly describe your feature request and why it would benefit {{.RepoName}}


### PR DESCRIPTION
This commit implements very basic contributing and issue template files.  Template files are displayed in a banner when a user tries to perform an action such as create a new issue.  More details can be found here: https://github.com/blog/2111-issue-and-pull-request-templates

Fixes #2460