### PR TITLE
remove overly verbose logging in managedAcceptBlocks

### DIFF
--- a/modules/consensus/accept.go
+++ b/modules/consensus/accept.go
@@ -241,7 +241,6 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 	chainExtended := false
 	changes := make([]changeEntry, 0, len(blocks))
 	setErr := cs.db.Update(func(tx *bolt.Tx) error {
-		cs.log.Printf("accept: starting block processing loop (%v blocks, height %v)", len(blocks), blockHeight(tx))
 		for i := 0; i < len(blocks); i++ {
 			// Start by checking the header of the block.
 			parent, err := cs.validateHeaderAndBlock(boltTxWrapper{tx}, blocks[i], blockIDs[i])
@@ -269,7 +268,6 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 				for _, b := range changeEntry.RevertedBlocks {
 					reverted = append(reverted, b.String()[:6])
 				}
-				cs.log.Printf("accept: added change %v, applying blocks %v, reverting blocks %v (height now %v)", changeEntry.ID(), applied, reverted, blockHeight(tx))
 			}
 			if err == modules.ErrNonExtendingBlock {
 				err = nil
@@ -286,7 +284,6 @@ func (cs *ConsensusSet) managedAcceptBlocks(blocks []types.Block) (blockchainExt
 		}
 		return nil
 	})
-	cs.log.Printf("accept: finished block processing loop")
 	if _, ok := setErr.(bolt.MmapError); ok {
 		cs.log.Println("ERROR: Bolt mmap failed:", setErr)
 		fmt.Println("Blockchain database has run out of disk space!")


### PR DESCRIPTION
these logging statements cause `consensus.log` to grow to many megabytes.