### PR TITLE
add uploadedBytes() to track how many bytes have been uploaded

### DIFF
--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -2277,7 +2277,8 @@ func TestUploadedBytesReporting(t *testing.T) {
 			uploadProgressBytes := uint64(float64(fullyRedundantSize) * rf.Files[0].UploadProgress / 100.0)
 			// Note: in Go 1.10 we will be able to write Math.Round(uploadProgressBytes) != rf.Files[0].UploadedBytes
 			if uploadProgressBytes != rf.Files[0].UploadedBytes && (uploadProgressBytes+1) != rf.Files[0].UploadedBytes {
-				t.Fatal(fmt.Sprintf("api reports having uploaded %v bytes when upload progress is %v%%, but the actual uploaded bytes count should be %v", rf.Files[0].UploadedBytes, rf.Files[0].UploadProgress, uploadProgressBytes))
+				t.Fatalf("api reports having uploaded %v bytes when upload progress is %v%%, but the actual uploaded bytes count should be %v\n",
+					rf.Files[0].UploadedBytes, rf.Files[0].UploadProgress, uploadProgressBytes)
 			}
 		}
 		time.Sleep(time.Second)
@@ -2294,7 +2295,8 @@ func TestUploadedBytesReporting(t *testing.T) {
 	// When the file is fully redundantly uploaded, UploadedBytes should
 	// equal the file's fully redundant size
 	if rf.Files[0].UploadedBytes != fullyRedundantSize {
-		t.Fatal(fmt.Sprintf("api reports having uploaded %v bytes when upload progress is 100%%, but the actual fully redundant file size is %v", rf.Files[0].UploadedBytes, fullyRedundantSize))
+		t.Fatalf("api reports having uploaded %v bytes when upload progress is 100%%, but the actual fully redundant file size is %v\n",
+			rf.Files[0].UploadedBytes, fullyRedundantSize)
 	}
 
 }

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -485,7 +485,7 @@ func renterfileslistcmd() {
 	fmt.Println("Tracking", len(rf.Files), "files:")
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	if renterListVerbose {
-		fmt.Fprintln(w, "File size\tAvailable\tProgress\tRedundancy\tRenewing\tSia path")
+		fmt.Fprintln(w, "File size\tAvailable\tUploaded\tProgress\tRedundancy\tRenewing\tSia path")
 	}
 	sort.Sort(bySiaPath(rf.Files))
 	for _, file := range rf.Files {
@@ -501,7 +501,7 @@ func renterfileslistcmd() {
 			if file.UploadProgress == -1 {
 				uploadProgressStr = "-"
 			}
-			fmt.Fprintf(w, "\t%s\t%8s\t%10s\t%s", availableStr, uploadProgressStr, redundancyStr, renewingStr)
+			fmt.Fprintf(w, "\t%s\t%9s\t%8s\t%10s\t%s", availableStr, filesizeUnits(int64(file.UploadedBytes)), uploadProgressStr, redundancyStr, renewingStr)
 		}
 		fmt.Fprintf(w, "\t%s", file.SiaPath)
 		if !renterListVerbose && !file.Available {

--- a/doc/API.md
+++ b/doc/API.md
@@ -863,6 +863,7 @@ lists the status of all files.
       "available":      true,
       "renewing":       true,
       "redundancy":     5,
+      "bytesuploaded":  209715200, // total bytes uploaded
       "uploadprogress": 100, // percent
       "expiration":     60000
     }

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -215,7 +215,7 @@ lists the status of all files.
       // Total number of bytes successfully uploaded via current file contracts.
       // This number includes padding and rendundancy, so a file with a size of
       // 8192 bytes might be padded to 40 MiB and, with a redundancy of 5,
-      // striped to 200 MiB for upload.
+      // encoded to 200 MiB for upload.
       "uploadedbytes": 209715200, // bytes
 
       // Percentage of the file uploaded, including redundancy. Uploading has

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -212,6 +212,12 @@ lists the status of all files.
       // with 0 redundancy.
       "redundancy": 5,
 
+      // Total number of bytes successfully uploaded via current file contracts.
+      // This number includes padding and rendundancy, so a file with a size of
+      // 8192 bytes might be padded to 40 MiB and, with a redundancy of 5,
+      // striped to 200 MiB for upload.
+      "uploadedbytes": 209715200, // bytes
+
       // Percentage of the file uploaded, including redundancy. Uploading has
       // completed when uploadprogress is 100. Files may be available for
       // download before upload progress is 100.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -80,6 +80,7 @@ type FileInfo struct {
 	Available      bool              `json:"available"`
 	Renewing       bool              `json:"renewing"`
 	Redundancy     float64           `json:"redundancy"`
+	UploadedBytes  uint64            `json:"uploadedbytes"`
 	UploadProgress float64           `json:"uploadprogress"`
 	Expiration     types.BlockHeight `json:"expiration"`
 }

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -107,7 +107,10 @@ func (f *file) available(isOffline func(types.FileContractID) bool) bool {
 func (f *file) uploadedBytes() uint64 {
 	var uploaded uint64
 	for _, fc := range f.contracts {
-		uploaded += uint64(len(fc.Pieces)) * f.pieceSize
+		// Note: we need to multiply by SectorSize here instead of
+		// f.pieceSize because the actual bytes uploaded include overhead
+		// from TwoFish encryption
+		uploaded += uint64(len(fc.Pieces)) * modules.SectorSize
 	}
 	return uploaded
 }
@@ -117,7 +120,7 @@ func (f *file) uploadedBytes() uint64 {
 // reaches 100%, and UploadProgress may report a value greater than 100%.
 func (f *file) uploadProgress() float64 {
 	uploaded := f.uploadedBytes()
-	desired := f.pieceSize * uint64(f.erasureCode.NumPieces()) * f.numChunks()
+	desired := modules.SectorSize * uint64(f.erasureCode.NumPieces()) * f.numChunks()
 
 	return math.Min(100*(float64(uploaded)/float64(desired)), 100)
 }

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -70,6 +70,22 @@ func TestFileAvailable(t *testing.T) {
 	}
 }
 
+// TestFileUploadedBytes tests that uploadedBytes() returns a value equal
+// to the number of pieces stored via contract times the size of each piece.
+func TestFileUploadedBytes(t *testing.T) {
+	f := &file{}
+	f.pieceSize = 2
+	f.contracts = make(map[types.FileContractID]fileContract)
+	f.contracts[types.FileContractID{}] = fileContract{
+		ID:     types.FileContractID{},
+		IP:     modules.NetAddress(""),
+		Pieces: make([]pieceData, 4),
+	}
+	if f.uploadedBytes() != 8 {
+		t.Errorf("expected uploadedBytes to be 8, got %v", f.uploadedBytes())
+	}
+}
+
 // TestFileUploadProgressPinning verifies that uploadProgress() returns at most
 // 100%, even if more pieces have been uploaded,
 func TestFileUploadProgressPinning(t *testing.T) {

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -70,18 +70,19 @@ func TestFileAvailable(t *testing.T) {
 	}
 }
 
-// TestFileUploadedBytes tests that uploadedBytes() returns a value equal
-// to the number of pieces stored via contract times the size of each piece.
+// TestFileUploadedBytes tests that uploadedBytes() returns a value equal to
+// the number of sectors stored via contract times the size of each sector.
 func TestFileUploadedBytes(t *testing.T) {
 	f := &file{}
-	f.pieceSize = 2
+	// ensure that a piece fits within a sector
+	f.pieceSize = modules.SectorSize / 2
 	f.contracts = make(map[types.FileContractID]fileContract)
 	f.contracts[types.FileContractID{}] = fileContract{
 		ID:     types.FileContractID{},
 		IP:     modules.NetAddress(""),
 		Pieces: make([]pieceData, 4),
 	}
-	if f.uploadedBytes() != 8 {
+	if f.uploadedBytes() != 4*modules.SectorSize {
 		t.Errorf("expected uploadedBytes to be 8, got %v", f.uploadedBytes())
 	}
 }


### PR DESCRIPTION
This resolves https://github.com/NebulousLabs/Sia/issues/2467

Currently an API caller can't accurately measure upload throughput because the upload API fields don't have information about how a file was chunked or padded. This PR directly exposes how many bytes have been uploaded via a file's contracts.