### PR TITLE
Changed description of managedUnlockStorageObligation

### DIFF
--- a/modules/host/storageobligationslock.go
+++ b/modules/host/storageobligationslock.go
@@ -55,9 +55,9 @@ func (h *Host) managedTryLockStorageObligation(soid types.FileContractID) error 
 // managedUnlockStorageObligation takes a storage obligation out from under lock in
 // the host.
 func (h *Host) managedUnlockStorageObligation(soid types.FileContractID) {
-	// Check if a lock has been created for this storage obligation. If not,
-	// create one. The map must be accessed under lock, but the request for the
-	// storage lock must not be made under lock.
+	// Check if a lock has been created for this storage obligation. The map
+	// must be accessed under lock, but the request for the unlock must not
+	// be made under lock.
 	h.mu.Lock()
 	tl, exists := h.lockedStorageObligations[soid]
 	if !exists {


### PR DESCRIPTION
Description was copied from `managedTryLockStorageObligation`