### PR TITLE
[WIP] Host contract API

### DIFF
--- a/modules/host.go
+++ b/modules/host.go
@@ -111,10 +111,29 @@ type (
 	// StorageObligation contains information about a storage obligation that
 	// the host has accepted.
 	StorageObligation struct {
-		NegotiationHeight types.BlockHeight `json:"negotiationheight"`
+		ObligationId             types.FileContractID `json:"obligationid"`
+		FileSize                 uint64               `json:"filesize"`
+		SectorRootsCount         uint64               `json:"sectorrootscount"`
+		ContractCost             types.Currency       `json:"contractcost"`
+		LockedCollateral         types.Currency       `json:"lockedcollateral"`
+		PotentialDownloadRevenue types.Currency       `json:"potentialdownloadrevenue"`
+		PotentialStorageRevenue  types.Currency       `json:"potentialstoragerevenue"`
+		PotentialUploadRevenue   types.Currency       `json:"potentialuploadrevenue"`
+		RiskedCollateral         types.Currency       `json:"riskedcollateral"`
+		TransactionFeesAdded     types.Currency       `json:"transactionfeesadded"`
 
+		// The negotiation height specifies the block height at which the file
+		// contract was negotiated. The expiration height and the proof deadline
+		// are equal to the window start and window end. Between the expiration height
+		// and the proof deadline, the host must submit the storage proof.
+		NegotiationHeight types.BlockHeight `json:"negotiationheight"`
+		ExpirationHeight  types.BlockHeight `json:"expirationheight"`
+		ProofDeadLine     types.BlockHeight `json:"proofdeadline"`
+
+		// Variables indicating whether the critical transactions in a storage
+		// obligation have been confirmed on the blockchain.
 		OriginConfirmed     bool   `json:"originconfirmed"`
-		RevisionConstructed bool   `json:"revisionconstructed"`
+		RevisionConstructed bool   `json:"revisioncontructed"`
 		RevisionConfirmed   bool   `json:"revisionconfirmed"`
 		ProofConstructed    bool   `json:"proofconstructed"`
 		ProofConfirmed      bool   `json:"proofconfirmed"`

--- a/modules/host/storageobligations.go
+++ b/modules/host/storageobligations.go
@@ -870,7 +870,20 @@ func (h *Host) StorageObligations() (sos []modules.StorageObligation) {
 				return build.ExtendErr("unable to unmarshal storage obligation:", err)
 			}
 			mso := modules.StorageObligation{
+				ObligationId:             so.id(),
+				FileSize:                 so.fileSize(),
+				SectorRootsCount:         uint64(len(so.SectorRoots)),
+				ContractCost:             so.ContractCost,
+				LockedCollateral:         so.LockedCollateral,
+				PotentialDownloadRevenue: so.PotentialDownloadRevenue,
+				PotentialStorageRevenue:  so.PotentialStorageRevenue,
+				PotentialUploadRevenue:   so.PotentialUploadRevenue,
+				RiskedCollateral:         so.RiskedCollateral,
+				TransactionFeesAdded:     so.TransactionFeesAdded,
+
 				NegotiationHeight: so.NegotiationHeight,
+				ExpirationHeight:  so.expiration(),
+				ProofDeadLine:     so.proofDeadline(),
 
 				OriginConfirmed:     so.OriginConfirmed,
 				RevisionConstructed: so.RevisionConstructed,

--- a/node/api/host.go
+++ b/node/api/host.go
@@ -24,6 +24,12 @@ var (
 )
 
 type (
+	// ContractInfoGET contains the information that is returned after a GET request
+	// to /host/contracts - information for the host about stored obligations.
+	ContractInfoGET struct {
+		Contracts []modules.StorageObligation `json:"obligations"`
+	}
+
 	// HostGET contains the information that is returned after a GET request to
 	// /host - a bunch of information about the status of the host.
 	HostGET struct {

--- a/node/api/host.go
+++ b/node/api/host.go
@@ -67,6 +67,44 @@ func folderIndex(folderPath string, storageFolders []modules.StorageFolderMetada
 	return -1, errStorageFolderNotFound
 }
 
+// hostContractInfoHandler handles the API call to get the contract information of the host.
+// Information is retrieved via the storage obligations from the host database.
+// TODO: filters are hard coded. Adding or removing storage obligation statuses will
+// currently break the API.
+func (api *API) hostContractInfoHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	statusStr := req.FormValue("status")
+	if statusStr == "" {
+		WriteError(w, Error{"Status must be provided to a /host/contracts call."}, http.StatusBadRequest)
+		return
+	}
+	var filter uint64
+	switch statusStr {
+	case "unresolved":
+		filter = 0
+	case "rejected":
+		filter = 1
+	case "succeeded":
+		filter = 2
+	case "failed":
+		filter = 3
+	case "all":
+		filter = 4
+	default:
+		WriteError(w, Error{"Unable to parse contract status."}, http.StatusBadRequest)
+		return
+	}
+	sos := []modules.StorageObligation{}
+	for _, so := range api.host.StorageObligations() {
+		if so.ObligationStatus == filter || filter == 4 {
+			sos = append(sos, so)
+		}
+	}
+	cg := ContractInfoGET{
+		Contracts: sos,
+	}
+	WriteJSON(w, cg)
+}
+
 // hostHandlerGET handles GET requests to the /host API endpoint, returning key
 // information about the host.
 func (api *API) hostHandlerGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {

--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -45,6 +45,7 @@ func (api *API) buildHTTPRoutes(requiredUserAgent string, requiredPassword strin
 		router.GET("/host", api.hostHandlerGET)                                                   // Get the host status.
 		router.POST("/host", RequirePassword(api.hostHandlerPOST, requiredPassword))              // Change the settings of the host.
 		router.POST("/host/announce", RequirePassword(api.hostAnnounceHandler, requiredPassword)) // Announce the host to the network.
+		router.GET("/host/contracts", api.hostContractInfoHandler)                                // Get info about contracts.
 		router.GET("/host/estimatescore", api.hostEstimateScoreGET)
 
 		// Calls pertaining to the storage manager that the host uses.


### PR DESCRIPTION
This PR introduces an API call to get basic information about stored contracts on the host.

Usage: `curl -A "Sia-Agent" "localhost:9980/host/contracts?status=xxxx"`
where `xxxx` can any of the following:

1. `unresolved`
1. `succeeded`
1. `failed`
1. `rejected`
1. `all`

First step to implement #2465 