### PR TITLE
Fix externalSettings race

### DIFF
--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -314,8 +314,8 @@ func (h *Host) Close() error {
 // set by the user (host is configured through InternalSettings), and are the
 // values that get displayed to other hosts on the network.
 func (h *Host) ExternalSettings() modules.HostExternalSettings {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	err := h.tg.Add()
 	if err != nil {
 		build.Critical("Call to ExternalSettings after close")

--- a/modules/host/negotiatedownload.go
+++ b/modules/host/negotiatedownload.go
@@ -42,11 +42,11 @@ func (h *Host) managedDownloadIteration(conn net.Conn, so *storageObligation) er
 	}
 
 	// Grab a set of variables that will be useful later in the function.
-	h.mu.RLock()
+	h.mu.Lock()
 	blockHeight := h.blockHeight
 	secretKey := h.secretKey
 	settings := h.externalSettings()
-	h.mu.RUnlock()
+	h.mu.Unlock()
 
 	// Read the download requests, followed by the file contract revision that
 	// pays for them.

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -73,9 +73,9 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	// If the host is not accepting contracts, the connection can be closed.
 	// The renter has been given enough information in the host settings to
 	// understand that the connection is going to be closed.
-	h.mu.RLock()
+	h.mu.Lock()
 	settings := h.externalSettings()
-	h.mu.RUnlock()
+	h.mu.Unlock()
 	if !settings.AcceptingContracts {
 		h.log.Debugln("Turning down contract because the host is not accepting contracts.")
 		return nil

--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -118,9 +118,9 @@ func (h *Host) managedRPCRenewContract(conn net.Conn) error {
 		return extendErr("unable to read renter public key: ", ErrorConnection(err.Error()))
 	}
 
-	h.mu.RLock()
+	h.mu.Lock()
 	settings := h.externalSettings()
-	h.mu.RUnlock()
+	h.mu.Unlock()
 
 	// Verify that the transaction coming over the wire is a proper renewal.
 	err = h.managedVerifyRenewedContract(so, txnSet, renterPK)
@@ -221,14 +221,14 @@ func (h *Host) managedVerifyRenewedContract(so storageObligation, txnSet []types
 		return extendErr("transaction without file contract: ", errEmptyObject)
 	}
 
-	h.mu.RLock()
+	h.mu.Lock()
 	blockHeight := h.blockHeight
 	externalSettings := h.externalSettings()
 	internalSettings := h.settings
 	lockedStorageCollateral := h.financialMetrics.LockedStorageCollateral
 	publicKey := h.publicKey
 	unlockHash := h.unlockHash
-	h.mu.RUnlock()
+	h.mu.Unlock()
 	fc := txnSet[len(txnSet)-1].FileContracts[0]
 
 	// The file size and merkle root must match the file size and merkle root

--- a/modules/host/negotiaterevisecontract.go
+++ b/modules/host/negotiaterevisecontract.go
@@ -37,11 +37,11 @@ func (h *Host) managedRevisionIteration(conn net.Conn, so *storageObligation, fi
 	}
 
 	// Read some variables from the host for use later in the function.
-	h.mu.RLock()
+	h.mu.Lock()
 	settings := h.externalSettings()
 	secretKey := h.secretKey
 	blockHeight := h.blockHeight
-	h.mu.RUnlock()
+	h.mu.Unlock()
 
 	// The renter is going to send its intended modifications, followed by the
 	// file contract revision that pays for them.


### PR DESCRIPTION
Increment the revision counter inside of `externalSettings` causes a race since the caller doesn't always hold a write lock when calling `externalSettings`. Our convention dictates that an unexported method has to be called under a write lock though.