### PR TITLE
reduce synchronize timeouts and increase block batch size

### DIFF
--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -39,7 +39,7 @@ var (
 	// the consensus set in a single iteration during the initial blockchain
 	// download.
 	MaxCatchUpBlocks = build.Select(build.Var{
-		Standard: types.BlockHeight(25),
+		Standard: types.BlockHeight(10),
 		Dev:      types.BlockHeight(50),
 		Testing:  types.BlockHeight(3),
 	}).(types.BlockHeight)
@@ -71,7 +71,7 @@ var (
 
 	// sendBlocksTimeout is the timeout for the SendBlocks RPC.
 	sendBlocksTimeout = build.Select(build.Var{
-		Standard: 120 * time.Second,
+		Standard: 180 * time.Second,
 		Dev:      40 * time.Second,
 		Testing:  5 * time.Second,
 	}).(time.Duration)

--- a/modules/consensus/synchronize.go
+++ b/modules/consensus/synchronize.go
@@ -39,7 +39,7 @@ var (
 	// the consensus set in a single iteration during the initial blockchain
 	// download.
 	MaxCatchUpBlocks = build.Select(build.Var{
-		Standard: types.BlockHeight(10),
+		Standard: types.BlockHeight(25),
 		Dev:      types.BlockHeight(50),
 		Testing:  types.BlockHeight(3),
 	}).(types.BlockHeight)
@@ -57,21 +57,21 @@ var (
 
 	// relayHeaderTimeout is the timeout for the RelayHeader RPC.
 	relayHeaderTimeout = build.Select(build.Var{
-		Standard: 3 * time.Minute,
+		Standard: 60 * time.Second,
 		Dev:      20 * time.Second,
 		Testing:  3 * time.Second,
 	}).(time.Duration)
 
 	// sendBlkTimeout is the timeout for the SendBlk RPC.
 	sendBlkTimeout = build.Select(build.Var{
-		Standard: 4 * time.Minute,
+		Standard: 90 * time.Second,
 		Dev:      30 * time.Second,
 		Testing:  4 * time.Second,
 	}).(time.Duration)
 
 	// sendBlocksTimeout is the timeout for the SendBlocks RPC.
 	sendBlocksTimeout = build.Select(build.Var{
-		Standard: 5 * time.Minute,
+		Standard: 120 * time.Second,
 		Dev:      40 * time.Second,
 		Testing:  5 * time.Second,
 	}).(time.Duration)


### PR DESCRIPTION
The `sendBlkTimeout` and `sendBlocksTimeout` are causing a huge amount of wasted time during the initial blockchain sync.  I've synchronized the blockchain 3 times with default settings and Sia spent an average of 10701 seconds downloading the blocks.  When I dropped the timeouts down to 10seconds I was able to download the blocks in just 815 seconds.

This PR tries to find a happy middle between slower peers and having a performant IBD.  I believe every peer should be able to respond within the timeout limits specified, and we won't spend so much time waiting for the peer to timeout if it's not responding.

Changing `MaxCatchUpBlocks` to 25 is meant to reduce the overhead of requesting and sending so many blocks.  This is harder to test since even if I ask for 100 blocks peers only send back 10 at a time right now, this change would have to propagate out to peers before we'll be able to measure its performance implications.

This PR is meant to improve the sync time while we wait for an overhaul of the consensus module.