### PR TITLE
Clearer defrag log message

### DIFF
--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -182,6 +182,6 @@ func (w *Wallet) threadedDefragWallet() {
 	}
 	w.log.Println("Submitting a transaction set to defragment the wallet's outputs, IDs:")
 	for _, txn := range txnSet {
-		w.log.Println("\t", txn.ID())
+		w.log.Println("Wallet defrag: \t", txn.ID())
 	}
 }


### PR DESCRIPTION
This is in response to #2814, but certainly not a complete solution.

Wallet defrag actions should be explicitly labeled in the `wallet.log` file.