### PR TITLE
add node creation framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ run = .
 pkgs = ./api ./build ./compatibility ./crypto ./encoding ./modules ./modules/consensus                                  \
        ./modules/explorer ./modules/gateway ./modules/host ./modules/host/contractmanager                               \
        ./modules/renter ./modules/renter/contractor ./modules/renter/hostdb ./modules/renter/hostdb/hosttree            \
-       ./modules/renter/proto ./modules/miner ./modules/wallet ./modules/transactionpool ./persist                      \
+       ./modules/renter/proto ./modules/miner ./modules/wallet ./modules/transactionpool ./node ./persist ./siatest     \
        ./cmd/siad ./cmd/siac ./sync ./types
 
 # fmt calls go fmt on all packages.
@@ -51,7 +51,8 @@ vet: release-std
 	go vet $(pkgs)
 
 # will always run on some packages for a while.
-lintpkgs = ./modules ./modules/gateway ./modules/host ./modules/renter/hostdb ./modules/renter/contractor ./persist
+lintpkgs = ./modules ./modules/gateway ./modules/host ./modules/renter/hostdb ./modules/renter/contractor ./node        \
+           ./persist ./siatest
 lint:
 	@for package in $(lintpkgs); do                           \
 		golint -min_confidence=1.0 $$package                  \

