### PR TITLE
Rename MaxAdjustmentDown and MaxAdjustmentUp

### DIFF
--- a/cmd/siad/server.go
+++ b/cmd/siad/server.go
@@ -79,8 +79,8 @@ type (
 		RootTarget types.Target `json:"roottarget"`
 		RootDepth  types.Target `json:"rootdepth"`
 
-		MaxAdjustmentUp   *big.Rat `json:"maxadjustmentup"`
-		MaxAdjustmentDown *big.Rat `json:"maxadjustmentdown"`
+		MaxTargetAdjustmentUp   *big.Rat `json:"maxtargetadjustmentup"`
+		MaxTargetAdjustmentDown *big.Rat `json:"maxtargetadjustmentdown"`
 
 		SiacoinPrecision types.Currency `json:"siacoinprecision"`
 	}
@@ -349,8 +349,8 @@ func (srv *Server) daemonConstantsHandler(w http.ResponseWriter, _ *http.Request
 		RootTarget: types.RootTarget,
 		RootDepth:  types.RootDepth,
 
-		MaxAdjustmentUp:   types.MaxAdjustmentUp,
-		MaxAdjustmentDown: types.MaxAdjustmentDown,
+		MaxTargetAdjustmentUp:   types.MaxTargetAdjustmentUp,
+		MaxTargetAdjustmentDown: types.MaxTargetAdjustmentDown,
 
 		SiacoinPrecision: types.SiacoinPrecision,
 	}

--- a/doc/API.md
+++ b/doc/API.md
@@ -128,8 +128,8 @@ returns the set of constants in use.
   "roottarget": [0,0,0,0,32,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
   "rootdepth":  [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255],
 
-  "maxadjustmentup":   "5/2",
-  "maxadjustmentdown": "2/5",
+  "maxtargetadjustmentup":   "5/2",
+  "maxtargetadjustmentdown": "2/5",
 
   "siacoinprecision": "1000000000000000000000000" // hastings per siacoin
 }

--- a/doc/api/Daemon.md
+++ b/doc/api/Daemon.md
@@ -83,10 +83,10 @@ returns the set of constants in use.
   "rootdepth": [255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255],
 
   // Largest allowed ratio between the old difficulty and the new difficulty.
-  "maxadjustmentup": "5/2",
+  "maxtargetadjustmentup": "5/2",
 
   // Smallest allowed ratio between the old difficulty and the new difficulty.
-  "maxadjustmentdown": "2/5",
+  "maxtargetadjustmentdown": "2/5",
 
   // Number of Hastings in one siacoin.
   "siacoinprecision": "1000000000000000000000000" // hastings per siacoin

--- a/modules/consensus/processedblock.go
+++ b/modules/consensus/processedblock.go
@@ -91,10 +91,10 @@ func (cs *ConsensusSet) targetAdjustmentBase(blockMap *bolt.Bucket, pb *processe
 // of total work, which prevents certain classes of difficulty adjusting
 // attacks.
 func clampTargetAdjustment(base *big.Rat) *big.Rat {
-	if base.Cmp(types.MaxAdjustmentUp) > 0 {
-		return types.MaxAdjustmentUp
-	} else if base.Cmp(types.MaxAdjustmentDown) < 0 {
-		return types.MaxAdjustmentDown
+	if base.Cmp(types.MaxTargetAdjustmentUp) > 0 {
+		return types.MaxTargetAdjustmentUp
+	} else if base.Cmp(types.MaxTargetAdjustmentDown) < 0 {
+		return types.MaxTargetAdjustmentDown
 	}
 	return base
 }

--- a/types/constants.go
+++ b/types/constants.go
@@ -55,14 +55,14 @@ var (
 	// any transactions spending the payout. File contract payouts also are subject to
 	// a maturity delay.
 	MaturityDelay BlockHeight
-	// MaxAdjustmentDown restrict how much the block difficulty is allowed to
+	// MaxTargetAdjustmentDown restrict how much the block difficulty is allowed to
 	// change in a single step, which is important to limit the effect of difficulty
 	// raising and lowering attacks.
-	MaxAdjustmentDown *big.Rat
-	// MaxAdjustmentUp restrict how much the block difficulty is allowed to
+	MaxTargetAdjustmentDown *big.Rat
+	// MaxTargetAdjustmentUp restrict how much the block difficulty is allowed to
 	// change in a single step, which is important to limit the effect of difficulty
 	// raising and lowering attacks.
-	MaxAdjustmentUp *big.Rat
+	MaxTargetAdjustmentUp *big.Rat
 	// MedianTimestampWindow tells us how many blocks to look back when calculating
 	// the median timestamp over the previous n blocks. The timestamp of a block is
 	// not allowed to be less than or equal to the median timestamp of the previous n
@@ -138,11 +138,11 @@ func init() {
 		GenesisTimestamp = Timestamp(1424139000) // Change as necessary.
 		RootTarget = Target{0, 0, 2}             // Standard developer CPUs will be able to mine blocks with the race library activated.
 
-		TargetWindow = 20                        // Difficulty is adjusted based on prior 20 blocks.
-		MaxAdjustmentUp = big.NewRat(120, 100)   // Difficulty adjusts quickly.
-		MaxAdjustmentDown = big.NewRat(100, 120) // Difficulty adjusts quickly.
-		FutureThreshold = 2 * 60                 // 2 minutes.
-		ExtremeFutureThreshold = 4 * 60          // 4 minutes.
+		TargetWindow = 20                              // Difficulty is adjusted based on prior 20 blocks.
+		MaxTargetAdjustmentUp = big.NewRat(120, 100)   // Difficulty adjusts quickly.
+		MaxTargetAdjustmentDown = big.NewRat(100, 120) // Difficulty adjusts quickly.
+		FutureThreshold = 2 * 60                       // 2 minutes.
+		ExtremeFutureThreshold = 4 * 60                // 4 minutes.
 
 		MinimumCoinbase = 30e3
 
@@ -181,8 +181,8 @@ func init() {
 		// only 1 second and testing mining should be happening substantially
 		// faster than that.
 		TargetWindow = 200
-		MaxAdjustmentUp = big.NewRat(10001, 10000)
-		MaxAdjustmentDown = big.NewRat(9999, 10000)
+		MaxTargetAdjustmentUp = big.NewRat(10001, 10000)
+		MaxTargetAdjustmentDown = big.NewRat(9999, 10000)
 		FutureThreshold = 3        // 3 seconds
 		ExtremeFutureThreshold = 6 // 6 seconds
 
@@ -256,8 +256,8 @@ func init() {
 		// difficulty is adjusted four times as often. This does result in
 		// greater difficulty oscillation, a tradeoff that was chosen to be
 		// acceptable due to Sia's more vulnerable position as an altcoin.
-		MaxAdjustmentUp = big.NewRat(25, 10)
-		MaxAdjustmentDown = big.NewRat(10, 25)
+		MaxTargetAdjustmentUp = big.NewRat(25, 10)
+		MaxTargetAdjustmentDown = big.NewRat(10, 25)
 
 		// Blocks will not be accepted if their timestamp is more than 3 hours
 		// into the future, but will be accepted as soon as they are no longer


### PR DESCRIPTION
Renaming MaxAdjustmentDown and MaxAdjustmentUp to MaxTargetAdjustmentDown and MaxTargetAdjustmentUp respectively as suggested by @DavidVorick  here:

https://github.com/NebulousLabs/Sia/pull/2786