### PR TITLE
Calculate potential values at startup

### DIFF
--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -172,10 +172,11 @@ func (h *Host) load() error {
 		return err
 	}
 
-	// Get the contract count and locked collateral by observing all of the incomplete
-	// storage obligations in the database.
-	// TODO: both contract count and locked collateral are not correctly updated during
-	// contract renewals. This leads to an offset to the real value over time.
+	// Get the contract count, locked collateral, potential contract compensation
+	// and potential storage revenue by observing all of the incomplete storage
+	// obligations in the database.
+	// TODO: host financial metrics are not correctly updated if there are errors
+	// during contract renewals. This leads to an offset to the real value over time.
 	h.financialMetrics.ContractCount = 0
 	h.financialMetrics.LockedStorageCollateral = types.NewCurrency64(0)
 	h.financialMetrics.PotentialContractCompensation = types.NewCurrency64(0)

--- a/modules/host/persist.go
+++ b/modules/host/persist.go
@@ -178,6 +178,8 @@ func (h *Host) load() error {
 	// contract renewals. This leads to an offset to the real value over time.
 	h.financialMetrics.ContractCount = 0
 	h.financialMetrics.LockedStorageCollateral = types.NewCurrency64(0)
+	h.financialMetrics.PotentialContractCompensation = types.NewCurrency64(0)
+	h.financialMetrics.PotentialStorageRevenue = types.NewCurrency64(0)
 	err = h.db.View(func(tx *bolt.Tx) error {
 		cursor := tx.Bucket(bucketStorageObligations).Cursor()
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
@@ -189,6 +191,8 @@ func (h *Host) load() error {
 			if so.ObligationStatus == obligationUnresolved {
 				h.financialMetrics.ContractCount++
 				h.financialMetrics.LockedStorageCollateral = h.financialMetrics.LockedStorageCollateral.Add(so.LockedCollateral)
+				h.financialMetrics.PotentialContractCompensation = h.financialMetrics.PotentialContractCompensation.Add(so.ContractCost)
+				h.financialMetrics.PotentialStorageRevenue = h.financialMetrics.PotentialStorageRevenue.Add(so.PotentialStorageRevenue)
 			}
 		}
 		return nil


### PR DESCRIPTION
This PR will extend the previous one where the locked storage collateral is re-calculated at start-up.
On my host this gives more sane (i.e. smaller) values that are more in line with the revenues. The impact will be proportional with the age of the host.