### PR TITLE
Remove consensus.db code that could cause instability

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -284,8 +284,7 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 				panic("after adding a change entry, there are no applied blocks but there are reverted blocks")
 			}
 		}
-		// Flush DB pages
-		return tx.FlushDBPages()
+		return nil
 	})
 	cs.log.Printf("accept: finished block processing loop")
 	if _, ok := setErr.(bolt.MmapError); ok {

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -190,16 +190,6 @@ func (cs *ConsensusSet) managedInitializeSubscribe(subscriber modules.ConsensusS
 		if err != nil {
 			return err
 		}
-		// Flush DB pages from memory. Caching the pages doesn't improve
-		// performance much anyway, since they are only read once.
-		cs.mu.Lock()
-		err = cs.db.Update(func(tx *bolt.Tx) error {
-			return tx.FlushDBPages()
-		})
-		cs.mu.Unlock()
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/modules/transactionpool/persist.go
+++ b/modules/transactionpool/persist.go
@@ -50,11 +50,6 @@ func (tp *TransactionPool) syncDB() {
 	if err != nil {
 		tp.log.Severe("ERROR: failed to initialize a db transaction:", err)
 	}
-	// Flush the cached DB pages from memory
-	err = tp.dbTx.FlushDBPages()
-	if err != nil {
-		tp.log.Severe("ERROR: failed to flush db pages:", err)
-	}
 }
 
 // resetDB deletes all consensus related persistence from the transaction pool.


### PR DESCRIPTION
We don't know for certain that these changes will fix the corruption we've observed, but it seems probable. Removing this code only impacts performance, not safety/correctness, and we can easily restore it if it doesn't have any effect on corruption.