### PR TITLE
Removing testing.T.Helper() call

### DIFF
--- a/modules/renter/proto/contractset_test.go
+++ b/modules/renter/proto/contractset_test.go
@@ -14,7 +14,6 @@ import (
 // mustAcquire is a convenience function for acquiring contracts that are
 // known to be in the set.
 func (cs *ContractSet) mustAcquire(t *testing.T, id types.FileContractID) modules.RenterContract {
-	t.Helper()
 	c, ok := cs.Acquire(id)
 	if !ok {
 		t.Fatal("no contract with that id")


### PR DESCRIPTION
As far as I can see, this isn't a defined function and results in build errors:

```
modules/renter/proto/contractset_test.go:17: t.Helper undefined (type *testing.T has no field or method Helper)
```