### PR TITLE
Add support for offline transaction signing

### DIFF
--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -277,7 +277,7 @@ func main() {
 
 	root.AddCommand(walletCmd)
 	walletCmd.AddCommand(walletAddressCmd, walletAddressesCmd, walletChangepasswordCmd, walletInitCmd, walletInitSeedCmd,
-		walletLoadCmd, walletLockCmd, walletSeedsCmd, walletSendCmd, walletSweepCmd,
+		walletLoadCmd, walletLockCmd, walletSeedsCmd, walletSendCmd, walletSweepCmd, walletSignCmd,
 		walletBalanceCmd, walletTransactionsCmd, walletUnlockCmd)
 	walletInitCmd.Flags().BoolVarP(&initPassword, "password", "p", false, "Prompt for a custom password")
 	walletInitCmd.Flags().BoolVarP(&initForce, "force", "", false, "destroy the existing wallet and re-encrypt")

--- a/doc/API.md
+++ b/doc/API.md
@@ -1314,19 +1314,24 @@ standard success or error response. See
 
 #### /wallet/sign [POST]
 
-Function: Sign a transaction. The wallet will attempt to sign any SiacoinInput
-in the transaction whose UnlockConditions are unset.
+Function: Sign a transaction. The wallet will attempt to sign each input
+specified.
 
-###### Query String Parameters
+###### Request Body
 ```
-transaction string
+{
+  "transaction": { }, // types.Transaction
+  "tosign": {
+    "3689bd3489679aabcde02e01345abcde": "138950f0129d74acd4eade3453b45678",
+    "132cee478a9bb98bdd23cf05376cdf2a": "7cbcd123578234ce0f12fe01a68ba9bf"
+  }
+}
 ```
 
-###### Response [(with comments)](/doc/api/Wallet.md#json-response-7)
+###### Response
 ```javascript
 {
-  "transaction": "AQAAAAAAAADBM1ca",
-  "signedinputs": [0, 1, 6]
+  "transaction": { } // types.Transaction
 }
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -1041,6 +1041,7 @@ Wallet
 | [/wallet/address](#walletaddress-get)                           | GET       |
 | [/wallet/addresses](#walletaddresses-get)                       | GET       |
 | [/wallet/backup](#walletbackup-get)                             | GET       |
+| [/wallet/changepassword](#walletchangepassword-post)            | POST      |
 | [/wallet/init](#walletinit-post)                                | POST      |
 | [/wallet/init/seed](#walletinitseed-post)                       | POST      |
 | [/wallet/lock](#walletlock-post)                                | POST      |
@@ -1049,13 +1050,14 @@ Wallet
 | [/wallet/siacoins](#walletsiacoins-post)                        | POST      |
 | [/wallet/siafunds](#walletsiafunds-post)                        | POST      |
 | [/wallet/siagkey](#walletsiagkey-post)                          | POST      |
+| [/wallet/sign](#walletsign-post)                                | POST      |
 | [/wallet/sweep/seed](#walletsweepseed-post)                     | POST      |
 | [/wallet/transaction/:___id___](#wallettransactionid-get)       | GET       |
 | [/wallet/transactions](#wallettransactions-get)                 | GET       |
 | [/wallet/transactions/:___addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
-| [/wallet/verify/address/:___addr___](#walletverifyaddressaddr-get)  | GET       |
-| [/wallet/changepassword](#walletchangepassword-post)            | POST      |
+| [/wallet/unspent](#walletunspent-get)                           | GET       |
+| [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
 
 For examples and detailed descriptions of request and response parameters,
 refer to [Wallet.md](/doc/api/Wallet.md).
@@ -1139,6 +1141,20 @@ find their wallet file.
 ###### Parameters [(with comments)](/doc/api/Wallet.md#query-string-parameters-1)
 ```
 destination
+```
+
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
+
+#### /wallet/changepassword  [POST]
+
+changes the wallet's encryption key.
+
+###### Query String Parameters [(with comments)](/doc/api/Wallet.md#query-string-parameters-12)
+```
+encryptionpassword
+newpassword
 ```
 
 ###### Response
@@ -1296,6 +1312,24 @@ keyfiles
 standard success or error response. See
 [#standard-responses](#standard-responses).
 
+#### /wallet/sign [POST]
+
+Function: Sign a transaction. The wallet will attempt to sign any SiacoinInput
+in the transaction whose UnlockConditions are unset.
+
+###### Query String Parameters
+```
+transaction string
+```
+
+###### Response [(with comments)](/doc/api/Wallet.md#json-response-7)
+```javascript
+{
+  "transaction": "AQAAAAAAAADBM1ca",
+  "signedinputs": [0, 1, 6]
+}
+```
+
 #### /wallet/sweep/seed [POST]
 
 Function: Scan the blockchain for outputs belonging to a seed and send them to
@@ -1428,6 +1462,27 @@ encryptionpassword
 standard success or error response. See
 [#standard-responses](#standard-responses).
 
+
+#### /wallet/unspent [GET]
+
+returns a list of outputs that the wallet can spend.
+
+###### JSON Response [(with comments)](/doc/api/Wallet.md#json-response-11)
+```javascript
+{
+  "outputs": [
+    {
+      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "fundtype": "siacoin output",
+      "maturityheight": 50000,
+      "walletaddress": true,
+      "relatedaddress": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
+      "value": "1234" // big int
+    }
+  ]
+}
+```
+
 #### /wallet/verify/address/:addr [GET]
 
 takes the address specified by :addr and returns a JSON response indicating if the address is valid.
@@ -1438,18 +1493,4 @@ takes the address specified by :addr and returns a JSON response indicating if t
 	"valid": true
 }
 ```
-
-#### /wallet/changepassword  [POST]
-
-changes the wallet's encryption key.
-
-###### Query String Parameters [(with comments)](/doc/api/Wallet.md#query-string-parameters-12)
-```
-encryptionpassword
-newpassword
-```
-
-###### Response
-standard success or error response. See
-[#standard-responses](#standard-responses).
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -1479,9 +1479,8 @@ returns a list of outputs that the wallet can spend.
     {
       "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       "fundtype": "siacoin output",
-      "maturityheight": 50000,
-      "walletaddress": true,
-      "relatedaddress": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
+      "confirmationheight": 50000,
+      "unlockhash": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
       "value": "1234" // big int
     }
   ]

--- a/doc/api/Transactionpool.md
+++ b/doc/api/Transactionpool.md
@@ -71,7 +71,7 @@ returns the ID for the requested transaction and its raw encoded parents and tra
 
 submits a raw transaction to the transaction pool, broadcasting it to the transaction pool's peers.
 
-###### Query String Parameters [(with comments)](/doc/api/Transactionpool.md#query-string-parameters)
+###### Query String Parameters
 
 ```
 parents     string // raw base64 encoded transaction parents

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -503,23 +503,28 @@ standard success or error response. See
 
 #### /wallet/sign [POST]
 
-Function: Sign a transaction. The wallet will attempt to sign any SiacoinInput
-in the transaction whose UnlockConditions are unset.
+Function: Sign a transaction. The wallet will attempt to sign each input
+specified.
 
-###### Query String Parameters
+###### Request Body
 ```
-// base64-encoded transaction to be signed
-transaction string
+{
+  // unsigned transaction
+  "transaction": { }, // types.Transaction
+
+  // inputs to sign; a mapping from OutputID to UnlockHash
+  "tosign": {
+    "3689bd3489679aabcde02e01345abcde": "138950f0129d74acd4eade3453b45678",
+    "132cee478a9bb98bdd23cf05376cdf2a": "7cbcd123578234ce0f12fe01a68ba9bf"
+  }
+}
 ```
 
 ###### Response
 ```javascript
 {
-  // raw, base64 encoded transaction data
-  "transaction": "AQAAAAAAAADBM1ca",
-
-  // indices of inputs that were signed
-  "signedinputs": [0, 1, 6]
+  // signed transaction
+  "transaction": { } // types.Transaction
 }
 ```
 

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -34,6 +34,7 @@ Index
 | [/wallet/address](#walletaddress-get)                           | GET       |
 | [/wallet/addresses](#walletaddresses-get)                       | GET       |
 | [/wallet/backup](#walletbackup-get)                             | GET       |
+| [/wallet/changepassword](#walletchangepassword-post)            | POST      |
 | [/wallet/init](#walletinit-post)                                | POST      |
 | [/wallet/init/seed](#walletinitseed-post)                       | POST      |
 | [/wallet/lock](#walletlock-post)                                | POST      |
@@ -42,13 +43,14 @@ Index
 | [/wallet/siacoins](#walletsiacoins-post)                        | POST      |
 | [/wallet/siafunds](#walletsiafunds-post)                        | POST      |
 | [/wallet/siagkey](#walletsiagkey-post)                          | POST      |
+| [/wallet/sign](#walletsign-post)                                | POST      |
 | [/wallet/sweep/seed](#walletsweepseed-post)                     | POST      |
 | [/wallet/transaction/___:id___](#wallettransactionid-get)       | GET       |
 | [/wallet/transactions](#wallettransactions-get)                 | GET       |
 | [/wallet/transactions/___:addr___](#wallettransactionsaddr-get) | GET       |
 | [/wallet/unlock](#walletunlock-post)                            | POST      |
+| [/wallet/unspent](#walletunspent-get)                           | GET       |
 | [/wallet/verify/address/:___addr___](#walletverifyaddress-get)  | GET       |
-| [/wallet/changepassword](#walletchangepassword-post)            | POST      |
 
 #### /wallet [GET]
 
@@ -179,6 +181,22 @@ destination
 ###### Response
 standard success or error response. See
 [API.md#standard-responses](/doc/API.md#standard-responses).
+
+#### /wallet/changepassword [POST]
+
+changes the wallet's encryption password.
+
+###### Query String Parameter
+```
+// encryptionpassword is the wallet's current encryption password.
+encryptionpassword
+// newpassword is the new password for the wallet.
+newpassword
+```
+
+###### Response
+standard success or error response. See
+[#standard-responses](#standard-responses).
 
 #### /wallet/init [POST]
 
@@ -483,6 +501,28 @@ keyfiles
 standard success or error response. See
 [API.md#standard-responses](/doc/API.md#standard-responses).
 
+#### /wallet/sign [POST]
+
+Function: Sign a transaction. The wallet will attempt to sign any SiacoinInput
+in the transaction whose UnlockConditions are unset.
+
+###### Query String Parameters
+```
+// base64-encoded transaction to be signed
+transaction string
+```
+
+###### Response
+```javascript
+{
+  // raw, base64 encoded transaction data
+  "transaction": "AQAAAAAAAADBM1ca",
+
+  // indices of inputs that were signed
+  "signedinputs": [0, 1, 6]
+}
+```
+
 #### /wallet/sweep/seed [POST]
 
 Function: Scan the blockchain for outputs belonging to a seed and send them to
@@ -693,6 +733,41 @@ encryptionpassword string
 standard success or error response. See
 [API.md#standard-responses](/doc/API.md#standard-responses).
 
+#### /wallet/unspent [GET]
+
+returns a list of outputs that the wallet can spend.
+
+###### Response
+```javascript
+{
+  // Array of outputs that the wallet can spend.
+  "outputs": [
+    {
+      // The id of the output.
+      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
+      // Type of output, either 'siacoin output' or 'siafund output'.
+      "fundtype": "siacoin output",
+
+      // Height of block in which the output appeared. To calculate the
+      // number of confirmations, subtract this number from the current
+      // block height.
+      "maturityheight": 50000,
+
+      // Irrelevant field shared by ProcessedOutput; always true.
+      "walletaddress": true,
+
+      // UnlockHash of the output.
+      "relatedaddress": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
+
+      // Amount of funds in the output; hastings for siacoin outputs, and
+      // siafunds for siafund outputs.
+      "value": "1234" // big int
+    }
+  ]
+}
+```
+
 #### /wallet/verify/address/:addr [GET]
 
 takes the address specified by :addr and returns a JSON response indicating if the address is valid.
@@ -704,19 +779,3 @@ takes the address specified by :addr and returns a JSON response indicating if t
 	"valid": true
 }
 ```
-
-#### /wallet/changepassword [POST]
-
-changes the wallet's encryption password.
-
-###### Query String Parameter
-```
-// encryptionpassword is the wallet's current encryption password.
-encryptionpassword
-// newpassword is the new password for the wallet.
-newpassword
-```
-
-###### Response
-standard success or error response. See
-[#standard-responses](#standard-responses).

--- a/doc/api/Wallet.md
+++ b/doc/api/Wallet.md
@@ -757,13 +757,10 @@ returns a list of outputs that the wallet can spend.
       // Height of block in which the output appeared. To calculate the
       // number of confirmations, subtract this number from the current
       // block height.
-      "maturityheight": 50000,
-
-      // Irrelevant field shared by ProcessedOutput; always true.
-      "walletaddress": true,
+      "confirmationheight": 50000,
 
       // UnlockHash of the output.
-      "relatedaddress": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
+      "unlockhash": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
 
       // Amount of funds in the output; hastings for siacoin outputs, and
       // siafunds for siafund outputs.

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -414,12 +414,11 @@ type (
 		// the output.
 		SpendableOutputs() []ProcessedOutput
 
-		// SignTransaction signs txn using secret keys controlled by w, which
-		// must be unlocked. For each SiacoinInput whose UnlockConditions are
-		// not set, SignTransaction attempts to fill in the UnlockConditions
-		// and adds a corresponding signature. It returns the indices of each
-		// signed input.
-		SignTransaction(txn *types.Transaction) []int
+		// SignTransaction signs txn using secret keys known to the wallet. toSign
+		// maps the ParentID of each unsigned input to the UnlockHash of that input's
+		// desired UnlockConditions. SignTransaction fills in the UnlockConditions for
+		// each such input and adds a corresponding signature.
+		SignTransaction(txn *types.Transaction, toSign map[types.OutputID]types.UnlockHash) error
 	}
 
 	// WalletSettings control the behavior of the Wallet.

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -408,6 +408,18 @@ type (
 		// DustThreshold returns the quantity per byte below which a Currency is
 		// considered to be Dust.
 		DustThreshold() types.Currency
+
+		// SpendableOutputs returns the outputs spendable by the wallet. For
+		// each output, MaturityHeight is the height of the block containing
+		// the output.
+		SpendableOutputs() []ProcessedOutput
+
+		// SignTransaction signs txn using secret keys controlled by w, which
+		// must be unlocked. For each SiacoinInput whose UnlockConditions are
+		// not set, SignTransaction attempts to fill in the UnlockConditions
+		// and adds a corresponding signature. It returns the indices of each
+		// signed input.
+		SignTransaction(txn *types.Transaction) []int
 	}
 
 	// WalletSettings control the behavior of the Wallet.

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -100,6 +100,16 @@ type (
 		Outputs []ProcessedOutput `json:"outputs"`
 	}
 
+	// A SpendableOutput is a SiacoinOutput or SiafundOutput that the wallet
+	// can spend.
+	SpendableOutput struct {
+		ID                 types.OutputID    `json:"id"`
+		FundType           types.Specifier   `json:"fundtype"`
+		UnlockHash         types.UnlockHash  `json:"unlockhash"`
+		Value              types.Currency    `json:"value"`
+		ConfirmationHeight types.BlockHeight `json:"confirmationheight"`
+	}
+
 	// TransactionBuilder is used to construct custom transactions. A transaction
 	// builder is initialized via 'RegisterTransaction' and then can be modified by
 	// adding funds or other fields. The transaction is completed by calling
@@ -409,10 +419,8 @@ type (
 		// considered to be Dust.
 		DustThreshold() types.Currency
 
-		// SpendableOutputs returns the outputs spendable by the wallet. For
-		// each output, MaturityHeight is the height of the block containing
-		// the output.
-		SpendableOutputs() []ProcessedOutput
+		// SpendableOutputs returns the outputs spendable by the wallet.
+		SpendableOutputs() []SpendableOutput
 
 		// SignTransaction signs txn using secret keys known to the wallet. toSign
 		// maps the ParentID of each unsigned input to the UnlockHash of that input's

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -474,10 +474,13 @@ func TestSignTransaction(t *testing.T) {
 			UnlockHash: types.UnlockHash{},
 		}},
 	}
+
 	// sign the transaction
-	signed := wt.wallet.SignTransaction(&txn)
-	if len(signed) != 1 || signed[0] != 0 {
-		t.Fatal("expected signed to equal [0]; got", signed)
+	err = wt.wallet.SignTransaction(&txn, map[types.OutputID]types.UnlockHash{
+		outputs[0].ID: outputs[0].RelatedAddress,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 	// txn should now have unlock condictions and a signature
 	if txn.SiacoinInputs[0].UnlockConditions.SignaturesRequired == 0 {

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -477,7 +477,7 @@ func TestSignTransaction(t *testing.T) {
 
 	// sign the transaction
 	err = wt.wallet.SignTransaction(&txn, map[types.OutputID]types.UnlockHash{
-		outputs[0].ID: outputs[0].RelatedAddress,
+		outputs[0].ID: outputs[0].UnlockHash,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -111,6 +111,7 @@ type Wallet struct {
 func (w *Wallet) Height() types.BlockHeight {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	w.syncDB()
 
 	var height uint64
 	err := w.db.View(func(tx *bolt.Tx) error {

--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -124,6 +124,8 @@ func (api *API) buildHTTPRoutes(requiredUserAgent string, requiredPassword strin
 		router.GET("/wallet/verify/address/:addr", api.walletVerifyAddressHandler)
 		router.POST("/wallet/unlock", RequirePassword(api.walletUnlockHandler, requiredPassword))
 		router.POST("/wallet/changepassword", RequirePassword(api.walletChangePasswordHandler, requiredPassword))
+		router.GET("/wallet/unspent", RequirePassword(api.walletUnspentHandler, requiredPassword))
+		router.POST("/wallet/sign", RequirePassword(api.walletSignHandler, requiredPassword))
 	}
 
 	// Apply UserAgent middleware and return the Router

--- a/node/api/wallet.go
+++ b/node/api/wallet.go
@@ -114,7 +114,7 @@ type (
 	// MaturityHeight field of each output indicates the height of the block
 	// that the output appeared in.
 	WalletUnspentGET struct {
-		Outputs []modules.ProcessedOutput `json:"outputs"`
+		Outputs []modules.SpendableOutput `json:"outputs"`
 	}
 
 	// WalletVerifyAddressGET contains a bool indicating if the address passed to


### PR DESCRIPTION
This mostly addresses #1927. I will make a follow-up PR shortly that adds support for watch-only wallets. In the meantime, you can simulate a watch-only wallet by creating a normal wallet and then locking it.

The basic process is:

1. GET `/wallet/unspent` to receive a list of spendable outputs
2. Construct an unsigned transaction using the outputs
3. Use `siac wallet sign` to sign the transaction
4. POST `/tpool/raw` to broadcast the transaction

wrt 3, `siac wallet sign` does not require `siad`; it's completely self-contained. The downside of this is that you need to regenerate a bunch of keys from the seed, and you pay that cost every time you sign a transaction. For wallets that have <10000 addresses, this cost should be barely noticeable, but for larger wallets, there is also a `/wallet/sign` endpoint that will perform the same signing operation using the keys already in memory.

Lastly, there's the question of how to encode the transactions. `/tpool/raw` expects base64-encoded binary, but that isn't a very convenient format for *constructing* transactions. I figured that JSON was a better choice for that, so `siac wallet sign` and `/wallet/sign` both expect the transaction to be JSON.