### PR TITLE
add /tpool/confirmed/:id endpoint

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -981,11 +981,25 @@ standard success or error response. See
 Transaction Pool
 ------
 
-| Route                           | HTTP verb |
-| ------------------------------- | --------- |
-| [/tpool/fee](#tpoolfee-get)     | GET       |
-| [/tpool/raw/:id](#tpoolraw-get) | GET       |
-| [/tpool/raw](#tpoolraw-post)    | POST      |
+| Route                                       | HTTP verb |
+| ------------------------------------------- | --------- |
+| [/tpool/confirmed/:id](#tpoolconfirmed-get) | GET       |
+| [/tpool/fee](#tpoolfee-get)                 | GET       |
+| [/tpool/raw/:id](#tpoolraw-get)             | GET       |
+| [/tpool/raw](#tpoolraw-post)                | POST      |
+
+#### /tpool/confirmed/:id [GET]
+
+returns whether the requested transaction has been seen on the blockchain.
+Note, however, that the block containing the transaction may later be
+invalidated by a reorg.
+
+###### JSON Response
+```javascript
+{
+  "confirmed": true
+}
+```
 
 #### /tpool/fee [GET]
 

--- a/doc/api/Transactionpool.md
+++ b/doc/api/Transactionpool.md
@@ -19,11 +19,25 @@ the transaction pool and submitting transactions to the transaction pool.
 Index
 -----
 
-| Route                           | HTTP verb |
-| ------------------------------- | --------- |
-| [/tpool/fee](#tpoolfee-get)     | GET       |
-| [/tpool/raw/:id](#tpoolraw-get) | GET       |
-| [/tpool/raw](#tpoolraw-post)    | POST      |
+| Route                                       | HTTP verb |
+| ------------------------------------------- | --------- |
+| [/tpool/confirmed/:id](#tpoolconfirmed-get) | GET       |
+| [/tpool/fee](#tpoolfee-get)                 | GET       |
+| [/tpool/raw/:id](#tpoolraw-get)             | GET       |
+| [/tpool/raw](#tpoolraw-post)                | POST      |
+
+#### /tpool/confirmed/:id [GET]
+
+returns whether the requested transaction has been seen on the blockchain.
+Note, however, that the block containing the transaction may later be
+invalidated by a reorg.
+
+###### JSON Response
+```javascript
+{
+  "confirmed": true
+}
+```
 
 #### /tpool/fee [GET]
 

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -124,6 +124,15 @@ type (
 		// that make this condition necessary.
 		PurgeTransactionPool()
 
+		// Transaction returns the transaction and unconfirmed parents
+		// corresponding to the provided transaction id.
+		Transaction(id types.TransactionID) (txn types.Transaction, unconfirmedParents []types.Transaction, exists bool)
+
+		// TransactionConfirmed returns true if the transaction has been seen on the
+		// blockchain. Note, however, that the block containing the transaction may
+		// later be invalidated by a reorg.
+		TransactionConfirmed(id types.TransactionID) bool
+
 		// TransactionList returns a list of all transactions in the transaction
 		// pool. The transactions are provided in an order that can acceptably be
 		// put into a block.
@@ -133,10 +142,6 @@ type (
 		// Subscribers will receive all consensus set changes as well as
 		// transaction pool changes, and should not subscribe to both.
 		TransactionPoolSubscribe(TransactionPoolSubscriber)
-
-		// Transaction returns the transaction and unconfirmed parents
-		// corresponding to the provided transaction id.
-		Transaction(id types.TransactionID) (txn types.Transaction, unconfirmedParents []types.Transaction, exists bool)
 
 		// Unsubscribe removes a subscriber from the transaction pool.
 		// This is necessary for clean shutdown of the miner.

--- a/modules/transactionpool/persist.go
+++ b/modules/transactionpool/persist.go
@@ -213,13 +213,15 @@ func (tp *TransactionPool) initPersist() error {
 	return nil
 }
 
-// transactionConfirmed returns true if the transaction has been confirmed on
-// the blockchain and false if the transaction has not been confirmed on the
-// blockchain.
+// TransactionConfirmed returns true if the transaction has been seen on the
+// blockchain. Note, however, that the block containing the transaction may
+// later be invalidated by a reorg.
+func (tp *TransactionPool) TransactionConfirmed(id types.TransactionID) bool {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	return tp.transactionConfirmed(tp.dbTx, id)
+}
+
 func (tp *TransactionPool) transactionConfirmed(tx *bolt.Tx, id types.TransactionID) bool {
-	confirmedBytes := tx.Bucket(bucketConfirmedTransactions).Get(id[:])
-	if confirmedBytes == nil {
-		return false
-	}
-	return true
+	return tx.Bucket(bucketConfirmedTransactions).Get(id[:]) != nil
 }

--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -96,6 +96,7 @@ func (api *API) buildHttpRoutes(requiredUserAgent string, requiredPassword strin
 		router.GET("/tpool/fee", api.tpoolFeeHandlerGET)
 		router.GET("/tpool/raw/:id", api.tpoolRawHandlerGET)
 		router.POST("/tpool/raw", api.tpoolRawHandlerPOST)
+		router.GET("/tpool/confirmed/:id", api.tpoolConfirmedGET)
 
 		// TODO: re-enable this route once the transaction pool API has been finalized
 		//router.GET("/transactionpool/transactions", api.transactionpoolTransactionsHandler)

--- a/node/api/transactionpool.go
+++ b/node/api/transactionpool.go
@@ -25,6 +25,10 @@ type (
 		Parents     []byte              `json:"parents"`
 		Transaction []byte              `json:"transaction"`
 	}
+
+	TpoolConfirmedGET struct {
+		Confirmed bool `json:"confirmed"`
+	}
 )
 
 // decodeTransactionID will decode a transaction id from a string.
@@ -107,4 +111,17 @@ func (api *API) tpoolRawHandlerPOST(w http.ResponseWriter, req *http.Request, _ 
 		return
 	}
 	WriteSuccess(w)
+}
+
+// tpoolConfirmedGET returns whether the specified transaction has
+// been seen on the blockchain.
+func (api *API) tpoolConfirmedGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	txid, err := decodeTransactionID(ps.ByName("id"))
+	if err != nil {
+		WriteError(w, Error{"error decoding transaction id:" + err.Error()}, http.StatusBadRequest)
+		return
+	}
+	WriteJSON(w, TpoolConfirmedGET{
+		Confirmed: api.tpool.TransactionConfirmed(txid),
+	})
 }


### PR DESCRIPTION
The tpool already had a `transactionConfirmed` method, so this is pretty simple stuff