### PR TITLE
export transaction helpers

### DIFF
--- a/types/transaction_helpers.go
+++ b/types/transaction_helpers.go
@@ -1,5 +1,3 @@
-// +build testing
-
 package types
 
 import (


### PR DESCRIPTION
As of Go 1.10, `go test` also runs `go vet`. `go vet` complains when a test file in one package uses test-only identifiers in another package. This is unfortunate, but there may be good justifications for this behavior.