### PR TITLE
Use remote address from opened socket instead of the claimed IP in peer list

### DIFF
--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -195,7 +195,9 @@ func (g *Gateway) managedAcceptConnv130Peer(conn net.Conn, remoteVersion string)
 			// NOTE: local may be true even if the supplied NetAddress is not
 			// actually reachable.
 			Local:      remoteAddr.IsLocal(),
-			NetAddress: remoteAddr,
+			// Ignoring claimed IP address (which should be == to the socket address)
+			// by the host but keeping note of the port number so we can call back
+			NetAddress: modules.NetAddress(net.JoinHostPort(remoteAddr.Host(), remoteHeader.NetAddress.Port())),
 			Version:    remoteVersion,
 		},
 		sess: newServerStream(conn, remoteVersion),

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -185,14 +185,17 @@ func (g *Gateway) managedAcceptConnv130Peer(conn net.Conn, remoteVersion string)
 		return err
 	}
 
+	// Get the remote address from opened socket
+	remoteAddr := modules.NetAddress(conn.RemoteAddr().String())
+
 	// Accept the peer.
 	peer := &peer{
 		Peer: modules.Peer{
 			Inbound: true,
 			// NOTE: local may be true even if the supplied NetAddress is not
 			// actually reachable.
-			Local:      remoteHeader.NetAddress.IsLocal(),
-			NetAddress: remoteHeader.NetAddress,
+			Local:      remoteAddr.IsLocal(),
+			NetAddress: remoteAddr,
 			Version:    remoteVersion,
 		},
 		sess: newServerStream(conn, remoteVersion),


### PR DESCRIPTION
Currently ```siac gateway list``` shows the claimed IP address sent in a sessionHeader. There are two main issues with this approach.
Since as it stands the local interface IP is sent in the sessionHeader (instead of the external IP) we end up with invalid IP addresses shown for inbound connections when we execute ```siac gateway list``` that don't correspond to actual open sockets in the system. This makes correlating outputs from network monitoring utilities like ```netstat``` and the likes with the output from ```siac``` impractical.
Example output from ```siac gateway list```
```
root@siad-dev:/home/siad-dev/Sia/gateway# siac gateway list | grep No | head -n 5
1.3.0    No        192.168.70.246:9981
1.3.0    No        192.168.0.20:9981
1.3.0    No        192.168.0.114:9981
1.3.0    No        192.168.199.225:9981
1.3.0    No        192.168.1.21:9981
```
Second, we are blindly trusting the remote party not to lie about their network address which will be shown in the peer list (since network check was removed in #2254).