### PR TITLE
Add block-by-id and id-by-height consensus endpoints

### DIFF
--- a/doc/api/Consensus.md
+++ b/doc/api/Consensus.md
@@ -23,6 +23,8 @@ Index
 | Route                                                                       | HTTP verb |
 | --------------------------------------------------------------------------- | --------- |
 | [/consensus](#consensus-get)                                                | GET       |
+| [/consensus/blocks/:id](#consensus-blocks-id-get)                           | GET       |
+| [/consensus/headers/:height](#consensus-headers-height-get)                 | GET       |
 | [/consensus/validate/transactionset](#consensusvalidatetransactionset-post) | POST      |
 
 #### /consensus [GET]
@@ -49,6 +51,15 @@ returns information about the consensus set, such as the current block height.
   "difficulty": "1234" // arbitrary-precision integer
 }
 ```
+
+#### /consensus/blocks/:id [GET]
+
+Returns the block for a given id.
+
+#### /consensus/headers/:height [GET]
+
+Returns header information of a block at a given height. At the moment only the
+BlockID is included, but this can be extended as needed.
 
 #### /consensus/validate/transactionset [POST]
 

--- a/modules/consensus.go
+++ b/modules/consensus.go
@@ -190,6 +190,10 @@ type (
 		// bool to indicate whether that block exists.
 		BlockAtHeight(types.BlockHeight) (types.Block, bool)
 
+		// BlocksByID returns a block found for a given ID, with a bool to
+		// indicate whether that block exists.
+		BlockByID(types.BlockID) (types.Block, bool)
+
 		// ChildTarget returns the target required to extend the current heaviest
 		// fork. This function is typically used by miners looking to extend the
 		// heaviest fork.

--- a/modules/consensus/consensusset.go
+++ b/modules/consensus/consensusset.go
@@ -202,6 +202,20 @@ func (cs *ConsensusSet) BlockAtHeight(height types.BlockHeight) (block types.Blo
 	return block, exists
 }
 
+// BlockByID returns the block for a given BlockID.
+func (cs *ConsensusSet) BlockByID(id types.BlockID) (block types.Block, exists bool) {
+	_ = cs.db.View(func(tx *bolt.Tx) error {
+		pb, err := getBlockMap(tx, id)
+		if err != nil {
+			return err
+		}
+		block = pb.Block
+		exists = true
+		return nil
+	})
+	return block, exists
+}
+
 // ChildTarget returns the target for the child of a block.
 func (cs *ConsensusSet) ChildTarget(id types.BlockID) (target types.Target, exists bool) {
 	// A call to a closed database can cause undefined behavior.

--- a/node/api/client/consensus.go
+++ b/node/api/client/consensus.go
@@ -15,12 +15,12 @@ func (c *Client) ConsensusGet() (cg api.ConsensusGET, err error) {
 
 // ConsensusBlocksIDGet requests the /consensus/blocks api resource
 func (c *Client) ConsensusBlocksIDGet(id types.BlockID) (block types.Block, err error) {
-	err = c.Get("/consensus/blocks?id="+id.String(), &block)
+	err = c.get("/consensus/blocks?id="+id.String(), &block)
 	return
 }
 
 // ConsensusBlocksHeightGet requests the /consensus/blocks api resource
 func (c *Client) ConsensusBlocksHeightGet(height types.BlockHeight) (block types.Block, err error) {
-	err = c.Get("/consensus/blocks?height="+fmt.Sprint(height), &block)
+	err = c.get("/consensus/blocks?height="+fmt.Sprint(height), &block)
 	return
 }

--- a/node/api/client/consensus.go
+++ b/node/api/client/consensus.go
@@ -1,9 +1,26 @@
 package client
 
-import "github.com/NebulousLabs/Sia/node/api"
+import (
+	"strconv"
+
+	"github.com/NebulousLabs/Sia/node/api"
+	"github.com/NebulousLabs/Sia/types"
+)
 
 // ConsensusGet requests the /consensus api resource
 func (c *Client) ConsensusGet() (cg api.ConsensusGET, err error) {
 	err = c.get("/consensus", &cg)
+	return
+}
+
+// ConsensusBlocksIDGet requests the /consensus/blocks/:id api resource
+func (c *Client) ConsensusBlocksIDGet(id types.BlockID) (block types.Block, err error) {
+	err = c.Get("/consensus/blocks/"+id.String(), &block)
+	return
+}
+
+// ConsensusHeadersHeightGet requests the /consensus/headers/:height api resource
+func (c *Client) ConsensusHeadersHeightGet(height types.BlockHeight) (chg api.ConsensusHeadersGET, err error) {
+	err = c.Get("/consensus/headers/"+strconv.FormatUint(uint64(height), 10), &chg)
 	return
 }

--- a/node/api/client/consensus.go
+++ b/node/api/client/consensus.go
@@ -13,14 +13,14 @@ func (c *Client) ConsensusGet() (cg api.ConsensusGET, err error) {
 	return
 }
 
-// ConsensusBlocksIDGet requests the /consensus/blocks/:id api resource
+// ConsensusBlocksIDGet requests the /consensus/blocks api resource
 func (c *Client) ConsensusBlocksIDGet(id types.BlockID) (block types.Block, err error) {
-	err = c.Get("/consensus/blocks/"+id.String(), &block)
+	err = c.Get("/consensus/blocks?id="+id.String(), &block)
 	return
 }
 
-// ConsensusHeadersHeightGet requests the /consensus/headers/:height api resource
-func (c *Client) ConsensusHeadersHeightGet(height types.BlockHeight) (chg api.ConsensusHeadersGET, err error) {
-	err = c.Get("/consensus/headers/"+strconv.FormatUint(uint64(height), 10), &chg)
+// ConsensusBlocksHeightGet requests the /consensus/blocks api resource
+func (c *Client) ConsensusBlocksHeightGet(height types.BlockHeight) (block types.Block, err error) {
+	err = c.Get("/consensus/blocks?height="+strconv.FormatUint(uint64(height), 10), &block)
 	return
 }

--- a/node/api/client/consensus.go
+++ b/node/api/client/consensus.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"strconv"
+	"fmt"
 
 	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
@@ -21,6 +21,6 @@ func (c *Client) ConsensusBlocksIDGet(id types.BlockID) (block types.Block, err 
 
 // ConsensusBlocksHeightGet requests the /consensus/blocks api resource
 func (c *Client) ConsensusBlocksHeightGet(height types.BlockHeight) (block types.Block, err error) {
-	err = c.Get("/consensus/blocks?height="+strconv.FormatUint(uint64(height), 10), &block)
+	err = c.Get("/consensus/blocks?height="+fmt.Sprint(height), &block)
 	return
 }

--- a/node/api/consensus.go
+++ b/node/api/consensus.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/NebulousLabs/Sia/types"
 
@@ -19,6 +21,11 @@ type ConsensusGET struct {
 	Difficulty   types.Currency    `json:"difficulty"`
 }
 
+// ConsensusHeadersGET contains information from a blocks header.
+type ConsensusHeadersGET struct {
+	BlockID types.BlockID `json:"blockid"`
+}
+
 // consensusHandler handles the API calls to /consensus.
 func (api *API) consensusHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	cbid := api.cs.CurrentBlock().ID()
@@ -29,6 +36,47 @@ func (api *API) consensusHandler(w http.ResponseWriter, req *http.Request, _ htt
 		CurrentBlock: cbid,
 		Target:       currentTarget,
 		Difficulty:   currentTarget.Difficulty(),
+	})
+}
+
+// consensusBlocksIDHandler handles the API calls to
+// /consensus/blocks/:id endpoint.
+func (api *API) consensusBlocksIDHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	// Unmarshal BlockID
+	var id types.BlockID
+	if err := id.LoadString(ps.ByName("id")); err != nil {
+		println(err.Error())
+		WriteError(w, Error{"failed to unmarshal blockid"}, http.StatusBadRequest)
+		return
+	}
+	// Retrieve block from consensus
+	b, exists := api.cs.BlockByID(id)
+	if !exists {
+		WriteError(w, Error{fmt.Sprintf("block with id %v doesn't exist", id)}, http.StatusBadRequest)
+		return
+	}
+	// Write response
+	WriteJSON(w, b)
+}
+
+// consensusHeadersHeightHandler handles the API calls to
+// consensus/headers/:height endpoint.
+func (api *API) consensusHeadersHeightHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	// Parse height
+	height, err := strconv.ParseUint(ps.ByName("height"), 10, 64)
+	if err != nil {
+		WriteError(w, Error{"failed to parse height"}, http.StatusBadRequest)
+		return
+	}
+	// Retrieve block at height
+	b, exists := api.cs.BlockAtHeight(types.BlockHeight(height))
+	if !exists {
+		WriteError(w, Error{fmt.Sprintf("could not find block at height %v", height)}, http.StatusBadRequest)
+		return
+	}
+	// Write reponse
+	WriteJSON(w, ConsensusHeadersGET{
+		BlockID: b.ID(),
 	})
 }
 

--- a/node/api/consensus.go
+++ b/node/api/consensus.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/NebulousLabs/Sia/types"
 
@@ -64,8 +64,8 @@ func (api *API) consensusBlocksHandler(w http.ResponseWriter, req *http.Request,
 	}
 	// Handle request by height
 	if height != "" {
-		h, err := strconv.ParseUint(height, 10, 64)
-		if err != nil {
+		var h uint64
+		if _, err := fmt.Sscan(height, &h); err != nil {
 			WriteError(w, Error{"failed to parse block height"}, http.StatusBadRequest)
 			return
 		}

--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -21,6 +21,8 @@ func (api *API) buildHTTPRoutes(requiredUserAgent string, requiredPassword strin
 	// Consensus API Calls
 	if api.cs != nil {
 		router.GET("/consensus", api.consensusHandler)
+		router.GET("/consensus/blocks/:id", api.consensusBlocksIDHandler)
+		router.GET("/consensus/headers/:height", api.consensusHeadersHeightHandler)
 		router.POST("/consensus/validate/transactionset", api.consensusValidateTransactionsetHandler)
 	}
 

--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -21,8 +21,7 @@ func (api *API) buildHTTPRoutes(requiredUserAgent string, requiredPassword strin
 	// Consensus API Calls
 	if api.cs != nil {
 		router.GET("/consensus", api.consensusHandler)
-		router.GET("/consensus/blocks/:id", api.consensusBlocksIDHandler)
-		router.GET("/consensus/headers/:height", api.consensusHeadersHeightHandler)
+		router.GET("/consensus/blocks", api.consensusBlocksHandler)
 		router.POST("/consensus/validate/transactionset", api.consensusValidateTransactionsetHandler)
 	}
 

--- a/siatest/consensus/consensus_test.go
+++ b/siatest/consensus/consensus_test.go
@@ -1,10 +1,12 @@
 package consensus
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/node"
 	"github.com/NebulousLabs/Sia/siatest"
+	"github.com/NebulousLabs/Sia/types"
 )
 
 // TestApiHeight checks if the consensus api endpoint works
@@ -47,5 +49,90 @@ func TestApiHeight(t *testing.T) {
 	}
 	if cg.Height != height+1 {
 		t.Fatal("Height should have increased by 1 block")
+	}
+}
+
+// TestConsensusHeadersHeightGet tests the /consensus/headers/:height
+// endpoint
+func TestConsensusHeadersHeightGet(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	testdir, err := siatest.TestDir(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new server
+	testNode, err := siatest.NewNode(node.AllModules(testdir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := testNode.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Get current block id using the /consensus endpoint
+	testNode.MineBlock()
+	cg, err := testNode.ConsensusGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Get the current block id using the /consensus/headers/height endpoint
+	// and compare it to the other value
+	chg, err := testNode.ConsensusHeadersHeightGet(cg.Height)
+	if err != nil {
+		t.Fatal("Failed to get header information", err)
+	}
+	if bytes.Compare(chg.BlockID[:], cg.CurrentBlock[:]) != 0 {
+		t.Fatal("BlockIDs do not match")
+	}
+}
+
+// TestConsensusBlocksIDGet tests the /consensus/blocks/:id endpoint
+func TestConsensusBlocksIDGet(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	testdir, err := siatest.TestDir(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new server
+	testNode, err := siatest.NewNode(node.AllModules(testdir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := testNode.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Send GET request
+	cg, err := testNode.ConsensusGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := testNode.ConsensusBlocksIDGet(cg.CurrentBlock)
+	if err != nil {
+		t.Fatal("Failed to retrieve block", err)
+	}
+	// Make sure all of the fields are initialized and not empty
+	var zeroID types.BlockID
+	if bytes.Compare(block.ParentID[:], zeroID[:]) == 0 {
+		t.Fatal("ParentID wasn't set correctly")
+	}
+	if block.Timestamp == types.Timestamp(0) {
+		t.Fatal("Timestamp wasn't set correctly")
+	}
+	if len(block.MinerPayouts) == 0 {
+		t.Fatal("Block has no miner payouts")
+	}
+	if len(block.Transactions) == 0 {
+		t.Fatal("Block doesn't have any transactions even though it should")
 	}
 }

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -280,6 +280,11 @@ func (bid BlockID) String() string {
 	return fmt.Sprintf("%x", bid[:])
 }
 
+// LoadString loads a BlockID from a string
+func (bid *BlockID) LoadString(str string) error {
+	return (*crypto.Hash)(bid).LoadString(str)
+}
+
 // UnmarshalJSON decodes the json hex string of the block id.
 func (bid *BlockID) UnmarshalJSON(b []byte) error {
 	return (*crypto.Hash)(bid).UnmarshalJSON(b)


### PR DESCRIPTION
This PR adds 2 endpoints.
1. the `/consensus/blocks/:id` endpoint which allows a user to retrieve a whole block by id
2. the `/consensus/headers/:height` endpoint. This might return the whole header in the future but only returns the BlockID at the moment.

I chose 2 separate wildcards since one endpoint returns a block and the other one is mostly used to return information about the block. In the future we might also add `/consensus/blocks/:height` or `consensus/headers/:id` in case it becomes necessary.