### PR TITLE
Add ./cmd/siac to lint pkgs #2705

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ vet: release-std
 	go vet $(pkgs)
 
 # will always run on some packages for a while.
-lintpkgs = ./build ./modules ./modules/gateway ./modules/host ./modules/renter ./modules/renter/contractor \
+lintpkgs = ./build ./cmd/siac ./modules ./modules/gateway ./modules/host ./modules/renter ./modules/renter/contractor \
            ./modules/renter/hostdb ./modules/wallet ./node ./node/api/server ./persist ./siatest
 lint:
 	golint -min_confidence=1.0 -set_exit_status $(lintpkgs)


### PR DESCRIPTION
Add ./cmd/siac to the list of pkgs to lint.