### PR TITLE
Fixing capitalization of storagespending

### DIFF
--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -98,7 +98,7 @@ type (
 		// Block height that the file contract began on.
 		StartHeight types.BlockHeight `json:"startheight"`
 		// Amount of contract funds that have been spent on storage.
-		StorageSpending types.Currency `json:"StorageSpending"`
+		StorageSpending types.Currency `json:"storagespending"`
 		// Total cost to the wallet of forming the file contract.
 		TotalCost types.Currency `json:"totalcost"`
 		// Amount of contract funds that have been spent on uploads.

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -99,6 +99,13 @@ type (
 		StartHeight types.BlockHeight `json:"startheight"`
 		// Amount of contract funds that have been spent on storage.
 		StorageSpending types.Currency `json:"storagespending"`
+		// DEPRECATED: This is the exact same value as StorageSpending, but it has
+		// incorrect capitalization. This was fixed in 1.3.2, but this field is kept
+		// to preserve backwards compatibility on clients who depend on the
+		// incorrect capitalization. This field will be removed in the future, so
+		// clients should switch to the StorageSpending field (above) with the
+		// correct lowercase name.
+		StorageSpendingDeprecated types.Currency `json:"StorageSpending"`
 		// Total cost to the wallet of forming the file contract.
 		TotalCost types.Currency `json:"totalcost"`
 		// Amount of contract funds that have been spent on uploads.
@@ -240,19 +247,20 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 		}
 
 		contracts = append(contracts, RenterContract{
-			DownloadSpending: c.DownloadSpending,
-			EndHeight:        c.EndHeight,
-			Fees:             c.TxnFee.Add(c.SiafundFee).Add(c.ContractFee),
-			HostPublicKey:    c.HostPublicKey,
-			ID:               c.ID,
-			LastTransaction:  c.Transaction,
-			NetAddress:       netAddress,
-			RenterFunds:      c.RenterFunds,
-			Size:             size,
-			StartHeight:      c.StartHeight,
-			StorageSpending:  c.StorageSpending,
-			TotalCost:        c.TotalCost,
-			UploadSpending:   c.UploadSpending,
+			DownloadSpending:          c.DownloadSpending,
+			EndHeight:                 c.EndHeight,
+			Fees:                      c.TxnFee.Add(c.SiafundFee).Add(c.ContractFee),
+			HostPublicKey:             c.HostPublicKey,
+			ID:                        c.ID,
+			LastTransaction:           c.Transaction,
+			NetAddress:                netAddress,
+			RenterFunds:               c.RenterFunds,
+			Size:                      size,
+			StartHeight:               c.StartHeight,
+			StorageSpending:           c.StorageSpending,
+			StorageSpendingDeprecated: c.StorageSpending,
+			TotalCost:                 c.TotalCost,
+			UploadSpending:            c.UploadSpending,
 		})
 	}
 	WriteJSON(w, RenterContracts{


### PR DESCRIPTION
storagespelling was spelled with capitalized letters, making the name
inconsistent with every other output of the Sia API.

This change will unfortunately break clients that depend on the incorrect
capitalization.