### PR TITLE
only update subscribers if there are any

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -306,9 +306,12 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 	if !chainExtended {
 		return false, modules.ErrNonExtendingBlock
 	}
-	// Send any changes to subscribers.
-	for i := 0; i < len(changes); i++ {
-		cs.updateSubscribers(changes[i])
+	// Check if there are any subscribers
+	if len(cs.subscribers) > 0 {
+		// Send any changes to subscribers.
+		for i := 0; i < len(changes); i++ {
+			cs.updateSubscribers(changes[i])
+		}
 	}
 	return chainExtended, nil
 }

--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -306,12 +306,9 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 	if !chainExtended {
 		return false, modules.ErrNonExtendingBlock
 	}
-	// Check if there are any subscribers
-	if len(cs.subscribers) > 0 {
-		// Send any changes to subscribers.
-		for i := 0; i < len(changes); i++ {
-			cs.updateSubscribers(changes[i])
-		}
+	// Send any changes to subscribers.
+	for i := 0; i < len(changes); i++ {
+		cs.updateSubscribers(changes[i])
 	}
 	return chainExtended, nil
 }

--- a/modules/consensus/subscribe.go
+++ b/modules/consensus/subscribe.go
@@ -99,6 +99,9 @@ func (cs *ConsensusSet) computeConsensusChange(tx *bolt.Tx, ce changeEntry) (mod
 // consensus set. updateSubscribers does not alter the changelog, the changelog
 // must be updated beforehand.
 func (cs *ConsensusSet) updateSubscribers(ce changeEntry) {
+	if len(cs.subscribers) == 0 {
+		return
+	}
 	// Get the consensus change and send it to all subscribers.
 	var cc modules.ConsensusChange
 	err := cs.db.View(func(tx *bolt.Tx) error {


### PR DESCRIPTION
When syncing the consensus.db from genesis as much as 25% of the time it takes to sync is spent on `cs.updateSubscribers()`.  There is no need update subscribers if you don't have any.

If you start `siad` with only a subset of the modules you may not have any subscribers.  For example `siad -M cg -d /root/Sia` results in 0 subscribers.

https://github.com/NebulousLabs/Sia/blob/17432ba5e810652768b5909a725e5d599f0414b6/modules/consensus/accept.go#L311