### PR TITLE
increment revision number in hostSettings

### DIFF
--- a/modules/host/negotiatesettings.go
+++ b/modules/host/negotiatesettings.go
@@ -25,6 +25,9 @@ func (h *Host) capacity() (total, remaining uint64) {
 
 // externalSettings compiles and returns the external settings for the host.
 func (h *Host) externalSettings() modules.HostExternalSettings {
+	// Increment the revision number for the external settings
+	h.revisionNumber++
+
 	totalStorage, remainingStorage := h.capacity()
 	var netAddr modules.NetAddress
 	if h.settings.NetAddress != "" {
@@ -83,7 +86,6 @@ func (h *Host) managedRPCSettings(conn net.Conn) error {
 	var hes modules.HostExternalSettings
 	var secretKey crypto.SecretKey
 	h.mu.Lock()
-	h.revisionNumber++
 	secretKey = h.secretKey
 	hes = h.externalSettings()
 	h.mu.Unlock()


### PR DESCRIPTION
Whenever `externalSettings` is called we calculate new contract fees according to the current transaction pool's fee estimation and in the future we will also dynamically adjust other metrics like storage and bandwidth price. That means two subsequent calls to `externalSettings` might not create the exact same settings.
That means we need to update the revision number every time we call `externalSettings` and can move the code that increments the revision number into `externalSettings` instead of incrementing it every time right before we call the method.