### PR TITLE
Display build metadata on `siad` startup and via `siac version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 # These variables get inserted into ./build/commit.go
-BUILD_TIME=$(shell date +%FT%T%z)
+BUILD_TIME=$(shell date)
 GIT_REVISION=$(shell git rev-parse --short HEAD)
-GIT_BRANCH=$(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 GIT_DIRTY=$(shell git diff-index --quiet HEAD -- || echo "✗-")
 
 ldflags= -X github.com/NebulousLabs/Sia/build.GitRevision=${GIT_DIRTY}${GIT_REVISION} \
--X github.com/NebulousLabs/Sia/build.GitBranch=${GIT_BRANCH} \
 -X github.com/NebulousLabs/Sia/build.BuildTime=${BUILD_TIME}
 
 # all will build and install release binaries

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_REVISION=$(shell git rev-parse --short HEAD)
 GIT_DIRTY=$(shell git diff-index --quiet HEAD -- || echo "✗-")
 
 ldflags= -X github.com/NebulousLabs/Sia/build.GitRevision=${GIT_DIRTY}${GIT_REVISION} \
--X github.com/NebulousLabs/Sia/build.BuildTime=${BUILD_TIME}
+-X "github.com/NebulousLabs/Sia/build.BuildTime=${BUILD_TIME}"
 
 # all will build and install release binaries
 all: release

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-# all will build and install release binaries.
+# These variables get inserted into ./build/commit.go
+BUILD_TIME=$(shell date +%FT%T%z)
+GIT_REVISION=$(shell git rev-parse --short HEAD)
+GIT_BRANCH=$(shell git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+GIT_DIRTY=$(shell git diff-index --quiet HEAD -- || echo "✗-")
+
+ldflags= -X github.com/NebulousLabs/Sia/build.GitRevision=${GIT_DIRTY}${GIT_REVISION} \
+-X github.com/NebulousLabs/Sia/build.GitBranch=${GIT_BRANCH} \
+-X github.com/NebulousLabs/Sia/build.BuildTime=${BUILD_TIME}
+
+# all will build and install release binaries
 all: release
 
 # dependencies installs all of the dependencies that are required for building
@@ -64,21 +74,21 @@ spellcheck:
 
 # debug builds and installs debug binaries.
 debug:
-	go install -tags='debug profile netgo' $(pkgs)
+	go install -tags='debug profile netgo' -ldflags='$(ldflags)' $(pkgs)
 debug-race:
-	go install -race -tags='debug profile netgo' $(pkgs)
+	go install -race -tags='debug profile netgo' -ldflags='$(ldflags)' $(pkgs)
 
 # dev builds and installs developer binaries.
 dev:
-	go install -tags='dev debug profile netgo' $(pkgs)
+	go install -tags='dev debug profile netgo' -ldflags='$(ldflags)' $(pkgs)
 dev-race:
-	go install -race -tags='dev debug profile netgo' $(pkgs)
+	go install -race -tags='dev debug profile netgo' -ldflags='$(ldflags)' $(pkgs)
 
 # release builds and installs release binaries.
 release:
-	go install -tags 'netgo' -a -ldflags='-s -w' $(pkgs)
+	go install -tags='netgo' -a -ldflags='-s -w $(ldflags)' $(pkgs)
 release-race:
-	go install -race -tags 'netgo' -a -ldflags='-s -w' $(pkgs)
+	go install -race -tags='netgo' -a -ldflags='-s -w $(ldflags)' $(pkgs)
 
 # clean removes all directories that get automatically created during
 # development.

--- a/build/commit.go
+++ b/build/commit.go
@@ -2,5 +2,8 @@ package build
 
 // GitRevision and BuildTime get assigned via the Makefile when built.
 var (
-	GitRevision, BuildTime string
+	// GitRevision is the git commit hash used when built
+	GitRevision string
+	// BuildTime is the date and time the build was completed
+	BuildTime string
 )

--- a/build/commit.go
+++ b/build/commit.go
@@ -1,0 +1,7 @@
+package build
+
+// GitRevision, GitBranch, and BuildTime get assigned via the Makefile when
+// built.
+var (
+	GitRevision, GitBranch, BuildTime string
+)

--- a/build/commit.go
+++ b/build/commit.go
@@ -1,7 +1,6 @@
 package build
 
-// GitRevision, GitBranch, and BuildTime get assigned via the Makefile when
-// built.
+// GitRevision and BuildTime get assigned via the Makefile when built.
 var (
-	GitRevision, GitBranch, BuildTime string
+	GitRevision, BuildTime string
 )

--- a/cmd/siac/daemoncmd.go
+++ b/cmd/siac/daemoncmd.go
@@ -49,8 +49,7 @@ func versioncmd() {
 	fmt.Println("\tVersion " + build.Version)
 	if build.GitRevision != "" {
 		fmt.Println("\tGit Revision " + build.GitRevision)
-		fmt.Println("\tGit Branch " + build.GitBranch)
-		fmt.Println("\tBuild Time " + build.BuildTime)
+		fmt.Println("\tBuild Time   " + build.BuildTime)
 	}
 	var dvg api.DaemonVersionGet
 	err := getAPI("/daemon/version", &dvg)
@@ -62,8 +61,7 @@ func versioncmd() {
 	fmt.Println("\tVersion " + dvg.Version)
 	if build.GitRevision != "" {
 		fmt.Println("\tGit Revision " + dvg.GitRevision)
-		fmt.Println("\tGit Branch " + dvg.GitBranch)
-		fmt.Println("\tBuild Time " + dvg.BuildTime)
+		fmt.Println("\tBuild Time   " + dvg.BuildTime)
 	}
 }
 

--- a/cmd/siac/daemoncmd.go
+++ b/cmd/siac/daemoncmd.go
@@ -45,14 +45,26 @@ type updateInfo struct {
 
 // version prints the version of siac and siad.
 func versioncmd() {
-	fmt.Println("Sia Client v" + build.Version)
+	fmt.Println("Sia Client")
+	fmt.Println("\tVersion " + build.Version)
+	if build.GitRevision != "" {
+		fmt.Println("\tGit Revision " + build.GitRevision)
+		fmt.Println("\tGit Branch " + build.GitBranch)
+		fmt.Println("\tBuild Time " + build.BuildTime)
+	}
 	var dvg api.DaemonVersionGet
 	err := getAPI("/daemon/version", &dvg)
 	if err != nil {
 		fmt.Println("Could not get daemon version:", err)
 		return
 	}
-	fmt.Println("Sia Daemon v" + dvg.Version)
+	fmt.Println("Sia Daemon")
+	fmt.Println("\tVersion " + dvg.Version)
+	if build.GitRevision != "" {
+		fmt.Println("\tGit Revision " + dvg.GitRevision)
+		fmt.Println("\tGit Branch " + dvg.GitBranch)
+		fmt.Println("\tBuild Time " + dvg.BuildTime)
+	}
 }
 
 // stopcmd is the handler for the command `siac stop`.

--- a/cmd/siad/daemon.go
+++ b/cmd/siad/daemon.go
@@ -151,8 +151,13 @@ func startDaemon(config Config) (err error) {
 		}
 	}
 
-	// Print the Siad Version
+	// Print the siad Version and GitRevision
 	fmt.Println("Sia Daemon v" + build.Version)
+	if build.GitRevision == "" {
+		fmt.Println("WARN: compiled without build commit or version. To compile correctly, please use the makefile")
+	} else {
+		fmt.Println("Git Revision " + build.GitRevision)
+	}
 
 	// Install a signal handler that will catch exceptions thrown by mmap'd
 	// files.

--- a/cmd/siad/server.go
+++ b/cmd/siad/server.go
@@ -89,7 +89,6 @@ type (
 	DaemonVersion struct {
 		Version     string `json:"version"`
 		GitRevision string `json:"gitrevision"`
-		GitBranch   string `json:"gitbranch"`
 		BuildTime   string `json:"buildtime"`
 	}
 	// UpdateInfo indicates whether an update is available, and to what
@@ -361,7 +360,7 @@ func (srv *Server) daemonConstantsHandler(w http.ResponseWriter, _ *http.Request
 
 // daemonVersionHandler handles the API call that requests the daemon's version.
 func (srv *Server) daemonVersionHandler(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	api.WriteJSON(w, DaemonVersion{Version: build.Version, GitRevision: build.GitRevision, GitBranch: build.GitBranch, BuildTime: build.BuildTime})
+	api.WriteJSON(w, DaemonVersion{Version: build.Version, GitRevision: build.GitRevision, BuildTime: build.BuildTime})
 }
 
 // daemonStopHandler handles the API call to stop the daemon cleanly.

--- a/cmd/siad/server.go
+++ b/cmd/siad/server.go
@@ -87,7 +87,10 @@ type (
 
 	// DaemonVersion holds the version information for siad
 	DaemonVersion struct {
-		Version string `json:"version"`
+		Version     string `json:"version"`
+		GitRevision string `json:"gitrevision"`
+		GitBranch   string `json:"gitbranch"`
+		BuildTime   string `json:"buildtime"`
 	}
 	// UpdateInfo indicates whether an update is available, and to what
 	// version.
@@ -358,7 +361,7 @@ func (srv *Server) daemonConstantsHandler(w http.ResponseWriter, _ *http.Request
 
 // daemonVersionHandler handles the API call that requests the daemon's version.
 func (srv *Server) daemonVersionHandler(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
-	api.WriteJSON(w, DaemonVersion{Version: build.Version})
+	api.WriteJSON(w, DaemonVersion{Version: build.Version, GitRevision: build.GitRevision, GitBranch: build.GitBranch, BuildTime: build.BuildTime})
 }
 
 // daemonStopHandler handles the API call to stop the daemon cleanly.

--- a/node/api/daemon.go
+++ b/node/api/daemon.go
@@ -2,5 +2,8 @@ package api
 
 // DaemonVersionGet contains information about the running daemon's version.
 type DaemonVersionGet struct {
-	Version string
+	Version     string
+	GitRevision string
+	GitBranch   string
+	BuildTime   string
 }

--- a/node/api/daemon.go
+++ b/node/api/daemon.go
@@ -4,6 +4,5 @@ package api
 type DaemonVersionGet struct {
 	Version     string
 	GitRevision string
-	GitBranch   string
 	BuildTime   string
 }


### PR DESCRIPTION
When running your own build it can sometimes be difficult to identify exactly which commit you are running from.  This adds additional build information to the `siac version` command, and displays the git revision hash when `siad` starts up.  If the build was not completed via the Makefile `siad` will display a warning on start and `siac version` will not display any of the build information.