### PR TITLE
Proposal: Sub underflow results in ZeroCurrency instead of noop

### DIFF
--- a/types/currency.go
+++ b/types/currency.go
@@ -175,7 +175,7 @@ func (x Currency) Sqrt() (c Currency) {
 // x < y.
 func (x Currency) Sub(y Currency) (c Currency) {
 	if x.Cmp(y) < 0 {
-		c = x
+		c = ZeroCurrency
 		build.Critical(ErrNegativeCurrency)
 	} else {
 		c.i.Sub(&x.i, &y.i)


### PR DESCRIPTION
There have been multiple reported issues caused by a Currency underflow. I think we have fixed it twice by simply setting the currency to 0.
Issue [#2863](https://github.com/NebulousLabs/Sia/issues/2863) brought this to my attention once more and this time the consequence of not returning 0 in case of an underflow might be more severe. The host might post too much collateral and later fail its own verification when the renter uploads/changes data. (could be related to the issue of Fornax on discord)
By changing the behavior of `Sub` we should be notified when an underflow happens and can still expect somewhat sane behavior.