### PR TITLE
Fix deleted renter file showing up after restart

### DIFF
--- a/modules/renter/files.go
+++ b/modules/renter/files.go
@@ -36,6 +36,7 @@ type file struct {
 	erasureCode modules.ErasureCoder // Static - can be accessed without lock.
 	pieceSize   uint64               // Static - can be accessed without lock.
 	mode        uint32               // actually an os.FileMode
+	deleted     bool                 // indicates if the file has been deleted.
 
 	staticUID string // A UID assigned to the file when it gets created.
 
@@ -245,6 +246,9 @@ func (r *Renter) DeleteFile(nickname string) error {
 	// delete the file's associated contract data.
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	// mark the file as deleted
+	f.deleted = true
 
 	// TODO: delete the sectors of the file as well.
 

--- a/modules/renter/persist.go
+++ b/modules/renter/persist.go
@@ -161,6 +161,9 @@ func (f *file) UnmarshalSia(r io.Reader) error {
 
 // saveFile saves a file to the renter directory.
 func (r *Renter) saveFile(f *file) error {
+	if f.deleted {
+		return errors.New("can't save deleted file")
+	}
 	// Create directory structure specified in nickname.
 	fullPath := filepath.Join(r.persistDir, f.name+ShareExtension)
 	err := os.MkdirAll(filepath.Dir(fullPath), 0700)


### PR DESCRIPTION
When a file is deleted while being repaired, the upload of the scheduled chunks will continue. Since the upload code modifies the uploaded file's metadata, the deleted `.sia` file will reappear and after a restart of sia, it will also be tracked by the renter again.
This PR fixes this by introducing a `deleted` field that prevents deleted files from being saved to disk.