### PR TITLE
Add a lock to guard concurrent map access in Renter.FileList

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -207,8 +207,8 @@ func (r *Renter) DeleteFile(nickname string) error {
 	return nil
 }
 
-// getTrackedFile returns the metadata for a tracked file, if the file exists.
-func (r *Renter) getTrackedFile(nickname string) (tf trackedFile, exists bool) {
+// managedGetTrackedFile returns the metadata for a tracked file, if the file exists.
+func (r *Renter) managedGetTrackedFile(nickname string) (tf trackedFile, exists bool) {
 	lockId := r.mu.RLock()
 	defer r.mu.RUnlock(lockId)
 	tf, exists = r.tracking[nickname]
@@ -239,7 +239,7 @@ func (r *Renter) FileList() []modules.FileInfo {
 		f.mu.RLock()
 		renewing := true
 		var localPath string
-		tf, exists := r.getTrackedFile(f.name)
+		tf, exists := r.managedGetTrackedFile(f.name)
 		if exists {
 			localPath = tf.RepairPath
 		}

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -207,6 +207,14 @@ func (r *Renter) DeleteFile(nickname string) error {
 	return nil
 }
 
+// getTrackedFile returns the metadata for a tracked file, if the file exists.
+func (r *Renter) getTrackedFile(nickname string) (tf trackedFile, exists bool) {
+	lockId := r.mu.RLock()
+	defer r.mu.RUnlock(lockId)
+	tf, exists = r.tracking[nickname]
+	return
+}
+
 // FileList returns all of the files that the renter has.
 func (r *Renter) FileList() []modules.FileInfo {
 	var files []*file
@@ -231,7 +239,7 @@ func (r *Renter) FileList() []modules.FileInfo {
 		f.mu.RLock()
 		renewing := true
 		var localPath string
-		tf, exists := r.tracking[f.name]
+		tf, exists := r.getTrackedFile(f.name)
 		if exists {
 			localPath = tf.RepairPath
 		}


### PR DESCRIPTION
FileList reads the map, r.tracking, but does not acquire a read lock beforehand,
which leads to crashes. This adds a helper function that acquires the read lock
during the map read.

Fixes #2473