### PR TITLE
Better handling of unapplied WAL transactions

### DIFF
--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -180,6 +180,11 @@ func (cs *ContractSet) NewDownloader(host modules.HostDBEntry, id types.FileCont
 	} else if err != nil {
 		return nil, err
 	}
+	// if we succeeded, we can safely discard the unappliedTxns
+	for _, txn := range sc.unappliedTxns {
+		txn.SignalUpdatesApplied()
+	}
+	sc.unappliedTxns = nil
 
 	// the host is now ready to accept revisions
 	return &Downloader{

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -207,6 +207,11 @@ func (cs *ContractSet) NewEditor(host modules.HostDBEntry, id types.FileContract
 	} else if err != nil {
 		return nil, err
 	}
+	// if we succeeded, we can safely discard the unappliedTxns
+	for _, txn := range sc.unappliedTxns {
+		txn.SignalUpdatesApplied()
+	}
+	sc.unappliedTxns = nil
 
 	// the host is now ready to accept revisions
 	return &Editor{


### PR DESCRIPTION
This should fix the bug we observed where really old revisions were being loaded.