### PR TITLE
Add vlong test for wallet's transaction output

### DIFF
--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -409,7 +409,7 @@ type (
 
 	// WalletSettings control the behavior of the Wallet.
 	WalletSettings struct {
-		Defrag bool `json:"defrag"`
+		NoDefrag bool `json:"noDefrag"`
 	}
 )
 

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -377,6 +377,12 @@ type (
 		// blockchain.
 		Rescanning() bool
 
+		// Settings returns the Wallet's current settings.
+		Settings() WalletSettings
+
+		// SetSettings sets the Wallet's settings.
+		SetSettings(WalletSettings)
+
 		// StartTransaction is a convenience method that calls
 		// RegisterTransaction(types.Transaction{}, nil)
 		StartTransaction() TransactionBuilder
@@ -399,6 +405,11 @@ type (
 		// DustThreshold returns the quantity per byte below which a Currency is
 		// considered to be Dust.
 		DustThreshold() types.Currency
+	}
+
+	// WalletSettings control the behavior of the Wallet.
+	WalletSettings struct {
+		Defrag bool `json:"defrag"`
 	}
 )
 

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -128,6 +128,11 @@ func (w *Wallet) managedCreateDefragTransaction() ([]types.Transaction, error) {
 // operation is only performed if the wallet has greater than defragThreshold
 // outputs.
 func (w *Wallet) threadedDefragWallet() {
+	// Don't defrag if it was disabled
+	if w.defragDisabled {
+		return
+	}
+
 	err := w.tg.Add()
 	if err != nil {
 		return

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -100,6 +100,10 @@ type Wallet struct {
 	// The wallet's ThreadGroup tells tracked functions to shut down and
 	// blocks until they have all exited before returning from Close.
 	tg siasync.ThreadGroup
+
+	// defragDisabled determines if the wallet is set to defrag outputs once it
+	// reaches a certain threshold
+	defragDisabled bool
 }
 
 // New creates a new wallet, loading any known addresses from the input file
@@ -207,4 +211,16 @@ func (w *Wallet) Rescanning() bool {
 		w.scanLock.Unlock()
 	}
 	return rescanning
+}
+
+// Returns the wallet's current settings
+func (w *Wallet) Settings() modules.WalletSettings {
+	return modules.WalletSettings{
+		Defrag: !w.defragDisabled,
+	}
+}
+
+// SetSettings will update the settings for the wallet.
+func (w *Wallet) SetSettings(s modules.WalletSettings) {
+	w.defragDisabled = !s.Defrag
 }

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -216,11 +216,11 @@ func (w *Wallet) Rescanning() bool {
 // Returns the wallet's current settings
 func (w *Wallet) Settings() modules.WalletSettings {
 	return modules.WalletSettings{
-		Defrag: !w.defragDisabled,
+		NoDefrag: w.defragDisabled,
 	}
 }
 
 // SetSettings will update the settings for the wallet.
 func (w *Wallet) SetSettings(s modules.WalletSettings) {
-	w.defragDisabled = !s.Defrag
+	w.defragDisabled = s.NoDefrag
 }

--- a/node/api/wallet_test.go
+++ b/node/api/wallet_test.go
@@ -1474,3 +1474,158 @@ func TestWalletGETDust(t *testing.T) {
 		t.Fatal("dustThreshold mismatch")
 	}
 }
+
+// testWalletTransactionEndpoint is a subtest that queries the transaction endpoint of a node.
+func testWalletTransactionEndpoint(t *testing.T, st *serverTester) {
+	// Mining blocks should have created transactions for the wallet containing
+	// miner payouts. Get the list of transactions.
+	var wtg WalletTransactionsGET
+	err := st.getAPI("/wallet/transactions?startheight=0&endheight=-1", &wtg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Query the details of all transactions using
+	// /wallet/transaction/:id
+	for _, txn := range wtg.ConfirmedTransactions {
+		var wtgid WalletTransactionGETid
+		wtgidQuery := fmt.Sprintf("/wallet/transaction/%s", txn.TransactionID)
+		err = st.getAPI(wtgidQuery, &wtgid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if wtgid.Transaction.TransactionID != txn.TransactionID {
+			t.Fatalf("Expected txn with id %v but was %v", txn.TransactionID, wtgid.Transaction.TransactionID)
+		}
+	}
+}
+
+// testWalletTransactionEndpoint is a subtest that queries the transactions endpoint of a node.
+func testWalletTransactionsEndpoint(t *testing.T, st *serverTester) {
+	var wtg WalletTransactionsGET
+	err := st.getAPI("/wallet/transactions?startheight=0&endheight=-1", &wtg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	totalTxns := len(wtg.ConfirmedTransactions)
+
+	// Query the details of all transactions one block at a time using
+	// /wallet/transactions
+	queriedTxns := 0
+	for i := types.BlockHeight(0); i <= st.cs.Height(); i++ {
+		err := st.getAPI(fmt.Sprintf("/wallet/transactions?startheight=%v&endheight=%v", i, i), &wtg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		queriedTxns += len(wtg.ConfirmedTransactions)
+	}
+	if queriedTxns != totalTxns {
+		t.Errorf("Expected %v txns but was %v", totalTxns, queriedTxns)
+	}
+
+	queriedTxns = 0
+	batchSize := types.BlockHeight(5)
+	for i := types.BlockHeight(0); i <= st.cs.Height(); i += (batchSize + 1) {
+		err := st.getAPI(fmt.Sprintf("/wallet/transactions?startheight=%v&endheight=%v", i, i+batchSize), &wtg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		queriedTxns += len(wtg.ConfirmedTransactions)
+	}
+	if queriedTxns != totalTxns {
+		t.Errorf("Expected %v txns but was %v", totalTxns, queriedTxns)
+	}
+}
+
+// TestWalletManyTransactions creates a wallet and sends a large number of
+// coins to itself. Afterwards it will execute subtests to test the wallet's
+// scalability.
+func TestWalletManyTransactions(t *testing.T) {
+	if testing.Short() || !build.VLONG {
+		t.SkipNow()
+	}
+
+	// Declare tests that should be executed
+	subtests := []struct {
+		name string
+		f    func(*testing.T, *serverTester)
+	}{
+		{"TestWalletTransactionEndpoint", testWalletTransactionEndpoint},
+		{"TestWalletTransactionsEndpoint", testWalletTransactionsEndpoint},
+	}
+
+	// Create tester
+	st, err := createServerTester(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.server.panicClose()
+
+	// Disable defrag for the wallet
+	st.wallet.SetSettings(modules.WalletSettings{
+		Defrag: false,
+	})
+
+	// Mining blocks should have created transactions for the wallet containing
+	// miner payouts. Get the list of transactions.
+	var wtg WalletTransactionsGET
+	err = st.getAPI("/wallet/transactions?startheight=0&endheight=-1", &wtg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wtg.ConfirmedTransactions) == 0 {
+		t.Fatal("expecting a few wallet transactions, corresponding to miner payouts.")
+	}
+	if len(wtg.UnconfirmedTransactions) != 0 {
+		t.Fatal("expecting 0 unconfirmed transactions")
+	}
+
+	// Remember the number of confirmed transactions
+	numConfirmedTxns := len(wtg.ConfirmedTransactions)
+
+	// Get lots of addresses from the wallet
+	numTxns := uint64(10000)
+	ucs, err := st.wallet.NextAddresses(numTxns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send SC to each address.
+	minedBlocks := 0
+	for i, uc := range ucs {
+		st.wallet.SendSiacoins(types.SiacoinPrecision, uc.UnlockHash())
+		if i%100 == 0 {
+			if _, err := st.miner.AddBlock(); err != nil {
+				t.Fatal(err)
+			}
+			minedBlocks++
+		}
+	}
+	if _, err := st.miner.AddBlock(); err != nil {
+		t.Fatal(err)
+	}
+	minedBlocks++
+
+	// After sending numTxns times there should be 2*numTxns confirmed
+	// transactions plus one for each mined block. Every send creates a setup
+	// transaction and the actual transaction.
+	err = st.getAPI("/wallet/transactions?startheight=0&endheight=-1", &wtg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedConfirmedTxns := numConfirmedTxns + int(2*numTxns) + minedBlocks
+	if len(wtg.ConfirmedTransactions) != expectedConfirmedTxns {
+		t.Fatalf("expecting %v confirmed transactions but was %v", expectedConfirmedTxns,
+			len(wtg.ConfirmedTransactions))
+	}
+	if len(wtg.UnconfirmedTransactions) != 0 {
+		t.Fatal("expecting 0 unconfirmed transactions")
+	}
+
+	// Execute tests
+	for _, subtest := range subtests {
+		t.Run(subtest.name, func(t *testing.T) {
+			subtest.f(t, st)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a test that creates a node with 10,000 txns in its wallet and runs subtests on this node to verify the integrity of the transaction and transactions endpoint.