### PR TITLE
Improve redundancy reporting

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -88,7 +88,7 @@ func (f *file) numChunks() uint64 {
 }
 
 // available indicates whether the file is ready to be downloaded.
-func (f *file) available(contractStatus func(types.FileContractID) (bool, bool)) bool {
+func (f *file) available(contractStatus func(types.FileContractID) (offline bool, goodForRenew bool)) bool {
 	chunkPieces := make([]int, f.numChunks())
 	for _, fc := range f.contracts {
 		if offline, _ := contractStatus(fc.ID); offline {
@@ -148,14 +148,14 @@ func (f *file) redundancy(contractStatus func(types.FileContractID) (bool, bool)
 		return -1
 	}
 	for _, fc := range f.contracts {
-		offline, gfr := contractStatus(fc.ID)
+		offline, goodForRenew := contractStatus(fc.ID)
 
 		// do not count pieces from the contract if the contract is offline
 		if offline {
 			continue
 		}
 		for _, p := range fc.Pieces {
-			if gfr {
+			if goodForRenew {
 				piecesPerChunk[p.Chunk]++
 			}
 			piecesPerChunkNoRenew[p.Chunk]++

--- a/modules/renter/files_test.go
+++ b/modules/renter/files_test.go
@@ -44,8 +44,8 @@ func TestFileAvailable(t *testing.T) {
 		erasureCode: rsc,
 		pieceSize:   100,
 	}
-	neverOffline := func(types.FileContractID) bool {
-		return false
+	neverOffline := func(types.FileContractID) (bool, bool) {
+		return false, true
 	}
 
 	if f.available(neverOffline) {
@@ -62,8 +62,8 @@ func TestFileAvailable(t *testing.T) {
 		t.Error("file should be available")
 	}
 
-	specificOffline := func(fcid types.FileContractID) bool {
-		return fcid == fc.ID
+	specificOffline := func(fcid types.FileContractID) (bool, bool) {
+		return fcid == fc.ID, true
 	}
 	if f.available(specificOffline) {
 		t.Error("file should not be available")
@@ -109,11 +109,8 @@ func TestFileUploadProgressPinning(t *testing.T) {
 // with varying number of filecontracts and erasure code settings.
 func TestFileRedundancy(t *testing.T) {
 	nDatas := []int{1, 2, 10}
-	neverOffline := func(types.FileContractID) bool {
-		return false
-	}
-	alwaysRenewable := func(types.FileContractID) bool {
-		return true
+	neverOffline := func(types.FileContractID) (bool, bool) {
+		return false, true
 	}
 	for _, nData := range nDatas {
 		rsc, _ := NewRSCode(nData, 10)
@@ -124,7 +121,7 @@ func TestFileRedundancy(t *testing.T) {
 			erasureCode: rsc,
 		}
 		// Test that an empty file has 0 redundancy.
-		if r := f.redundancy(neverOffline, alwaysRenewable); r != 0 {
+		if r := f.redundancy(neverOffline); r != 0 {
 			t.Error("expected 0 redundancy, got", r)
 		}
 		// Test that a file with 1 filecontract that has a piece for every chunk but
@@ -140,7 +137,7 @@ func TestFileRedundancy(t *testing.T) {
 			fc.Pieces = append(fc.Pieces, pd)
 		}
 		f.contracts[fc.ID] = fc
-		if r := f.redundancy(neverOffline, alwaysRenewable); r != 0 {
+		if r := f.redundancy(neverOffline); r != 0 {
 			t.Error("expected 0 redundancy, got", r)
 		}
 		// Test that adding another filecontract with a piece for every chunk but one
@@ -156,7 +153,7 @@ func TestFileRedundancy(t *testing.T) {
 			fc.Pieces = append(fc.Pieces, pd)
 		}
 		f.contracts[fc.ID] = fc
-		if r := f.redundancy(neverOffline, alwaysRenewable); r != 0 {
+		if r := f.redundancy(neverOffline); r != 0 {
 			t.Error("expected 0 redundancy, got", r)
 		}
 		// Test that adding a file contract with a piece for the missing chunk
@@ -172,7 +169,7 @@ func TestFileRedundancy(t *testing.T) {
 		f.contracts[fc.ID] = fc
 		// 1.0 / MinPieces because the chunk with the least number of pieces has 1 piece.
 		expectedR := 1.0 / float64(f.erasureCode.MinPieces())
-		if r := f.redundancy(neverOffline, alwaysRenewable); r != expectedR {
+		if r := f.redundancy(neverOffline); r != expectedR {
 			t.Errorf("expected %f redundancy, got %f", expectedR, r)
 		}
 		// Test that adding a file contract that has erasureCode.MinPieces() pieces
@@ -191,7 +188,7 @@ func TestFileRedundancy(t *testing.T) {
 		f.contracts[fc.ID] = fc
 		// 1+MinPieces / MinPieces because the chunk with the least number of pieces has 1+MinPieces pieces.
 		expectedR = float64(1+f.erasureCode.MinPieces()) / float64(f.erasureCode.MinPieces())
-		if r := f.redundancy(neverOffline, alwaysRenewable); r != expectedR {
+		if r := f.redundancy(neverOffline); r != expectedR {
 			t.Errorf("expected %f redundancy, got %f", expectedR, r)
 		}
 
@@ -208,10 +205,10 @@ func TestFileRedundancy(t *testing.T) {
 			}
 		}
 		f.contracts[fc.ID] = fc
-		specificOffline := func(fcid types.FileContractID) bool {
-			return fcid == fc.ID
+		specificOffline := func(fcid types.FileContractID) (bool, bool) {
+			return fcid == fc.ID, true
 		}
-		if r := f.redundancy(specificOffline, alwaysRenewable); r != expectedR {
+		if r := f.redundancy(specificOffline); r != expectedR {
 			t.Errorf("expected redundancy to ignore offline file contracts, wanted %f got %f", expectedR, r)
 		}
 	}


### PR DESCRIPTION
This PR improves the redundancy report of the renter endpoint.
The renter doesn't count contracts that are not good for renewal towards redundancy while the renter endpoint does. That's why the renter might report redundancies > 3x.
Unfortunately we can't simply change the renter endpoint's behavior to match the renter's internal behavior since that might lead to redundancies < 1x which might lead to a poor UX even though the files can still be downloaded.
That's why this PR changes the endpoint to calculate both redundancies and if the redundancy without `goodForRenew` contracts drops below 1 it reports the higher redundancy.