### PR TITLE
Adding ./modules/renter to lintpkgs and fixing all the lint errors. #…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ vet: release-std
 	go vet $(pkgs)
 
 # will always run on some packages for a while.
-lintpkgs = ./modules ./modules/gateway ./modules/host ./modules/renter/hostdb ./modules/renter/contractor ./node \
-           ./node/api/server ./persist ./siatest
+lintpkgs = ./modules ./modules/gateway ./modules/host ./modules/renter ./modules/renter/hostdb ./modules/renter/contractor \
+           ./node ./node/api/server ./persist ./siatest
 lint:
 	golint -min_confidence=1.0 -set_exit_status $(lintpkgs)
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -308,9 +308,9 @@ type Renter interface {
 	// contain multiple files. The paths of the added files are returned.
 	LoadSharedFiles(source string) ([]string, error)
 
-	// LoadSharedFilesAscii loads an ASCII-encoded '.sia' file into the
+	// LoadSharedFilesASCII loads an ASCII-encoded '.sia' file into the
 	// renter.
-	LoadSharedFilesAscii(asciiSia string) ([]string, error)
+	LoadSharedFilesASCII(asciiSia string) ([]string, error)
 
 	// PriceEstimation estimates the cost in siacoins of performing various
 	// storage and data operations.
@@ -337,7 +337,7 @@ type Renter interface {
 	ShareFiles(paths []string, shareDest string) error
 
 	// ShareFilesAscii creates an ASCII-encoded '.sia' file.
-	ShareFilesAscii(paths []string) (asciiSia string, err error)
+	ShareFilesASCII(paths []string) (asciiSia string, err error)
 
 	// Upload uploads a file using the input parameters.
 	Upload(FileUploadParams) error

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -684,7 +684,7 @@ func (dw *DownloadBufferWriter) Bytes() []byte {
 	return dw.data
 }
 
-// Close() implements DownloadWriter's Close method.
+// Close implements DownloadWriter's Close method.
 func (dw *DownloadBufferWriter) Close() error {
 	return nil
 }
@@ -738,13 +738,13 @@ func (dw *DownloadFileWriter) Close() error {
 	return dw.f.Close()
 }
 
-// DownloadHttpWriter is a http response writer-backed implementation of
+// DownloadHTTPWriter is a http response writer-backed implementation of
 // DownloadWriter.  The writer writes all content that is written to the
 // current `offset` directly to the ResponseWriter, and buffers all content
 // that is written at other offsets.  After every write to the ResponseWriter
 // the `offset` and `length` fields are updated, and buffer content written
 // until
-type DownloadHttpWriter struct {
+type DownloadHTTPWriter struct {
 	w              io.Writer
 	offset         int            // The index in the original file of the last byte written to the response writer.
 	firstByteIndex int            // The index of the first byte in the original file.
@@ -752,9 +752,9 @@ type DownloadHttpWriter struct {
 	buffer         map[int][]byte // Buffer used for storing the chunks until download finished.
 }
 
-// NewDownloadHttpWriter creates a new instance of http.ResponseWriter backed DownloadWriter.
-func NewDownloadHttpWriter(w io.Writer, offset, length uint64) *DownloadHttpWriter {
-	return &DownloadHttpWriter{
+// NewDownloadHTTPWriter creates a new instance of http.ResponseWriter backed DownloadWriter.
+func NewDownloadHTTPWriter(w io.Writer, offset, length uint64) *DownloadHTTPWriter {
+	return &DownloadHTTPWriter{
 		w:              w,
 		offset:         0,           // Current offset in the output file.
 		firstByteIndex: int(offset), // Index of first byte in original file.
@@ -766,18 +766,18 @@ func NewDownloadHttpWriter(w io.Writer, offset, length uint64) *DownloadHttpWrit
 // Destination implements the Destination method of the DownloadWriter
 // interface and informs callers where this download writer is
 // being written to.
-func (dw *DownloadHttpWriter) Destination() string {
+func (dw *DownloadHTTPWriter) Destination() string {
 	return "httpresp"
 }
 
-// Cloes implements DownloadWriter's Close method.
-func (dw *DownloadHttpWriter) Close() error {
+// Close implements DownloadWriter's Close method.
+func (dw *DownloadHTTPWriter) Close() error {
 	return nil
 }
 
 // WriteAt buffers parts of the file until the entire file can be
 // flushed to the client. Returns the number of bytes written or an error.
-func (dw *DownloadHttpWriter) WriteAt(b []byte, off int64) (int, error) {
+func (dw *DownloadHTTPWriter) WriteAt(b []byte, off int64) (int, error) {
 	// Write bytes to buffer.
 	offsetInBuffer := int(off) - dw.firstByteIndex
 	dw.buffer[offsetInBuffer] = b

--- a/modules/renter/downloadqueue.go
+++ b/modules/renter/downloadqueue.go
@@ -16,19 +16,19 @@ func (r *Renter) Download(p modules.RenterDownloadParameters) error {
 	file, exists := r.files[p.Siapath]
 	r.mu.RUnlock(lockID)
 	if !exists {
-		return errors.New(fmt.Sprintf("no file with that path: %s", p.Siapath))
+		return fmt.Errorf("no file with that path: %s", p.Siapath)
 	}
 
-	isHttpResp := p.Httpwriter != nil
+	isHTTPResp := p.Httpwriter != nil
 
 	// validate download parameters
-	if p.Async && isHttpResp {
+	if p.Async && isHTTPResp {
 		return errors.New("cannot async download to http response")
 	}
-	if isHttpResp && p.Destination != "" {
+	if isHTTPResp && p.Destination != "" {
 		return errors.New("destination cannot be specified when downloading to http response")
 	}
-	if !isHttpResp && p.Destination == "" {
+	if !isHTTPResp && p.Destination == "" {
 		return errors.New("destination not supplied")
 	}
 	if p.Destination != "" && !filepath.IsAbs(p.Destination) {
@@ -49,8 +49,8 @@ func (r *Renter) Download(p modules.RenterDownloadParameters) error {
 	// Instantiate the correct DownloadWriter implementation
 	// (e.g. content written to file or response body).
 	var dw modules.DownloadWriter
-	if isHttpResp {
-		dw = NewDownloadHttpWriter(p.Httpwriter, p.Offset, p.Length)
+	if isHTTPResp {
+		dw = NewDownloadHTTPWriter(p.Httpwriter, p.Offset, p.Length)
 	} else {
 		dfw, err := NewDownloadFileWriter(p.Destination, p.Offset, p.Length)
 		if err != nil {

--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -15,9 +15,12 @@ import (
 )
 
 var (
+	// ErrEmptyFilename is an error when filename is empty
 	ErrEmptyFilename = errors.New("filename must be a nonempty string")
-	ErrPathOverload  = errors.New("a file already exists at that location")
-	ErrUnknownPath   = errors.New("no file known with that path")
+	// ErrPathOverload is an error when a file already exists at that location
+	ErrPathOverload = errors.New("a file already exists at that location")
+	// ErrUnknownPath is an error when a file cannot be found with the given path
+	ErrUnknownPath = errors.New("no file known with that path")
 )
 
 // A file is a single file that has been uploaded to the network. Files are
@@ -235,7 +238,7 @@ func (r *Renter) FileList() []modules.FileInfo {
 
 	var fileList []modules.FileInfo
 	for _, f := range files {
-		lockId := r.mu.RLock()
+		lockID := r.mu.RLock()
 		f.mu.RLock()
 		renewing := true
 		var localPath string
@@ -255,7 +258,7 @@ func (r *Renter) FileList() []modules.FileInfo {
 			Expiration:     f.expiration(),
 		})
 		f.mu.RUnlock()
-		r.mu.RUnlock(lockId)
+		r.mu.RUnlock(lockID)
 	}
 	return fileList
 }

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -18,15 +18,21 @@ import (
 )
 
 const (
-	logFile         = modules.RenterDir + ".log"
+	logFile = modules.RenterDir + ".log"
+	// PersistFilename is the filename to be used when persisting renter information to a JSON file
 	PersistFilename = "renter.json"
-	ShareExtension  = ".sia"
+	// ShareExtension is the extension to be used
+	ShareExtension = ".sia"
 )
 
 var (
-	ErrBadFile        = errors.New("not a .sia file")
-	ErrIncompatible   = errors.New("file is not compatible with current version")
-	ErrNoNicknames    = errors.New("at least one nickname must be supplied")
+	//ErrBadFile is an error when a file does not qualify as .sia file
+	ErrBadFile = errors.New("not a .sia file")
+	// ErrIncompatible is an error when file is not compatible with current version
+	ErrIncompatible = errors.New("file is not compatible with current version")
+	// ErrNoNicknames is an error when no nickname is given
+	ErrNoNicknames = errors.New("at least one nickname must be supplied")
+	// ErrNonShareSuffix is an error when the suffix of a file does not match the defined share extension
 	ErrNonShareSuffix = errors.New("suffix of file must be " + ShareExtension)
 
 	saveMetadata = persist.Metadata{
@@ -268,7 +274,7 @@ func shareFiles(files []*file, w io.Writer) error {
 	return zip.Close()
 }
 
-// ShareFile saves the specified files to shareDest.
+// ShareFiles saves the specified files to shareDest.
 func (r *Renter) ShareFiles(nicknames []string, shareDest string) error {
 	lockID := r.mu.RLock()
 	defer r.mu.RUnlock(lockID)
@@ -303,8 +309,8 @@ func (r *Renter) ShareFiles(nicknames []string, shareDest string) error {
 	return nil
 }
 
-// ShareFilesAscii returns the specified files in ASCII format.
-func (r *Renter) ShareFilesAscii(nicknames []string) (string, error) {
+// ShareFilesASCII returns the specified files in ASCII format.
+func (r *Renter) ShareFilesASCII(nicknames []string) (string, error) {
 	lockID := r.mu.RLock()
 	defer r.mu.RUnlock(lockID)
 
@@ -427,9 +433,9 @@ func (r *Renter) LoadSharedFiles(filename string) ([]string, error) {
 	return r.loadSharedFiles(file)
 }
 
-// LoadSharedFilesAscii loads an ASCII-encoded .sia file into the renter. It
+// LoadSharedFilesASCII loads an ASCII-encoded .sia file into the renter. It
 // returns the nicknames of the loaded files.
-func (r *Renter) LoadSharedFilesAscii(asciiSia string) ([]string, error) {
+func (r *Renter) LoadSharedFilesASCII(asciiSia string) ([]string, error) {
 	lockID := r.mu.Lock()
 	defer r.mu.Unlock(lockID)
 

--- a/modules/renter/persist_test.go
+++ b/modules/renter/persist_test.go
@@ -156,7 +156,7 @@ func TestFileShareLoadASCII(t *testing.T) {
 	rt.renter.files[savedFile.name] = savedFile
 	rt.renter.mu.Unlock(id)
 
-	ascii, err := rt.renter.ShareFilesAscii([]string{savedFile.name})
+	ascii, err := rt.renter.ShareFilesASCII([]string{savedFile.name})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestFileShareLoadASCII(t *testing.T) {
 	// Remove the file from the renter.
 	delete(rt.renter.files, savedFile.name)
 
-	names, err := rt.renter.LoadSharedFilesAscii(ascii)
+	names, err := rt.renter.LoadSharedFilesASCII(ascii)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -410,26 +410,42 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 	return nil
 }
 
-// hostdb passthroughs
-func (r *Renter) ActiveHosts() []modules.HostDBEntry                      { return r.hostDB.ActiveHosts() }
-func (r *Renter) AllHosts() []modules.HostDBEntry                         { return r.hostDB.AllHosts() }
+// ActiveHosts returns an array of hostDB's active hosts
+func (r *Renter) ActiveHosts() []modules.HostDBEntry { return r.hostDB.ActiveHosts() }
+
+// AllHosts returns an array of all hosts
+func (r *Renter) AllHosts() []modules.HostDBEntry { return r.hostDB.AllHosts() }
+
+// Host returns the host associated with the given public key
 func (r *Renter) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) { return r.hostDB.Host(spk) }
+
+// ScoreBreakdown returns the score breakdown
 func (r *Renter) ScoreBreakdown(e modules.HostDBEntry) modules.HostScoreBreakdown {
 	return r.hostDB.ScoreBreakdown(e)
 }
+
+// EstimateHostScore returns the estimated host score
 func (r *Renter) EstimateHostScore(e modules.HostDBEntry) modules.HostScoreBreakdown {
 	return r.hostDB.EstimateHostScore(e)
 }
 
-// contractor passthroughs
-func (r *Renter) Contracts() []modules.RenterContract        { return r.hostContractor.Contracts() }
-func (r *Renter) CurrentPeriod() types.BlockHeight           { return r.hostContractor.CurrentPeriod() }
+// Contracts returns an array of host contractor's contracts
+func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
+
+// CurrentPeriod returns the host contractor's current period
+func (r *Renter) CurrentPeriod() types.BlockHeight { return r.hostContractor.CurrentPeriod() }
+
+// PeriodSpending returns the host contractor's period spending
 func (r *Renter) PeriodSpending() modules.ContractorSpending { return r.hostContractor.PeriodSpending() }
+
+// Settings returns the host contractor's allowance
 func (r *Renter) Settings() modules.RenterSettings {
 	return modules.RenterSettings{
 		Allowance: r.hostContractor.Allowance(),
 	}
 }
+
+// ProcessConsensusChange returns the process consensus change
 func (r *Renter) ProcessConsensusChange(cc modules.ConsensusChange) {
 	id := r.mu.Lock()
 	r.lastEstimation = modules.RenterPriceEstimation{}

--- a/modules/renter/repairchunk.go
+++ b/modules/renter/repairchunk.go
@@ -62,10 +62,11 @@ func (r *Renter) managedDownloadLogicalChunkData(chunk *unfinishedChunk) error {
 	if d.Err() != nil {
 		buf.data = nil
 		return d.Err()
-	} else {
-		chunk.logicalChunkData = buf.Bytes()
-		return nil
 	}
+
+	chunk.logicalChunkData = buf.Bytes()
+	return nil
+
 }
 
 // managedFetchAndRepairChunk will fetch the logical data for a chunk, create

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -300,7 +300,7 @@ func (api *API) renterLoadHandler(w http.ResponseWriter, req *http.Request, _ ht
 // renterLoadAsciiHandler handles the API call to load a '.sia' file
 // in ASCII form.
 func (api *API) renterLoadAsciiHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	files, err := api.renter.LoadSharedFilesAscii(req.FormValue("asciisia"))
+	files, err := api.renter.LoadSharedFilesASCII(req.FormValue("asciisia"))
 	if err != nil {
 		WriteError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
@@ -477,7 +477,7 @@ func (api *API) renterShareHandler(w http.ResponseWriter, req *http.Request, ps 
 // renterShareAsciiHandler handles the API call to return a '.sia' file
 // in ascii form.
 func (api *API) renterShareAsciiHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-	ascii, err := api.renter.ShareFilesAscii(strings.Split(req.FormValue("siapaths"), ","))
+	ascii, err := api.renter.ShareFilesASCII(strings.Split(req.FormValue("siapaths"), ","))
 	if err != nil {
 		WriteError(w, Error{err.Error()}, http.StatusBadRequest)
 		return


### PR DESCRIPTION
This PR will add the ./modules/renter in lintpkgs in Makefile and also fixes the lint errors. This will be one of the many tasks for #2702 to clean up lint errors across the project.