### PR TITLE
Fix possible concurrency issue in contractset

### DIFF
--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -34,6 +34,15 @@ func (cs *ContractSet) Acquire(id types.FileContractID) (*SafeContract, bool) {
 		return nil, false
 	}
 	safeContract.mu.Lock()
+	// We need to check if the contract is still in the map or if it has been
+	// deleted in the meantime.
+	cs.mu.Lock()
+	_, ok = cs.contracts[id]
+	cs.mu.Unlock()
+	if !ok {
+		safeContract.mu.Unlock()
+		return nil, false
+	}
 	return safeContract, true
 }
 

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -54,6 +54,7 @@ func (cs *ContractSet) Delete(c *SafeContract) {
 	safeContract, ok := cs.contracts[c.header.ID()]
 	if !ok {
 		cs.mu.Unlock()
+		build.Critical("Delete called on already deleted contract")
 		return
 	}
 	delete(cs.contracts, c.header.ID())


### PR DESCRIPTION
This PR should fix a possible deadlock. A deadlock could happen the following way:

Thread A calls `Acquire` and gets a contract.
Thread B and C also call `Acquire` and have to wait for the lock of thread A.
Thread A calls `Delete` instead of `Return` on the contract and unlocks the lock for B but C still has to wait.
Thread B gets the contract and does some work. After that it decides to call `Delete` too. Unfortunately the contract is not in the map anymore. This means we can't find it and don't unlock the lock on it.
Thread C waits forever.

The changes in this PR should guarantee that we can't acquire a contract that has been deleted by a different thread while waiting for the contract's lock.