### PR TITLE
make the chunk responsible for stanby workers

### DIFF
--- a/modules/renter/repairchunk.go
+++ b/modules/renter/repairchunk.go
@@ -73,12 +73,8 @@ func (r *Renter) managedDownloadLogicalChunkData(chunk *unfinishedChunk) error {
 // the physical pieces for the chunk, and then distribute them. The returned
 // bool indicates whether the chunk was successfully distributed to workers.
 func (r *Renter) managedFetchAndRepairChunk(chunk *unfinishedChunk) bool {
-	// Only download this file if more than 25% of the redundancy is missing.
-	minMissingPiecesToDownload := (chunk.piecesNeeded - chunk.minimumPieces) / 4
-	download := chunk.piecesCompleted+minMissingPiecesToDownload < chunk.piecesNeeded
-
 	// Fetch the logical data for the chunk.
-	err := r.managedFetchLogicalChunkData(chunk, download)
+	err := r.managedFetchLogicalChunkData(chunk)
 	if err != nil {
 		// Logical data is not available, nothing to do.
 		r.log.Debugln("Fetching logical data of a chunk failed:", err)
@@ -131,7 +127,11 @@ func (r *Renter) managedFetchAndRepairChunk(chunk *unfinishedChunk) bool {
 //
 // chunk.data should be passed as 'nil' to the download, to keep memory usage as
 // light as possible.
-func (r *Renter) managedFetchLogicalChunkData(chunk *unfinishedChunk, download bool) error {
+func (r *Renter) managedFetchLogicalChunkData(chunk *unfinishedChunk) error {
+	// Only download this file if more than 25% of the redundancy is missing.
+	minMissingPiecesToDownload := (chunk.piecesNeeded - chunk.minimumPieces) / 4
+	download := chunk.piecesCompleted+minMissingPiecesToDownload < chunk.piecesNeeded
+
 	// Download the chunk if it's not on disk.
 	if chunk.localPath == "" && download {
 		return r.managedDownloadLogicalChunkData(chunk)

--- a/modules/renter/repairchunk.go
+++ b/modules/renter/repairchunk.go
@@ -101,7 +101,7 @@ func (r *Renter) managedFetchAndRepairChunk(chunk *unfinishedChunk) bool {
 		r.log.Critical("not enough physical pieces to match the upload settings of the file")
 		return false
 	}
-	// Loop through the pieces and encrypt any that our needed, while dropping
+	// Loop through the pieces and encrypt any that are needed, while dropping
 	// any pieces that are not needed.
 	for i := 0; i < len(chunk.pieceUsage); i++ {
 		if chunk.pieceUsage[i] {


### PR DESCRIPTION
previously, workers would remember which chunks they were on standby for, and
periodically check whether they were needed to perform extra work. This had some
downtime issues, and complicated a lot of the worker functions.

Now, the chunk itself remembers which workers are on standby, and will notify
them if there's a failure that requires another worker to take action.