### PR TITLE
check if allowance < allSpending

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -108,8 +108,8 @@ func (c *Contractor) PeriodSpending() modules.ContractorSpending {
 	}
 	allSpending := spending.ContractSpending.Add(spending.DownloadSpending).Add(spending.UploadSpending).Add(spending.StorageSpending)
 
-	// If there is no allowance, the unspent funds are 0
-	if !c.allowance.Funds.IsZero() {
+	// If the allowance is smaller than the spending, the unspent funds are 0
+	if !(c.allowance.Funds.Cmp(allSpending) < 0) {
 		spending.Unspent = c.allowance.Funds.Sub(allSpending)
 	}
 	return spending


### PR DESCRIPTION
It seems like setting the allowance to a value < than the amount of spend funds results in a panic. This PR checks if allowance < allSpending and returns 0 unspent funds if that's the case.