### PR TITLE
always send conn.LocalAddr in sessionHeader

### DIFF
--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -166,13 +166,14 @@ func acceptableSessionHeader(ourHeader, remoteHeader sessionHeader, remoteAddr s
 // The requesting peer is added as a node and a peer. The peer is only added if
 // a nil error is returned.
 func (g *Gateway) managedAcceptConnv130Peer(conn net.Conn, remoteVersion string) error {
-	g.log.Debugln("Sending sessionHeader with address", g.myAddr, g.myAddr.IsLocal())
 	// Perform header handshake.
 	g.mu.RLock()
+	host, _, _ := net.SplitHostPort(conn.LocalAddr().String())
+	ourAddr := modules.NetAddress(net.JoinHostPort(host, g.myAddr.Port()))
 	ourHeader := sessionHeader{
 		GenesisID:  types.GenesisID,
 		UniqueID:   g.id,
-		NetAddress: g.myAddr,
+		NetAddress: ourAddr,
 	}
 	g.mu.RUnlock()
 
@@ -358,13 +359,14 @@ func exchangeRemoteHeader(conn net.Conn, ourHeader sessionHeader) (sessionHeader
 // managedConnectv130Peer connects to peers >= v1.3.0. The peer is added as a
 // node and a peer. The peer is only added if a nil error is returned.
 func (g *Gateway) managedConnectv130Peer(conn net.Conn, remoteVersion string, remoteAddr modules.NetAddress) error {
-	g.log.Debugln("Sending sessionHeader with address", g.myAddr, g.myAddr.IsLocal())
 	// Perform header handshake.
 	g.mu.RLock()
+	host, _, _ := net.SplitHostPort(conn.LocalAddr().String())
+	ourAddr := modules.NetAddress(net.JoinHostPort(host, g.myAddr.Port()))
 	ourHeader := sessionHeader{
 		GenesisID:  types.GenesisID,
 		UniqueID:   g.id,
-		NetAddress: g.myAddr,
+		NetAddress: ourAddr,
 	}
 	g.mu.RUnlock()
 


### PR DESCRIPTION
Since older nodes reject hostnames that don't match the connection, just send whatever hostname the connection reports. This should resolve the issue of IPv6 peers being rejected by IPv4 peers.

cc @dNetGuru 