### PR TITLE
Peer to peer ip discovery

### DIFF
--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -212,3 +212,23 @@ var (
 		Testing:  5 * time.Second,
 	}).(time.Duration)
 )
+
+var (
+	// minPeersForIPDiscovery is the minimum number of peer connections we wait
+	// for before we try to discover our public ip from them. It is also the
+	// minimum number of successful replies we expect from our peers before we
+	// accept a result.
+	minPeersForIPDiscovery = build.Select(build.Var{
+		Standard: 5,
+		Dev:      1,
+		Testing:  1,
+	}).(int)
+
+	// peerDiscoveryRetryInterval is the time we wait when there were not
+	// enough peers to determine our public ip address before trying again.
+	peerDiscoveryRetryInterval = build.Select(build.Var{
+		Standard: 10 * time.Second,
+		Dev:      1 * time.Second,
+		Testing:  100 * time.Millisecond,
+	}).(time.Duration)
+)

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -224,6 +224,30 @@ var (
 		Testing:  2,
 	}).(int)
 
+	// timeoutIPDiscovery is the time after which managedIPFromPeers will fail
+	// if the ip couldn't be discovered successfully.
+	timeoutIPDiscovery = build.Select(build.Var{
+		Standard: 5 * time.Minute,
+		Dev:      5 * time.Minute,
+		Testing:  time.Minute,
+	}).(time.Duration)
+
+	// rediscoverIPIntervalSuccess is the time that has to pass after a
+	// successful IP discovery before we rediscover the IP.
+	rediscoverIPIntervalSuccess = build.Select(build.Var{
+		Standard: 6 * time.Hour,
+		Dev:      10 * time.Minute,
+		Testing:  30 * time.Second,
+	}).(time.Duration)
+
+	// rediscoverIPIntervalFailure is the time that has to pass after a failed
+	// IP discovery before we try again.
+	rediscoverIPIntervalFailure = build.Select(build.Var{
+		Standard: 30 * time.Minute,
+		Dev:      5 * time.Minute,
+		Testing:  10 * time.Second,
+	}).(time.Duration)
+
 	// peerDiscoveryRetryInterval is the time we wait when there were not
 	// enough peers to determine our public ip address before trying again.
 	peerDiscoveryRetryInterval = build.Select(build.Var{

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -220,8 +220,8 @@ var (
 	// accept a result.
 	minPeersForIPDiscovery = build.Select(build.Var{
 		Standard: 5,
-		Dev:      1,
-		Testing:  1,
+		Dev:      3,
+		Testing:  2,
 	}).(int)
 
 	// peerDiscoveryRetryInterval is the time we wait when there were not

--- a/modules/gateway/consts.go
+++ b/modules/gateway/consts.go
@@ -235,7 +235,7 @@ var (
 	// rediscoverIPIntervalSuccess is the time that has to pass after a
 	// successful IP discovery before we rediscover the IP.
 	rediscoverIPIntervalSuccess = build.Select(build.Var{
-		Standard: 6 * time.Hour,
+		Standard: 3 * time.Hour,
 		Dev:      10 * time.Minute,
 		Testing:  30 * time.Second,
 	}).(time.Duration)
@@ -243,8 +243,8 @@ var (
 	// rediscoverIPIntervalFailure is the time that has to pass after a failed
 	// IP discovery before we try again.
 	rediscoverIPIntervalFailure = build.Select(build.Var{
-		Standard: 30 * time.Minute,
-		Dev:      5 * time.Minute,
+		Standard: 15 * time.Minute,
+		Dev:      1 * time.Minute,
 		Testing:  10 * time.Second,
 	}).(time.Duration)
 

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -233,10 +233,12 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 
 	// Register RPCs.
 	g.RegisterRPC("ShareNodes", g.shareNodes)
+	g.RegisterRPC("DiscoverIP", g.discoverPeerIP)
 	g.RegisterConnectCall("ShareNodes", g.requestNodes)
 	// Establish the de-registration of the RPCs.
 	g.threads.OnStop(func() {
 		g.UnregisterRPC("ShareNodes")
+		g.UnregisterRPC("DiscoverIP")
 		g.UnregisterConnectCall("ShareNodes")
 	})
 

--- a/modules/gateway/ip.go
+++ b/modules/gateway/ip.go
@@ -21,7 +21,8 @@ func (g *Gateway) discoverPeerIP(conn modules.PeerConn) error {
 	return encoding.WriteObject(conn, host)
 }
 
-// managedIPFromPeers asks the peers the node is connected to for the node's public ip address. If not enough peers are available
+// managedIPFromPeers asks the peers the node is connected to for the node's
+// public ip address. If not enough peers are available
 func (g *Gateway) managedIPFromPeers() (string, error) {
 	for {
 		// Check for shutdown signal.
@@ -79,6 +80,7 @@ func (g *Gateway) managedIPFromPeers() (string, error) {
 		// it valid.
 		for addr, count := range addresses {
 			if count > successfulResponses/2 {
+				g.log.Println("ip successfully discovered using peers:", addr)
 				return addr, nil
 			}
 		}

--- a/modules/gateway/ip.go
+++ b/modules/gateway/ip.go
@@ -1,0 +1,87 @@
+package gateway
+
+import (
+	"net"
+	"time"
+
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/errors"
+)
+
+// discoverPeerIP is the handler for the discoverPeer RPC. It returns the
+// public ip of the caller back to the caller. This allows for peer-to-peer ip
+// discovery without centralized services.
+func (g *Gateway) discoverPeerIP(conn modules.PeerConn) error {
+	conn.SetDeadline(time.Now().Add(connStdDeadline))
+	host, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		return errors.AddContext(err, "failed to split host from port")
+	}
+	return encoding.WriteObject(conn, host)
+}
+
+// managedIPFromPeers asks the peers the node is connected to for the node's public ip address. If not enough peers are available
+func (g *Gateway) managedIPFromPeers() (string, error) {
+	for {
+		// Check for shutdown signal.
+		select {
+		case <-g.peerTG.StopChan():
+			return "", errors.New("interrupted by shutdown")
+		default:
+		}
+
+		// Get peers
+		g.mu.RLock()
+		peers := g.Peers()
+		g.mu.RUnlock()
+
+		// Check if there are enough peers. Otherwise wait.
+		if len(peers) < minPeersForIPDiscovery {
+			select {
+			case <-time.After(peerDiscoveryRetryInterval):
+			case <-g.peerTG.StopChan():
+			}
+			continue
+		}
+
+		// Ask all the peers about our ip in parallel
+		returnChan := make(chan modules.NetAddress)
+		for _, peer := range peers {
+			go g.RPC(peer.NetAddress, "DiscoverIP", func(conn modules.PeerConn) error {
+				var address string
+				err := encoding.ReadObject(conn, &address, 100)
+				returnChan <- modules.NetAddress(address)
+				return err
+			})
+		}
+		// Wait for their responses
+		addresses := make(map[string]int)
+		for i := 0; i < len(peers); i++ {
+			addr := <-returnChan
+			if addr.IsValid() == nil {
+				addresses[addr.Host()]++
+			}
+		}
+		// If there haven't been enough successful responses we wait some time.
+		if len(addresses) < minPeersForIPDiscovery {
+			select {
+			case <-time.After(peerDiscoveryRetryInterval):
+			case <-g.peerTG.StopChan():
+			}
+			continue
+		}
+		// If an address was returned by more than half the peers we consider
+		// it valid.
+		for addr, count := range addresses {
+			if count > len(addresses)/2 {
+				return addr, nil
+			}
+		}
+		// Otherwise we wait before trying again.
+		select {
+		case <-time.After(peerDiscoveryRetryInterval):
+		case <-g.peerTG.StopChan():
+		}
+	}
+}

--- a/modules/gateway/ip_test.go
+++ b/modules/gateway/ip_test.go
@@ -1,0 +1,45 @@
+package gateway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/modules"
+)
+
+// TestIpRPC tests the ip discovery RPC.
+func TestIpRPC(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	// Create gateways for testing.
+	g1 := newNamedTestingGateway(t, "1")
+	defer g1.Close()
+	g2 := newNamedTestingGateway(t, "2")
+	defer g2.Close()
+
+	// Connect gateways.
+	err := g1.Connect(g2.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call RPC
+	err = g1.RPC(g2.Address(), "DiscoverIP", func(conn modules.PeerConn) error {
+		var address string
+		err := encoding.ReadObject(conn, &address, 100)
+		if err != nil {
+			t.Error("failed to read object from response", err)
+		}
+		if address != g1.Address().Host() {
+			return fmt.Errorf("ip addresses don't match %v != %v", g1.Address().Host(), address)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal("RPC failed", err)
+	}
+}

--- a/modules/gateway/ip_test.go
+++ b/modules/gateway/ip_test.go
@@ -43,3 +43,38 @@ func TestIpRPC(t *testing.T) {
 		t.Fatal("RPC failed", err)
 	}
 }
+
+// TestIpFromPeers test the functionality of managedIPFromPeers.
+func TestIPFromPeers(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	t.Parallel()
+
+	// Create gateways for testing.
+	g1 := newNamedTestingGateway(t, "1")
+	defer g1.Close()
+	g2 := newNamedTestingGateway(t, "2")
+	defer g2.Close()
+	g3 := newNamedTestingGateway(t, "3")
+	defer g2.Close()
+
+	// Connect gateways.
+	err := g1.Connect(g2.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = g1.Connect(g3.Address())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Discover ip using the peers
+	host, err := g1.managedIPFromPeers()
+	if err != nil {
+		t.Fatal("failed to get ip", err)
+	}
+	if host != g1.Address().Host() {
+		t.Fatalf("ip should be %v but was %v", g1.Address().Host(), host)
+	}
+}

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -41,9 +41,7 @@ func myExternalIP() (string, error) {
 	return strings.TrimSpace(string(buf)), nil
 }
 
-// threadedLearnHostname discovers the external IP of the Gateway. Once the IP
-// has been discovered, it registers the ShareNodes RPC to be called on new
-// connections, advertising the IP to other nodes.
+// threadedLearnHostname discovers the external IP of the Gateway regularly.
 func (g *Gateway) threadedLearnHostname() {
 	if err := g.threads.Add(); err != nil {
 		return
@@ -54,36 +52,54 @@ func (g *Gateway) threadedLearnHostname() {
 		return
 	}
 
-	// try UPnP first, then fallback to myexternalip.com
-	var host string
-	d, err := upnp.Discover()
-	if err == nil {
-		host, err = d.ExternalIP()
-	}
-	if err != nil {
-		host, err = myExternalIP()
-	}
-	if err != nil {
-		host, err = g.managedIPFromPeers()
-	}
-	if err != nil {
-		g.log.Println("WARN: failed to discover external IP:", err)
-		return
-	}
+	for {
+		// try UPnP first, then fallback to myexternalip.com and peer-to-peer
+		// discovery.
+		var host string
+		d, err := upnp.Discover()
+		if err == nil {
+			host, err = d.ExternalIP()
+		}
+		if err != nil {
+			host, err = myExternalIP()
+		}
+		if err != nil {
+			host, err = g.managedIPFromPeers()
+		}
+		if err != nil {
+			g.log.Println("WARN: failed to discover external IP:", err)
+		}
+		// If we were unable to discover our IP we try again later.
+		if err != nil {
+			select {
+			case <-g.threads.StopChan():
+				return
+			case <-time.After(rediscoverIPIntervalFailure):
+				continue
+			}
+		}
 
-	g.mu.RLock()
-	addr := modules.NetAddress(net.JoinHostPort(host, g.port))
-	g.mu.RUnlock()
-	if err := addr.IsValid(); err != nil {
-		g.log.Printf("WARN: discovered hostname %q is invalid: %v", addr, err)
-		return
+		g.mu.RLock()
+		addr := modules.NetAddress(net.JoinHostPort(host, g.port))
+		g.mu.RUnlock()
+		if err := addr.IsValid(); err != nil {
+			g.log.Printf("WARN: discovered hostname %q is invalid: %v", addr, err)
+			return
+		}
+
+		g.mu.Lock()
+		g.myAddr = addr
+		g.mu.Unlock()
+
+		g.log.Println("INFO: our address is", addr)
+
+		// Rediscover the IP later in case it changed.
+		select {
+		case <-g.threads.StopChan():
+			return
+		case <-time.After(rediscoverIPIntervalSuccess):
+		}
 	}
-
-	g.mu.Lock()
-	g.myAddr = addr
-	g.mu.Unlock()
-
-	g.log.Println("INFO: our address is", addr)
 }
 
 // threadedForwardPort adds a port mapping to the router.

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -64,6 +64,9 @@ func (g *Gateway) threadedLearnHostname() {
 		host, err = myExternalIP()
 	}
 	if err != nil {
+		host, err = g.managedIPFromPeers()
+	}
+	if err != nil {
 		g.log.Println("WARN: failed to discover external IP:", err)
 		return
 	}

--- a/modules/gateway/upnp.go
+++ b/modules/gateway/upnp.go
@@ -70,10 +70,11 @@ func (g *Gateway) threadedLearnHostname() {
 			g.log.Println("WARN: failed to discover external IP:", err)
 		}
 		// If we were unable to discover our IP we try again later.
-		if err != nil && g.managedSleep(rediscoverIPIntervalFailure) {
+		if err != nil {
+			if !g.managedSleep(rediscoverIPIntervalFailure) {
+				return // shutdown interrupted sleep
+			}
 			continue
-		} else if err != nil {
-			return // shutdown interrupted sleep
 		}
 
 		g.mu.RLock()
@@ -81,10 +82,11 @@ func (g *Gateway) threadedLearnHostname() {
 		g.mu.RUnlock()
 		if err := addr.IsValid(); err != nil {
 			g.log.Printf("WARN: discovered hostname %q is invalid: %v", addr, err)
-			if err != nil && g.managedSleep(rediscoverIPIntervalFailure) {
+			if err != nil {
+				if !g.managedSleep(rediscoverIPIntervalFailure) {
+					return // shutdown interrupted sleep
+				}
 				continue
-			} else if err != nil {
-				return // shutdown interrupted sleep
 			}
 		}
 


### PR DESCRIPTION
So far the only centralized aspect of Sia has been the way a node discovers its public ip address if upnp isn't available. Our workaround was to use myexternalip.com as a fallback but recently they started banning certain ranges of ips and are therefore not reliable. This PR adds a second fallback (that will hopefully replace myexternalip.com completely one day) by using the peers the node is connected to. Once a certain number of peers is available, we query each one of them and if the majority of responses report the same ip, we accept it as our own public ip.