### PR TITLE
log contract ID on contract formation

### DIFF
--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -175,7 +175,7 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, contractFundin
 	}
 
 	contractValue := contract.RenterFunds
-	c.log.Printf("Formed contract with %v for %v", host.NetAddress, contractValue.HumanString())
+	c.log.Printf("Formed contract %v with %v for %v", contract.ID, host.NetAddress, contractValue.HumanString())
 	return contract, nil
 }
 


### PR DESCRIPTION
On renewal attempts, Sia logs the ID of the contract associated with the log message, but it does not log it when the contract is formed. Logging the contract helps debug issues related to contracts, so adding the contract ID to the log output.