### PR TITLE
automatically adjust contract pricing

### DIFF
--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -78,10 +78,10 @@ var (
 	defaultCollateralBudget = types.SiacoinPrecision.Mul64(100e3)
 
 	// defaultContractPrice defines the default price of creating a contract
-	// with the host. The default is set to 0 siacoins. This should be fine
-	// since we use the FeeEstimation function for an estimation which already
-	// has a sane minimum > 0.
-	defaultContractPrice = types.ZeroCurrency // 0 siacoins
+	// with the host. The current default is 0.05. This was chosen since it is
+	// 1/2e6 times 10,000 bytes. 1/2e6 is the current transaction pool's fee
+	// estimation minimum.
+	defaultContractPrice = types.SiacoinPrecision.Div64(200) // 0.05 siacoins
 
 	// defaultDownloadBandwidthPrice defines the default price of upload
 	// bandwidth. The default is set to 10 siacoins per gigabyte, because

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -78,9 +78,9 @@ var (
 	defaultCollateralBudget = types.SiacoinPrecision.Mul64(100e3)
 
 	// defaultContractPrice defines the default price of creating a contract
-	// with the host. The default is set to 30 siacoins, which the file
-	// contract revision can have 15 siacoins put towards it, and the storage
-	// proof can have 15 siacoins put towards it.
+	// with the host. The default is set to 0 siacoins. This should be fine
+	// since we use the FeeEstimation function for an estimation which already
+	// has a sane minimum > 0.
 	defaultContractPrice = types.ZeroCurrency // 0 siacoins
 
 	// defaultDownloadBandwidthPrice defines the default price of upload

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -81,7 +81,7 @@ var (
 	// with the host. The default is set to 30 siacoins, which the file
 	// contract revision can have 15 siacoins put towards it, and the storage
 	// proof can have 15 siacoins put towards it.
-	defaultContractPrice = types.SiacoinPrecision.Mul64(3) // 3 siacoins
+	defaultContractPrice = types.ZeroCurrency // 0 siacoins
 
 	// defaultDownloadBandwidthPrice defines the default price of upload
 	// bandwidth. The default is set to 10 siacoins per gigabyte, because

--- a/modules/host/consts.go
+++ b/modules/host/consts.go
@@ -78,10 +78,9 @@ var (
 	defaultCollateralBudget = types.SiacoinPrecision.Mul64(100e3)
 
 	// defaultContractPrice defines the default price of creating a contract
-	// with the host. The current default is 0.05. This was chosen since it is
-	// 1/2e6 times 10,000 bytes. 1/2e6 is the current transaction pool's fee
-	// estimation minimum.
-	defaultContractPrice = types.SiacoinPrecision.Div64(200) // 0.05 siacoins
+	// with the host. The current default is 0.1. This was chosen since it is
+	// the minimum fee estimation of the transactionpool for 10e3 bytes.
+	defaultContractPrice = types.SiacoinPrecision.Div64(10) // 0.1 siacoins
 
 	// defaultDownloadBandwidthPrice defines the default price of upload
 	// bandwidth. The default is set to 10 siacoins per gigabyte, because

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -213,7 +213,7 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 	so := storageObligation{
 		SectorRoots: initialSectorRoots,
 
-		ContractCost:            h.settings.MinContractPrice,
+		ContractCost:            h.externalSettings().ContractPrice,
 		LockedCollateral:        hostCollateral,
 		PotentialStorageRevenue: hostInitialRevenue,
 		RiskedCollateral:        hostInitialRisk,

--- a/modules/host/negotiate.go
+++ b/modules/host/negotiate.go
@@ -164,7 +164,7 @@ func createRevisionSignature(fcr types.FileContractRevision, renterSig types.Tra
 // collateral, and then try submitting the file contract to the transaction
 // pool. If there is no error, the completed transaction set will be returned
 // to the caller.
-func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, renterPK crypto.PublicKey, renterSignatures []types.TransactionSignature, renterRevisionSignature types.TransactionSignature, initialSectorRoots []crypto.Hash, hostCollateral, hostInitialRevenue, hostInitialRisk types.Currency) ([]types.TransactionSignature, types.TransactionSignature, types.FileContractID, error) {
+func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, renterPK crypto.PublicKey, renterSignatures []types.TransactionSignature, renterRevisionSignature types.TransactionSignature, initialSectorRoots []crypto.Hash, hostCollateral, hostInitialRevenue, hostInitialRisk types.Currency, settings modules.HostExternalSettings) ([]types.TransactionSignature, types.TransactionSignature, types.FileContractID, error) {
 	for _, sig := range renterSignatures {
 		builder.AddTransactionSignature(sig)
 	}
@@ -213,7 +213,7 @@ func (h *Host) managedFinalizeContract(builder modules.TransactionBuilder, rente
 	so := storageObligation{
 		SectorRoots: initialSectorRoots,
 
-		ContractCost:            h.externalSettings().ContractPrice,
+		ContractCost:            settings.ContractPrice,
 		LockedCollateral:        hostCollateral,
 		PotentialStorageRevenue: hostInitialRevenue,
 		RiskedCollateral:        hostInitialRisk,

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -45,7 +45,7 @@ func (h *Host) managedDownloadIteration(conn net.Conn, so *storageObligation) er
 	h.mu.RLock()
 	blockHeight := h.blockHeight
 	secretKey := h.secretKey
-	settings := h.settings
+	settings := h.externalSettings()
 	h.mu.RUnlock()
 
 	// Read the download requests, followed by the file contract revision that
@@ -81,7 +81,7 @@ func (h *Host) managedDownloadIteration(conn net.Conn, so *storageObligation) er
 
 		// Verify that the correct amount of money has been moved from the
 		// renter's contract funds to the host's contract funds.
-		expectedTransfer := settings.MinDownloadBandwidthPrice.Mul64(totalSize)
+		expectedTransfer := settings.DownloadBandwidthPrice.Mul64(totalSize)
 		err = verifyPaymentRevision(existingRevision, paymentRevision, blockHeight, expectedTransfer)
 		if err != nil {
 			return extendErr("payment verification failed: ", err)

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -108,7 +108,7 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 
 	// The host verifies that the file contract coming over the wire is
 	// acceptable.
-	err = h.managedVerifyNewContract(txnSet, renterPK)
+	err = h.managedVerifyNewContract(txnSet, renterPK, settings)
 	if err != nil {
 		// The incoming file contract is not acceptable to the host, indicate
 		// why to the renter.
@@ -198,7 +198,7 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 
 // managedVerifyNewContract checks that an incoming file contract matches the host's
 // expectations for a valid contract.
-func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK crypto.PublicKey) error {
+func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK crypto.PublicKey, eSettings modules.HostExternalSettings) error {
 	// Check that the transaction set is not empty.
 	if len(txnSet) < 1 {
 		return extendErr("zero-length transaction set: ", errEmptyObject)
@@ -212,7 +212,6 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	blockHeight := h.blockHeight
 	lockedStorageCollateral := h.financialMetrics.LockedStorageCollateral
 	publicKey := h.publicKey
-	eSettings := h.externalSettings()
 	iSettings := h.settings
 	unlockHash := h.unlockHash
 	h.mu.RUnlock()

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -171,7 +171,7 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	h.mu.RLock()
 	hostCollateral := contractCollateral(settings, txnSet[len(txnSet)-1].FileContracts[0])
 	h.mu.RUnlock()
-	hostTxnSignatures, hostRevisionSignature, newSOID, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, nil, hostCollateral, types.ZeroCurrency, types.ZeroCurrency)
+	hostTxnSignatures, hostRevisionSignature, newSOID, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, nil, hostCollateral, types.ZeroCurrency, types.ZeroCurrency, settings)
 	if err != nil {
 		// The incoming file contract is not acceptable to the host, indicate
 		// why to the renter.

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -24,8 +24,8 @@ var (
 // contractCollateral returns the amount of collateral that the host is
 // expected to add to the file contract based on the payout of the file
 // contract and based on the host settings.
-func contractCollateral(settings modules.HostInternalSettings, fc types.FileContract) types.Currency {
-	return fc.ValidProofOutputs[1].Value.Sub(settings.MinContractPrice)
+func contractCollateral(settings modules.HostExternalSettings, fc types.FileContract) types.Currency {
+	return fc.ValidProofOutputs[1].Value.Sub(settings.ContractPrice)
 }
 
 // managedAddCollateral adds the host's collateral to the file contract
@@ -33,7 +33,7 @@ func contractCollateral(settings modules.HostInternalSettings, fc types.FileCont
 // transaction, as well as any new parents that get added to the transaction
 // set. The builder that is used to add the collateral is also returned,
 // because the new transaction has not yet been signed.
-func (h *Host) managedAddCollateral(settings modules.HostInternalSettings, txnSet []types.Transaction) (builder modules.TransactionBuilder, newParents []types.Transaction, newInputs []types.SiacoinInput, newOutputs []types.SiacoinOutput, err error) {
+func (h *Host) managedAddCollateral(settings modules.HostExternalSettings, txnSet []types.Transaction) (builder modules.TransactionBuilder, newParents []types.Transaction, newInputs []types.SiacoinInput, newOutputs []types.SiacoinOutput, err error) {
 	txn := txnSet[len(txnSet)-1]
 	parents := txnSet[:len(txnSet)-1]
 	fc := txn.FileContracts[0]
@@ -74,7 +74,7 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	// The renter has been given enough information in the host settings to
 	// understand that the connection is going to be closed.
 	h.mu.RLock()
-	settings := h.settings
+	settings := h.externalSettings()
 	h.mu.RUnlock()
 	if !settings.AcceptingContracts {
 		h.log.Debugln("Turning down contract because the host is not accepting contracts.")
@@ -169,7 +169,7 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	// During finalization, the signature for the revision is also checked, and
 	// signatures for the revision transaction are created.
 	h.mu.RLock()
-	hostCollateral := contractCollateral(h.settings, txnSet[len(txnSet)-1].FileContracts[0])
+	hostCollateral := contractCollateral(settings, txnSet[len(txnSet)-1].FileContracts[0])
 	h.mu.RUnlock()
 	hostTxnSignatures, hostRevisionSignature, newSOID, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, nil, hostCollateral, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
@@ -212,7 +212,8 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	blockHeight := h.blockHeight
 	lockedStorageCollateral := h.financialMetrics.LockedStorageCollateral
 	publicKey := h.publicKey
-	settings := h.settings
+	eSettings := h.externalSettings()
+	iSettings := h.settings
 	unlockHash := h.unlockHash
 	h.mu.RUnlock()
 	fc := txnSet[len(txnSet)-1].FileContracts[0]
@@ -232,12 +233,12 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	}
 	// WindowEnd must be at least settings.WindowSize blocks after
 	// WindowStart.
-	if fc.WindowEnd < fc.WindowStart+settings.WindowSize {
+	if fc.WindowEnd < fc.WindowStart+eSettings.WindowSize {
 		return errSmallWindow
 	}
 	// WindowEnd must not be more than settings.MaxDuration blocks into the
 	// future.
-	if fc.WindowStart > blockHeight+settings.MaxDuration {
+	if fc.WindowStart > blockHeight+eSettings.MaxDuration {
 		return errLongDuration
 	}
 
@@ -261,18 +262,18 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	// Check that there's enough payout for the host to cover at least the
 	// contract price. This will prevent negative currency panics when working
 	// with the collateral.
-	if fc.ValidProofOutputs[1].Value.Cmp(settings.MinContractPrice) < 0 {
+	if fc.ValidProofOutputs[1].Value.Cmp(eSettings.ContractPrice) < 0 {
 		return errLowHostValidOutput
 	}
 	// Check that the collateral does not exceed the maximum amount of
 	// collateral allowed.
-	expectedCollateral := contractCollateral(settings, fc)
-	if expectedCollateral.Cmp(settings.MaxCollateral) > 0 {
+	expectedCollateral := contractCollateral(eSettings, fc)
+	if expectedCollateral.Cmp(eSettings.MaxCollateral) > 0 {
 		return errMaxCollateralReached
 	}
 	// Check that the host has enough room in the collateral budget to add this
 	// collateral.
-	if lockedStorageCollateral.Add(expectedCollateral).Cmp(settings.CollateralBudget) > 0 {
+	if lockedStorageCollateral.Add(expectedCollateral).Cmp(iSettings.CollateralBudget) > 0 {
 		return errCollateralBudgetExceeded
 	}
 

--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -186,7 +186,7 @@ func (h *Host) managedRPCRenewContract(conn net.Conn) error {
 	renewRevenue := renewBasePrice(so, settings, fc)
 	renewRisk := renewBaseCollateral(so, settings, fc)
 	h.mu.RUnlock()
-	hostTxnSignatures, hostRevisionSignature, newSOID, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, so.SectorRoots, renewCollateral, renewRevenue, renewRisk)
+	hostTxnSignatures, hostRevisionSignature, newSOID, err := h.managedFinalizeContract(txnBuilder, renterPK, renterTxnSignatures, renterRevisionSignature, so.SectorRoots, renewCollateral, renewRevenue, renewRisk, settings)
 	if err != nil {
 		modules.WriteNegotiationRejection(conn, err) // Error is ignored to preserve type for extendErr
 		return extendErr("failed to finalize contract: ", err)

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -38,7 +38,7 @@ func (h *Host) managedRevisionIteration(conn net.Conn, so *storageObligation, fi
 
 	// Read some variables from the host for use later in the function.
 	h.mu.RLock()
-	settings := h.settings
+	settings := h.externalSettings()
 	secretKey := h.secretKey
 	blockHeight := h.blockHeight
 	h.mu.RUnlock()
@@ -96,8 +96,8 @@ func (h *Host) managedRevisionIteration(conn net.Conn, so *storageObligation, fi
 				// Update finances.
 				blocksRemaining := so.proofDeadline() - blockHeight
 				blockBytesCurrency := types.NewCurrency64(uint64(blocksRemaining)).Mul64(modules.SectorSize)
-				bandwidthRevenue = bandwidthRevenue.Add(settings.MinUploadBandwidthPrice.Mul64(modules.SectorSize))
-				storageRevenue = storageRevenue.Add(settings.MinStoragePrice.Mul(blockBytesCurrency))
+				bandwidthRevenue = bandwidthRevenue.Add(settings.UploadBandwidthPrice.Mul64(modules.SectorSize))
+				storageRevenue = storageRevenue.Add(settings.StoragePrice.Mul(blockBytesCurrency))
 				newCollateral = newCollateral.Add(settings.Collateral.Mul(blockBytesCurrency))
 
 				// Insert the sector into the root list.
@@ -122,7 +122,7 @@ func (h *Host) managedRevisionIteration(conn net.Conn, so *storageObligation, fi
 				copy(sector[modification.Offset:], modification.Data)
 
 				// Update finances.
-				bandwidthRevenue = bandwidthRevenue.Add(settings.MinUploadBandwidthPrice.Mul64(uint64(len(modification.Data))))
+				bandwidthRevenue = bandwidthRevenue.Add(settings.UploadBandwidthPrice.Mul64(uint64(len(modification.Data))))
 
 				// Update the sectors removed and gained to indicate that the old
 				// sector has been replaced with a new sector.

--- a/modules/host/negotiatesettings.go
+++ b/modules/host/negotiatesettings.go
@@ -35,7 +35,7 @@ func (h *Host) externalSettings() modules.HostExternalSettings {
 
 	// Calculate contract price
 	_, maxFee := h.tpool.FeeEstimation()
-	contractPrice := maxFee.Mul64(10e3)
+	contractPrice := maxFee.Mul64(10e3) // estimated size of txns host needs to fund
 	if contractPrice.Cmp(h.settings.MinContractPrice) < 0 {
 		contractPrice = h.settings.MinContractPrice
 	}

--- a/modules/host/negotiatesettings.go
+++ b/modules/host/negotiatesettings.go
@@ -32,6 +32,14 @@ func (h *Host) externalSettings() modules.HostExternalSettings {
 	} else {
 		netAddr = h.autoAddress
 	}
+
+	// Calculate contract price
+	_, maxFee := h.tpool.FeeEstimation()
+	contractPrice := maxFee.Mul64(10e3)
+	if contractPrice.Cmp(h.settings.MinContractPrice) < 0 {
+		contractPrice = h.settings.MinContractPrice
+	}
+
 	return modules.HostExternalSettings{
 		AcceptingContracts:   h.settings.AcceptingContracts,
 		MaxDownloadBatchSize: h.settings.MaxDownloadBatchSize,
@@ -47,7 +55,7 @@ func (h *Host) externalSettings() modules.HostExternalSettings {
 		Collateral:    h.settings.Collateral,
 		MaxCollateral: h.settings.MaxCollateral,
 
-		ContractPrice:          h.settings.MinContractPrice,
+		ContractPrice:          contractPrice,
 		DownloadBandwidthPrice: h.settings.MinDownloadBandwidthPrice,
 		StoragePrice:           h.settings.MinStoragePrice,
 		UploadBandwidthPrice:   h.settings.MinUploadBandwidthPrice,

--- a/modules/transactionpool/consts.go
+++ b/modules/transactionpool/consts.go
@@ -68,7 +68,7 @@ var (
 var (
 	// minEstimation defines a sane minimum fee per byte for transactions.  This
 	// will typically be only suggested as a fee in the absence of congestion.
-	minEstimation = types.SiacoinPrecision.Div64(2e6)
+	minEstimation = types.SiacoinPrecision.Div64(100).Div64(1e3)
 )
 
 // Variables related to propagating transactions through the network.

--- a/modules/transactionpool/consts.go
+++ b/modules/transactionpool/consts.go
@@ -68,7 +68,7 @@ var (
 var (
 	// minEstimation defines a sane minimum fee per byte for transactions.  This
 	// will typically be only suggested as a fee in the absence of congestion.
-	minEstimation = types.SiacoinPrecision.Div64(100).Div64(1e3)
+	minEstimation = types.SiacoinPrecision.Div64(2e6)
 )
 
 // Variables related to propagating transactions through the network.


### PR DESCRIPTION
This PR is pretty much the successor of [PR#2070](https://github.com/NebulousLabs/Sia/pull/2070). It's easier and simply uses the transactionpool to figure out the correct fees for the contract price.
It also changes a few parts in the code that previously used the internal settings to use the external ones. I think the internal settings are meant to provide a minimum while the external ones reflect the current price of the renter. Therefore we should probably use the external ones if we do stuff like checking if the renter pays enough for bandwidth.