### PR TITLE
Don't print "history not sorted" error in release build

### DIFF
--- a/modules/renter/hostdb/hostweight.go
+++ b/modules/renter/hostdb/hostweight.go
@@ -313,7 +313,11 @@ func (hdb *HostDB) uptimeAdjustments(entry modules.HostDBEntry) float64 {
 	recentSuccess := entry.ScanHistory[0].Success
 	for _, scan := range entry.ScanHistory[1:] {
 		if recentTime.After(scan.Timestamp) {
-			hdb.log.Critical("Host entry scan history not sorted.")
+			if build.DEBUG {
+				hdb.log.Critical("Host entry scan history not sorted.")
+			} else {
+				hdb.log.Print("WARNING: Host entry scan history not sorted.")
+			}
 			// Ignore the unsorted scan entry.
 			continue
 		}


### PR DESCRIPTION
The hostdb currently ignores unsorted entries in a Release build. I think we shouldn't print an error at all in a Release build, but only log it. Otherwise we might confuse users.

Related to: [#1799](https://github.com/NebulousLabs/Sia/issues/1799)