### PR TITLE
[WIP] Improve unconfirmed txn handling in wallet

### DIFF
--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -175,7 +175,7 @@ func (w *Wallet) threadedDefragWallet() {
 		return
 	}
 	// Submit the defrag to the transaction pool.
-	err = w.tpool.AcceptTransactionSet(txnSet)
+	err = w.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		w.log.Println("WARN: defrag transaction was rejected:", err)
 		return

--- a/modules/wallet/defrag_test.go
+++ b/modules/wallet/defrag_test.go
@@ -96,7 +96,7 @@ func TestDefragWalletDust(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wt.tpool.AcceptTransactionSet(txns)
+	err = wt.wallet.managedCommitTransactionSet(txns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestDefragOutputExhaustion(t *testing.T) {
 				if err != nil {
 					t.Error("Error signing fragmenting transaction:", err)
 				}
-				err = wt.tpool.AcceptTransactionSet(txns)
+				err = wt.wallet.managedCommitTransactionSet(txns)
 				if err != nil {
 					t.Error("Error accepting fragmenting transaction:", err)
 				}

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -122,7 +122,7 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) (txn
 	if w.deps.Disrupt("SendSiacoinsInterrupted") {
 		return nil, errors.New("failed to accept transaction set (SendSiacoinsInterrupted)")
 	}
-	err = w.tpool.AcceptTransactionSet(txnSet)
+	err = w.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		w.log.Println("Attempt to send coins has failed - transaction pool rejected transaction:", err)
 		return nil, build.ExtendErr("unable to get transaction accepted", err)
@@ -185,7 +185,7 @@ func (w *Wallet) SendSiacoinsMulti(outputs []types.SiacoinOutput) (txns []types.
 	if w.deps.Disrupt("SendSiacoinsInterrupted") {
 		return nil, errors.New("failed to accept transaction set (SendSiacoinsInterrupted)")
 	}
-	err = w.tpool.AcceptTransactionSet(txnSet)
+	err = w.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		w.log.Println("Attempt to send coins has failed - transaction pool rejected transaction:", err)
 		return nil, build.ExtendErr("unable to get transaction accepted", err)
@@ -227,7 +227,7 @@ func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]t
 	if err != nil {
 		return nil, err
 	}
-	err = w.tpool.AcceptTransactionSet(txnSet)
+	err = w.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -510,7 +510,7 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 		txnSet := append(parents, txn)
 
 		// submit the transactions
-		err = w.tpool.AcceptTransactionSet(txnSet)
+		err = w.managedCommitTransactionSet(txnSet)
 		if err != nil {
 			return
 		}

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -93,7 +93,7 @@ func TestViewAdded(t *testing.T) {
 		t.Error("seems like there's memory sharing happening between txn calls")
 	}
 	// Set1 should be missing some signatures.
-	err = wt.tpool.AcceptTransactionSet(set1)
+	err = wt.wallet.managedCommitTransactionSet(set1)
 	if err == nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestViewAdded(t *testing.T) {
 		b2.AddTransactionSignature(unfinishedTxn3.TransactionSignatures[sigIndex])
 	}
 	set2, err := b2.Sign(true)
-	err = wt.tpool.AcceptTransactionSet(set2)
+	err = wt.wallet.managedCommitTransactionSet(set2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestViewAdded(t *testing.T) {
 		b.AddTransactionSignature(finishedTxn.TransactionSignatures[sigIndex])
 	}
 	set3Txn, set3Parents := b.View()
-	err = wt.tpool.AcceptTransactionSet(append(set3Parents, set3Txn))
+	err = wt.wallet.managedCommitTransactionSet(append(set3Parents, set3Txn))
 	if err != modules.ErrDuplicateTransactionSet {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestDoubleSignError(t *testing.T) {
 	if err != nil && txnSet2 != nil {
 		t.Error("errored call to sign did not return a nil txn set")
 	}
-	err = wt.tpool.AcceptTransactionSet(txnSet)
+	err = wt.wallet.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,11 +235,11 @@ func TestConcurrentBuilders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = wt.tpool.AcceptTransactionSet(tset1)
+	err = wt.wallet.managedCommitTransactionSet(tset1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = wt.tpool.AcceptTransactionSet(tset2)
+	err = wt.wallet.managedCommitTransactionSet(tset2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = wt.tpool.AcceptTransactionSet(tSet)
+	err = wt.wallet.managedCommitTransactionSet(tSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = wt.tpool.AcceptTransactionSet(tset1)
+	err = wt.wallet.managedCommitTransactionSet(tset1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,7 @@ func TestParallelBuilders(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = wt.tpool.AcceptTransactionSet(tset)
+			err = wt.wallet.managedCommitTransactionSet(tset)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -106,6 +106,23 @@ type Wallet struct {
 	defragDisabled bool
 }
 
+// acceptTransactionSet is a convenience wrapper for the transaction pools
+// commitTransactionSet method. It only returns an error if the transaction was
+// rejected and won't be rebroadcasted over time
+func (w *Wallet) commitTransactionSet(txns []types.Transaction) error {
+	w.mu.Unlock()
+	err := w.tpool.AcceptTransactionSet(txns)
+	w.mu.Lock()
+	return err
+}
+
+// managedCommitTransactionSet is a thread-safe version of acceptTransactionSet
+func (w *Wallet) managedCommitTransactionSet(txns []types.Transaction) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.commitTransactionSet(txns)
+}
+
 // New creates a new wallet, loading any known addresses from the input file
 // name and then using the file to save in the future. Keys and addresses are
 // not loaded into the wallet during the call to 'new', but rather during the

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -373,7 +373,7 @@ func TestAdvanceLookaheadNoRescan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wt.tpool.AcceptTransactionSet(tSet)
+	err = wt.wallet.managedCommitTransactionSet(tSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -447,7 +447,7 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wt.tpool.AcceptTransactionSet(txnSet)
+	err = wt.wallet.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,7 +490,7 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wt.tpool.AcceptTransactionSet(txnSet)
+	err = wt.wallet.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,7 +581,7 @@ func TestDistantWallets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = wt.tpool.AcceptTransactionSet(txnSet)
+	err = wt.wallet.managedCommitTransactionSet(txnSet)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The wallet should be able to track transactions even if they haven't been accepted into the transaction set. For this to work, the wallet has to be able to add transactions to its set of unconfirmed transactions without relying on the transaction pool. This PR introduces a wrapper for `AcceptTransactionSet` to achieve this.