### PR TITLE
rename contractset.log to contractset.wal

### DIFF
--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -193,7 +193,7 @@ func (g *Gateway) managedAcceptConnv130Peer(conn net.Conn, remoteVersion string)
 			Inbound: true,
 			// NOTE: local may be true even if the supplied NetAddress is not
 			// actually reachable.
-			Local:      remoteAddr.IsLocal(),
+			Local: remoteAddr.IsLocal(),
 			// Ignoring claimed IP address (which should be == to the socket address)
 			// by the host but keeping note of the port number so we can call back
 			NetAddress: modules.NetAddress(net.JoinHostPort(remoteAddr.Host(), remoteHeader.NetAddress.Port())),

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -139,7 +139,12 @@ func NewContractSet(dir string) (*ContractSet, error) {
 
 	// Load the WAL. Any recovered updates will be applied after loading
 	// contracts.
-	walTxns, wal, err := writeaheadlog.New(filepath.Join(dir, "contractset.log"))
+	// COMPATv1.3.1RC2 Rename old wals to have the 'wal' extension.
+	err = os.Rename(filepath.Join(dir, "contractset.log"), filepath.Join(dir, "contractset.wal"))
+	if !os.IsNotExist(err) {
+		return nil, err
+	}
+	walTxns, wal, err := writeaheadlog.New(filepath.Join(dir, "contractset.wal"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR renames the contractset to have the 'wal' extension.