### PR TITLE
only add addrs relevant to the wallet

### DIFF
--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -262,10 +262,14 @@ func dbAddAddrTransaction(tx *bolt.Tx, addr types.UnlockHash, txn uint64) error 
 func dbAddProcessedTransactionAddrs(tx *bolt.Tx, pt modules.ProcessedTransaction, txn uint64) error {
 	addrs := make(map[types.UnlockHash]struct{})
 	for _, input := range pt.Inputs {
-		addrs[input.RelatedAddress] = struct{}{}
+		if input.WalletAddress {
+			addrs[input.RelatedAddress] = struct{}{}
+		}
 	}
 	for _, output := range pt.Outputs {
-		addrs[output.RelatedAddress] = struct{}{}
+		if output.WalletAddress {
+			addrs[output.RelatedAddress] = struct{}{}
+		}
 	}
 	for addr := range addrs {
 		if err := dbAddAddrTransaction(tx, addr, txn); err != nil {

--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -265,14 +265,13 @@ func dbAddProcessedTransactionAddrs(tx *bolt.Tx, pt modules.ProcessedTransaction
 		addrs[input.RelatedAddress] = struct{}{}
 	}
 	for _, output := range pt.Outputs {
+		// miner fees don't have an address, so skip them
+		if output.FundType == types.SpecifierMinerFee {
+			continue
+		}
 		addrs[output.RelatedAddress] = struct{}{}
 	}
 	for addr := range addrs {
-		if addr == (types.UnlockHash{}) {
-			// skip the void address; it's associated with too many
-			// transactions, which is problematic for large wallets
-			continue
-		}
 		if err := dbAddAddrTransaction(tx, addr, txn); err != nil {
 			return errors.AddContext(err, fmt.Sprintf("failed to add txn %v to address %v",
 				pt.TransactionID, addr))

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -383,8 +383,9 @@ func (w *Wallet) computeProcessedTransactionsFromBlock(tx *bolt.Tx, block types.
 
 		for _, fee := range txn.MinerFees {
 			pt.Outputs = append(pt.Outputs, modules.ProcessedOutput{
-				FundType: types.SpecifierMinerFee,
-				Value:    fee,
+				FundType:       types.SpecifierMinerFee,
+				MaturityHeight: consensusHeight + types.MaturityDelay,
+				Value:          fee,
 			})
 		}
 		pts = append(pts, pt)


### PR DESCRIPTION
Previously, all addresses in transactions relevant to the wallet would be added to the `bucketAddrTransactions` bucket, which maps addresses to the transactions they appear in.
This caused problems due to the "zero address" (`types.UnlockHash{}`) appearing in transactions. Since [miner fee outputs leave the `RelatedAddress` field empty](https://github.com/NebulousLabs/Sia/blob/53b53997d16ec8b9865ea0cb469c31be44e6b2ca/modules/wallet/update.go#L384-L389) (i.e. zero), the mapping for the zero address effectively maps to every transaction relevant to the wallet that has miner fees.
For really high-volume wallets, like exchanges, this caused the zero address to map to over 625,000 transactions. This subsequently led to a bug where the mapping could not be decoded, as 625k * (8 bytes per mapping) is the [maximum allowed size](https://github.com/NebulousLabs/Sia/blob/53b53997d16ec8b9865ea0cb469c31be44e6b2ca/encoding/marshal.go#L15-L23) of an encoded value.

This PR fixes the issue by only adding addresses to `bucketAddrTransactions` if they are relevant to the wallet. This means you will no longer be able to query the `AddressTransactions` method for addresses not relevant to the wallet, but that seems like a non-issue, given that the wallet only stores transactions relevant to it in the first place. If you need to search for non-owned addresses, you'll have to use an explorer.