### PR TITLE
Add dependency injection to siatest package

### DIFF
--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -204,11 +204,11 @@ func New(cs consensusSet, wallet walletShim, tpool transactionPool, hdb hostDB, 
 	}
 
 	// Create Contractor using production dependencies.
-	return newContractor(cs, &walletBridge{w: wallet}, tpool, hdb, contractSet, newPersist(persistDir), logger, modules.ProdDependencies)
+	return NewCustomContractor(cs, &WalletBridge{W: wallet}, tpool, hdb, contractSet, NewPersist(persistDir), logger, modules.ProdDependencies)
 }
 
-// newContractor creates a Contractor using the provided dependencies.
-func newContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, contractSet *proto.ContractSet, p persister, l *persist.Logger, deps modules.Dependencies) (*Contractor, error) {
+// NewCustomContractor creates a Contractor using the provided dependencies.
+func NewCustomContractor(cs consensusSet, w wallet, tp transactionPool, hdb hostDB, contractSet *proto.ContractSet, p persister, l *persist.Logger, deps modules.Dependencies) (*Contractor, error) {
 	// Create the Contractor object.
 	c := &Contractor{
 		cs:      cs,

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -294,7 +294,7 @@ func TestAllowanceSpending(t *testing.T) {
 	}
 
 	var minerRewards types.Currency
-	w := c.wallet.(*walletBridge).w.(modules.Wallet)
+	w := c.wallet.(*WalletBridge).W.(modules.Wallet)
 	txns, err := w.Transactions(0, 1000)
 	if err != nil {
 		t.Fatal(err)
@@ -522,7 +522,7 @@ func (ws *testWalletShim) StartTransaction() modules.TransactionBuilder {
 // TestWalletBridge tests the walletBridge type.
 func TestWalletBridge(t *testing.T) {
 	shim := new(testWalletShim)
-	bridge := walletBridge{shim}
+	bridge := WalletBridge{shim}
 	bridge.NextAddress()
 	if !shim.nextAddressCalled {
 		t.Error("NextAddress was not called on the shim")

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -64,12 +64,12 @@ type (
 
 // Because wallet is not directly compatible with modules.Wallet (wrong
 // type signature for StartTransaction), we must provide a bridge type.
-type walletBridge struct {
-	w walletShim
+type WalletBridge struct {
+	W walletShim
 }
 
-func (ws *walletBridge) NextAddress() (types.UnlockConditions, error) { return ws.w.NextAddress() }
-func (ws *walletBridge) StartTransaction() transactionBuilder         { return ws.w.StartTransaction() }
+func (ws *WalletBridge) NextAddress() (types.UnlockConditions, error) { return ws.W.NextAddress() }
+func (ws *WalletBridge) StartTransaction() transactionBuilder         { return ws.W.StartTransaction() }
 
 // stdPersist implements the persister interface. The filename required by
 // these functions is internal to stdPersist.
@@ -90,7 +90,7 @@ func (p *stdPersist) load(data *contractorPersist) error {
 	return persist.LoadJSON(persistMeta, &data, p.filename)
 }
 
-func newPersist(dir string) *stdPersist {
+func NewPersist(dir string) *stdPersist {
 	return &stdPersist{
 		filename: filepath.Join(dir, "contractor.json"),
 	}

--- a/modules/renter/contractor/persist_test.go
+++ b/modules/renter/contractor/persist_test.go
@@ -63,7 +63,7 @@ func TestSaveLoad(t *testing.T) {
 	}
 
 	// use stdPersist instead of mock
-	c.persist = newPersist(build.TempDir("contractor", t.Name()))
+	c.persist = NewPersist(build.TempDir("contractor", t.Name()))
 	os.MkdirAll(build.TempDir("contractor", t.Name()), 0700)
 
 	// save, clear, and reload
@@ -115,7 +115,7 @@ func TestConvertPersist(t *testing.T) {
 
 	// load the persist
 	var p contractorPersist
-	err = newPersist(dir).load(&p)
+	err = NewPersist(dir).load(&p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -64,13 +64,13 @@ func New(g modules.Gateway, cs modules.ConsensusSet, persistDir string) (*HostDB
 		return nil, errNilCS
 	}
 	// Create HostDB using production dependencies.
-	return newHostDB(g, cs, persistDir, modules.ProdDependencies)
+	return NewCustomHostDB(g, cs, persistDir, modules.ProdDependencies)
 }
 
-// newHostDB creates a HostDB using the provided dependencies. It loads the old
+// NewCustomHostDB creates a HostDB using the provided dependencies. It loads the old
 // persistence data, spawns the HostDB's scanning threads, and subscribes it to
 // the consensusSet.
-func newHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir string, deps modules.Dependencies) (*HostDB, error) {
+func NewCustomHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir string, deps modules.Dependencies) (*HostDB, error) {
 	// Create the HostDB object.
 	hdb := &HostDB{
 		cs:         cs,

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -93,7 +93,7 @@ func newHDBTesterDeps(name string, deps modules.Dependencies) (*hdbTester, error
 	if err != nil {
 		return nil, err
 	}
-	hdb, err := newHostDB(g, cs, filepath.Join(testDir, modules.RenterDir), deps)
+	hdb, err := NewCustomHostDB(g, cs, filepath.Join(testDir, modules.RenterDir), deps)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/renter/hostdb/persist_test.go
+++ b/modules/renter/hostdb/persist_test.go
@@ -71,7 +71,7 @@ func TestSaveLoad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hdbt.hdb, err = newHostDB(hdbt.gateway, hdbt.cs, filepath.Join(hdbt.persistDir, modules.RenterDir), &quitAfterLoadDeps{})
+	hdbt.hdb, err = NewCustomHostDB(hdbt.gateway, hdbt.cs, filepath.Join(hdbt.persistDir, modules.RenterDir), &quitAfterLoadDeps{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -384,8 +384,8 @@ func validateSiapath(siapath string) error {
 // Enforce that Renter satisfies the modules.Renter interface.
 var _ modules.Renter = (*Renter)(nil)
 
-// newRenter initializes a renter and returns it.
-func newRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.TransactionPool, hdb hostDB, hc hostContractor, persistDir string, deps modules.Dependencies) (*Renter, error) {
+// NewCustomRenter initializes a renter and returns it.
+func NewCustomRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.TransactionPool, hdb hostDB, hc hostContractor, persistDir string, deps modules.Dependencies) (*Renter, error) {
 	if g == nil {
 		return nil, errNilGateway
 	}
@@ -472,5 +472,5 @@ func New(g modules.Gateway, cs modules.ConsensusSet, wallet modules.Wallet, tpoo
 		return nil, err
 	}
 
-	return newRenter(g, cs, tpool, hdb, hc, persistDir, modules.ProdDependencies)
+	return NewCustomRenter(g, cs, tpool, hdb, hc, persistDir, modules.ProdDependencies)
 }

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -127,10 +127,11 @@ func (w *Wallet) Height() types.BlockHeight {
 // not loaded into the wallet during the call to 'new', but rather during the
 // call to 'Unlock'.
 func New(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string) (*Wallet, error) {
-	return newWallet(cs, tpool, persistDir, modules.ProdDependencies)
+	return NewCustomWallet(cs, tpool, persistDir, modules.ProdDependencies)
 }
 
-func newWallet(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string, deps modules.Dependencies) (*Wallet, error) {
+// NewCustomWallet creates a new wallet using custom dependencies.
+func NewCustomWallet(cs modules.ConsensusSet, tpool modules.TransactionPool, persistDir string, deps modules.Dependencies) (*Wallet, error) {
 	// Check for nil dependencies.
 	if cs == nil {
 		return nil, errNilConsensusSet

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -46,7 +46,7 @@ func createWalletTester(name string, deps modules.Dependencies) (*walletTester, 
 	if err != nil {
 		return nil, err
 	}
-	w, err := newWallet(cs, tp, filepath.Join(testdir, modules.WalletDir), deps)
+	w, err := NewCustomWallet(cs, tp, filepath.Join(testdir, modules.WalletDir), deps)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -18,8 +18,12 @@ import (
 	"github.com/NebulousLabs/Sia/modules/host"
 	"github.com/NebulousLabs/Sia/modules/miner"
 	"github.com/NebulousLabs/Sia/modules/renter"
+	"github.com/NebulousLabs/Sia/modules/renter/contractor"
+	"github.com/NebulousLabs/Sia/modules/renter/hostdb"
+	"github.com/NebulousLabs/Sia/modules/renter/proto"
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	"github.com/NebulousLabs/Sia/modules/wallet"
+	"github.com/NebulousLabs/Sia/persist"
 
 	"github.com/NebulousLabs/errors"
 )
@@ -70,6 +74,13 @@ type NodeParams struct {
 	Renter          modules.Renter
 	TransactionPool modules.TransactionPool
 	Wallet          modules.Wallet
+
+	// Dependencies for each module supporting dependency injection.
+	ContractorDeps  modules.Dependencies
+	ContractSetDeps modules.Dependencies
+	HostDBDeps      modules.Dependencies
+	RenterDeps      modules.Dependencies
+	WalletDeps      modules.Dependencies
 
 	// The high level directory where all the persistence gets stored for the
 	// moudles.
@@ -205,7 +216,11 @@ func New(params NodeParams) (*Node, error) {
 		if !params.CreateWallet {
 			return nil, nil
 		}
-		return wallet.New(cs, tp, filepath.Join(dir, modules.WalletDir))
+		walletDeps := params.WalletDeps
+		if walletDeps == nil {
+			walletDeps = modules.ProdDependencies
+		}
+		return wallet.NewCustomWallet(cs, tp, filepath.Join(dir, modules.WalletDir), walletDeps)
 	}()
 	if err != nil {
 		return nil, errors.Extend(err, errors.New("unable to create wallet"))
@@ -239,7 +254,44 @@ func New(params NodeParams) (*Node, error) {
 		if !params.CreateRenter {
 			return nil, nil
 		}
-		return renter.New(g, cs, w, tp, filepath.Join(dir, modules.RenterDir))
+		contractorDeps := params.ContractorDeps
+		if contractorDeps == nil {
+			contractorDeps = modules.ProdDependencies
+		}
+		contractSetDeps := params.ContractSetDeps
+		if contractSetDeps == nil {
+			contractSetDeps = modules.ProdDependencies
+		}
+		hostDBDeps := params.HostDBDeps
+		if hostDBDeps == nil {
+			hostDBDeps = modules.ProdDependencies
+		}
+		renterDeps := params.RenterDeps
+		if renterDeps == nil {
+			renterDeps = modules.ProdDependencies
+		}
+		persistDir := filepath.Join(dir, modules.RenterDir)
+
+		// HostDB
+		hdb, err := hostdb.NewCustomHostDB(g, cs, persistDir, hostDBDeps)
+		if err != nil {
+			return nil, err
+		}
+		// ContractSet
+		contractSet, err := proto.NewContractSet(filepath.Join(persistDir, "contracts"), contractSetDeps)
+		if err != nil {
+			return nil, err
+		}
+		// Contractor
+		logger, err := persist.NewFileLogger(filepath.Join(persistDir, "contractor.log"))
+		if err != nil {
+			return nil, err
+		}
+		hc, err := contractor.NewCustomContractor(cs, &contractor.WalletBridge{W: w}, tp, hdb, contractSet, contractor.NewPersist(persistDir), logger, contractorDeps)
+		if err != nil {
+			return nil, err
+		}
+		return renter.NewCustomRenter(g, cs, tp, hdb, hc, persistDir, renterDeps)
 	}()
 	if err != nil {
 		return nil, errors.Extend(err, errors.New("unable to create renter"))


### PR DESCRIPTION
This PR adds dependency injection to the siatest package by adding fields to the `NodeParams` for each module's dependencies. If the field is not set, a production dependency will be used instead.

e.g. a renter node could be created like this:
```
template := Renter("path/to/my/renter")
template.RenterDeps = myCustomDeps
renter, err := node.New(template)
```