### PR TITLE
Add wallet consensus height to /wallet endpoint

### DIFF
--- a/cmd/siac/walletcmd.go
+++ b/cmd/siac/walletcmd.go
@@ -414,6 +414,7 @@ Unlock the wallet to view balance
 
 	fmt.Printf(`Wallet status:
 %s, Unlocked
+Height:              %v
 Confirmed Balance:   %v
 Unconfirmed Delta:  %v
 Exact:               %v H
@@ -421,7 +422,7 @@ Siafunds:            %v SF
 Siafund Claims:      %v H
 
 Estimated Fee:       %v / KB
-`, encStatus, currencyUnits(status.ConfirmedSiacoinBalance), delta,
+`, encStatus, status.Height, currencyUnits(status.ConfirmedSiacoinBalance), delta,
 		status.ConfirmedSiacoinBalance, status.SiafundBalance, status.SiacoinClaimBalance,
 		fees.Maximum.Mul64(1e3).HumanString())
 }

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -347,6 +347,8 @@ type (
 		// not considered in the unconfirmed balance.
 		UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency)
 
+		Height() types.BlockHeight
+
 		// AddressTransactions returns all of the transactions that are related
 		// to a given address.
 		AddressTransactions(types.UnlockHash) []ProcessedTransaction

--- a/node/api/wallet.go
+++ b/node/api/wallet.go
@@ -18,9 +18,10 @@ import (
 type (
 	// WalletGET contains general information about the wallet.
 	WalletGET struct {
-		Encrypted  bool `json:"encrypted"`
-		Unlocked   bool `json:"unlocked"`
-		Rescanning bool `json:"rescanning"`
+		Encrypted  bool              `json:"encrypted"`
+		Unlocked   bool              `json:"unlocked"`
+		Rescanning bool              `json:"rescanning"`
+		Height     types.BlockHeight `json:"height"`
 
 		ConfirmedSiacoinBalance     types.Currency `json:"confirmedsiacoinbalance"`
 		UnconfirmedOutgoingSiacoins types.Currency `json:"unconfirmedoutgoingsiacoins"`
@@ -128,6 +129,7 @@ func (api *API) walletHandler(w http.ResponseWriter, req *http.Request, _ httpro
 		Encrypted:  api.wallet.Encrypted(),
 		Unlocked:   api.wallet.Unlocked(),
 		Rescanning: api.wallet.Rescanning(),
+		Height:     api.wallet.Height(),
 
 		ConfirmedSiacoinBalance:     siacoinBal,
 		UnconfirmedOutgoingSiacoins: siacoinsOut,


### PR DESCRIPTION
Temporary PR that adds the wallets consensus height to the /wallet endpoint for debugging purposes.

Usage: `curl -i -A "Sia-Agent" localhost:9980/wallet` or `siac wallet`