### PR TITLE
Drop siacoin outputs if we failed to build transaction

### DIFF
--- a/modules/wallet/defrag_test.go
+++ b/modules/wallet/defrag_test.go
@@ -15,7 +15,7 @@ func TestDefragWallet(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestDefragWalletDust(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestDefragOutputExhaustion(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/defrag_test.go
+++ b/modules/wallet/defrag_test.go
@@ -15,7 +15,7 @@ func TestDefragWallet(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestDefragWalletDust(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestDefragOutputExhaustion(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/dependencies.go
+++ b/modules/wallet/dependencies.go
@@ -4,7 +4,7 @@ package wallet
 // complexity can be reduced by defining each dependency as the minimum
 // possible subset of the real dependency.
 type (
-	// dependencies defines all of the dependencies of the Host.
+	// Dependencies defines all of the dependencies of the Host.
 	Dependencies interface {
 		// disrupt can be inserted in the code as a way to inject problems,
 		disrupt(string) bool
@@ -12,12 +12,12 @@ type (
 )
 
 type (
-	// productionDependencies is an empty struct
+	// ProductionDependencies is an empty struct
 	ProductionDependencies struct{}
 )
 
 // disrupt will always return false, but can be over-written during testing to
 // trigger disruptions.
-func (ProductionDependencies) disrupt(string) bool {
+func (*ProductionDependencies) disrupt(string) bool {
 	return false
 }

--- a/modules/wallet/dependencies.go
+++ b/modules/wallet/dependencies.go
@@ -1,0 +1,23 @@
+package wallet
+
+// These interfaces define the Wallet's dependencies. Mocking implementation
+// complexity can be reduced by defining each dependency as the minimum
+// possible subset of the real dependency.
+type (
+	// dependencies defines all of the dependencies of the Host.
+	dependencies interface {
+		// disrupt can be inserted in the code as a way to inject problems,
+		disrupt(string) bool
+	}
+)
+
+type (
+	// productionDependencies is an empty struct
+	productionDependencies struct{}
+)
+
+// disrupt will always return false, but can be over-written during testing to
+// trigger disruptions.
+func (productionDependencies) disrupt(string) bool {
+	return false
+}

--- a/modules/wallet/dependencies.go
+++ b/modules/wallet/dependencies.go
@@ -5,7 +5,7 @@ package wallet
 // possible subset of the real dependency.
 type (
 	// dependencies defines all of the dependencies of the Host.
-	dependencies interface {
+	Dependencies interface {
 		// disrupt can be inserted in the code as a way to inject problems,
 		disrupt(string) bool
 	}
@@ -13,11 +13,11 @@ type (
 
 type (
 	// productionDependencies is an empty struct
-	productionDependencies struct{}
+	ProductionDependencies struct{}
 )
 
 // disrupt will always return false, but can be over-written during testing to
 // trigger disruptions.
-func (productionDependencies) disrupt(string) bool {
+func (ProductionDependencies) disrupt(string) bool {
 	return false
 }

--- a/modules/wallet/dependencies_test.go
+++ b/modules/wallet/dependencies_test.go
@@ -5,16 +5,22 @@ type (
 	// SendSiacoins and SendSiacoinsMulti to fail before AcceptTransactionSet
 	// is called
 	dependencySendSiacoinsInterrupted struct {
-		productionDependencies
-		f bool
+		ProductionDependencies
+		f bool // indicates if the next call should fail
 	}
 )
 
 // disrupt will return true if fail was called and the correct string value is
 // provided
-func (d dependencySendSiacoinsInterrupted) disrupt(s string) bool {
-	if s == "SendSiacoinsInterrupted" {
+func (d *dependencySendSiacoinsInterrupted) disrupt(s string) bool {
+	if d.f && s == "SendSiacoinsInterrupted" {
+		d.f = false
 		return true
 	}
 	return false
+}
+
+// fail causes the next SendsiacoinsInterrupted disrupt to return true
+func (d *dependencySendSiacoinsInterrupted) fail() {
+	d.f = true
 }

--- a/modules/wallet/dependencies_test.go
+++ b/modules/wallet/dependencies_test.go
@@ -1,0 +1,20 @@
+package wallet
+
+type (
+	// dependencyAcceptTxnSetFailed is a dependency used to cause a call to
+	// SendSiacoins and SendSiacoinsMulti to fail before AcceptTransactionSet
+	// is called
+	dependencySendSiacoinsInterrupted struct {
+		productionDependencies
+		f bool
+	}
+)
+
+// disrupt will return true if fail was called and the correct string value is
+// provided
+func (d dependencySendSiacoinsInterrupted) disrupt(s string) bool {
+	if s == "SendSiacoinsInterrupted" {
+		return true
+	}
+	return false
+}

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -194,7 +194,7 @@ func TestLock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestInitFromSeedConcurrentUnlock(t *testing.T) {
 		t.SkipNow()
 	}
 	// create a wallet with some money
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func TestUnlockConcurrent(t *testing.T) {
 		t.SkipNow()
 	}
 	// create a wallet with some money
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +349,7 @@ func TestInitFromSeed(t *testing.T) {
 		t.SkipNow()
 	}
 	// create a wallet with some money
-	wt, err := createWalletTester("TestInitFromSeed0", productionDependencies{})
+	wt, err := createWalletTester("TestInitFromSeed0", &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,7 +439,7 @@ func TestChangeKey(t *testing.T) {
 		t.SkipNow()
 	}
 
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -194,7 +194,7 @@ func TestLock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestInitFromSeedConcurrentUnlock(t *testing.T) {
 		t.SkipNow()
 	}
 	// create a wallet with some money
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func TestUnlockConcurrent(t *testing.T) {
 		t.SkipNow()
 	}
 	// create a wallet with some money
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +349,7 @@ func TestInitFromSeed(t *testing.T) {
 		t.SkipNow()
 	}
 	// create a wallet with some money
-	wt, err := createWalletTester("TestInitFromSeed0")
+	wt, err := createWalletTester("TestInitFromSeed0", productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,7 +439,7 @@ func TestChangeKey(t *testing.T) {
 		t.SkipNow()
 	}
 
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -183,7 +183,7 @@ func (w *Wallet) SendSiacoinsMulti(outputs []types.SiacoinOutput) (txns []types.
 		return nil, build.ExtendErr("unable to sign transaction", err)
 	}
 	if w.deps.disrupt("SendSiacoinsInterrupted") {
-		return nil, errors.New("Failed to accept transaction set. (SendSiacoinsInterrupted)")
+		return nil, errors.New("failed to accept transaction set (SendSiacoinsInterrupted)")
 	}
 	err = w.tpool.AcceptTransactionSet(txnSet)
 	if err != nil {

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -120,7 +120,7 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) (txn
 		return nil, build.ExtendErr("unable to sign transaction", err)
 	}
 	if w.deps.disrupt("SendSiacoinsInterrupted") {
-		return nil, errors.New("Failed to accept transaction set. (SendSiacoinsInterrupted)")
+		return nil, errors.New("failed to accept transaction set (SendSiacoinsInterrupted)")
 	}
 	err = w.tpool.AcceptTransactionSet(txnSet)
 	if err != nil {

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"errors"
+
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -112,6 +114,9 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) ([]t
 		w.log.Println("Attempt to send coins has failed - failed to sign transaction:", err)
 		return nil, build.ExtendErr("unable to sign transaction", err)
 	}
+	if w.deps.disrupt("SendSiacoinsInterrupted") {
+		return nil, errors.New("Failed to accept transaction set. (SendSiacoinsInterrupted)")
+	}
 	err = w.tpool.AcceptTransactionSet(txnSet)
 	if err != nil {
 		w.log.Println("Attempt to send coins has failed - transaction pool rejected transaction:", err)
@@ -166,6 +171,9 @@ func (w *Wallet) SendSiacoinsMulti(outputs []types.SiacoinOutput) ([]types.Trans
 	if err != nil {
 		w.log.Println("Attempt to send coins has failed - failed to sign transaction:", err)
 		return nil, build.ExtendErr("unable to sign transaction", err)
+	}
+	if w.deps.disrupt("SendSiacoinsInterrupted") {
+		return nil, errors.New("Failed to accept transaction set. (SendSiacoinsInterrupted)")
 	}
 	err = w.tpool.AcceptTransactionSet(txnSet)
 	if err != nil {

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -207,14 +207,15 @@ func TestSendSiacoinsAcceptTxnSetFailed(t *testing.T) {
 	wt.wallet.mu.Unlock()
 
 	// Try to send coins using SendSiacoinsMulti
-	scos := make([]types.SiacoinOutput, 10)
-	for _, sco := range scos {
+	numOutputs := 10
+	scos := make([]types.SiacoinOutput, numOutputs)
+	for i := 0; i < numOutputs; i++ {
 		uc, err := wt.wallet.NextAddress()
 		if err != nil {
 			t.Fatal(err)
 		}
-		sco.Value = types.SiacoinPrecision
-		sco.UnlockHash = uc.UnlockHash()
+		scos[i].Value = types.SiacoinPrecision
+		scos[i].UnlockHash = uc.UnlockHash()
 	}
 	deps.fail()
 	_, err = wt.wallet.SendSiacoinsMulti(scos)
@@ -242,4 +243,16 @@ func TestSendSiacoinsAcceptTxnSetFailed(t *testing.T) {
 		t.Fatal("bucketSpentOutputs isn't empty")
 	}
 	wt.wallet.mu.Unlock()
+
+	// Send the money again without the failing dependency
+	_, err = wt.wallet.SendSiacoinsMulti(scos)
+	if err != nil {
+		t.Fatalf("SendSiacoinsMulti failed: %v", err)
+	}
+
+	// Send some coins using SendSiacoins
+	_, err = wt.wallet.SendSiacoins(types.SiacoinPrecision, uc.UnlockHash())
+	if err != nil {
+		t.Fatalf("SendSiacoins failed: %v", err)
+	}
 }

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -12,7 +12,7 @@ func TestSendSiacoins(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestIntegrationSendOverUnder(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestIntegrationSpendHalfHalf(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestIntegrationSpendUnconfirmed(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,4 +182,62 @@ func TestIntegrationSortedOutputsSorting(t *testing.T) {
 			t.Error("a value is out of place: ", i)
 		}
 	}
+}
+
+// TestSendSiacoinsFailed checks if SendSiacoins and SendSiacoinsMulti behave
+// correctly when funcing the Transaction succeeded but accepting it didn't.
+func TestSendSiacoinsAcceptTxnSetFailed(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	deps := dependencySendSiacoinsInterrupted{}
+	wt, err := createWalletTester(t.Name(), deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	// There should be no spent transactions in the database at this point
+	wt.wallet.mu.Lock()
+	wt.wallet.syncDB()
+	if wt.wallet.dbTx.Bucket(bucketSpentOutputs).Stats().KeyN != 0 {
+		wt.wallet.mu.Unlock()
+		t.Fatal("bucketSpentOutputs isn't empty")
+	}
+	wt.wallet.mu.Unlock()
+
+	// Try to send coins using SendSiacoinsMulti
+	scos := make([]types.SiacoinOutput, 10)
+	for _, sco := range scos {
+		uc, err := wt.wallet.NextAddress()
+		if err != nil {
+			t.Fatal(err)
+		}
+		sco.Value = types.SiacoinPrecision
+		sco.UnlockHash = uc.UnlockHash()
+	}
+	_, err = wt.wallet.SendSiacoinsMulti(scos)
+	if err == nil {
+		t.Fatal("SendSiacoinsMulti should have failed but didn't")
+	}
+
+	// Send some coins using SendSiacoins
+	uc, err := wt.wallet.NextAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = wt.wallet.SendSiacoins(types.SiacoinPrecision, uc.UnlockHash())
+	if err == nil {
+		t.Fatal("SendSiacoins should have failed but didn't")
+	}
+
+	// There should still be no spent transactions in the database
+	wt.wallet.mu.Lock()
+	wt.wallet.syncDB()
+	bucket := wt.wallet.dbTx.Bucket(bucketSpentOutputs)
+	if bucket.Stats().KeyN != 0 {
+		wt.wallet.mu.Unlock()
+		t.Fatal("bucketSpentOutputs isn't empty")
+	}
+	wt.wallet.mu.Unlock()
 }

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -12,7 +12,7 @@ func TestSendSiacoins(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestIntegrationSendOverUnder(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestIntegrationSpendHalfHalf(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestIntegrationSpendUnconfirmed(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestSendSiacoinsAcceptTxnSetFailed(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	deps := dependencySendSiacoinsInterrupted{}
+	deps := &dependencySendSiacoinsInterrupted{}
 	wt, err := createWalletTester(t.Name(), deps)
 	if err != nil {
 		t.Fatal(err)
@@ -216,6 +216,7 @@ func TestSendSiacoinsAcceptTxnSetFailed(t *testing.T) {
 		sco.Value = types.SiacoinPrecision
 		sco.UnlockHash = uc.UnlockHash()
 	}
+	deps.fail()
 	_, err = wt.wallet.SendSiacoinsMulti(scos)
 	if err == nil {
 		t.Fatal("SendSiacoinsMulti should have failed but didn't")
@@ -226,6 +227,7 @@ func TestSendSiacoinsAcceptTxnSetFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	deps.fail()
 	_, err = wt.wallet.SendSiacoins(types.SiacoinPrecision, uc.UnlockHash())
 	if err == nil {
 		t.Fatal("SendSiacoins should have failed but didn't")

--- a/modules/wallet/scan_test.go
+++ b/modules/wallet/scan_test.go
@@ -90,7 +90,7 @@ func TestScanLoop(t *testing.T) {
 	}
 
 	// create a wallet
-	wt, err := createWalletTester("TestScanLoop", productionDependencies{})
+	wt, err := createWalletTester("TestScanLoop", &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/scan_test.go
+++ b/modules/wallet/scan_test.go
@@ -90,7 +90,7 @@ func TestScanLoop(t *testing.T) {
 	}
 
 	// create a wallet
-	wt, err := createWalletTester("TestScanLoop")
+	wt, err := createWalletTester("TestScanLoop", productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -91,7 +91,7 @@ func TestLoadSeed(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func TestSweepSeedCoins(t *testing.T) {
 	}
 	t.Parallel()
 	// create a wallet with some money
-	wt, err := createWalletTester("TestSweepSeedCoins0", productionDependencies{})
+	wt, err := createWalletTester("TestSweepSeedCoins0", &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestSweepSeedFunds(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestSweepSeedFunds", productionDependencies{})
+	wt, err := createWalletTester("TestSweepSeedFunds", &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func TestSweepSeedSentFunds(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestSweepSeedSentFunds", productionDependencies{})
+	wt, err := createWalletTester("TestSweepSeedSentFunds", &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestSweepSeedCoinsAndFunds(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestSweepSeedCoinsAndFunds", productionDependencies{})
+	wt, err := createWalletTester("TestSweepSeedCoinsAndFunds", &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -91,7 +91,7 @@ func TestLoadSeed(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func TestSweepSeedCoins(t *testing.T) {
 	}
 	t.Parallel()
 	// create a wallet with some money
-	wt, err := createWalletTester("TestSweepSeedCoins0")
+	wt, err := createWalletTester("TestSweepSeedCoins0", productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestSweepSeedFunds(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestSweepSeedFunds")
+	wt, err := createWalletTester("TestSweepSeedFunds", productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func TestSweepSeedSentFunds(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestSweepSeedSentFunds")
+	wt, err := createWalletTester("TestSweepSeedSentFunds", productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestSweepSeedCoinsAndFunds(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Parallel()
-	wt, err := createWalletTester("TestSweepSeedCoinsAndFunds")
+	wt, err := createWalletTester("TestSweepSeedCoinsAndFunds", productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -37,7 +37,7 @@ func TestViewAdded(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestDoubleSignError(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestConcurrentBuilders(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestParallelBuilders(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -37,7 +37,7 @@ func TestViewAdded(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestDoubleSignError(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestConcurrentBuilders(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestParallelBuilders(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/transactions_test.go
+++ b/modules/wallet/transactions_test.go
@@ -13,7 +13,7 @@ func TestIntegrationTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestIntegrationTransaction(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestIntegrationAddressTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestAddressTransactionRevertedBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +251,7 @@ func TestTransactionInputOutputIDs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestTransactionInputOutputIDs(t *testing.T) {
 // using the near-worst-case scenario of 10,000 transactions to search through
 // with only a single relevant transaction.
 func BenchmarkAddressTransactions(b *testing.B) {
-	wt, err := createWalletTester(b.Name())
+	wt, err := createWalletTester(b.Name(), productionDependencies{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/modules/wallet/transactions_test.go
+++ b/modules/wallet/transactions_test.go
@@ -13,7 +13,7 @@ func TestIntegrationTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestIntegrationTransaction(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestIntegrationAddressTransactions(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestAddressTransactionRevertedBlock(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +251,7 @@ func TestTransactionInputOutputIDs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestTransactionInputOutputIDs(t *testing.T) {
 // using the near-worst-case scenario of 10,000 transactions to search through
 // with only a single relevant transaction.
 func BenchmarkAddressTransactions(b *testing.B) {
-	wt, err := createWalletTester(b.Name(), productionDependencies{})
+	wt, err := createWalletTester(b.Name(), &ProductionDependencies{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/modules/wallet/unseeded_test.go
+++ b/modules/wallet/unseeded_test.go
@@ -13,7 +13,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/unseeded_test.go
+++ b/modules/wallet/unseeded_test.go
@@ -13,7 +13,7 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/update_test.go
+++ b/modules/wallet/update_test.go
@@ -12,7 +12,7 @@ func TestUpdate(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestUpdate", productionDependencies{})
+	wt, err := createWalletTester("TestUpdate", &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/update_test.go
+++ b/modules/wallet/update_test.go
@@ -12,7 +12,7 @@ func TestUpdate(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester("TestUpdate")
+	wt, err := createWalletTester("TestUpdate", productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -61,6 +61,7 @@ type Wallet struct {
 	// The wallet's dependencies.
 	cs    modules.ConsensusSet
 	tpool modules.TransactionPool
+	deps  dependencies
 
 	// The following set of fields are responsible for tracking the confirmed
 	// outputs, and for being able to spend them. The seeds are used to derive
@@ -106,6 +107,10 @@ type Wallet struct {
 // not loaded into the wallet during the call to 'new', but rather during the
 // call to 'Unlock'.
 func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string) (*Wallet, error) {
+	return newWallet(cs, tpool, persistDir, productionDependencies{})
+}
+
+func newWallet(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string, deps dependencies) (*Wallet, error) {
 	// Check for nil dependencies.
 	if cs == nil {
 		return nil, errNilConsensusSet
@@ -125,6 +130,8 @@ func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir stri
 		unconfirmedSets: make(map[modules.TransactionSetID][]types.TransactionID),
 
 		persistDir: persistDir,
+
+		deps: deps,
 	}
 	err := w.initPersist()
 	if err != nil {

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -107,10 +107,10 @@ type Wallet struct {
 // not loaded into the wallet during the call to 'new', but rather during the
 // call to 'Unlock'.
 func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string) (*Wallet, error) {
-	return newWallet(cs, tpool, persistDir, productionDependencies{})
+	return newWallet(cs, tpool, persistDir, &ProductionDependencies{})
 }
 
-func newWallet(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string, deps dependencies) (*Wallet, error) {
+func newWallet(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string, deps Dependencies) (*Wallet, error) {
 	// Check for nil dependencies.
 	if cs == nil {
 		return nil, errNilConsensusSet

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -61,7 +61,7 @@ type Wallet struct {
 	// The wallet's dependencies.
 	cs    modules.ConsensusSet
 	tpool modules.TransactionPool
-	deps  dependencies
+	deps  Dependencies
 
 	// The following set of fields are responsible for tracking the confirmed
 	// outputs, and for being able to spend them. The seeds are used to derive

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -31,7 +31,7 @@ type walletTester struct {
 }
 
 // createWalletTester takes a testing.T and creates a WalletTester.
-func createWalletTester(name string, deps dependencies) (*walletTester, error) {
+func createWalletTester(name string, deps Dependencies) (*walletTester, error) {
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
@@ -228,7 +228,7 @@ func TestRescanning(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestLookaheadGeneration(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +333,7 @@ func TestAdvanceLookaheadNoRescan(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -527,7 +527,7 @@ func TestDistantWallets(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name(), productionDependencies{})
+	wt, err := createWalletTester(t.Name(), &ProductionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -31,7 +31,7 @@ type walletTester struct {
 }
 
 // createWalletTester takes a testing.T and creates a WalletTester.
-func createWalletTester(name string) (*walletTester, error) {
+func createWalletTester(name string, deps dependencies) (*walletTester, error) {
 	// Create the modules
 	testdir := build.TempDir(modules.WalletDir, name)
 	g, err := gateway.New("localhost:0", false, filepath.Join(testdir, modules.GatewayDir))
@@ -46,7 +46,7 @@ func createWalletTester(name string) (*walletTester, error) {
 	if err != nil {
 		return nil, err
 	}
-	w, err := New(cs, tp, filepath.Join(testdir, modules.WalletDir))
+	w, err := newWallet(cs, tp, filepath.Join(testdir, modules.WalletDir), deps)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func TestRescanning(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestLookaheadGeneration(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +333,7 @@ func TestAdvanceLookaheadNoRescan(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -527,7 +527,7 @@ func TestDistantWallets(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	wt, err := createWalletTester(t.Name())
+	wt, err := createWalletTester(t.Name(), productionDependencies{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
It seems like we didn't drop outputs when we use the wallets sending functions. This might cause issues.