### PR TITLE
Use validateSiapath function with RenameFile

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -302,9 +302,9 @@ func (r *Renter) RenameFile(currentName, newName string) error {
 	lockID := r.mu.Lock()
 	defer r.mu.Unlock(lockID)
 
-	// Check that newName is nonempty.
-	if newName == "" {
-		return ErrEmptyFilename
+	err := validateSiapath(newName)
+	if err != nil {
+		return err
 	}
 
 	// Check that currentName exists and newName doesn't.
@@ -320,7 +320,7 @@ func (r *Renter) RenameFile(currentName, newName string) error {
 	// Modify the file and save it to disk.
 	file.mu.Lock()
 	file.name = newName
-	err := r.saveFile(file)
+	err = r.saveFile(file)
 	file.mu.Unlock()
 	if err != nil {
 		return err

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -362,12 +362,10 @@ func validateSiapath(siapath string) error {
 	if strings.HasPrefix(siapath, "./") {
 		return errors.New("siapath connot begin with ./")
 	}
-	// check Contains
-	if strings.Contains(siapath, "/../") {
-		return errors.New("siapath cannot contain /../")
-	}
-	if strings.Contains(siapath, "/./") {
-		return errors.New("siapath cannot contain /./")
+	for _, pathElem := range strings.Split(siapath, "/") {
+		if pathElem == "." || pathElem == ".." {
+			return errors.New("siapath cannot contain . or .. elements")
+		}
 	}
 	return nil
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -352,6 +352,7 @@ func validateSiapath(siapath string) error {
 	if siapath == "." {
 		return errors.New("siapath cannot be .")
 	}
+	// check prefix
 	if strings.HasPrefix(siapath, "/") {
 		return errors.New("siapath cannot begin with /")
 	}
@@ -360,6 +361,13 @@ func validateSiapath(siapath string) error {
 	}
 	if strings.HasPrefix(siapath, "./") {
 		return errors.New("siapath connot begin with ./")
+	}
+	// check Contains
+	if strings.Contains(siapath, "/../") {
+		return errors.New("siapath cannot contain /../")
+	}
+	if strings.Contains(siapath, "/./") {
+		return errors.New("siapath cannot contain /./")
 	}
 	return nil
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -343,22 +343,24 @@ func (r *Renter) ProcessConsensusChange(cc modules.ConsensusChange) {
 // ../ is disallowed to prevent directory traversal, and paths must not begin
 // with / or be empty.
 func validateSiapath(siapath string) error {
-	if strings.HasPrefix(siapath, "/") {
-		return errors.New("siapath cannot begin with /")
-	}
-
 	if siapath == "" {
 		return ErrEmptyFilename
 	}
-
-	if strings.Contains(siapath, "../") {
-		return errors.New("directory traversal is not allowed")
+	if siapath == ".." {
+		return errors.New("siapath cannot be ..")
 	}
-
-	if strings.Contains(siapath, "./") {
-		return errors.New("siapath contains invalid characters")
+	if siapath == "." {
+		return errors.New("siapath cannot be .")
 	}
-
+	if strings.HasPrefix(siapath, "/") {
+		return errors.New("siapath cannot begin with /")
+	}
+	if strings.HasPrefix(siapath, "../") {
+		return errors.New("siapath cannot begin with ../")
+	}
+	if strings.HasPrefix(siapath, "./") {
+		return errors.New("siapath connot begin with ./")
+	}
 	return nil
 }
 

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -27,30 +26,6 @@ var (
 	// errUploadDirectory is returned if the user tries to upload a directory.
 	errUploadDirectory = errors.New("cannot upload directory")
 )
-
-// validateSiapath checks that a Siapath is a legal filename.
-// ../ is disallowed to prevent directory traversal, and paths must not begin
-// with / or be empty.
-func validateSiapath(siapath string) error {
-	if strings.HasPrefix(siapath, "/") {
-		return errors.New("siapath cannot begin with /")
-	}
-
-	if siapath == "" {
-		return ErrEmptyFilename
-	}
-
-	// TODO: What about names like "This is a sentence and a folder./This is a
-	// folder where the name trails off.../This is a file."
-	if strings.Contains(siapath, "../") {
-		return errors.New("directory traversal is not allowed")
-	}
-	if strings.Contains(siapath, "./") {
-		return errors.New("siapath contains invalid characters")
-	}
-
-	return nil
-}
 
 // validateSource verifies that a sourcePath meets the
 // requirements for upload.


### PR DESCRIPTION
This PR is in response to #2440 and another issue reported via Discord where a user was able to rename a file alias to a name with illegal characters.  Eventually we'll want to expand our validateSiapth function to prevent other illegal characters as they are discovered.