### PR TITLE
expose the api server from the api package

### DIFF
--- a/api/renterhost_test.go
+++ b/api/renterhost_test.go
@@ -89,7 +89,7 @@ func TestHostObligationAcceptingContracts(t *testing.T) {
 
 	// redundancy should reach 1
 	var rf RenterFiles
-	err = retry(60, time.Second, func() error {
+	err = retry(120, time.Millisecond*250, func() error {
 		st.getAPI("/renter/files", &rf)
 		if len(rf.Files) >= 1 && rf.Files[0].Available {
 			return nil
@@ -109,7 +109,7 @@ func TestHostObligationAcceptingContracts(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(time.Millisecond * 200)
+		time.Sleep(time.Millisecond * 100)
 	}
 	downloadPath := filepath.Join(st.dir, "test-downloaded-verify.dat")
 	err = st.stdGetAPI("/renter/download/test?destination=" + downloadPath)
@@ -123,7 +123,7 @@ func TestHostObligationAcceptingContracts(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(time.Millisecond * 200)
+		time.Sleep(time.Millisecond * 100)
 	}
 
 	// should have successful proofs
@@ -249,6 +249,15 @@ func TestRenterLocalRepair(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Mine a block so the renter realizes the host is offline.
+	b, err := st.miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = waitForBlock(b.ID(), st)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// wait for the redundancy to decrement
 	err = retry(60, time.Second, func() error {
@@ -270,7 +279,6 @@ func TestRenterLocalRepair(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer stNewHost.server.Close()
-
 	testGroup = []*serverTester{st, stNewHost}
 
 	// Connect the testers to eachother so that they are all on the same
@@ -290,6 +298,7 @@ func TestRenterLocalRepair(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Set up storage on the new host.
 	err = stNewHost.setHostStorage()
 	if err != nil {
 		t.Fatal(err)
@@ -298,11 +307,14 @@ func TestRenterLocalRepair(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = stNewHost.miner.AddBlock()
+	// Mine a block so the renter sees the host in its hostdb. Need to mine two
+	// blocks because after the announcement, the renter node's blockchain is
+	// actually behind.
+	b, err = stNewHost.miner.AddBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = waitForBlock(stNewHost.cs.CurrentBlock().ID(), st)
+	err = waitForBlock(b.ID(), testGroup[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,6 +341,20 @@ func TestRenterLocalRepair(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err, ah)
+	}
+
+	// Mine a block so the contractor sees that it can form a new contract.
+	b, err = testGroup[0].miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = waitForBlock(b.ID(), testGroup[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = synchronizationCheck(testGroup)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// Block until we formed a contract with the new host.
@@ -556,6 +582,16 @@ func TestRemoteFileRepair(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mine a block so the contractor sees that it can form a new contract.
+	_, err = testGroup[0].miner.AddBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = synchronizationCheck(testGroup)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/NebulousLabs/Sia/modules"
+
+	"github.com/NebulousLabs/errors"
+	"github.com/NebulousLabs/threadgroup"
+)
+
+// A Server is a collection of siad modules that can be communicated with over
+// an http api.
+type Server struct {
+	api               *API
+	apiServer         *http.Server
+	listener          net.Listener
+	requiredUserAgent string
+	tg                threadgroup.ThreadGroup
+}
+
+// Close closes the Server's listener, causing the HTTP server to shut down.
+func (srv *Server) Close() error {
+	err := srv.tg.Stop()
+	if err != nil {
+		return errors.AddContext(err, "unable to close server")
+	}
+
+	// Safely close each module.
+	var errs []error
+	mods := []struct {
+		name string
+		c    io.Closer
+	}{
+		{"explorer", srv.api.explorer},
+		{"host", srv.api.host},
+		{"renter", srv.api.renter},
+		{"miner", srv.api.miner},
+		{"wallet", srv.api.wallet},
+		{"tpool", srv.api.tpool},
+		{"consensus", srv.api.cs},
+		{"gateway", srv.api.gateway},
+	}
+	for _, mod := range mods {
+		if mod.c != nil {
+			if err := mod.c.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("%v.Close failed: %v", mod.name, err))
+			}
+		}
+	}
+	return errors.Compose(errs...)
+}
+
+// Serve listens for and handles API calls. It is a blocking function.
+func (srv *Server) Serve() error {
+	err := srv.tg.Add()
+	if err != nil {
+		return errors.AddContext(err, "unable to initialize server")
+	}
+	defer srv.tg.Done()
+
+	// The server will run until an error is encountered or the listener is
+	// closed, via either the Close method or by signal handling.  Closing the
+	// listener will result in the benign error handled below.
+	err = srv.apiServer.Serve(srv.listener)
+	if err != nil && !strings.HasSuffix(err.Error(), "use of closed network connection") {
+		return err
+	}
+	return nil
+}
+
+// NewServer creates a new API server from the provided modules. The API will
+// require authentication using HTTP basic auth if the supplied password is not
+// the empty string. Usernames are ignored for authentication. This type of
+// authentication sends passwords in plaintext and should therefore only be
+// used if the APIaddr is localhost.
+func NewServer(APIaddr string, requiredUserAgent string, requiredPassword string, cs modules.ConsensusSet, e modules.Explorer, g modules.Gateway, h modules.Host, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet) (*Server, error) {
+	var tg threadgroup.ThreadGroup
+	listener, err := net.Listen("tcp", APIaddr)
+	if err != nil {
+		return nil, err
+	}
+	tg.OnStop(func() error {
+		return errors.AddContext(listener.Close(), "unable to close server listener")
+	})
+
+	api := New(requiredUserAgent, requiredPassword, cs, e, g, h, m, r, tp, w)
+	srv := &Server{
+		api: api,
+
+		listener:          listener,
+		requiredUserAgent: requiredUserAgent,
+		apiServer: &http.Server{
+			Handler: api,
+		},
+	}
+	return srv, nil
+}

--- a/api/server_helpers_test.go
+++ b/api/server_helpers_test.go
@@ -3,15 +3,10 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
 	"runtime/debug"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -30,22 +25,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
-// A Server is essentially a collection of modules and an API server to talk
-// to them all.
-type Server struct {
-	api *API
-
-	apiServer         *http.Server
-	listener          net.Listener
-	requiredUserAgent string
-
-	// wg is used to block Close() from returning until Serve() has finished. A
-	// WaitGroup is used instead of a chan struct{} so that Close() can be called
-	// without necessarily calling Serve() first.
-	wg sync.WaitGroup
-}
-
-// panicClose will cloae a Server, panicking if there is an error upon close.
+// panicClose will close a Server, panicking if there is an error upon close.
 func (srv *Server) panicClose() {
 	err := srv.Close()
 	if err != nil {
@@ -53,86 +33,6 @@ func (srv *Server) panicClose() {
 		debug.PrintStack()
 		panic(err)
 	}
-}
-
-// Close closes the Server's listener, causing the HTTP server to shut down.
-func (srv *Server) Close() error {
-	var errs []error
-
-	// Close the listener, which will cause Server.Serve() to return.
-	if err := srv.listener.Close(); err != nil {
-		errs = append(errs, fmt.Errorf("listener.Close failed: %v", err))
-	}
-
-	// Wait for Server.Serve() to exit. We wait so that it's guaranteed that the
-	// server has completely closed after Close() returns. This is particularly
-	// useful during testing so that we don't exit a test before Serve() finishes.
-	srv.wg.Wait()
-
-	// Safely close each module.
-	mods := []struct {
-		name string
-		c    io.Closer
-	}{
-		{"explorer", srv.api.explorer},
-		{"host", srv.api.host},
-		{"renter", srv.api.renter},
-		{"miner", srv.api.miner},
-		{"wallet", srv.api.wallet},
-		{"tpool", srv.api.tpool},
-		{"consensus", srv.api.cs},
-		{"gateway", srv.api.gateway},
-	}
-	for _, mod := range mods {
-		if mod.c != nil {
-			if err := mod.c.Close(); err != nil {
-				errs = append(errs, fmt.Errorf("%v.Close failed: %v", mod.name, err))
-			}
-		}
-	}
-
-	return build.JoinErrors(errs, "\n")
-}
-
-// Serve listens for and handles API calls. It is a blocking function.
-func (srv *Server) Serve() error {
-	// Block the Close() method until Serve() has finished.
-	srv.wg.Add(1)
-	defer srv.wg.Done()
-
-	// The server will run until an error is encountered or the listener is
-	// closed, via either the Close method or the signal handling above.
-	// Closing the listener will result in the benign error handled below.
-	err := srv.apiServer.Serve(srv.listener)
-	if err != nil && !strings.HasSuffix(err.Error(), "use of closed network connection") {
-		return err
-	}
-	return nil
-}
-
-// NewServer creates a new API server from the provided modules. The API will
-// require authentication using HTTP basic auth if the supplied password is not
-// the empty string. Usernames are ignored for authentication. This type of
-// authentication sends passwords in plaintext and should therefore only be
-// used if the APIaddr is localhost.
-func NewServer(APIaddr string, requiredUserAgent string, requiredPassword string, cs modules.ConsensusSet, e modules.Explorer, g modules.Gateway, h modules.Host, m modules.Miner, r modules.Renter, tp modules.TransactionPool, w modules.Wallet) (*Server, error) {
-	l, err := net.Listen("tcp", APIaddr)
-	if err != nil {
-		return nil, err
-	}
-
-	a := New(requiredUserAgent, requiredPassword, cs, e, g, h, m, r, tp, w)
-	srv := &Server{
-		api: a,
-
-		listener:          l,
-		requiredUserAgent: requiredUserAgent,
-		apiServer: &http.Server{
-			Handler: a,
-		},
-	}
-
-	return srv, nil
 }
 
 // serverTester contains a server and a set of channels for keeping all of the


### PR DESCRIPTION
After some feedback from the community, I realized we should be exposing both server and client functions from the api package. Right now if you want to create your own Sia instance in go code, you have to create your own listener and server. Now we've got functions to do that.

You still have to create all of your own modules and dependency chains, so while this removes one of the annoying steps, it doesn't remove the biggest one.