### PR TITLE
WIP: Fix host counter

### DIFF
--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -369,16 +369,6 @@ func (h *Host) managedAddStorageObligation(so storageObligation) error {
 			return err
 		}
 
-		// Update the host financial metrics with regards to this storage
-		// obligation.
-		h.financialMetrics.ContractCount++
-		h.financialMetrics.PotentialContractCompensation = h.financialMetrics.PotentialContractCompensation.Add(so.ContractCost)
-		h.financialMetrics.LockedStorageCollateral = h.financialMetrics.LockedStorageCollateral.Add(so.LockedCollateral)
-		h.financialMetrics.PotentialStorageRevenue = h.financialMetrics.PotentialStorageRevenue.Add(so.PotentialStorageRevenue)
-		h.financialMetrics.PotentialDownloadBandwidthRevenue = h.financialMetrics.PotentialDownloadBandwidthRevenue.Add(so.PotentialDownloadRevenue)
-		h.financialMetrics.PotentialUploadBandwidthRevenue = h.financialMetrics.PotentialUploadBandwidthRevenue.Add(so.PotentialUploadRevenue)
-		h.financialMetrics.RiskedStorageCollateral = h.financialMetrics.RiskedStorageCollateral.Add(so.RiskedCollateral)
-		h.financialMetrics.TransactionFeeExpenses = h.financialMetrics.TransactionFeeExpenses.Add(so.TransactionFeesAdded)
 		return nil
 	}()
 	if err != nil {
@@ -414,6 +404,18 @@ func (h *Host) managedAddStorageObligation(so storageObligation) error {
 		h.log.Println("Error with transaction set, redacting obligation, id", so.id())
 		return composeErrors(err, h.removeStorageObligation(so, obligationRejected))
 	}
+
+	// Update the host financial metrics with regards to this storage
+	// obligation.
+	h.financialMetrics.ContractCount++
+	h.financialMetrics.PotentialContractCompensation = h.financialMetrics.PotentialContractCompensation.Add(so.ContractCost)
+	h.financialMetrics.LockedStorageCollateral = h.financialMetrics.LockedStorageCollateral.Add(so.LockedCollateral)
+	h.financialMetrics.PotentialStorageRevenue = h.financialMetrics.PotentialStorageRevenue.Add(so.PotentialStorageRevenue)
+	h.financialMetrics.PotentialDownloadBandwidthRevenue = h.financialMetrics.PotentialDownloadBandwidthRevenue.Add(so.PotentialDownloadRevenue)
+	h.financialMetrics.PotentialUploadBandwidthRevenue = h.financialMetrics.PotentialUploadBandwidthRevenue.Add(so.PotentialUploadRevenue)
+	h.financialMetrics.RiskedStorageCollateral = h.financialMetrics.RiskedStorageCollateral.Add(so.RiskedCollateral)
+	h.financialMetrics.TransactionFeeExpenses = h.financialMetrics.TransactionFeeExpenses.Add(so.TransactionFeesAdded)
+
 	return nil
 }
 

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -405,9 +405,13 @@ func (h *Host) managedAddStorageObligation(so storageObligation) error {
 		return composeErrors(err, h.removeStorageObligation(so, obligationRejected))
 	}
 
+	// Increase contract count by one only if this is a new filecontract.
+	if len(so.SectorRoots) == 0 {
+		h.financialMetrics.ContractCount++
+	}
+
 	// Update the host financial metrics with regards to this storage
 	// obligation.
-	h.financialMetrics.ContractCount++
 	h.financialMetrics.PotentialContractCompensation = h.financialMetrics.PotentialContractCompensation.Add(so.ContractCost)
 	h.financialMetrics.LockedStorageCollateral = h.financialMetrics.LockedStorageCollateral.Add(so.LockedCollateral)
 	h.financialMetrics.PotentialStorageRevenue = h.financialMetrics.PotentialStorageRevenue.Add(so.PotentialStorageRevenue)


### PR DESCRIPTION
@DavidVorick This is a first attempt to fix the host financial metrics that are off most of the time for all the hosts.

I noticed that whenever my host financial metrics increased a lot in a small period of time, there were at the same time consensus errors in the `host.log`. These errors always repeated themselves 6 times with 15s interval. See [consensus.log](https://gist.github.com/nielscastien/ca633c579e225dd3d5bcc5c287e9b2bb).

Therefore, I looked at `negotiate.go` and found out that there is a loop that calls
 `err = h.managedAddStorageObligation(so) `. 
Worst case this function is called 6 times if there are issues with the acceptance of the transaction set (leading to the logged errors). Every time this function is called on the same storage obligation, the host financial metrics are updated.

This PR tries to fix the double counting issue. But if I am correct, this will also lead to additional insertions into the host database. This might lead to several other bugs where a host can't provide a storage proof when a storage obligation ends.

I know the focus is on upgrading the renter. But this could potentially fix a lot of errors for the hosts. Any feedback is welcome...

cc @lukechampine 