### PR TITLE
fix make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-# all will build and install developer binaries, which have debugging enabled
-# and much faster mining and block constants.
-all: release-std
+# all will build and install release binaries.
+all: release
 
 # dependencies installs all of the dependencies that are required for building
 # Sia.


### PR DESCRIPTION
#2827 broke `make all`, which used to run `release-std`. The comment was also inconsistent with the behavior. I changed the comment instead of the behavior, but I'm fine changing the behavior instead. In practice I only use `make` to quickly check for compile-time errors, so the exact build constants don't affect my workflow.