### PR TITLE
Change Makefile build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,17 +63,23 @@ lint:
 spellcheck:
 	misspell -error .
 
+# debug builds and installs debug binaries.
+debug:
+	go install -tags='debug profile netgo' $(pkgs)
+debug-race:
+	go install -race -tags='debug profile netgo' $(pkgs)
+
 # dev builds and installs developer binaries.
 dev:
+	go install -tags='dev debug profile netgo' $(pkgs)
+dev-race:
 	go install -race -tags='dev debug profile netgo' $(pkgs)
 
 # release builds and installs release binaries.
 release:
-	go install -tags='debug profile netgo' $(pkgs)
-release-race:
-	go install -race -tags='debug profile netgo' $(pkgs)
-release-std:
 	go install -tags 'netgo' -a -ldflags='-s -w' $(pkgs)
+release-race:
+	go install -race -tags 'netgo' -a -ldflags='-s -w' $(pkgs)
 
 # clean removes all directories that get automatically created during
 # development.


### PR DESCRIPTION
This PR will result in 6 different build commands that can be used to build and install siad.

`make release`          (release build)
`make release-race`  (release build with race check)
`make debug`            (build with debug flag set and without optimizations)
`make debug-race`    (same as make debug with race check)
`make dev`                 (same as make debug + dev flag)
`make dev-race`        (same as make debug-race + dev flat)