--- a/api/ecosystem_helpers_test.go
+++ b/api/ecosystem_helpers_test.go
@@ -113,7 +113,7 @@ func announceAllHosts(sts []*serverTester) error {
 	// that each node has a full hostdb.
 	for _, st := range sts {
 		var ah HostdbActiveGET
-		for i := 0; i < 50; i++ {
+		for i := 0; i < 100; i++ {
 			err = st.getAPI("/hostdb/active", &ah)
 			if err != nil {
 				return err

--- a/api/renter_test.go
+++ b/api/renter_test.go
@@ -1505,9 +1505,6 @@ func TestRenterPricesHandlerPricey(t *testing.T) {
 	// Grab the price estimates for when there are a bunch of hosts with the
 	// same stats.
 	var rpeMulti modules.RenterPriceEstimation
-	if err = st.announceHost(); err != nil {
-		t.Fatal(err)
-	}
 	if err = st.getAPI("/renter/prices", &rpeMulti); err != nil {
 		t.Fatal(err)
 	}

--- a/modules/miner.go
+++ b/modules/miner.go
@@ -57,9 +57,6 @@ type TestMiner interface {
 	// each can safely start from nonce 0.
 	BlockForWork() (types.Block, types.Target, error)
 
-	// Close is necessary for clean shutdown during testing.
-	Close() error
-
 	// FindBlock will have the miner make 1 attempt to find a solved block that
 	// builds on the current consensus set. It will give up after a few
 	// seconds, returning the block and a bool indicating whether the block is
@@ -70,6 +67,10 @@ type TestMiner interface {
 	// which amounts to trying a few thousand different nonces. SolveBlock is
 	// primarily used for testing.
 	SolveBlock(types.Block, types.Target) (types.Block, bool)
+
+	// Needs to have all other miner functions in addition to shortcuts for
+	// mining blocks.
+	Miner
 }
 
 // The Miner interface provides access to mining features.

--- a/node/node.go
+++ b/node/node.go
@@ -117,12 +117,12 @@ func (n *Node) Close() (err error) {
 	return err
 }
 
-// NewNode will create a new test node. The inputs to the function are the
-// respective 'New' calls for each module. We need to use this awkward method
-// of initialization because the siatest package cannot import any of the
-// modules directly (so that the modules may use the siatest package to test
+// New will create a new test node. The inputs to the function are the
+// respective 'New' calls for each module. We need to use this awkward method of
+// initialization because the siatest package cannot import any of the modules
+// directly (so that the modules may use the siatest package to test
 // themselves).
-func NewNode(params NodeParams) (*Node, error) {
+func New(params NodeParams) (*Node, error) {
 	dir := params.Dir
 
 	// Gateway.

--- a/node/node.go
+++ b/node/node.go
@@ -1,0 +1,289 @@
+// Package node provides tooling for creating a Sia node. Sia nodes consist of a
+// collection of modules. The node package gives you tools to easily assemble
+// various combinations of modules with varying dependencies and settings,
+// including templates for assembling sane no-hassle Sia nodes.
+package node
+
+// TODO: Add support for the explorer.
+
+// TODO: Add support for custom dependencies for all of the modules.
+
+import (
+	"path/filepath"
+
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/modules/consensus"
+	"github.com/NebulousLabs/Sia/modules/gateway"
+	"github.com/NebulousLabs/Sia/modules/host"
+	"github.com/NebulousLabs/Sia/modules/miner"
+	"github.com/NebulousLabs/Sia/modules/renter"
+	"github.com/NebulousLabs/Sia/modules/transactionpool"
+	"github.com/NebulousLabs/Sia/modules/wallet"
+
+	"github.com/NebulousLabs/errors"
+)
+
+// NodeParams contains a bunch of parameters for creating a new test node. As
+// there are many options, templates are provided that you can modify which
+// cover the most common use cases.
+//
+// Each module is created separately. There are several ways to create a module,
+// though not all methods are currently available for each module. You should
+// only use one method for creating a module, using multiple methods will cause
+// an error.
+//		+ Indicate with the 'CreateModule' bool that a module should be created
+//		  automatically. To create the module with custom dependencies, pass the
+//		  custom dependencies in using the 'ModuleDependencies' field.
+//		+ Pass an existing module in directly.
+//		+ Set 'CreateModule' to false and do not pass in an existing module.
+//		  This will result in a 'nil' module, meaning the node will not have
+//		  that module.
+type NodeParams struct {
+	// Omissions - if the omit flag is set for a module, that module will not
+	// be included in the test node.
+	//
+	// If you omit a module, you will implicitly omit all dependencies as well.
+	CreateConsensusSet    bool
+	CreateExplorer        bool
+	CreateGateway         bool
+	CreateHost            bool
+	CreateMiner           bool
+	CreateRenter          bool
+	CreateTransactionPool bool
+	CreateWallet          bool
+
+	// Custom modules - if the modules is provided directly, the provided
+	// module will be used instead of creating a new one. If a custom module is
+	// provided, the 'omit' flag for that module must be set to false (which is
+	// the default setting).
+	ConsensusSet    modules.ConsensusSet
+	Explorer        modules.Explorer
+	Gateway         modules.Gateway
+	Host            modules.Host
+	Miner           modules.TestMiner
+	Renter          modules.Renter
+	TransactionPool modules.TransactionPool
+	Wallet          modules.Wallet
+
+	// The high level directory where all the persistence gets stored for the
+	// moudles.
+	Dir string
+}
+
+// Node is a collection of Sia modules operating together as a Sia node.
+type Node struct {
+	// The modules of the node. Modules that are not initialized will be nil.
+	ConsensusSet    modules.ConsensusSet
+	Explorer        modules.Explorer
+	Gateway         modules.Gateway
+	Host            modules.Host
+	Miner           modules.TestMiner
+	Renter          modules.Renter
+	TransactionPool modules.TransactionPool
+	Wallet          modules.Wallet
+
+	// The high level directory where all the persistence gets stored for the
+	// moudles.
+	Dir string
+}
+
+// Close will call close on every module within the node, combining and
+// returning the errors.
+func (n *Node) Close() (err error) {
+	if n.Explorer != nil {
+		err = errors.Compose(n.Explorer.Close())
+	}
+	if n.Miner != nil {
+		err = errors.Compose(n.Miner.Close())
+	}
+	if n.Host != nil {
+		err = errors.Compose(n.Host.Close())
+	}
+	if n.Renter != nil {
+		err = errors.Compose(n.Renter.Close())
+	}
+	if n.Wallet != nil {
+		err = errors.Compose(n.Wallet.Close())
+	}
+	if n.TransactionPool != nil {
+		err = errors.Compose(n.TransactionPool.Close())
+	}
+	if n.ConsensusSet != nil {
+		err = errors.Compose(n.ConsensusSet.Close())
+	}
+	if n.Gateway != nil {
+		err = errors.Compose(n.Gateway.Close())
+	}
+	return err
+}
+
+// NewNode will create a new test node. The inputs to the function are the
+// respective 'New' calls for each module. We need to use this awkward method
+// of initialization because the siatest package cannot import any of the
+// modules directly (so that the modules may use the siatest package to test
+// themselves).
+func NewNode(params NodeParams) (*Node, error) {
+	dir := params.Dir
+
+	// Gateway.
+	g, err := func() (modules.Gateway, error) {
+		if params.CreateGateway && params.Gateway != nil {
+			return nil, errors.New("cannot both create a gateway and use a passed in gateway")
+		}
+		/* Template for dealing with optional dependencies:
+		if !params.CreateGateway && parames.GatewayDependencies != nil {
+			return nil, errors.New("cannot pass in gateway dependencies if you are not creating a gateway")
+		}
+		*/
+		if params.Gateway != nil {
+			return params.Gateway, nil
+		}
+		if !params.CreateGateway {
+			return nil, nil
+		}
+		/* Template for dealing with optional dependencies:
+		if params.GatewayDependencies == nil {
+			gateway.New(...
+		} else {
+			gateway.NewDeps(...
+		}
+		*/
+		return gateway.New("localhost:0", false, filepath.Join(dir, modules.GatewayDir))
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create gateway"))
+	}
+
+	// Consensus.
+	cs, err := func() (modules.ConsensusSet, error) {
+		if params.CreateConsensusSet && params.ConsensusSet != nil {
+			return nil, errors.New("cannot both create consensus and use passed in consensus")
+		}
+		if params.ConsensusSet != nil {
+			return params.ConsensusSet, nil
+		}
+		if !params.CreateConsensusSet {
+			return nil, nil
+		}
+		return consensus.New(g, false, filepath.Join(dir, modules.ConsensusDir))
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create consensus set"))
+	}
+
+	// Transaction Pool.
+	tp, err := func() (modules.TransactionPool, error) {
+		if params.CreateTransactionPool && params.TransactionPool != nil {
+			return nil, errors.New("cannot create transaction pool and also use custom transaction pool")
+		}
+		if params.TransactionPool != nil {
+			return params.TransactionPool, nil
+		}
+		if !params.CreateTransactionPool {
+			return nil, nil
+		}
+		return transactionpool.New(cs, g, filepath.Join(dir, modules.TransactionPoolDir))
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create transaction pool"))
+	}
+
+	// Wallet.
+	w, err := func() (modules.Wallet, error) {
+		if params.CreateWallet && params.Wallet != nil {
+			return nil, errors.New("cannot create wallet and use custom wallet")
+		}
+		if params.Wallet != nil {
+			return params.Wallet, nil
+		}
+		if !params.CreateWallet {
+			return nil, nil
+		}
+		return wallet.New(cs, tp, filepath.Join(dir, modules.WalletDir))
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create wallet"))
+	}
+
+	// Host.
+	h, err := func() (modules.Host, error) {
+		if params.CreateHost && params.Host != nil {
+			return nil, errors.New("cannot create host and use custom host")
+		}
+		if params.Host != nil {
+			return params.Host, nil
+		}
+		if !params.CreateHost {
+			return nil, nil
+		}
+		return host.New(cs, tp, w, "localhost:0", filepath.Join(dir, modules.HostDir))
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create host"))
+	}
+
+	// Renter.
+	r, err := func() (modules.Renter, error) {
+		if params.CreateRenter && params.Renter != nil {
+			return nil, errors.New("cannot create renter and also use custom renter")
+		}
+		if params.Renter != nil {
+			return params.Renter, nil
+		}
+		if !params.CreateRenter {
+			return nil, nil
+		}
+		return renter.New(g, cs, w, tp, filepath.Join(dir, modules.RenterDir))
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create renter"))
+	}
+
+	// Miner.
+	m, err := func() (modules.TestMiner, error) {
+		if params.CreateMiner && params.Miner != nil {
+			return nil, errors.New("cannot create miner and also use custom miner")
+		}
+		if params.Miner != nil {
+			return params.Miner, nil
+		}
+		if !params.CreateMiner {
+			return nil, nil
+		}
+		return miner.New(cs, tp, w, filepath.Join(dir, modules.MinerDir))
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create miner"))
+	}
+
+	// Explorer.
+	e, err := func() (modules.Explorer, error) {
+		if !params.CreateExplorer && params.Explorer != nil {
+			return nil, errors.New("cannot create explorer and also use custom explorer")
+		}
+		if params.Explorer != nil {
+			return params.Explorer, nil
+		}
+		if !params.CreateExplorer {
+			return nil, nil
+		}
+		// TODO: Implement explorer.
+		return nil, errors.New("explorer not implemented")
+	}()
+	if err != nil {
+		return nil, errors.Extend(err, errors.New("unable to create explorer"))
+	}
+
+	return &Node{
+		ConsensusSet:    cs,
+		Explorer:        e,
+		Gateway:         g,
+		Host:            h,
+		Miner:           m,
+		Renter:          r,
+		TransactionPool: tp,
+		Wallet:          w,
+
+		Dir: dir,
+	}, nil
+}

--- a/node/templates.go
+++ b/node/templates.go
@@ -1,0 +1,46 @@
+package node
+
+// templates.go contains a bunch of sane default templates that you can use to
+// create Sia nodes.
+
+var (
+	// AllModulesTemplate is a template for a Sia node that has all modules
+	// enabled.
+	AllModulesTemplate = NodeParams{
+		CreateConsensusSet:    true,
+		CreateExplorer:        false, // TODO: Implement explorer.
+		CreateGateway:         true,
+		CreateHost:            true,
+		CreateMiner:           true,
+		CreateRenter:          true,
+		CreateTransactionPool: true,
+		CreateWallet:          true,
+	}
+
+	// WalletTemplate is a template for a Sia node that has a functioning
+	// wallet. The node has a wallet and all dependencies, but no other modules.
+	WalletTemplate = NodeParams{
+		CreateConsensusSet:    true,
+		CreateExplorer:        false,
+		CreateGateway:         true,
+		CreateHost:            false,
+		CreateMiner:           false,
+		CreateRenter:          false,
+		CreateTransactionPool: true,
+		CreateWallet:          true,
+	}
+)
+
+// AllModules returns an AllModulesTemplate filled out with the provided dir.
+func AllModules(dir string) NodeParams {
+	template := AllModulesTemplate
+	template.Dir = dir
+	return template
+}
+
+// Wallet returns a WalletTemplate filled out with the provided dir.
+func Wallet(dir string) NodeParams {
+	template := WalletTemplate
+	template.Dir = dir
+	return template
+}

--- a/node/templates_test.go
+++ b/node/templates_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/NebulousLabs/Sia/siatest"
 )
 
-// TestNewNode is a basic smoke test for NewNode that uses all of the templates
-// to verify a working NewNode function.
-func TestNewNode(t *testing.T) {
+// TestNew is a basic smoke test for New that uses all of the templates to
+// verify a working New function.
+func TestNew(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -18,7 +18,7 @@ func TestNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n, err := NewNode(AllModules(dir))
+	n, err := New(AllModules(dir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n, err = NewNode(Wallet(dir))
+	n, err = New(Wallet(dir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/templates_test.go
+++ b/node/templates_test.go
@@ -1,0 +1,92 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/NebulousLabs/Sia/siatest"
+)
+
+// TestNewNode is a basic smoke test for NewNode that uses all of the templates
+// to verify a working NewNode function.
+func TestNewNode(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Test AllModulesTemplate.
+	dir, err := siatest.TestDir("node", t.Name()+"-AllModulesTemplate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := NewNode(AllModules(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.Gateway == nil {
+		t.Error("gateway not set correctly")
+	}
+	if n.ConsensusSet == nil {
+		t.Error("consensus set not set correctly")
+	}
+	if n.Explorer == nil {
+		// TODO: Add the explorer to the node package.
+		t.Log("Need to add the explorer to the SiaNode framework.")
+	}
+	if n.TransactionPool == nil {
+		t.Error("transaction pool not set correctly")
+	}
+	if n.Wallet == nil {
+		t.Error("wallet not set correctly")
+	}
+	if n.Host == nil {
+		t.Error("host not set correctly")
+	}
+	if n.Renter == nil {
+		t.Error("renter not set correctly")
+	}
+	if n.Miner == nil {
+		t.Error("miner not set correctly")
+	}
+	err = n.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test WalletTemplate.
+	dir, err = siatest.TestDir("node", t.Name()+"-WalletTemplate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err = NewNode(Wallet(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n.Gateway == nil {
+		t.Error("gateway not set correctly")
+	}
+	if n.ConsensusSet == nil {
+		t.Error("consensus set not set correctly")
+	}
+	if n.Explorer != nil {
+		t.Error("explorer should not be created when using the wallet template")
+	}
+	if n.TransactionPool == nil {
+		t.Error("transaction pool not set correctly")
+	}
+	if n.Wallet == nil {
+		t.Error("wallet not set correctly")
+	}
+	if n.Host != nil {
+		t.Error("host should not be created when using the wallet template")
+	}
+	if n.Renter != nil {
+		t.Error("renter should not be created when using the wallet template")
+	}
+	if n.Miner != nil {
+		t.Error("miner should not be created when using the wallet template")
+	}
+	err = n.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/siatest/dir.go
+++ b/siatest/dir.go
@@ -1,0 +1,24 @@
+package siatest
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	// SiaTestingDir is the directory that contains all of the files and
+	// folders created during testing.
+	SiaTestingDir = filepath.Join(os.TempDir(), "SiaTesting")
+)
+
+// TestDir joins the provided directories and prefixes them with the Sia
+// testing directory, removing any files or directories that previously existed
+// at that location.
+func TestDir(dirs ...string) (string, error) {
+	path := filepath.Join(SiaTestingDir, filepath.Join(dirs...))
+	err := os.RemoveAll(path)
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/siatest/retry.go
+++ b/siatest/retry.go
@@ -1,0 +1,20 @@
+package siatest
+
+import (
+	"time"
+)
+
+// Retry will call 'fn' 'tries' times, waiting 'durationBetweenAttempts'
+// between each attempt, returning 'nil' the first time that 'fn' returns nil.
+// If 'nil' is never returned, then the final error returned by 'fn' is
+// returned.
+func Retry(tries int, durationBetweenAttempts time.Duration, fn func() error) (err error) {
+	for i := 1; i < tries; i++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(durationBetweenAttempts)
+	}
+	return fn()
+}


### PR DESCRIPTION
Now we've got an easy function to create a node, and templates that allow you to easily choose from some sane defaults. It's also pretty easy to start from a template by making a copy, and then make just a few tweaks to get what you need without having to fill out the whole struct yourself.

The goal here was to make it easy to create a Sia instance.

Next up will be the `server` package, and then the `client` package.