### PR TITLE
Fix possible heapWG deadlock

### DIFF
--- a/modules/renter/workerupload.go
+++ b/modules/renter/workerupload.go
@@ -167,10 +167,7 @@ func (w *worker) onUploadCooldown() bool {
 func (w *worker) managedProcessUploadChunk(uc *unfinishedChunk) (nextChunk *unfinishedChunk, pieceIndex uint64) {
 	// Determine the usability value of this worker.
 	utility, exists := w.renter.hostContractor.ContractUtility(w.contract.ID)
-	if !exists {
-		return nil, 0
-	}
-	goodForUpload := utility.GoodForUpload
+	goodForUpload := exists && utility.GoodForUpload
 
 	// Determine what sort of help this chunk needs.
 	w.mu.Lock()


### PR DESCRIPTION
When `exists == false` we return without dropping the chunk in `managedProcessUploadChunk`. Since this function is only ever called once on a chunk, it will never be dropped after that and `heapWG.done()`will never be called. This results in a deadlock when shutting down the renter.