### PR TITLE
fix http server race

### DIFF
--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -145,7 +145,6 @@ func cleanCloseHandler(next http.Handler) http.Handler {
 		}(w, r)
 		select {
 		case <-done:
-		case <-r.Context().Done():
 		}
 
 		// Sanity check - thread should not take more than an hour to return. This


### PR DESCRIPTION
This PR fixes the random race condition when we call `WriteJSON`.
It seems like the std lib flushes the underlying buffer in `FinishRequest`, but before calling `FinishRequest` it cancels the context. This means, that `r.Context().Done()` will always trigger before `done` in our `select` and might cause a situation where `FinishRequest` is called at the same time as `ServeHTTP`. Both of those functions use the same buffer.