### PR TITLE
check for address existence in host.checkUnlockHash

### DIFF
--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -180,7 +180,15 @@ type Host struct {
 // from the wallet. That may fail due to the wallet being locked, in which case
 // an error is returned.
 func (h *Host) checkUnlockHash() error {
-	if h.unlockHash == (types.UnlockHash{}) {
+	addrs := h.wallet.AllAddresses()
+	hasAddr := false
+	for _, addr := range addrs {
+		if h.unlockHash == addr {
+			hasAddr = true
+			break
+		}
+	}
+	if !hasAddr || h.unlockHash == (types.UnlockHash{}) {
 		uc, err := h.wallet.NextAddress()
 		if err != nil {
 			return err

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -249,7 +249,15 @@ func (m *Miner) Close() error {
 // checkAddress checks that the miner has an address, fetching an address from
 // the wallet if not.
 func (m *Miner) checkAddress() error {
-	if m.persist.Address != (types.UnlockHash{}) {
+	addrs := m.wallet.AllAddresses()
+	hasAddr := false
+	for _, addr := range addrs {
+		if m.persist.Address == addr {
+			hasAddr = true
+			break
+		}
+	}
+	if m.persist.Address != (types.UnlockHash{}) && hasAddr {
 		return nil
 	}
 	uc, err := m.wallet.NextAddress()


### PR DESCRIPTION
This should help with #2447. After this change, `checkUnlockHash` is only called on announce, should it be called once per block as well?