### PR TITLE
blacklist peers <1.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ dependencies:
 	go get -u github.com/NebulousLabs/entropy-mnemonics
 	go get -u github.com/NebulousLabs/errors
 	go get -u github.com/NebulousLabs/go-upnp
-	go get -u github.com/NebulousLabs/muxado
 	go get -u github.com/NebulousLabs/threadgroup
 	go get -u github.com/NebulousLabs/writeaheadlog
 	go get -u github.com/klauspost/reedsolomon

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -28,9 +28,8 @@ const (
 	// minAcceptableVersion is the version below which the gateway will refuse to
 	// connect to peers and reject connection attempts.
 	//
-	// Reject peers < v0.4.0 as the previous version is v0.3.3 which is
-	// pre-hardfork.
-	minAcceptableVersion = "0.4.0"
+	// Reject peers < v1.3.0 due to hardfork.
+	minAcceptableVersion = "1.3.0"
 
 	// saveFrequency defines how often the gateway saves its persistence.
 	saveFrequency = time.Minute * 2

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -422,15 +422,15 @@ func TestUnitAcceptableVersion(t *testing.T) {
 	}
 	validVersions := []string{
 		minAcceptableVersion,
-		"0.4.0",
-		"0.6.0",
-		"0.6.1",
-		"0.9",
-		"0.999",
-		"0.9999999999",
-		"1",
-		"1.0",
-		"1.0.0",
+		"1.4.0",
+		"1.6.0",
+		"1.6.1",
+		"1.9",
+		"1.999",
+		"1.9999999999",
+		"2",
+		"2.0",
+		"2.0.0",
 		"9",
 		"9.0",
 		"9.0.0",
@@ -742,13 +742,15 @@ func TestAcceptConnRejectsVersions(t *testing.T) {
 			errWant:             errPeerRejectedConn,
 			msg:                 "acceptConn shouldn't accept a remote peer whose version is 0.3.9.9.9",
 		},
-		// Test that acceptConn succeeds when the remote peer's version is 0.4.0.
+		// Test that acceptConn succeeds when the remote peer's version is
+		// minAcceptableVersion
 		{
-			remoteVersion:       "0.4.0",
+			remoteVersion:       minAcceptableVersion,
 			versionResponseWant: build.Version,
 			msg:                 "acceptConn should accept a remote peer whose version is 0.4.0",
 		},
-		// Test that acceptConn succeeds when the remote peer's version is > 0.4.0.
+		// Test that acceptConn succeeds when the remote peer's version is
+		// above minAcceptableVersion
 		{
 			remoteVersion:       "9",
 			versionResponseWant: build.Version,

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -141,12 +141,12 @@ func (g *Gateway) threadedListenPeer(p *peer) {
 	defer g.peerTG.Done()
 
 	// Spin up a goroutine to listen for a shutdown signal from both the peer
-	// and from the gateway. In the event of either, close the muxado session.
+	// and from the gateway. In the event of either, close the session.
 	connClosedChan := make(chan struct{})
 	peerCloseChan := make(chan struct{})
 	go func() {
-		// Signal that the muxado session has been successfully closed, and
-		// that this goroutine has terminated.
+		// Signal that the session has been successfully closed, and that this
+		// goroutine has terminated.
 		defer close(connClosedChan)
 
 		// Listen for a stop signal.


### PR DESCRIPTION
This lets us strip out a bunch of compatibility code, including muxado (finally).