### PR TITLE
Pass ratelimit object when wraping net.Conn instead of having global ratelimit.

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -156,6 +156,12 @@ func (c *Contractor) ResolveID(id types.FileContractID) types.FileContractID {
 	return newID
 }
 
+// SetRateLimits sets the bandwidth limits for connections created by the
+// contractSet.
+func (c *Contractor) SetRateLimits(readBPS, writeBPS int64, packetSize uint64) {
+	c.contracts.SetRateLimits(readBPS, writeBPS, packetSize)
+}
+
 // Close closes the Contractor.
 func (c *Contractor) Close() error {
 	return c.tg.Stop()
@@ -222,6 +228,7 @@ func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, co
 		renewing:          make(map[types.FileContractID]bool),
 		revising:          make(map[types.FileContractID]bool),
 	}
+
 	// Close the contract set and logger upon shutdown.
 	c.tg.AfterStop(func() {
 		if err := c.contracts.Close(); err != nil {

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -173,7 +173,7 @@ func NewContractSet(dir string) (*ContractSet, error) {
 		wal:       wal,
 		dir:       dir,
 	}
-	// Set the initial rate limit to 'unlimited'.
+	// Set the initial rate limit to 'unlimited' bandwidth with 4kib packets.
 	cs.rl = ratelimit.NewRateLimit(0, 0, 0)
 
 	// Load the contract files.

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -9,6 +9,7 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
+	"github.com/NebulousLabs/ratelimit"
 
 	"github.com/NebulousLabs/writeaheadlog"
 )
@@ -21,6 +22,7 @@ type ContractSet struct {
 	wal       *writeaheadlog.WAL
 	dir       string
 	mu        sync.Mutex
+	rl        *ratelimit.RateLimit
 }
 
 // Acquire looks up the contract with the specified FileContractID and locks
@@ -97,6 +99,12 @@ func (cs *ContractSet) Return(c *SafeContract) {
 	safeContract.mu.Unlock()
 }
 
+// SetRateLimits sets the bandwidth limits for connections created by the
+// contractSet.
+func (cs *ContractSet) SetRateLimits(readBPS, writeBPS int64, packetSize uint64) {
+	cs.rl.SetLimits(readBPS, writeBPS, packetSize)
+}
+
 // View returns a copy of the contract with the specified ID. The contracts is
 // not locked. Certain fields, including the MerkleRoots, are set to nil for
 // safety reasons. If the contract is not present in the set, View
@@ -165,6 +173,8 @@ func NewContractSet(dir string) (*ContractSet, error) {
 		wal:       wal,
 		dir:       dir,
 	}
+	// Set the initial rate limit to 'unlimited'.
+	cs.rl = ratelimit.NewRateLimit(0, 0, 0)
 
 	// Load the contract files.
 	dirNames, err := d.Readdirnames(-1)

--- a/modules/renter/proto/downloader.go
+++ b/modules/renter/proto/downloader.go
@@ -165,11 +165,11 @@ func (cs *ContractSet) NewDownloader(host modules.HostDBEntry, id types.FileCont
 		}
 	}()
 
-	conn, closeChan, err := initiateRevisionLoop(host, contract, modules.RPCDownload, cancel)
+	conn, closeChan, err := initiateRevisionLoop(host, contract, modules.RPCDownload, cancel, cs.rl)
 	if IsRevisionMismatch(err) && len(sc.unappliedTxns) > 0 {
 		// we have desynced from the host. If we have unapplied updates from the
 		// WAL, try applying them.
-		conn, closeChan, err = initiateRevisionLoop(host, sc.unappliedHeader(), modules.RPCDownload, cancel)
+		conn, closeChan, err = initiateRevisionLoop(host, sc.unappliedHeader(), modules.RPCDownload, cancel, cs.rl)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -291,9 +291,9 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 	if s.MaxDownloadSpeed == 0 && s.MaxUploadSpeed == 0 {
 		r.hostContractor.SetRateLimits(0, 0, 0)
 	} else {
-		// TODO: In the future we might want the user to be able to configure the
-		// packetSize using the API. For now the sane default is modules.SectorSize
-		// if the user wants to limit the connection.
+		// TODO: In the future we might want the user to be able to configure
+		// the packetSize using the API. For now the sane default is 16kib if
+		// the user wants to limit the connection.
 		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
 	}
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -294,7 +294,7 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 		// TODO: In the future we might want the user to be able to configure the
 		// packetSize using the API. For now the sane default is modules.SectorSize
 		// if the user wants to limit the connection.
-		r.hostContractor.SetRateLimits(s.DownloadSpeed, s.UploadSpeed, 4*4096)
+		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
 	}
 
 	r.managedUpdateWorkerPool()

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -291,6 +291,9 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 	if s.MaxDownloadSpeed == 0 && s.MaxUploadSpeed == 0 {
 		r.hostContractor.SetRateLimits(0, 0, 0)
 	} else {
+		// TODO: In the future we might want the user to be able to configure the
+		// packetSize using the API. For now the sane default is modules.SectorSize
+		// if the user wants to limit the connection.
 		r.hostContractor.SetRateLimits(s.DownloadSpeed, s.UploadSpeed, 4*4096)
 	}
 

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -50,13 +50,24 @@ func (c *Client) RenterFilesGet() (rf api.RenterFiles, err error) {
 	return
 }
 
-// RenterPost uses the /renter endpoint to change the renter's allowance
-func (c *Client) RenterPost(allowance modules.Allowance) (err error) {
+// RenterPostAllowance uses the /renter endpoint to change the renter's allowance
+func (c *Client) RenterPostAllowance(allowance modules.Allowance) (err error) {
 	values := url.Values{}
 	values.Set("funds", allowance.Funds.String())
 	values.Set("hosts", strconv.FormatUint(allowance.Hosts, 10))
 	values.Set("period", strconv.FormatUint(uint64(allowance.Period), 10))
 	values.Set("renewwindow", strconv.FormatUint(uint64(allowance.RenewWindow), 10))
+	err = c.post("/renter", values.Encode(), nil)
+	return
+}
+
+// RenterPostRateLimit uses the /renter endpoint to change the renter's bandwidth rate
+// limit.
+func (c *Client) RenterPostRateLimit(readBPS, writeBPS int64, packetSize uint64) (err error) {
+	values := url.Values{}
+	values.Set("downloadspeed", strconv.FormatInt(readBPS, 10))
+	values.Set("uploadspeed", strconv.FormatInt(writeBPS, 10))
+	values.Set("packetsize", strconv.FormatUint(packetSize, 10))
 	err = c.post("/renter", values.Encode(), nil)
 	return
 }

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -63,11 +63,10 @@ func (c *Client) RenterPostAllowance(allowance modules.Allowance) (err error) {
 
 // RenterPostRateLimit uses the /renter endpoint to change the renter's bandwidth rate
 // limit.
-func (c *Client) RenterPostRateLimit(readBPS, writeBPS int64, packetSize uint64) (err error) {
+func (c *Client) RenterPostRateLimit(readBPS, writeBPS int64) (err error) {
 	values := url.Values{}
-	values.Set("downloadspeed", strconv.FormatInt(readBPS, 10))
-	values.Set("uploadspeed", strconv.FormatInt(writeBPS, 10))
-	values.Set("packetsize", strconv.FormatUint(packetSize, 10))
+	values.Set("maxdownloadspeed", strconv.FormatInt(readBPS, 10))
+	values.Set("maxuploadspeed", strconv.FormatInt(writeBPS, 10))
 	err = c.post("/renter", values.Encode(), nil)
 	return
 }

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -97,11 +97,11 @@ func testDownloadMultipleLargeSectors(t *testing.T, tg *siatest.TestGroup) {
 	// Grab the first of the group's renters
 	renter := tg.Renters()[0]
 	// set download limits and reset them after test.
-	if err := renter.RenterPostRateLimit(int64(fileSize)*2, 0, modules.SectorSize); err != nil {
+	if err := renter.RenterPostRateLimit(int64(fileSize)*2, 0); err != nil {
 		t.Fatal("failed to set renter bandwidth limit", err)
 	}
 	defer func() {
-		if err := renter.RenterPostRateLimit(0, 0, modules.SectorSize); err != nil {
+		if err := renter.RenterPostRateLimit(0, 0); err != nil {
 			t.Error("failed to reset renter bandwidth limit", err)
 		}
 	}()

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -302,7 +302,7 @@ func randomDir() string {
 // setRenterAllowances sets the allowance of each renter
 func setRenterAllowances(renters map[*TestNode]struct{}) error {
 	for renter := range renters {
-		if err := renter.RenterPost(defaultAllowance); err != nil {
+		if err := renter.RenterPostAllowance(defaultAllowance); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR changes the ratelimit to be module specific and not global by having to pass a `RateLimit` object to the constructor that wraps a `net.Conn`

This should not be merged without [#3](https://github.com/NebulousLabs/ratelimit/pull/3).
