### PR TITLE
Added ./compatibility and ./crypto to lint packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ vet: release-std
 	go vet $(pkgs)
 
 # will always run on some packages for a while.
-lintpkgs = ./build ./cmd/siac ./cmd/siad ./modules ./modules/gateway ./modules/host ./modules/renter ./modules/renter/contractor \
-           ./modules/renter/hostdb ./modules/wallet ./node ./node/api/server ./persist ./siatest
+lintpkgs = ./build ./cmd/siac ./cmd/siad ./compatibility ./crypto ./modules ./modules/gateway ./modules/host ./modules/renter \
+           ./modules/renter/contractor ./modules/renter/hostdb ./modules/wallet ./node ./node/api/server ./persist ./siatest
 lint:
 	golint -min_confidence=1.0 -set_exit_status $(lintpkgs)
 

--- a/crypto/encrypt.go
+++ b/crypto/encrypt.go
@@ -20,14 +20,15 @@ const (
 )
 
 var (
-	// ErrInsufficientLen is an error when supplied ciphertext is not long enough to contain a nonce
+	// ErrInsufficientLen is an error when supplied ciphertext is not 
+        // long enough to contain a nonce.
 	ErrInsufficientLen = errors.New("supplied ciphertext is not long enough to contain a nonce")
 )
 
 type (
-	// Ciphertext {insert comment here}
+	// Ciphertext is an encrypted []byte.
 	Ciphertext []byte
-	// TwofishKey {insert comment here}
+	// TwofishKey is a key used for encrypting and decrypting data.
 	TwofishKey [EntropySize]byte
 )
 
@@ -99,7 +100,8 @@ func (c Ciphertext) MarshalJSON() ([]byte, error) {
 	return json.Marshal([]byte(c))
 }
 
-// UnmarshalJSON parses the JSON-encoded b and returns an instance of CipherText
+// UnmarshalJSON parses the JSON-encoded b and returns an instance of 
+// CipherText.
 func (c *Ciphertext) UnmarshalJSON(b []byte) error {
 	var umarB []byte
 	err := json.Unmarshal(b, &umarB)

--- a/crypto/encrypt.go
+++ b/crypto/encrypt.go
@@ -15,19 +15,23 @@ import (
 )
 
 const (
-	TwofishOverhead = 28 // number of bytes added by EncryptBytes
+	// TwofishOverhead is the number of bytes added by EncryptBytes
+	TwofishOverhead = 28
 )
 
 var (
+	// ErrInsufficientLen is an error when supplied ciphertext is not long enough to contain a nonce
 	ErrInsufficientLen = errors.New("supplied ciphertext is not long enough to contain a nonce")
 )
 
 type (
+	// Ciphertext {insert comment here}
 	Ciphertext []byte
+	// TwofishKey {insert comment here}
 	TwofishKey [EntropySize]byte
 )
 
-// GenerateEncryptionKey produces a key that can be used for encrypting and
+// GenerateTwofishKey produces a key that can be used for encrypting and
 // decrypting files.
 func GenerateTwofishKey() (key TwofishKey) {
 	fastrand.Read(key[:])
@@ -90,10 +94,12 @@ func (key TwofishKey) NewReader(r io.Reader) io.Reader {
 	return &cipher.StreamReader{S: stream, R: r}
 }
 
+// MarshalJSON returns the JSON encoding of a CipherText
 func (c Ciphertext) MarshalJSON() ([]byte, error) {
 	return json.Marshal([]byte(c))
 }
 
+// UnmarshalJSON parses the JSON-encoded b and returns an instance of CipherText
 func (c *Ciphertext) UnmarshalJSON(b []byte) error {
 	var umarB []byte
 	err := json.Unmarshal(b, &umarB)

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -19,10 +19,12 @@ import (
 )
 
 const (
+	// HashSize {insert comment here}
 	HashSize = 32
 )
 
 type (
+	// Hash {insert comment here}
 	Hash [HashSize]byte
 
 	// HashSlice is used for sorting
@@ -30,6 +32,7 @@ type (
 )
 
 var (
+	// ErrHashWrongLen is the error when encoded value has the wrong length to be a hash
 	ErrHashWrongLen = errors.New("encoded value has the wrong length to be a hash")
 )
 

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -19,12 +19,12 @@ import (
 )
 
 const (
-	// HashSize {insert comment here}
+	// HashSize is the length of a Hash in bytes. 
 	HashSize = 32
 )
 
 type (
-	// Hash {insert comment here}
+	// Hash is a BLAKE2b 256-bit digest. 
 	Hash [HashSize]byte
 
 	// HashSlice is used for sorting
@@ -32,7 +32,8 @@ type (
 )
 
 var (
-	// ErrHashWrongLen is the error when encoded value has the wrong length to be a hash
+	// ErrHashWrongLen is the error when encoded value has the wrong 
+        // length to be a hash.
 	ErrHashWrongLen = errors.New("encoded value has the wrong length to be a hash")
 )
 


### PR DESCRIPTION
This PR is for #2702. ./compatibility module didn't show any lint errors so I added ./crypto.

 I also needed some help with some of the comments below. See lines with {insert comment here}.