### PR TITLE
don't upload unless there are enough good hosts

### DIFF
--- a/modules/renter/repairscanner.go
+++ b/modules/renter/repairscanner.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 )
 
@@ -248,7 +249,9 @@ func (r *Renter) managedPrepareNextChunk(ch *chunkHeap, hosts map[string]struct{
 	}
 	// If there are not enough good hosts for this chunk we ignore it for now
 	nextChunk := heap.Pop(ch).(*unfinishedChunk)
-	if numGoodHosts < nextChunk.piecesNeeded {
+	if !build.DEBUG && numGoodHosts < nextChunk.piecesNeeded {
+		// Only abort in Release builds. Tests often don't have enough hosts to
+		// restore full redundancy
 		return
 	}
 

--- a/modules/renter/worker.go
+++ b/modules/renter/worker.go
@@ -29,6 +29,7 @@ type worker struct {
 	uploadChan           chan struct{}     // lowest priority
 
 	// Operation failure statistics for the worker.
+	lastFailure               error     // The most recent failure. Is reset after cooldown.
 	downloadRecentFailure     time.Time // Only modified by the primary download loop.
 	uploadRecentFailure       time.Time // Only modified by primary repair loop.
 	uploadConsecutiveFailures int


### PR DESCRIPTION
We don't want to upload a chunk unless we are sure there are potentially enough good contracts for that chunk.
This PR also moves the cooldown check into a separate function and lets the worker remember the last error that caused it to get penalized. 