### PR TITLE
Extend renter settings endpoint for ratelimiting bandwidth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ dependencies:
 	go get -u github.com/NebulousLabs/entropy-mnemonics
 	go get -u github.com/NebulousLabs/errors
 	go get -u github.com/NebulousLabs/go-upnp
+	go get -u github.com/NebulousLabs/ratelimit
 	go get -u github.com/NebulousLabs/threadgroup
 	go get -u github.com/NebulousLabs/writeaheadlog
 	go get -u github.com/klauspost/reedsolomon

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -163,7 +163,10 @@ type RenterPriceEstimation struct {
 
 // RenterSettings control the behavior of the Renter.
 type RenterSettings struct {
-	Allowance Allowance `json:"allowance"`
+	Allowance     Allowance `json:"allowance"`
+	PacketSize    uint64    `json:"packetsize"`
+	UploadSpeed   int64     `json:"uploadspeed"`
+	DownloadSpeed int64     `json:"downloadspeed"`
 }
 
 // HostDBScans represents a sortable slice of scans.

--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -43,6 +43,9 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	if reflect.DeepEqual(a, modules.Allowance{}) {
 		return c.managedCancelAllowance()
 	}
+	if reflect.DeepEqual(a, c.allowance) {
+		return nil
+	}
 
 	// sanity checks
 	if a.Hosts == 0 {

--- a/node/api/api.go
+++ b/node/api/api.go
@@ -121,7 +121,7 @@ func New(requiredUserAgent string, requiredPassword string, cs modules.Consensus
 	}
 
 	// Register API handlers
-	api.buildHttpRoutes(requiredUserAgent, requiredPassword)
+	api.buildHTTPRoutes(requiredUserAgent, requiredPassword)
 
 	return api
 }

--- a/node/api/host_test.go
+++ b/node/api/host_test.go
@@ -210,6 +210,8 @@ func TestWorkingStatus(t *testing.T) {
 	allowanceValues := url.Values{}
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
 		t.Fatal(err)
 	}
@@ -329,6 +331,8 @@ func TestStorageHandler(t *testing.T) {
 	allowanceValues := url.Values{}
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
 		t.Fatal(err)
 	}
@@ -577,6 +581,8 @@ func TestResizeNonemptyStorageFolder(t *testing.T) {
 	allowanceValues := url.Values{}
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
 		t.Fatal(err)
 	}
@@ -935,6 +941,8 @@ func TestRemoveStorageFolderForced(t *testing.T) {
 	allowanceValues := url.Values{}
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	if err = st.stdPostAPI("/renter", allowanceValues); err != nil {
 		t.Fatal(err)
 	}

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -1,8 +1,5 @@
 package api
 
-// TODO: When setting renter settings, leave empty values unchanged instead of
-// zeroing them out.
-
 import (
 	"fmt"
 	"net/http"
@@ -178,62 +175,81 @@ func (api *API) renterHandlerGET(w http.ResponseWriter, req *http.Request, _ htt
 
 // renterHandlerPOST handles the API call to set the Renter's settings.
 func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	// Scan the allowance amount.
-	funds, ok := scanAmount(req.FormValue("funds"))
-	if !ok {
-		WriteError(w, Error{"unable to parse funds"}, http.StatusBadRequest)
-		return
-	}
+	// Get the existing settings
+	settings := api.renter.Settings()
 
+	// Scan the allowance amount. (optional parameter)
+	if f := req.FormValue("funds"); f != "" {
+		funds, ok := scanAmount(req.FormValue("funds"))
+		if !ok {
+			WriteError(w, Error{"unable to parse funds"}, http.StatusBadRequest)
+			return
+		}
+		settings.Allowance.Funds = funds
+	}
 	// Scan the number of hosts to use. (optional parameter)
-	var hosts uint64
-	if req.FormValue("hosts") != "" {
-		_, err := fmt.Sscan(req.FormValue("hosts"), &hosts)
-		if err != nil {
+	if h := req.FormValue("hosts"); h != "" {
+		var hosts uint64
+		if _, err := fmt.Sscan(h, &hosts); err != nil {
 			WriteError(w, Error{"unable to parse hosts: " + err.Error()}, http.StatusBadRequest)
 			return
-		}
-		if hosts != 0 && hosts < requiredHosts {
+		} else if hosts != 0 && hosts < requiredHosts {
 			WriteError(w, Error{fmt.Sprintf("insufficient number of hosts, need at least %v but have %v", recommendedHosts, hosts)}, http.StatusBadRequest)
+		} else {
+			settings.Allowance.Hosts = hosts
+		}
+	}
+	// Scan the period. (optional parameter)
+	if p := req.FormValue("period"); p != "" {
+		var period types.BlockHeight
+		if _, err := fmt.Sscan(p, &period); err != nil {
+			WriteError(w, Error{"unable to parse period: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
-	} else {
-		hosts = recommendedHosts
+		settings.Allowance.Period = types.BlockHeight(period)
 	}
-
-	// Scan the period.
-	var period types.BlockHeight
-	_, err := fmt.Sscan(req.FormValue("period"), &period)
-	if err != nil {
-		WriteError(w, Error{"unable to parse period: " + err.Error()}, http.StatusBadRequest)
-		return
-	}
-
 	// Scan the renew window. (optional parameter)
-	var renewWindow types.BlockHeight
-	if req.FormValue("renewwindow") != "" {
-		_, err = fmt.Sscan(req.FormValue("renewwindow"), &renewWindow)
-		if err != nil {
+	if rw := req.FormValue("renewwindow"); rw != "" {
+		var renewWindow types.BlockHeight
+		if _, err := fmt.Sscan(rw, &renewWindow); err != nil {
 			WriteError(w, Error{"unable to parse renewwindow: " + err.Error()}, http.StatusBadRequest)
 			return
-		}
-		if renewWindow != 0 && renewWindow < requiredRenewWindow {
+		} else if renewWindow != 0 && types.BlockHeight(renewWindow) < requiredRenewWindow {
 			WriteError(w, Error{fmt.Sprintf("renew window is too small, must be at least %v blocks but have %v blocks", requiredRenewWindow, renewWindow)}, http.StatusBadRequest)
 			return
+		} else {
+			settings.Allowance.RenewWindow = types.BlockHeight(renewWindow)
 		}
-	} else {
-		renewWindow = period / 2
 	}
-
+	// Scan the packet size. (optional parameter)
+	if p := req.FormValue("packetsize"); p != "" {
+		var packetSize uint64
+		if _, err := fmt.Sscan(p, &packetSize); err != nil {
+			WriteError(w, Error{"unable to parse packetsize: " + err.Error()}, http.StatusBadRequest)
+			return
+		}
+		settings.PacketSize = packetSize
+	}
+	// Scan the download speed limit. (optional parameter)
+	if d := req.FormValue("downloadspeed"); d != "" {
+		var downloadSpeed int64
+		if _, err := fmt.Sscan(d, &downloadSpeed); err != nil {
+			WriteError(w, Error{"unable to parse downloadspeed: " + err.Error()}, http.StatusBadRequest)
+			return
+		}
+		settings.DownloadSpeed = downloadSpeed
+	}
+	// Scan the upload speed limit. (optional parameter)
+	if u := req.FormValue("uploadspeed"); u != "" {
+		var uploadSpeed int64
+		if _, err := fmt.Sscan(u, &uploadSpeed); err != nil {
+			WriteError(w, Error{"unable to parse uploadspeed: " + err.Error()}, http.StatusBadRequest)
+			return
+		}
+		settings.UploadSpeed = uploadSpeed
+	}
 	// Set the settings in the renter.
-	err = api.renter.SetSettings(modules.RenterSettings{
-		Allowance: modules.Allowance{
-			Funds:       funds,
-			Hosts:       hosts,
-			Period:      period,
-			RenewWindow: renewWindow,
-		},
-	})
+	err := api.renter.SetSettings(settings)
 	if err != nil {
 		WriteError(w, Error{err.Error()}, http.StatusBadRequest)
 		return
@@ -335,7 +351,7 @@ func (api *API) renterLoadHandler(w http.ResponseWriter, req *http.Request, _ ht
 
 // renterLoadAsciiHandler handles the API call to load a '.sia' file
 // in ASCII form.
-func (api *API) renterLoadAsciiHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+func (api *API) renterLoadASCIIHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	files, err := api.renter.LoadSharedFilesASCII(req.FormValue("asciisia"))
 	if err != nil {
 		WriteError(w, Error{err.Error()}, http.StatusBadRequest)
@@ -512,7 +528,7 @@ func (api *API) renterShareHandler(w http.ResponseWriter, req *http.Request, ps 
 
 // renterShareAsciiHandler handles the API call to return a '.sia' file
 // in ascii form.
-func (api *API) renterShareAsciiHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+func (api *API) renterShareASCIIHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	ascii, err := api.renter.ShareFilesASCII(strings.Split(req.FormValue("siapaths"), ","))
 	if err != nil {
 		WriteError(w, Error{err.Error()}, http.StatusBadRequest)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -180,7 +180,7 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 
 	// Scan the allowance amount. (optional parameter)
 	if f := req.FormValue("funds"); f != "" {
-		funds, ok := scanAmount(req.FormValue("funds"))
+		funds, ok := scanAmount(f)
 		if !ok {
 			WriteError(w, Error{"unable to parse funds"}, http.StatusBadRequest)
 			return

--- a/node/api/renterhost_test.go
+++ b/node/api/renterhost_test.go
@@ -51,6 +51,7 @@ func TestHostObligationAcceptingContracts(t *testing.T) {
 	allowanceValues.Set("funds", "50000000000000000000000000000") // 50k SC
 	allowanceValues.Set("hosts", "1")
 	allowanceValues.Set("period", "10")
+	allowanceValues.Set("renewwindow", "5")
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -184,6 +185,7 @@ func TestRenterLocalRepair(t *testing.T) {
 	allowanceValues.Set("funds", "50000000000000000000000000000") // 50k SC
 	allowanceValues.Set("hosts", "2")
 	allowanceValues.Set("period", "10")
+	allowanceValues.Set("renewwindow", "5")
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -441,6 +443,7 @@ func TestRemoteFileRepair(t *testing.T) {
 	allowanceValues.Set("funds", "50000000000000000000000000000") // 50k SC
 	allowanceValues.Set("hosts", "2")
 	allowanceValues.Set("period", "10")
+	allowanceValues.Set("renewwindow", "5")
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -692,9 +695,12 @@ func TestHostAndRentVanilla(t *testing.T) {
 	allowanceValues := url.Values{}
 	testFunds := "10000000000000000000000000000" // 10k SC
 	testPeriod := "20"
+	renewWindow := "10"
 	testPeriodInt := 20
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", renewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -1225,6 +1231,8 @@ func TestRenterUploadDownload(t *testing.T) {
 	testPeriod := "10"
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -1367,6 +1375,8 @@ func TestRenterCancelAllowance(t *testing.T) {
 	testPeriod := "20"
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -1463,6 +1473,8 @@ func TestRenterParallelDelete(t *testing.T) {
 	testPeriod := "10"
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -1585,6 +1597,8 @@ func TestRenterRenew(t *testing.T) {
 	testPeriod := 10
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", strconv.Itoa(testPeriod))
+	allowanceValues.Set("renewwindow", strconv.Itoa(testPeriod/2))
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -1824,6 +1838,8 @@ func TestHostAndRentReload(t *testing.T) {
 	testPeriod := "10"
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -2134,6 +2150,7 @@ func TestRedundancyReporting(t *testing.T) {
 	allowanceValues.Set("funds", "50000000000000000000000000000") // 50k SC
 	allowanceValues.Set("hosts", "2")
 	allowanceValues.Set("period", "10")
+	allowanceValues.Set("renewwindow", "5")
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)
@@ -2334,6 +2351,7 @@ func TestUploadedBytesReporting(t *testing.T) {
 	allowanceValues.Set("funds", "50000000000000000000000000000") // 50k SC
 	allowanceValues.Set("hosts", "2")
 	allowanceValues.Set("period", "10")
+	allowanceValues.Set("renewwindow", "5")
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)

--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -12,7 +12,7 @@ import (
 // buildHttpRoutes sets up and returns an * httprouter.Router.
 // it connected the Router to the given api using the required
 // parameters: requiredUserAgent and requiredPassword
-func (api *API) buildHttpRoutes(requiredUserAgent string, requiredPassword string) {
+func (api *API) buildHTTPRoutes(requiredUserAgent string, requiredPassword string) {
 	router := httprouter.New()
 
 	router.NotFound = http.HandlerFunc(UnrecognizedCallHandler)

--- a/node/api/wallet_test.go
+++ b/node/api/wallet_test.go
@@ -1149,6 +1149,8 @@ func TestWalletSiafunds(t *testing.T) {
 	testPeriod := "20"
 	allowanceValues.Set("funds", testFunds)
 	allowanceValues.Set("period", testPeriod)
+	allowanceValues.Set("renewwindow", testRenewWindow)
+	allowanceValues.Set("hosts", fmt.Sprint(recommendedHosts))
 	err = st.stdPostAPI("/renter", allowanceValues)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR changes quite a few things about the renter's settings endpoint. All fields of the allowance must be optional to change because we don't want to change the allowance every time we want to change a different setting. That means many tests fail and also have to be adjusted.
Now `SetAllowance` will still sanity check the allowance before applying it, but every value that is not set will cause the setting to be unchanged. If that results in a field being not set in still not being set, `SetAllowance` should return an error. That means the user can't simply call the endpoint without providing parameters and still expect sane values to be set automatically.