### PR TITLE
Remove renter's merkle roots from ram

### DIFF
--- a/crypto/merkle.go
+++ b/crypto/merkle.go
@@ -82,6 +82,12 @@ func (ct *CachedMerkleTree) Push(h Hash) {
 	ct.CachedTree.Push(h[:])
 }
 
+// PushSubTree is a redefinition of merkletree.CachedTree.PushSubTree, with the
+// added type safety of only accepting a hash.
+func (ct *CachedMerkleTree) PushSubTree(height int, h Hash) error {
+	return ct.CachedTree.PushSubTree(height, h[:])
+}
+
 // Root is a redefinition of merkletree.CachedTree.Root, returning a Hash
 // instead of a []byte.
 func (ct *CachedMerkleTree) Root() (h Hash) {

--- a/modules/renter/proto/consts.go
+++ b/modules/renter/proto/consts.go
@@ -11,6 +11,10 @@ import (
 const (
 	// contractExtension is the extension given to contract files.
 	contractExtension = ".contract"
+
+	// rootsDiskLoadBulkSize is the max number of roots we read from disk at
+	// once to avoid using up all the ram.
+	rootsDiskLoadBulkSize = 1024 * crypto.HashSize // 32 kib
 )
 
 var (

--- a/modules/renter/proto/consts.go
+++ b/modules/renter/proto/consts.go
@@ -15,6 +15,10 @@ const (
 	// rootsDiskLoadBulkSize is the max number of roots we read from disk at
 	// once to avoid using up all the ram.
 	rootsDiskLoadBulkSize = 1024 * crypto.HashSize // 32 kib
+
+	// remainingFile is a constant used to indicate that a fileSection can access
+	// the whole remaining file instead of being boung to a certain end offset.
+	remainingFile = -1
 )
 
 var (

--- a/modules/renter/proto/consts.go
+++ b/modules/renter/proto/consts.go
@@ -17,7 +17,7 @@ const (
 	rootsDiskLoadBulkSize = 1024 * crypto.HashSize // 32 kib
 
 	// remainingFile is a constant used to indicate that a fileSection can access
-	// the whole remaining file instead of being boung to a certain end offset.
+	// the whole remaining file instead of being bound to a certain end offset.
 	remainingFile = -1
 )
 

--- a/modules/renter/proto/contract.go
+++ b/modules/renter/proto/contract.go
@@ -133,6 +133,13 @@ type SafeContract struct {
 	// applied to the contract file.
 	unappliedTxns []*writeaheadlog.Transaction
 
+	// file is the file of the safe contract that contains the roots. This
+	// file is usually shared with the SafeContract which means multiple
+	// threads could potentially write to the same file. That's why the
+	// SafeContract should never modify the file beyond the
+	// contractHeaderSize and the merkleRoots should never modify data
+	// before that. Both should also use WriteAt and ReadAt instead of
+	// Write and Read.
 	f   *os.File // TODO: use a dependency for this
 	wal *writeaheadlog.WAL
 	mu  sync.Mutex

--- a/modules/renter/proto/contract.go
+++ b/modules/renter/proto/contract.go
@@ -401,7 +401,7 @@ func (cs *ContractSet) managedInsertContract(h contractHeader, roots []crypto.Ha
 	}
 	// create fileSections
 	headerSection := newFileSection(f, 0, contractHeaderSize)
-	rootsSection := newFileSection(f, contractHeaderSize+1, -1)
+	rootsSection := newFileSection(f, contractHeaderSize, -1)
 	// write header
 	if _, err := headerSection.WriteAt(encoding.Marshal(h), 0); err != nil {
 		return modules.RenterContract{}, err
@@ -436,7 +436,7 @@ func (cs *ContractSet) loadSafeContract(filename string, walTxns []*writeaheadlo
 		return err
 	}
 	headerSection := newFileSection(f, 0, contractHeaderSize)
-	rootsSection := newFileSection(f, contractHeaderSize+1, remainingFile)
+	rootsSection := newFileSection(f, contractHeaderSize, remainingFile)
 
 	// read header
 	var header contractHeader

--- a/modules/renter/proto/contract.go
+++ b/modules/renter/proto/contract.go
@@ -248,13 +248,7 @@ func (c *SafeContract) applySetRoot(root crypto.Hash, index int) error {
 	if _, err := c.f.WriteAt(root[:], rootOffset); err != nil {
 		return err
 	}
-	numMerkleRoots := c.merkleRoots.len()
-	if index == numMerkleRoots {
-		c.merkleRoots.push(root)
-	} else {
-		return c.merkleRoots.insert(index, root)
-	}
-	return nil
+	return c.merkleRoots.insert(index, root)
 }
 
 func (c *SafeContract) recordUploadIntent(rev types.FileContractRevision, root crypto.Hash, storageCost, bandwidthCost types.Currency) (*writeaheadlog.Transaction, error) {

--- a/modules/renter/proto/contract.go
+++ b/modules/renter/proto/contract.go
@@ -436,7 +436,7 @@ func (cs *ContractSet) loadSafeContract(filename string, walTxns []*writeaheadlo
 		return err
 	}
 	headerSection := newFileSection(f, 0, contractHeaderSize)
-	rootsSection := newFileSection(f, contractHeaderSize+1, -1)
+	rootsSection := newFileSection(f, contractHeaderSize+1, remainingFile)
 
 	// read header
 	var header contractHeader

--- a/modules/renter/proto/contract_test.go
+++ b/modules/renter/proto/contract_test.go
@@ -71,7 +71,7 @@ func TestContractUncommittedTxn(t *testing.T) {
 	// the state of the contract should match the initial state
 	// NOTE: can't use reflect.DeepEqual for the header because it contains
 	// types.Currency fields
-	merkleRoots, err := sc.merkleRoots()
+	merkleRoots, err := sc.merkleRoots.merkleRoots()
 	if err != nil {
 		t.Fatal("failed to get merkle roots", err)
 	}
@@ -95,7 +95,7 @@ func TestContractUncommittedTxn(t *testing.T) {
 		t.Fatal("WAL transaction changed")
 	}
 	// the state of the contract should match the initial state
-	merkleRoots, err = sc.merkleRoots()
+	merkleRoots, err = sc.merkleRoots.merkleRoots()
 	if err != nil {
 		t.Fatal("failed to get merkle roots:", err)
 	}
@@ -115,7 +115,7 @@ func TestContractUncommittedTxn(t *testing.T) {
 		t.Fatal("expected 0 unappliedTxns, got", len(sc.unappliedTxns))
 	}
 	// the state of the contract should now match the revised state
-	merkleRoots, err = sc.merkleRoots()
+	merkleRoots, err = sc.merkleRoots.merkleRoots()
 	if err != nil {
 		t.Fatal("failed to get merkle roots:", err)
 	}

--- a/modules/renter/proto/contract_test.go
+++ b/modules/renter/proto/contract_test.go
@@ -71,9 +71,13 @@ func TestContractUncommittedTxn(t *testing.T) {
 	// the state of the contract should match the initial state
 	// NOTE: can't use reflect.DeepEqual for the header because it contains
 	// types.Currency fields
+	merkleRoots, err := sc.merkleRoots()
+	if err != nil {
+		t.Fatal("failed to get merkle roots", err)
+	}
 	if !bytes.Equal(encoding.Marshal(sc.header), encoding.Marshal(initialHeader)) {
 		t.Fatal("contractHeader should match initial contractHeader")
-	} else if !reflect.DeepEqual(sc.merkleRoots, initialRoots) {
+	} else if !reflect.DeepEqual(merkleRoots, initialRoots) {
 		t.Fatal("Merkle roots should match initial Merkle roots")
 	}
 
@@ -91,9 +95,13 @@ func TestContractUncommittedTxn(t *testing.T) {
 		t.Fatal("WAL transaction changed")
 	}
 	// the state of the contract should match the initial state
+	merkleRoots, err = sc.merkleRoots()
+	if err != nil {
+		t.Fatal("failed to get merkle roots:", err)
+	}
 	if !bytes.Equal(encoding.Marshal(sc.header), encoding.Marshal(initialHeader)) {
 		t.Fatal("contractHeader should match initial contractHeader", sc.header, initialHeader)
-	} else if !reflect.DeepEqual(sc.merkleRoots, initialRoots) {
+	} else if !reflect.DeepEqual(merkleRoots, initialRoots) {
 		t.Fatal("Merkle roots should match initial Merkle roots")
 	}
 
@@ -107,9 +115,13 @@ func TestContractUncommittedTxn(t *testing.T) {
 		t.Fatal("expected 0 unappliedTxns, got", len(sc.unappliedTxns))
 	}
 	// the state of the contract should now match the revised state
+	merkleRoots, err = sc.merkleRoots()
+	if err != nil {
+		t.Fatal("failed to get merkle roots:", err)
+	}
 	if !bytes.Equal(encoding.Marshal(sc.header), encoding.Marshal(revisedHeader)) {
 		t.Fatal("contractHeader should match revised contractHeader", sc.header, revisedHeader)
-	} else if !reflect.DeepEqual(sc.merkleRoots, revisedRoots) {
+	} else if !reflect.DeepEqual(merkleRoots, revisedRoots) {
 		t.Fatal("Merkle roots should match revised Merkle roots")
 	}
 }

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -135,7 +135,7 @@ func (cs *ContractSet) ViewAll() []modules.RenterContract {
 // Close closes all contracts in a contract set, this means rendering it unusable for I/O
 func (cs *ContractSet) Close() error {
 	for _, c := range cs.contracts {
-		c.f.Close()
+		c.headerFile.Close()
 	}
 	_, err := cs.wal.CloseIncomplete()
 	return err

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -91,7 +91,7 @@ func (he *Editor) Upload(data []byte) (_ modules.RenterContract, _ crypto.Hash, 
 
 	// calculate the new Merkle root
 	sectorRoot := crypto.MerkleRoot(data)
-	merkleRoot := sc.merkleRoots.newRoot(sectorRoot)
+	merkleRoot := sc.merkleRoots.checkNewRoot(sectorRoot)
 
 	// create the action and revision
 	actions := []modules.RevisionAction{{

--- a/modules/renter/proto/editor.go
+++ b/modules/renter/proto/editor.go
@@ -89,21 +89,14 @@ func (he *Editor) Upload(data []byte) (_ modules.RenterContract, _ crypto.Hash, 
 		return modules.RenterContract{}, crypto.Hash{}, errors.New("contract has insufficient collateral to support upload")
 	}
 
-	// Get merkle roots
-	oldRoots, err := sc.merkleRoots()
-	if err != nil {
-		return modules.RenterContract{}, crypto.Hash{}, err
-	}
-
 	// calculate the new Merkle root
 	sectorRoot := crypto.MerkleRoot(data)
-	newRoots := append(oldRoots, sectorRoot)
-	merkleRoot := cachedMerkleRoot(newRoots)
+	merkleRoot := sc.merkleRoots.newRoot(sectorRoot)
 
 	// create the action and revision
 	actions := []modules.RevisionAction{{
 		Type:        modules.ActionInsert,
-		SectorIndex: uint64(sc.numMerkleRoots),
+		SectorIndex: uint64(sc.merkleRoots.len()),
 		Data:        data,
 	}}
 	rev := newUploadRevision(contract.LastRevision(), merkleRoot, sectorPrice, sectorCollateral)

--- a/modules/renter/proto/filesection.go
+++ b/modules/renter/proto/filesection.go
@@ -1,0 +1,91 @@
+package proto
+
+import (
+	"os"
+)
+
+// fileSection is a helper struct that is used to split a file up in multiple
+// sections. This guarantees that each part of the file can only write to and
+// read from its corresponding section.
+type fileSection struct {
+	f     *os.File
+	start int64
+	end   int64
+}
+
+// newFileSection creates a new fileSection from a file and the provided bounds
+// of the section.
+func newFileSection(f *os.File, start, end int64) *fileSection {
+	if start < 0 {
+		panic("filesection can't start at an index < 0")
+	}
+	if end < start && end != -1 {
+		panic("the end of a filesection can't be before the start")
+	}
+	return &fileSection{
+		f:     f,
+		start: start,
+		end:   end,
+	}
+}
+
+// Close calls Close on the fileSection's underlying file.
+func (f *fileSection) Close() error {
+	return f.f.Close()
+}
+
+// Size uses the underlying file's stats to return the size of the sector.
+func (f *fileSection) Size() (int64, error) {
+	info, err := f.f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	size := info.Size() - f.start
+	if size < 0 {
+		size = 0
+	}
+	if size > f.end-f.start && f.end != -1 {
+		size = f.end - f.start
+	}
+	return size, nil
+}
+
+// ReadAt calls the fileSection's underlying file's ReadAt method if the read
+// happens within the bounds of the section. Otherwise it returns io.EOF.
+func (f *fileSection) ReadAt(b []byte, off int64) (int, error) {
+	if off < 0 {
+		panic("can't read from an offset before the section start")
+	}
+	if f.start+off+int64(len(b)) > f.end && f.end != -1 {
+		panic("can't read from an offset after the section end")
+	}
+	return f.f.ReadAt(b, f.start+off)
+}
+
+// Sync calls Sync on the fileSection's underlying file.
+func (f *fileSection) Sync() error {
+	return f.f.Sync()
+}
+
+// Truncate calls Truncate on the fileSection's underlying file.
+func (f *fileSection) Truncate(size int64) error {
+	if f.start+size < f.start {
+		panic("can't truncate file to be smaller than the section start")
+	}
+	if f.start+size > f.end && f.end != -1 {
+		panic("can't truncate file to be bigger than the section")
+	}
+	return f.f.Truncate(f.start + size)
+}
+
+// WriteAt calls the fileSection's underlying file's WriteAt method if the
+// write happens within the bounds of the section. Otherwise it returns io.EOF.
+func (f *fileSection) WriteAt(b []byte, off int64) (int, error) {
+	if off < 0 {
+		panic("can't read from an offset before the section start")
+	}
+	if f.start+off+int64(len(b)) > f.end && f.end != -1 {
+		panic("can't read from an offset after the section end")
+	}
+	return f.f.WriteAt(b, off+f.start)
+}

--- a/modules/renter/proto/filesection.go
+++ b/modules/renter/proto/filesection.go
@@ -69,6 +69,13 @@ func (f *fileSection) Sync() error {
 
 // Truncate calls Truncate on the fileSection's underlying file.
 func (f *fileSection) Truncate(size int64) error {
+	currentSize, err := f.Size()
+	if err != nil {
+		return err
+	}
+	if currentSize == f.end-f.start && f.end != -1 {
+		panic("can't shrink section that has reached its max size unless it has no end boundary")
+	}
 	if f.start+size < f.start {
 		panic("can't truncate file to be smaller than the section start")
 	}

--- a/modules/renter/proto/filesection.go
+++ b/modules/renter/proto/filesection.go
@@ -75,9 +75,6 @@ func (f *fileSection) Truncate(size int64) error {
 	if f.start+size < f.start {
 		panic("can't truncate file to be smaller than the section start")
 	}
-	if f.start+size > f.end && f.end != remainingFile {
-		panic("can't truncate file to be bigger than the section")
-	}
 	return f.f.Truncate(f.start + size)
 }
 

--- a/modules/renter/proto/filesection_test.go
+++ b/modules/renter/proto/filesection_test.go
@@ -1,0 +1,314 @@
+package proto
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/fastrand"
+)
+
+// SafeReadAt is a wrapper for ReadAt that recovers from a potential panic and
+// returns it as an error.
+func (f *fileSection) SafeReadAt(b []byte, off int64) (n int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	return f.ReadAt(b, off)
+}
+
+// SafeTruncate is a wrapper for Truncate that recovers from a potential panic
+// and returns it as an error.
+func (f *fileSection) SafeTruncate(size int64) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	return f.Truncate(size)
+}
+
+// SafeWriteAt is a wrapper for WriteAt that recovers from a potential panic
+// and returns it as an error.
+func (f *fileSection) SafeWriteAt(b []byte, off int64) (n int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	return f.WriteAt(b, off)
+}
+
+// TestFileSectionBoundariesValidReadWrites uses valid read and write
+// operations on the fileSection to make sure that the data is written to and
+// read from the section correctly without corrupting other sections.
+func TestFileSectionBoundariesValidReadWrites(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	testDir := build.TempDir(t.Name())
+	if err := os.MkdirAll(testDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	testFile, err := os.Create(filepath.Join(testDir, "testfile.dat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create 3 sections.
+	s1Size := 100
+	s2Size := 100
+	s1 := newFileSection(testFile, 0, int64(s1Size))
+	s2 := newFileSection(testFile, int64(s1Size), int64(s1Size+s2Size))
+	s3 := newFileSection(testFile, int64(s1Size+s2Size), remainingFile)
+
+	// Write as much data to the sections as they can fit.
+	s1Data := fastrand.Bytes(s1Size)
+	s2Data := fastrand.Bytes(s2Size)
+	s3Data := fastrand.Bytes(s2Size) // s3 has an infinite size so we just write s2Size bytes.
+
+	n, err := s1.SafeWriteAt(s1Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(s1Data) {
+		t.Fatalf("expected %v bytes to be written instead of %v", len(s1Data), n)
+	}
+	n, err = s2.SafeWriteAt(s2Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(s2Data) {
+		t.Fatalf("expected %v bytes to be written instead of %v", len(s2Data), n)
+	}
+	n, err = s3.SafeWriteAt(s3Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(s3Data) {
+		t.Fatalf("expected %v bytes to be written instead of %v", len(s3Data), n)
+	}
+
+	// Read the written data from the file and check if it matches.
+	readS1Data := make([]byte, len(s1Data))
+	readS2Data := make([]byte, len(s2Data))
+	readS3Data := make([]byte, len(s3Data))
+	_, err = s1.SafeReadAt(readS1Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s2.SafeReadAt(readS2Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s3.SafeReadAt(readS3Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fi, err := testFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	size := fi.Size()
+	size1, err := s1.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	size2, err := s2.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	size3, err := s3.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size1 != int64(s1Size) {
+		t.Fatalf("expected size to be %v but was %v", s1Size, size1)
+	}
+	if size2 != int64(s2Size) {
+		t.Fatalf("expected size to be %v but was %v", s2Size, size2)
+	}
+	if size3 != int64(s2Size) {
+		t.Fatalf("expected size to be %v but was %v", s2Size, size3)
+	}
+	if size != size1+size2+size3 {
+		t.Fatalf("total size should be %v but was %v", size, size1+size2+size3)
+	}
+
+	if !bytes.Equal(s1Data, readS1Data) {
+		t.Fatal("the read data doesn't match the written data")
+	}
+	if !bytes.Equal(s2Data, readS2Data) {
+		t.Fatal("the read data doesn't match the written data")
+	}
+	if !bytes.Equal(s3Data, readS3Data) {
+		t.Fatal("the read data doesn't match the written data")
+	}
+
+	// Read the written data directly from the underlying file and check again.
+	_, err = testFile.ReadAt(readS1Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = testFile.ReadAt(readS2Data, int64(s1Size))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = testFile.ReadAt(readS3Data, int64(s1Size+s2Size))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(s1Data, readS1Data) {
+		t.Fatal("the read data doesn't match the written data")
+	}
+	if !bytes.Equal(s2Data, readS2Data) {
+		t.Fatal("the read data doesn't match the written data")
+	}
+	if !bytes.Equal(s3Data, readS3Data) {
+		t.Fatal("the read data doesn't match the written data")
+	}
+}
+
+// TestFileSectionBoundariesInvalidReadWrites tries a variation of invalid read
+// and write operations on the section to make sure the caller can't write to
+// neighboring sections by accident.
+func TestFileSectionBoundariesInvalidReadWrites(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	testDir := build.TempDir(t.Name())
+	if err := os.MkdirAll(testDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	testFile, err := os.Create(filepath.Join(testDir, "testfile.dat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create 3 sections.
+	s1Size := 100
+	s2Size := 100
+	s1 := newFileSection(testFile, 0, int64(s1Size))
+	s2 := newFileSection(testFile, int64(s1Size), int64(s1Size+s2Size))
+
+	// Fill the file with some random data
+	randomData := fastrand.Bytes(s1Size + s2Size + 100)
+	if _, err := testFile.WriteAt(randomData, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Create some random data for the following calls to write. That data
+	// should never be written since all the calls should fail.
+	data := fastrand.Bytes(1)
+
+	// Try a number of invalid read and write operations. They should all fail.
+	if _, err := s1.SafeWriteAt(data, int64(s1Size)); err == nil {
+		t.Fatal("sector shouldn't be able to write data beyond its end boundary")
+	}
+	if _, err := s2.SafeWriteAt(data, -1); err == nil {
+		t.Fatal("sector shouldn't be able to write data below its start boundary")
+	}
+	if _, err := s1.SafeReadAt(data, int64(s1Size)); err == nil {
+		t.Fatal("sector shouldn't be able to read data beyond its end boundary")
+	}
+	if _, err := s2.SafeReadAt(data, -1); err == nil {
+		t.Fatal("sector shouldn't be able to read data below its start boundary")
+	}
+
+	// The file should still have the same random data from the beginning.
+	fileData, err := ioutil.ReadAll(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(fileData, randomData) {
+		t.Fatal("file data doesn't match the initial data")
+	}
+}
+
+// TestFileSectionTruncate checks if file sections without an open end boundary
+// can be truncated and makes sure that the last section can't truncate the
+// file below its boundary.
+func TestFileSectionTruncate(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	testDir := build.TempDir(t.Name())
+	if err := os.MkdirAll(testDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	testFile, err := os.Create(filepath.Join(testDir, "testfile.dat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create 3 sections.
+	s1Size := 100
+	s2Size := 100
+	s1 := newFileSection(testFile, 0, int64(s1Size))
+	s2 := newFileSection(testFile, int64(s1Size), int64(s1Size+s2Size))
+	s3 := newFileSection(testFile, int64(s1Size+s2Size), remainingFile)
+
+	// Write as much data to the sections as they can fit.
+	s1Data := fastrand.Bytes(s1Size)
+	s2Data := fastrand.Bytes(s2Size)
+	s3Data := fastrand.Bytes(s2Size) // s3 has an infinite size so we just write s2Size bytes.
+
+	n, err := s1.SafeWriteAt(s1Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(s1Data) {
+		t.Fatalf("expected %v bytes to be written instead of %v", len(s1Data), n)
+	}
+	n, err = s2.SafeWriteAt(s2Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(s2Data) {
+		t.Fatalf("expected %v bytes to be written instead of %v", len(s2Data), n)
+	}
+	n, err = s3.SafeWriteAt(s3Data, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(s3Data) {
+		t.Fatalf("expected %v bytes to be written instead of %v", len(s3Data), n)
+	}
+
+	// Try to truncate s1 and s2. That shouldn't be possible.
+	if err := s1.SafeTruncate(int64(fastrand.Intn(s1Size + 1))); err == nil {
+		t.Fatal("it shouldn't be possible to truncate a section with a fixed end boundary.")
+	}
+	if err := s2.SafeTruncate(int64(fastrand.Intn(s2Size + 1))); err == nil {
+		t.Fatal("it shouldn't be possible to truncate a section with a fixed end boundary.")
+	}
+
+	// Try to truncate s3 to size 0. This should be possible and also reduce
+	// the total file size.
+	if err := s3.SafeTruncate(0); err != nil {
+		t.Fatal("failed to truncate s3", err)
+	}
+	fi, err := testFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() != int64(s1Size+s2Size) {
+		t.Fatalf("expected size after truncate is %v but was %v", s1Size+s2Size, fi.Size())
+	}
+	size, err := s3.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != 0 {
+		t.Fatalf("size was %v but should be %v", size, 0)
+	}
+	// Try to truncate s3 below its start. That shouldn't be possible.
+	if err := s3.SafeTruncate(-1); err == nil {
+		t.Fatal("it shouldn't be possible to truncate a section to a negative size")
+	}
+}

--- a/modules/renter/proto/merkleroots.go
+++ b/modules/renter/proto/merkleroots.go
@@ -175,6 +175,9 @@ func (mr *merkleRoots) insert(index int, root crypto.Hash) error {
 	if index > mr.numMerkleRoots {
 		return errors.New("can't insert at a index greater than the number of roots")
 	}
+	if index == mr.numMerkleRoots {
+		return mr.push(root)
+	}
 	// Replaced the root on disk.
 	_, err := mr.file.WriteAt(root[:], rootIndexToOffset(index))
 	if err != nil {

--- a/modules/renter/proto/merkleroots.go
+++ b/modules/renter/proto/merkleroots.go
@@ -1,0 +1,248 @@
+package proto
+
+import (
+	"io"
+	"os"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/errors"
+)
+
+// merkleRootsCacheHeight is the height of the subTrees in cachedSubTrees. A
+// height of 7 means that 128 sector roots are covered by a single cached
+// subTree.
+const merkleRootsCacheHeight = 7
+
+type (
+	// merkleRoots is a helper struct that makes it easier to add/insert/remove
+	// merkleRoots within a SafeContract.
+	merkleRoots struct {
+		// cachedSubTrees are cached trees that can be used to more efficiently
+		// compute the merkle root of a contract. The cached trees are not
+		// persisted and are computed after startup.
+		cachedSubTrees []*cachedSubTree
+		// uncachedRoots contains the sector roots that are not part of a
+		// cached subTree. The uncachedRoots slice should never get longer than
+		// 2^merkleRootsCacheHeight since that would simply result in a new
+		// cached subTree in cachedSubTrees.
+		uncachedRoots []crypto.Hash
+
+		// file is the file of the safe contract that contains the root.
+		file *os.File
+		// numMerkleRoots is the number of merkle roots in file.
+		numMerkleRoots int
+	}
+
+	cachedSubTree struct {
+		height int
+		sum    crypto.Hash
+	}
+)
+
+// loadExistingMerkleRoots reads creates a merkleRoots object from existing
+// merkle roots.
+func loadExistingMerkleRoots(file *os.File) (mr *merkleRoots, err error) {
+	mr = &merkleRoots{
+		file: file,
+	}
+	// Get the number of roots stored in the file.
+	mr.numMerkleRoots, err = mr.lenFromFile()
+	if err != nil {
+		return
+	}
+	// Seek to the first root's offset.
+	if _, err = file.Seek(rootIndexToOffset(0), io.SeekStart); err != nil {
+		return
+	}
+	// Read the roots from the file without reading all of them at once.
+	for i := 0; i < mr.numMerkleRoots; i++ {
+		var root crypto.Hash
+		if _, err = io.ReadFull(file, root[:]); err == io.EOF {
+			break
+		} else if err != nil {
+			return
+		}
+
+		// Append the root to the unachedRoots
+		mr.uncachedRoots = append(mr.uncachedRoots, root)
+
+		// If the uncachedRoots grew too large we add them to the cache.
+		if len(mr.uncachedRoots) == 1<<merkleRootsCacheHeight {
+			st := newCachedSubTree(mr.uncachedRoots)
+			mr.cachedSubTrees = append(mr.cachedSubTrees, st)
+			mr.uncachedRoots = mr.uncachedRoots[:0]
+		}
+	}
+	return mr, nil
+}
+
+// newCachedSubTree creates a cachedSubTree from exactly
+// 2^merkleRootsCacheHeight roots.
+func newCachedSubTree(roots []crypto.Hash) *cachedSubTree {
+	// Sanity check the input length.
+	if len(roots) != 1<<merkleRootsCacheHeight {
+		build.Critical("can't create a cached subTree from the provided number of roots")
+	}
+	return &cachedSubTree{
+		height: int(merkleRootsCacheHeight + sectorHeight),
+		sum:    cachedMerkleRoot(roots),
+	}
+}
+
+// newMerkleRoots creates a new merkleRoots object. This doesn't load existing
+// roots from file and will assume that the file doesn't contain any roots.
+// Don't use this on a file that contains roots.
+func newMerkleRoots(file *os.File) *merkleRoots {
+	return &merkleRoots{
+		file: file,
+	}
+}
+
+// rootIndexToOffset calculates the offset of the merkle root at index i from
+// the beginning of the contract file.
+func rootIndexToOffset(i int) int64 {
+	return contractHeaderSize + crypto.HashSize*int64(i)
+}
+
+// delete deletes the sector root at a certain index.
+func (mr *merkleRoots) delete(i int) error {
+	// Check if the index is correct
+	if i >= mr.numMerkleRoots {
+		build.Critical("can't delete non-existing root")
+		return nil
+	}
+	// If i is the index of the last element we call deleteLastRoot.
+	if i == mr.numMerkleRoots-1 {
+		return mr.deleteLastRoot()
+	}
+	// - swap root at i with last root of mr.uncachedRoots. If that is not
+	// possible because len(mr.uncachedRoots) == 0 we need to delete the last
+	// cache and append its elements to mr.uncachedRoots before we swap.
+	// - if root at i is in a cache we need to reconstruct that cache after swapping.
+	// - call deleteLastRoot to get rid of the swapped element at the end of mr.u
+	panic("not implemented yet")
+}
+
+// deleteLastRoot deletes the last sector root of the contract.
+func (mr *merkleRoots) deleteLastRoot() error {
+	// - Truncate file
+	// - If len(mr.cachedSubTrees) == 0 delete the last subtree, load its
+	// elements from disk and append them to mr.uncachedRoots
+	panic("not implemented yet")
+}
+
+// insert inserts a root by replacing a root at an existing index.
+func (mr *merkleRoots) insert(index int, root crypto.Hash) error {
+	if index > mr.numMerkleRoots {
+		return errors.New("can't insert at a index greater than the number of roots")
+	}
+	panic("not yet implemented")
+}
+
+// lenFromFile returns the number of merkle roots by computing it from the
+// filesize.
+func (mr *merkleRoots) lenFromFile() (int, error) {
+	offset, err := mr.file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, err
+	}
+	// If we haven't written a single root yet we just return 0.
+	rootStart := rootIndexToOffset(0)
+	if offset < rootStart {
+		return 0, nil
+	}
+
+	// Sanity check contract file length.
+	if (offset-rootStart)%crypto.HashSize != 0 {
+		build.Critical("contract file has unexpected length and might be corrupted.")
+	}
+	return int((offset - rootStart) / crypto.HashSize), nil
+}
+
+// len returns the number of merkle roots. It should always return the same
+// number as lenFromFile.
+func (mr *merkleRoots) len() int {
+	return mr.numMerkleRoots
+}
+
+// push appends a merkle root to the end of the contract. If the number of
+// uncached merkle roots grows too big we cache them in a new subTree.
+func (mr *merkleRoots) push(root crypto.Hash) error {
+	// Sanity check the number of uncached roots before adding a new one.
+	if len(mr.uncachedRoots) == 1<<merkleRootsCacheHeight {
+		build.Critical("the number of uncachedRoots is too big. They should've been cached by now")
+	}
+	// Calculate the root offset within the file and write it to disk.
+	rootOffset := rootIndexToOffset(mr.len())
+	if _, err := mr.file.WriteAt(root[:], rootOffset); err != nil {
+		return err
+	}
+	// Add the root to the unached roots. If uncachedRoots is big enoug we can
+	// cache those roots.
+	mr.uncachedRoots = append(mr.uncachedRoots, root)
+	if len(mr.uncachedRoots) == 1<<merkleRootsCacheHeight {
+		mr.cachedSubTrees = append(mr.cachedSubTrees, newCachedSubTree(mr.uncachedRoots))
+		mr.uncachedRoots = mr.uncachedRoots[:0]
+	}
+
+	// Increment the number of roots.
+	mr.numMerkleRoots++
+	return nil
+}
+
+// root returns the root of the merkle roots.
+func (mr *merkleRoots) root() crypto.Hash {
+	tree := crypto.NewCachedTree(sectorHeight)
+	for _, st := range mr.cachedSubTrees {
+		if err := tree.PushSubTree(st.height, st.sum); err != nil {
+			// This should never fail.
+			build.Critical(err)
+		}
+	}
+	for _, root := range mr.uncachedRoots {
+		tree.Push(root)
+	}
+	return tree.Root()
+}
+
+// newRoot returns the root of the merkleTree after appending the newRoot
+// without actually appending it.
+func (mr *merkleRoots) newRoot(newRoot crypto.Hash) crypto.Hash {
+	tree := crypto.NewCachedTree(sectorHeight)
+	for _, st := range mr.cachedSubTrees {
+		if err := tree.PushSubTree(st.height, st.sum); err != nil {
+			// This should never fail.
+			build.Critical(err)
+		}
+	}
+	for _, root := range mr.uncachedRoots {
+		tree.Push(root)
+	}
+	// Push the new root.
+	tree.Push(newRoot)
+	return tree.Root()
+}
+
+// merkleRoots reads all the merkle roots from disk and returns them. This is
+// not very fast and should only be used for testing purposes.
+func (mr *merkleRoots) merkleRoots() ([]crypto.Hash, error) {
+	merkleRoots := make([]crypto.Hash, 0, mr.numMerkleRoots)
+	if _, err := mr.file.Seek(rootIndexToOffset(0), io.SeekStart); err != nil {
+		return merkleRoots, err
+	}
+	for {
+		var root crypto.Hash
+		if _, err := io.ReadFull(mr.file, root[:]); err == io.EOF {
+			break
+		} else if err != nil {
+			return merkleRoots, errors.AddContext(err, "failed to read root from disk")
+		}
+		merkleRoots = append(merkleRoots, root)
+	}
+	// Sanity check: should have read exactly numMerkleRoots roots.
+	if len(merkleRoots) != mr.numMerkleRoots {
+		build.Critical("Number of merkle roots on disk doesn't match numMerkleRoots")
+	}
+	return merkleRoots, nil
+}

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -47,11 +48,8 @@ func cmpRoots(m1, m2 *merkleRoots) error {
 		}
 	}
 	for i := 0; i < len(m1.cachedSubTrees); i++ {
-		if m1.cachedSubTrees[i].height != m2.cachedSubTrees[i].height {
-			return errors.New("cached root height doesn't match")
-		}
-		if m1.cachedSubTrees[i].sum != m2.cachedSubTrees[i].sum {
-			return errors.New("cached root sum doesn't match")
+		if !reflect.DeepEqual(m1.cachedSubTrees[i], m2.cachedSubTrees[i]) {
+			return fmt.Errorf("cached trees at index %v don't match", i)
 		}
 	}
 	return nil

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -1,0 +1,63 @@
+package proto
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/errors"
+	"github.com/NebulousLabs/fastrand"
+)
+
+func TestLoadExistingMerkleRoots(t *testing.T) {
+	// Create a file for the test.
+	dir := build.TempDir(t.Name())
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	filePath := path.Join(dir, "file.dat")
+	file, err := os.Create(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create sector roots.
+	merkleRoots := newMerkleRoots(file)
+	for i := 0; i < 200; i++ {
+		hash := crypto.Hash{}
+		copy(hash[:], fastrand.Bytes(crypto.HashSize)[:])
+		merkleRoots.push(hash)
+	}
+
+	// Load the existing file using LoadExistingMerkleRoots
+	merkleRoots2, err := loadExistingMerkleRoots(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merkleRoots2.len() != merkleRoots.len() {
+		t.Errorf("expected len %v but was %v", merkleRoots.len(), merkleRoots2.len())
+	}
+	// Check if they have the same roots.
+	roots, err := merkleRoots.merkleRoots()
+	roots2, err2 := merkleRoots2.merkleRoots()
+	if errors.Compose(err, err2) != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < len(roots); i++ {
+		if roots[i] != roots2[i] {
+			t.Errorf("roots at index %v don't match", i)
+		}
+	}
+	// Check if the cached subTrees match.
+	if len(merkleRoots.cachedSubTrees) != len(merkleRoots2.cachedSubTrees) {
+		t.Fatalf("expected %v cached trees but got %v",
+			len(merkleRoots.cachedSubTrees), len(merkleRoots2.cachedSubTrees))
+	}
+
+	// Check if the computed roots match.
+	if merkleRoots.root() != merkleRoots2.root() {
+		t.Fatal("the roots don't match")
+	}
+}

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -251,7 +251,7 @@ func TestDeleteLastRoot(t *testing.T) {
 		t.Fatal("roots on disk don't match number of roots in memory")
 	}
 	// There should be 2^merkleRootsCacheHeight - 1 uncached roots now.
-	if len(merkleRoots.uncachedRoots) != (1<<merkleRootsCacheHeight)-1 {
+	if len(merkleRoots.uncachedRoots) != merkleRootsPerCache-1 {
 		t.Fatal("expected 2^merkleRootsCacheHeight - 1 uncached roots but was",
 			len(merkleRoots.uncachedRoots))
 	}

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -73,7 +73,8 @@ func TestLoadExistingMerkleRoots(t *testing.T) {
 	}
 
 	// Create sector roots.
-	merkleRoots := newMerkleRoots(file)
+	rootSection := newFileSection(file, 0, -1)
+	merkleRoots := newMerkleRoots(rootSection)
 	for i := 0; i < 200; i++ {
 		hash := crypto.Hash{}
 		copy(hash[:], fastrand.Bytes(crypto.HashSize)[:])
@@ -81,7 +82,7 @@ func TestLoadExistingMerkleRoots(t *testing.T) {
 	}
 
 	// Load the existing file using LoadExistingMerkleRoots
-	merkleRoots2, err := loadExistingMerkleRoots(file)
+	merkleRoots2, err := loadExistingMerkleRoots(rootSection)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +128,8 @@ func TestInsertMerkleRoot(t *testing.T) {
 	}
 
 	// Create sector roots.
-	merkleRoots := newMerkleRoots(file)
+	rootSection := newFileSection(file, 0, -1)
+	merkleRoots := newMerkleRoots(rootSection)
 	for i := 0; i < 200; i++ {
 		hash := crypto.Hash{}
 		copy(hash[:], fastrand.Bytes(crypto.HashSize)[:])
@@ -151,7 +153,7 @@ func TestInsertMerkleRoot(t *testing.T) {
 	}
 	// Reload the roots. The in-memory structure and the roots on disk should
 	// still be consistent.
-	loadedRoots, err := loadExistingMerkleRoots(merkleRoots.file)
+	loadedRoots, err := loadExistingMerkleRoots(merkleRoots.rootsFile)
 	if err != nil {
 		t.Fatal("failed to load existing roots", err)
 	}
@@ -176,7 +178,7 @@ func TestInsertMerkleRoot(t *testing.T) {
 	}
 	// Reload the roots. The in-memory structure and the roots on disk should
 	// still be consistent.
-	loadedRoots, err = loadExistingMerkleRoots(merkleRoots.file)
+	loadedRoots, err = loadExistingMerkleRoots(merkleRoots.rootsFile)
 	if err != nil {
 		t.Fatal("failed to load existing roots", err)
 	}
@@ -204,7 +206,8 @@ func TestDeleteLastRoot(t *testing.T) {
 	// makes the first delete remove a uncached root and the second delete has
 	// to remove a cached tree.
 	numMerkleRoots := merkleRootsPerCache + 1
-	merkleRoots := newMerkleRoots(file)
+	rootSection := newFileSection(file, 0, -1)
+	merkleRoots := newMerkleRoots(rootSection)
 	for i := 0; i < numMerkleRoots; i++ {
 		hash := crypto.Hash{}
 		copy(hash[:], fastrand.Bytes(crypto.HashSize)[:])
@@ -262,7 +265,7 @@ func TestDeleteLastRoot(t *testing.T) {
 
 	// Reload the roots. The in-memory structure and the roots on disk should
 	// still be consistent.
-	loadedRoots, err := loadExistingMerkleRoots(merkleRoots.file)
+	loadedRoots, err := loadExistingMerkleRoots(merkleRoots.rootsFile)
 	if err != nil {
 		t.Fatal("failed to load existing roots", err)
 	}
@@ -289,7 +292,8 @@ func TestDelete(t *testing.T) {
 
 	// Create many sector roots.
 	numMerkleRoots := 1000
-	merkleRoots := newMerkleRoots(file)
+	rootSection := newFileSection(file, 0, -1)
+	merkleRoots := newMerkleRoots(rootSection)
 	for i := 0; i < numMerkleRoots; i++ {
 		hash := crypto.Hash{}
 		copy(hash[:], fastrand.Bytes(crypto.HashSize)[:])
@@ -299,7 +303,7 @@ func TestDelete(t *testing.T) {
 	for merkleRoots.numMerkleRoots > 0 {
 		// 1% chance to reload the roots and check if they are consistent.
 		if fastrand.Intn(100) == 0 {
-			loadedRoots, err := loadExistingMerkleRoots(merkleRoots.file)
+			loadedRoots, err := loadExistingMerkleRoots(merkleRoots.rootsFile)
 			if err != nil {
 				t.Fatal("failed to load existing roots", err)
 			}
@@ -374,7 +378,8 @@ func TestMerkleRootsRandom(t *testing.T) {
 
 	// Create many sector roots.
 	numMerkleRoots := 10000
-	merkleRoots := newMerkleRoots(file)
+	rootSection := newFileSection(file, 0, -1)
+	merkleRoots := newMerkleRoots(rootSection)
 	for i := 0; i < numMerkleRoots; i++ {
 		hash := crypto.Hash{}
 		copy(hash[:], fastrand.Bytes(crypto.HashSize)[:])
@@ -385,7 +390,7 @@ func TestMerkleRootsRandom(t *testing.T) {
 	for i := 0; i < numMerkleRoots; i++ {
 		// 1% chance to reload the roots and check if they are consistent.
 		if fastrand.Intn(100) == 0 {
-			loadedRoots, err := loadExistingMerkleRoots(merkleRoots.file)
+			loadedRoots, err := loadExistingMerkleRoots(merkleRoots.rootsFile)
 			if err != nil {
 				t.Fatal("failed to load existing roots")
 			}

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -345,7 +345,7 @@ func TestDelete(t *testing.T) {
 		if cached && len(merkleRoots.cachedSubTrees) > cachedIndex {
 			subTreeLen := merkleRootsPerCache
 			from := cachedIndex * merkleRootsPerCache
-			roots, err := merkleRoots.merkleRootsFromIndex(from, from+subTreeLen)
+			roots, err := merkleRoots.merkleRootsFromIndexFromDisk(from, from+subTreeLen)
 			if err != nil {
 				t.Fatal("failed to read roots of subTree", err)
 			}

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -139,8 +139,13 @@ func TestInsertMerkleRoot(t *testing.T) {
 	// Replace the last root with a new hash. It shouldn't be cached and
 	// therefore no cached tree needs to be updated.
 	newHash := crypto.Hash{}
+	insertIndex := merkleRoots.len() - 1
 	copy(newHash[:], fastrand.Bytes(crypto.HashSize)[:])
-	if err := merkleRoots.insert(merkleRoots.len()-1, newHash); err != nil {
+	if err := merkleRoots.insert(insertIndex, newHash); err != nil {
+		t.Fatal("failed to insert root", err)
+	}
+	// Insert again at the same index to make sure insert is idempotent.
+	if err := merkleRoots.insert(insertIndex, newHash); err != nil {
 		t.Fatal("failed to insert root", err)
 	}
 	// Check if the last root matches the new hash.

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/NebulousLabs/fastrand"
 )
 
+// TestLoadExistingMerkleRoots tests if it is possible to load existing merkle
+// roots from disk.
 func TestLoadExistingMerkleRoots(t *testing.T) {
 	// Create a file for the test.
 	dir := build.TempDir(t.Name())
@@ -59,5 +61,60 @@ func TestLoadExistingMerkleRoots(t *testing.T) {
 	// Check if the computed roots match.
 	if merkleRoots.root() != merkleRoots2.root() {
 		t.Fatal("the roots don't match")
+	}
+}
+
+// TestInsertMerkleRoot tests the merkleRoots' insert method.
+func TestInsertMerkleRoot(t *testing.T) {
+	// Create a file for the test.
+	dir := build.TempDir(t.Name())
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	filePath := path.Join(dir, "file.dat")
+	file, err := os.Create(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create sector roots.
+	merkleRoots := newMerkleRoots(file)
+	for i := 0; i < 200; i++ {
+		hash := crypto.Hash{}
+		copy(hash[:], fastrand.Bytes(crypto.HashSize)[:])
+		merkleRoots.push(hash)
+	}
+
+	// Replace the last root with a new hash. It shouldn't be cached and
+	// therefore no cached tree needs to be updated.
+	newHash := crypto.Hash{}
+	copy(newHash[:], fastrand.Bytes(crypto.HashSize)[:])
+	if err := merkleRoots.insert(merkleRoots.len()-1, newHash); err != nil {
+		t.Fatal("failed to insert root", err)
+	}
+	// Check if the second-to-last root matches the new hash.
+	roots, err := merkleRoots.merkleRoots()
+	if err != nil {
+		t.Fatal("failed to get roots from disk", err)
+	}
+	if roots[len(roots)-1] != newHash {
+		t.Fatal("root wasn't updated correctly on disk")
+	}
+
+	// Replace the first root with the new hash. It should be cached and
+	// therefore the first cached tree should also change.
+	if err := merkleRoots.insert(0, newHash); err != nil {
+		t.Fatal("failed to insert root", err)
+	}
+	// Check if the second-to-last root matches the new hash.
+	roots, err = merkleRoots.merkleRoots()
+	if err != nil {
+		t.Fatal("failed to get roots from disk", err)
+	}
+	if roots[0] != newHash {
+		t.Fatal("root wasn't updated correctly on disk")
+	}
+	if merkleRoots.cachedSubTrees[0].sum != newCachedSubTree(roots[:1<<merkleRootsCacheHeight]).sum {
+		t.Fatal("cachedSubtree doesn't have expected sum")
 	}
 }

--- a/modules/renter/proto/merkleroots_test.go
+++ b/modules/renter/proto/merkleroots_test.go
@@ -14,6 +14,9 @@ import (
 // TestLoadExistingMerkleRoots tests if it is possible to load existing merkle
 // roots from disk.
 func TestLoadExistingMerkleRoots(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	// Create a file for the test.
 	dir := build.TempDir(t.Name())
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -66,6 +69,9 @@ func TestLoadExistingMerkleRoots(t *testing.T) {
 
 // TestInsertMerkleRoot tests the merkleRoots' insert method.
 func TestInsertMerkleRoot(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	dir := build.TempDir(t.Name())
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
@@ -120,6 +126,9 @@ func TestInsertMerkleRoot(t *testing.T) {
 
 // TestDeleteLastRoot tests the deleteLastRoot method.
 func TestDeleteLastRoot(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	dir := build.TempDir(t.Name())
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
@@ -194,6 +203,9 @@ func TestDeleteLastRoot(t *testing.T) {
 // TestDeleteLastRoot tests the deleteLastRoot method by creating many roots
 // and deleting random indices until there are no more roots left.
 func TestDelete(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	dir := build.TempDir(t.Name())
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
@@ -252,12 +264,8 @@ func TestDelete(t *testing.T) {
 		if cached && len(merkleRoots.cachedSubTrees) > cachedIndex {
 			subTreeLen := int(1 << merkleRootsCacheHeight)
 			from := cachedIndex * (1 << merkleRootsCacheHeight)
-			rooots, err := merkleRoots.merkleRoots()
 			roots, err := merkleRoots.merkleRootsFromIndex(from, from+subTreeLen)
 			if err != nil {
-				println("from", from)
-				println("len", len(rooots))
-				println("expectedlen", merkleRoots.numMerkleRoots)
 				t.Fatal("failed to read roots of subTree", err)
 			}
 			if merkleRoots.cachedSubTrees[cachedIndex].sum != newCachedSubTree(roots).sum {

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -283,8 +283,14 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 		SiafundFee:  types.Tax(startHeight, fc.Payout),
 	}
 
+	// Get old roots
+	oldRoots, err := oldContract.merkleRoots()
+	if err != nil {
+		return modules.RenterContract{}, err
+	}
+
 	// Add contract to set.
-	meta, err := cs.managedInsertContract(header, oldContract.merkleRoots)
+	meta, err := cs.managedInsertContract(header, oldRoots)
 	if err != nil {
 		return modules.RenterContract{}, err
 	}

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -284,7 +284,7 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 	}
 
 	// Get old roots
-	oldRoots, err := oldContract.merkleRoots()
+	oldRoots, err := oldContract.merkleRoots.merkleRoots()
 	if err != nil {
 		return modules.RenterContract{}, err
 	}


### PR DESCRIPTION
Instead of having all the merkle roots of every contract in memory, the renter should load them from disk if needed.