### PR TITLE
[WIP] Add uploadTime and modTime metadata to files

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
@@ -36,6 +37,8 @@ type file struct {
 	erasureCode modules.ErasureCoder // Static - can be accessed without lock.
 	pieceSize   uint64               // Static - can be accessed without lock.
 	mode        uint32               // actually an os.FileMode
+	uploadTime  time.Time            // Static - can be accessed without lock.
+	modTime     time.Time            // actually an os.ModTime
 
 	staticUID string // A UID assigned to the file when it gets created.
 

--- a/modules/renter/upload.go
+++ b/modules/renter/upload.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
@@ -83,6 +84,8 @@ func (r *Renter) Upload(up modules.FileUploadParams) error {
 	// Create file object.
 	f := newFile(up.SiaPath, up.ErasureCode, pieceSize, uint64(fileInfo.Size()))
 	f.mode = uint32(fileInfo.Mode())
+	f.modTime = fileInfo.ModTime()
+	f.uploadTime = time.Now()
 
 	// Add file to renter.
 	lockID = r.mu.Lock()


### PR DESCRIPTION
uploadTime is a time.Now field for when the file was uploaded to the Sia network.  modTime is a os.Stat ModTime field for when the file was last modified as reported by the client filesystem.  Feature Request #2479