### PR TITLE
switch renter memory model to support multiple working threads

### DIFF
--- a/modules/renter/repairchunk.go
+++ b/modules/renter/repairchunk.go
@@ -90,7 +90,7 @@ func (r *Renter) managedFetchAndRepairChunk(chunk *unfinishedChunk) bool {
 	chunk.physicalChunkData, err = chunk.renterFile.erasureCode.Encode(chunk.logicalChunkData)
 	memoryFreed := uint64(len(chunk.logicalChunkData))
 	chunk.logicalChunkData = nil
-	r.managedMemoryAvailableAdd(memoryFreed)
+	r.managedMemoryReturn(memoryFreed)
 	chunk.memoryReleased += memoryFreed
 	memoryFreed = 0
 	if err != nil {
@@ -118,7 +118,7 @@ func (r *Renter) managedFetchAndRepairChunk(chunk *unfinishedChunk) bool {
 		}
 	}
 	// Return the released memory.
-	r.managedMemoryAvailableAdd(memoryFreed)
+	r.managedMemoryReturn(memoryFreed)
 	chunk.memoryReleased += memoryFreed
 
 	// Distribute the chunk to the workers.
@@ -203,6 +203,6 @@ func (r *Renter) managedReleaseIdleChunkPieces(uc *unfinishedChunk) {
 	}
 	uc.mu.Unlock()
 	if memoryReleased > 0 {
-		r.managedMemoryAvailableAdd(uint64(memoryReleased))
+		r.managedMemoryReturn(uint64(memoryReleased))
 	}
 }

--- a/modules/renter/workerupload.go
+++ b/modules/renter/workerupload.go
@@ -217,6 +217,6 @@ func (w *worker) managedUpload(uc *unfinishedChunk, pieceIndex uint64) {
 	uc.physicalChunkData[pieceIndex] = nil
 	uc.memoryReleased += uint64(releaseSize)
 	uc.mu.Unlock()
-	w.renter.managedMemoryAvailableAdd(uint64(releaseSize))
+	w.renter.managedMemoryReturn(uint64(releaseSize))
 	w.dropChunk(uc)
 }


### PR DESCRIPTION
Changed the memory model from a model that could only support one thread (the upload thread) to a model that can now support multiple threads (upload thread and download thread).