### PR TITLE
fix TestAllowanceSpending failing on AppVeyor

### DIFF
--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -395,7 +395,7 @@ func TestAllowanceSpending(t *testing.T) {
 
 	// Retry to give the threadedMaintenenace some time to finish
 	var newReportedSpending modules.ContractorSpending
-	err = build.Retry(10, time.Second, func() error {
+	err = build.Retry(100, 100*time.Millisecond, func() error {
 		newReportedSpending = c.PeriodSpending()
 		if reflect.DeepEqual(newReportedSpending, reportedSpending) {
 			return errors.New("reported spending was identical after entering a renew period")


### PR DESCRIPTION
As the name suggests I'm trying to fix the `TestAllowanceSpending` test. It seems that the maintenance thread doesn't always finish in time. Introducing a `retry` should fix that.