### PR TITLE
Outdated value, fixes #2298

### DIFF
--- a/doc/Standard.md
+++ b/doc/Standard.md
@@ -9,9 +9,9 @@ Transaction Size
 ----------------
 
 Consensus rules limit the size of a block, but not the size of a transaction.
-Standard rules however limit the size of a single transaction to 16kb.
+Standard rules however limit the size of a single transaction to 32kb.
 
-A chain of dependent transactions cannot exceed 500kb.
+A chain of dependent transactions cannot exceed 250kb.
 
 Double Spend Rules
 ------------------


### PR DESCRIPTION
Fixes #2298 

[transactionpool.go](https://github.com/NebulousLabs/Sia/blob/f370982a7fa3c98d37fcc151a67e349883b55d8e/modules/transactionpool.go#L15) defines the following values:

```
// TransactionSizeLimit defines the size of the largest transaction that
// will be accepted by the transaction pool according to the IsStandard
// rules.
TransactionSizeLimit = 32e3

// TransactionSetSizeLimit defines the largest set of dependent unconfirmed
// transactions that will be accepted by the transaction pool.
TransactionSetSizeLimit = 250e3
```