### PR TITLE
adding Sia Improvement Proposals section

### DIFF
--- a/doc/sips/README.md
+++ b/doc/sips/README.md
@@ -1,0 +1,5 @@
+People wishing to submit Sia Improvement Proposals (SIPs) should first propose their idea to the Sia Discord server. After discussion, please open a PR. After copy-editing and acceptance, it will be published here.
+
+Having a SIP here does not make it a formally accepted standard until its status becomes Final or Active.
+
+Those proposing changes should consider that ultimately consent may rest with the consensus of the Sia users.


### PR DESCRIPTION
After much debate in the Sia Discord I thought it might be nice to have a Sia Improvement Proposal section for formal improvement requests.  This is meant to mimic the Bitcoin Improvement Proposals repo found at https://github.com/bitcoin/bips.