### PR TITLE
Add siac command to get data from /host/contracts endpoint

### DIFF
--- a/cmd/siac/consensuscmd.go
+++ b/cmd/siac/consensuscmd.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -22,8 +21,7 @@ var (
 // consensuscmd is the handler for the command `siac consensus`.
 // Prints the current state of consensus.
 func consensuscmd() {
-	var cg api.ConsensusGET
-	err := getAPI("/consensus", &cg)
+	cg, err := httpClient.ConsensusGet()
 	if err != nil {
 		die("Could not get current consensus state:", err)
 	}

--- a/cmd/siac/daemoncmd.go
+++ b/cmd/siac/daemoncmd.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/NebulousLabs/Sia/build"
-	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/spf13/cobra"
 )
 
@@ -38,11 +37,6 @@ var (
 	}
 )
 
-type updateInfo struct {
-	Available bool   `json:"available"`
-	Version   string `json:"version"`
-}
-
 // version prints the version of siac and siad.
 func versioncmd() {
 	fmt.Println("Sia Client")
@@ -51,8 +45,7 @@ func versioncmd() {
 		fmt.Println("\tGit Revision " + build.GitRevision)
 		fmt.Println("\tBuild Time   " + build.BuildTime)
 	}
-	var dvg api.DaemonVersionGet
-	err := getAPI("/daemon/version", &dvg)
+	dvg, err := httpClient.DaemonVersionGet()
 	if err != nil {
 		fmt.Println("Could not get daemon version:", err)
 		return
@@ -68,7 +61,7 @@ func versioncmd() {
 // stopcmd is the handler for the command `siac stop`.
 // Stops the daemon.
 func stopcmd() {
-	err := get("/daemon/stop")
+	err := httpClient.DaemonStopGet()
 	if err != nil {
 		die("Could not stop daemon:", err)
 	}
@@ -76,8 +69,7 @@ func stopcmd() {
 }
 
 func updatecmd() {
-	var update updateInfo
-	err := getAPI("/daemon/update", &update)
+	update, err := httpClient.DaemonUpdateGet()
 	if err != nil {
 		fmt.Println("Could not check for update:", err)
 		return
@@ -87,7 +79,7 @@ func updatecmd() {
 		return
 	}
 
-	err = post("/daemon/update", "")
+	err = httpClient.DaemonUpdatePost()
 	if err != nil {
 		fmt.Println("Could not apply update:", err)
 		return
@@ -96,8 +88,7 @@ func updatecmd() {
 }
 
 func updatecheckcmd() {
-	var update updateInfo
-	err := getAPI("/daemon/update", &update)
+	update, err := httpClient.DaemonUpdateGet()
 	if err != nil {
 		fmt.Println("Could not check for update:", err)
 		return

--- a/cmd/siac/export.go
+++ b/cmd/siac/export.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/spf13/cobra"
@@ -31,8 +30,7 @@ var (
 // renterexportcontracttxnscmd is the handler for the command `siac renter export contract-txns`.
 // Exports the current contract set to JSON.
 func renterexportcontracttxnscmd(destination string) {
-	var cs api.RenterContracts
-	err := getAPI("/renter/contracts", &cs)
+	cs, err := httpClient.RenterContractsGet()
 	if err != nil {
 		die("Could not retrieve contracts:", err)
 	}

--- a/cmd/siac/gatewaycmd.go
+++ b/cmd/siac/gatewaycmd.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/spf13/cobra"
-
-	"github.com/NebulousLabs/Sia/node/api"
 )
 
 var (
@@ -50,7 +49,7 @@ var (
 // gatewayconnectcmd is the handler for the command `siac gateway add [address]`.
 // Adds a new peer to the peer list.
 func gatewayconnectcmd(addr string) {
-	err := post("/gateway/connect/"+addr, "")
+	err := httpClient.GatewayConnectPost(modules.NetAddress(addr))
 	if err != nil {
 		die("Could not add peer:", err)
 	}
@@ -60,7 +59,7 @@ func gatewayconnectcmd(addr string) {
 // gatewaydisconnectcmd is the handler for the command `siac gateway remove [address]`.
 // Removes a peer from the peer list.
 func gatewaydisconnectcmd(addr string) {
-	err := post("/gateway/disconnect/"+addr, "")
+	err := httpClient.GatewayDisconnectPost(modules.NetAddress(addr))
 	if err != nil {
 		die("Could not remove peer:", err)
 	}
@@ -70,8 +69,7 @@ func gatewaydisconnectcmd(addr string) {
 // gatewayaddresscmd is the handler for the command `siac gateway address`.
 // Prints the gateway's network address.
 func gatewayaddresscmd() {
-	var info api.GatewayGET
-	err := getAPI("/gateway", &info)
+	info, err := httpClient.GatewayGet()
 	if err != nil {
 		die("Could not get gateway address:", err)
 	}
@@ -81,8 +79,7 @@ func gatewayaddresscmd() {
 // gatewaycmd is the handler for the command `siac gateway`.
 // Prints the gateway's network address and number of peers.
 func gatewaycmd() {
-	var info api.GatewayGET
-	err := getAPI("/gateway", &info)
+	info, err := httpClient.GatewayGet()
 	if err != nil {
 		die("Could not get gateway address:", err)
 	}
@@ -93,8 +90,7 @@ func gatewaycmd() {
 // gatewaylistcmd is the handler for the command `siac gateway list`.
 // Prints a list of all peers.
 func gatewaylistcmd() {
-	var info api.GatewayGET
-	err := getAPI("/gateway", &info)
+	info, err := httpClient.GatewayGet()
 	if err != nil {
 		die("Could not get peer list:", err)
 	}

--- a/cmd/siac/hostcmd.go
+++ b/cmd/siac/hostcmd.go
@@ -74,11 +74,11 @@ To configure the host to accept new contracts, set acceptingcontracts to true:
 	}
 
 	hostContractCmd = &cobra.Command{
-		Use:   "contracts [format] [filter]",
+		Use:   "contracts",
 		Short: "Show host contracts",
 		Long: `Show host contracts sorted by expiration height.
 
-Available formats:
+Available output types:
      value:  show financial information
      status: show status information
 `,
@@ -396,13 +396,13 @@ func hostconfigcmd(param, value string) {
 	fmt.Printf("Estimated conversion rate: %v%%\n", eg.ConversionRate)
 }
 
-// hostcontractcmd is the handler for the command `siac host contracts [format] [filter]`.
-func hostcontractcmd(format, filter string) {
-	switch format {
+// hostcontractcmd is the handler for the command `siac host contracts [type]`.
+func hostcontractcmd() {
+	switch hostContractOutputType {
 	case "value", "status":
 		break
 	default:
-		die("\"" + format + "\" is not a format")
+		die("\"" + hostContractOutputType + "\" is not a format")
 
 	}
 	cg, err := httpClient.HostContractInfoGet()
@@ -411,7 +411,7 @@ func hostcontractcmd(format, filter string) {
 	}
 	sort.Slice(cg.Contracts, func(i, j int) bool { return cg.Contracts[i].ExpirationHeight < cg.Contracts[j].ExpirationHeight })
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-	if format == "value" {
+	if hostContractOutputType == "value" {
 		fmt.Fprintf(w, "Obligation Id\tObligation Status\tContract Cost\tLocked Collateral\tRisked Collateral\tPotential Revenue\tExpiration Height\tTransaction Fees\n")
 		for _, so := range cg.Contracts {
 			potentialRevenue := so.PotentialDownloadRevenue.Add(so.PotentialUploadRevenue).Add(so.PotentialStorageRevenue)
@@ -419,8 +419,8 @@ func hostcontractcmd(format, filter string) {
 				currencyUnits(so.RiskedCollateral), currencyUnits(potentialRevenue), so.ExpirationHeight, currencyUnits(so.TransactionFeesAdded))
 		}
 	}
-	if format == "status" {
-		fmt.Fprintf(w, "Obligation Id\tObligation Status\tExpiration Height\tOrigin Confirmed\tRevision Constructed\tRevision Confirmed\tProof Constructed\tProof Confirmed\n")
+	if hostContractOutputType == "status" {
+		fmt.Fprintf(w, "Obligation ID\tObligation Status\tExpiration Height\tOrigin Confirmed\tRevision Constructed\tRevision Confirmed\tProof Constructed\tProof Confirmed\n")
 		for _, so := range cg.Contracts {
 			fmt.Fprintf(w, "%s\t%s\t%d\t%t\t%t\t%t\t%t\t%t\n", so.ObligationId, strings.TrimPrefix(so.ObligationStatus, "obligation"), so.ExpirationHeight, so.OriginConfirmed,
 				so.RevisionConstructed, so.RevisionConfirmed, so.ProofConstructed, so.ProofConfirmed)

--- a/cmd/siac/hostcmd.go
+++ b/cmd/siac/hostcmd.go
@@ -73,6 +73,25 @@ To configure the host to accept new contracts, set acceptingcontracts to true:
 		Run: wrap(hostconfigcmd),
 	}
 
+	hostContractCmd = &cobra.Command{
+		Use:   "contracts [format] [filter]",
+		Short: "Show host contracts",
+		Long: `Show host contracts sorted by expiration height.
+
+Available formats:
+     value:  show financial information
+     status: show status information
+
+Available filters:
+     all:        show all obligations
+     failed:     show obligations with status failed
+     unresolved: show obligations with status unresolved
+     rejected:   show obligations with status rejected
+     succeeded:  show obligations with status succeeded
+`,
+		Run: wrap(hostcontractcmd),
+	}
+
 	hostFolderAddCmd = &cobra.Command{
 		Use:   "add [path] [size]",
 		Short: "Add a storage folder to the host",
@@ -382,6 +401,58 @@ func hostconfigcmd(param, value string) {
 		die("could not get host score estimate:", err)
 	}
 	fmt.Printf("Estimated conversion rate: %v%%\n", eg.ConversionRate)
+}
+
+// hostcontractcmd is the handler for the command `siac host contracts [format] [filter]`.
+func hostcontractcmd(format, filter string) {
+	switch format {
+	case "value", "status":
+		break
+	default:
+		die("\"" + format + "\" is not a format")
+
+	}
+	switch filter {
+	case "rejected":
+		filter = "obligationRejected"
+	case "failed":
+		filter = "obligationFailed"
+	case "succeeded":
+		filter = "obligationSucceeded"
+	case "unresolved":
+		filter = "obligationUnresolved"
+	case "all":
+		filter = "all"
+	default:
+		die("\"" + filter + "\" is not a filter value")
+	}
+	cg := new(api.ContractInfoGET)
+	err := getAPI("/host/contracts", cg)
+	if err != nil {
+		die("Could not fetch host contract info:", err)
+	}
+	sort.Slice(cg.Contracts, func(i, j int) bool { return cg.Contracts[i].ExpirationHeight < cg.Contracts[j].ExpirationHeight })
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+	if format == "value" {
+		fmt.Fprintf(w, "Obligation Id\tObligation Status\tContract Cost\tLocked Collateral\tRisked Collateral\tPotential Revenue\tExpiration Height\tTransaction Fees\n")
+		for _, so := range cg.Contracts {
+			if so.ObligationStatus == filter || filter == "all" {
+				potentialRevenue := so.PotentialDownloadRevenue.Add(so.PotentialUploadRevenue).Add(so.PotentialStorageRevenue)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n", so.ObligationId, so.ObligationStatus, currencyUnits(so.ContractCost), currencyUnits(so.LockedCollateral),
+					currencyUnits(so.RiskedCollateral), currencyUnits(potentialRevenue), so.ExpirationHeight, currencyUnits(so.TransactionFeesAdded))
+			}
+		}
+	}
+	if format == "status" {
+		fmt.Fprintf(w, "Obligation Id\tObligation Status\tExpiration Height\tOrigin Confirmed\tRevision Constructed\tRevision Confirmed\tProof Constructed\tProof Confirmed\n")
+		for _, so := range cg.Contracts {
+			if so.ObligationStatus == filter || filter == "all" {
+				fmt.Fprintf(w, "%s\t%s\t%d\t%t\t%t\t%t\t%t\t%t\n", so.ObligationId, so.ObligationStatus, so.ExpirationHeight, so.OriginConfirmed,
+					so.RevisionConstructed, so.RevisionConfirmed, so.ProofConstructed, so.ProofConfirmed)
+			}
+		}
+	}
+	w.Flush()
 }
 
 // hostannouncecmd is the handler for the command `siac host announce`.

--- a/cmd/siac/hostcmd.go
+++ b/cmd/siac/hostcmd.go
@@ -405,8 +405,7 @@ func hostcontractcmd(format, filter string) {
 		die("\"" + format + "\" is not a format")
 
 	}
-	cg := new(api.ContractInfoGET)
-	err := getAPI("/host/contracts", cg)
+	cg, err := httpClient.HostContractInfoGet()
 	if err != nil {
 		die("Could not fetch host contract info:", err)
 	}

--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -1,39 +1,29 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"reflect"
 
 	"github.com/spf13/cobra"
 
 	"github.com/NebulousLabs/Sia/build"
-	"github.com/NebulousLabs/Sia/node/api"
+	"github.com/NebulousLabs/Sia/node/api/client"
 )
 
 var (
 	// Flags.
-	addr              string // override default API address
-	hostVerbose       bool   // display additional host info
-	initForce         bool   // destroy and reencrypt the wallet on init if it already exists
-	initPassword      bool   // supply a custom password when creating a wallet
-	renterListVerbose bool   // Show additional info about uploaded files.
-	renterShowHistory bool   // Show download history in addition to download queue.
+	hostVerbose       bool // display additional host info
+	initForce         bool // destroy and reencrypt the wallet on init if it already exists
+	initPassword      bool // supply a custom password when creating a wallet
+	renterListVerbose bool // Show additional info about uploaded files.
+	renterShowHistory bool // Show download history in addition to download queue.
 )
 
 var (
 	// Globals.
-	rootCmd *cobra.Command // Root command cobra object, used by bash completion cmd.
-)
-
-var (
-	// User-supplied password, cached so that we don't need to prompt multiple
-	// times.
-	apiPassword string
+	rootCmd    *cobra.Command // Root command cobra object, used by bash completion cmd.
+	httpClient client.Client
 )
 
 // Exit codes.
@@ -43,173 +33,8 @@ const (
 	exitCodeUsage   = 64 // EX_USAGE in sysexits.h
 )
 
-// non2xx returns true for non-success HTTP status codes.
-func non2xx(code int) bool {
-	return code < 200 || code > 299
-}
-
-// decodeError returns the api.Error from a API response. This method should
-// only be called if the response's status code is non-2xx. The error returned
-// may not be of type api.Error in the event of an error unmarshalling the
-// JSON.
-func decodeError(resp *http.Response) error {
-	var apiErr api.Error
-	err := json.NewDecoder(resp.Body).Decode(&apiErr)
-	if err != nil {
-		return err
-	}
-	return apiErr
-}
-
-// apiGet wraps a GET request with a status code check, such that if the GET does
-// not return 2xx, the error will be read and returned. The response body is
-// not closed.
-func apiGet(call string) (*http.Response, error) {
-	if host, port, _ := net.SplitHostPort(addr); host == "" {
-		addr = net.JoinHostPort("localhost", port)
-	}
-	resp, err := api.HttpGET("http://" + addr + call)
-	if err != nil {
-		return nil, errors.New("no response from daemon")
-	}
-	// check error code
-	if resp.StatusCode == http.StatusUnauthorized {
-		// retry request with authentication.
-		resp.Body.Close()
-		if apiPassword == "" {
-			apiPassword = os.Getenv("SIA_API_PASSWORD")
-			if apiPassword != "" {
-				fmt.Println("Using SIA_API_PASSWORD environment variable")
-			} else {
-				// prompt for password and store it in a global var for subsequent
-				// calls
-				apiPassword, err = passwordPrompt("API password: ")
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-		resp, err = api.HttpGETAuthenticated("http://"+addr+call, apiPassword)
-		if err != nil {
-			return nil, errors.New("no response from daemon - authentication failed")
-		}
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		resp.Body.Close()
-		return nil, errors.New("API call not recognized: " + call)
-	}
-	if non2xx(resp.StatusCode) {
-		err := decodeError(resp)
-		resp.Body.Close()
-		return nil, err
-	}
-	return resp, nil
-}
-
-// getAPI makes a GET API call and decodes the response. An error is returned
-// if the response status is not 2xx.
-func getAPI(call string, obj interface{}) error {
-	resp, err := apiGet(call)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNoContent {
-		return errors.New("expecting a response, but API returned status code 204 No Content")
-	}
-
-	err = json.NewDecoder(resp.Body).Decode(obj)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// get makes an API call and discards the response. An error is returned if the
-// response status is not 2xx.
-func get(call string) error {
-	resp, err := apiGet(call)
-	if err != nil {
-		return err
-	}
-	resp.Body.Close()
-	return nil
-}
-
-// apiPost wraps a POST request with a status code check, such that if the POST
-// does not return 2xx, the error will be read and returned. The response body
-// is not closed.
-func apiPost(call, vals string) (*http.Response, error) {
-	if host, port, _ := net.SplitHostPort(addr); host == "" {
-		addr = net.JoinHostPort("localhost", port)
-	}
-
-	resp, err := api.HttpPOST("http://"+addr+call, vals)
-	if err != nil {
-		return nil, errors.New("no response from daemon")
-	}
-	// check error code
-	if resp.StatusCode == http.StatusUnauthorized {
-		resp.Body.Close()
-		apiPassword = os.Getenv("SIA_API_PASSWORD")
-		if apiPassword != "" {
-			fmt.Println("Using SIA_API_PASSWORD environment variable")
-		} else {
-			// Prompt for password and retry request with authentication.
-			apiPassword, err = passwordPrompt("API password: ")
-			if err != nil {
-				return nil, err
-			}
-		}
-		resp, err = api.HttpPOSTAuthenticated("http://"+addr+call, vals, apiPassword)
-		if err != nil {
-			return nil, errors.New("no response from daemon - authentication failed")
-		}
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		resp.Body.Close()
-		return nil, errors.New("API call not recognized: " + call)
-	}
-	if non2xx(resp.StatusCode) {
-		err := decodeError(resp)
-		resp.Body.Close()
-		return nil, err
-	}
-	return resp, nil
-}
-
-// postResp makes a POST API call and decodes the response. An error is
-// returned if the response status is not 2xx.
-func postResp(call, vals string, obj interface{}) error {
-	resp, err := apiPost(call, vals)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNoContent {
-		return errors.New("expecting a response, but API returned status code 204 No Content")
-	}
-
-	err = json.NewDecoder(resp.Body).Decode(obj)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // post makes an API call and discards the response. An error is returned if
 // the response status is not 2xx.
-func post(call, vals string) error {
-	resp, err := apiPost(call, vals)
-	if err != nil {
-		return err
-	}
-	resp.Body.Close()
-	return nil
-}
-
 // wrap wraps a generic command with a check that the command has been
 // passed the correct number of arguments. The command must take only strings
 // as arguments.
@@ -309,8 +134,15 @@ func main() {
 	root.AddCommand(bashcomplCmd)
 	root.AddCommand(mangenCmd)
 
-	// parse flags
-	root.PersistentFlags().StringVarP(&addr, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")
+	// Check if the api password environment variable is set.
+	apiPassword := os.Getenv("SIA_API_PASSWORD")
+	if apiPassword != "" {
+		fmt.Println("Using SIA_API_PASSWORD environment variable")
+	}
+	// initialize client
+	root.PersistentFlags().StringVarP(&httpClient.Address, "addr", "a", "localhost:9980", "which host/port to communicate with (i.e. the host/port siad is listening on)")
+	root.PersistentFlags().StringVarP(&httpClient.Password, "apipassword", "", apiPassword, "the password for the API's http authentication")
+	root.PersistentFlags().StringVarP(&httpClient.UserAgent, "useragent", "", "Sia-Agent", "the useragent used by siac to connect to the daemon's API")
 
 	// run
 	if err := root.Execute(); err != nil {

--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -13,11 +13,12 @@ import (
 
 var (
 	// Flags.
-	hostVerbose       bool // display additional host info
-	initForce         bool // destroy and reencrypt the wallet on init if it already exists
-	initPassword      bool // supply a custom password when creating a wallet
-	renterListVerbose bool // Show additional info about uploaded files.
-	renterShowHistory bool // Show download history in addition to download queue.
+	hostContractOutputType string // output type for host contracts
+	hostVerbose            bool   // display additional host info
+	initForce              bool   // destroy and reencrypt the wallet on init if it already exists
+	initPassword           bool   // supply a custom password when creating a wallet
+	renterListVerbose      bool   // Show additional info about uploaded files.
+	renterShowHistory      bool   // Show download history in addition to download queue.
 )
 
 var (
@@ -91,6 +92,7 @@ func main() {
 	hostFolderCmd.AddCommand(hostFolderAddCmd, hostFolderRemoveCmd, hostFolderResizeCmd)
 	hostSectorCmd.AddCommand(hostSectorDeleteCmd)
 	hostCmd.Flags().BoolVarP(&hostVerbose, "verbose", "v", false, "Display detailed host info")
+	hostContractCmd.Flags().StringVarP(&hostContractOutputType, "type", "t", "value", "Select output type")
 
 	root.AddCommand(hostdbCmd)
 	hostdbCmd.AddCommand(hostdbViewCmd)

--- a/cmd/siac/main.go
+++ b/cmd/siac/main.go
@@ -87,7 +87,7 @@ func main() {
 	updateCmd.AddCommand(updateCheckCmd)
 
 	root.AddCommand(hostCmd)
-	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostFolderCmd, hostSectorCmd)
+	hostCmd.AddCommand(hostConfigCmd, hostAnnounceCmd, hostFolderCmd, hostContractCmd, hostSectorCmd)
 	hostFolderCmd.AddCommand(hostFolderAddCmd, hostFolderRemoveCmd, hostFolderResizeCmd)
 	hostSectorCmd.AddCommand(hostSectorDeleteCmd)
 	hostCmd.Flags().BoolVarP(&hostVerbose, "verbose", "v", false, "Display detailed host info")

--- a/cmd/siac/minercmd.go
+++ b/cmd/siac/minercmd.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/NebulousLabs/Sia/node/api"
-
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +32,7 @@ var (
 // minerstartcmd is the handler for the command `siac miner start`.
 // Starts the CPU miner.
 func minerstartcmd() {
-	err := get("/miner/start")
+	err := httpClient.MinerStartGet()
 	if err != nil {
 		die("Could not start miner:", err)
 	}
@@ -44,8 +42,7 @@ func minerstartcmd() {
 // minercmd is the handler for the command `siac miner`.
 // Prints the status of the miner.
 func minercmd() {
-	status := new(api.MinerGET)
-	err := getAPI("/miner", status)
+	status, err := httpClient.MinerGet()
 	if err != nil {
 		die("Could not get miner status:", err)
 	}
@@ -64,7 +61,7 @@ Blocks Mined: %d (%d stale)
 // minerstopcmd is the handler for the command `siac miner stop`.
 // Stops the CPU miner.
 func minerstopcmd() {
-	err := get("/miner/stop")
+	err := httpClient.MinerStopGet()
 	if err != nil {
 		die("Could not stop miner:", err)
 	}

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -150,8 +150,7 @@ func abs(path string) string {
 // rentercmd displays the renter's financial metrics and lists the files it is
 // tracking.
 func rentercmd() {
-	var rg api.RenterGET
-	err := getAPI("/renter", &rg)
+	rg, err := httpClient.RenterGet()
 	if err != nil {
 		die("Could not get renter info:", err)
 	}
@@ -185,8 +184,7 @@ func rentercmd() {
 // renteruploadscmd is the handler for the command `siac renter uploads`.
 // Lists files currently uploading.
 func renteruploadscmd() {
-	var rf api.RenterFiles
-	err := getAPI("/renter/files", &rf)
+	rf, err := httpClient.RenterFilesGet()
 	if err != nil {
 		die("Could not get upload queue:", err)
 	}
@@ -217,8 +215,7 @@ func renteruploadscmd() {
 // Lists files currently downloading, and optionally previously downloaded
 // files if the -H or --history flag is specified.
 func renterdownloadscmd() {
-	var queue api.RenterDownloadQueue
-	err := getAPI("/renter/downloads", &queue)
+	queue, err := httpClient.RenterDownloadsGet()
 	if err != nil {
 		die("Could not get download queue:", err)
 	}
@@ -260,8 +257,7 @@ func renterdownloadscmd() {
 
 // renterallowancecmd displays the current allowance.
 func renterallowancecmd() {
-	var rg api.RenterGET
-	err := getAPI("/renter", &rg)
+	rg, err := httpClient.RenterGet()
 	if err != nil {
 		die("Could not get allowance:", err)
 	}
@@ -276,7 +272,7 @@ func renterallowancecmd() {
 
 // renterallowancecancelcmd cancels the current allowance.
 func renterallowancecancelcmd() {
-	err := post("/renter", "hosts=0&funds=0&period=0&renewwindow=0")
+	err := httpClient.RenterCancelAllowance()
 	if err != nil {
 		die("error canceling allowance:", err)
 	}
@@ -299,24 +295,36 @@ func rentersetallowancecmd(cmd *cobra.Command, args []string) {
 	}
 	blocks, err := parsePeriod(args[1])
 	if err != nil {
-		die("Could not parse period")
+		die("Could not parse period:", err)
 	}
-	queryString := fmt.Sprintf("funds=%s&period=%s", hastings, blocks)
+	allowance := modules.Allowance{}
+	_, err = fmt.Sscan(hastings, &allowance.Funds)
+	if err != nil {
+		die("Could not parse amount:", err)
+	}
+
+	_, err = fmt.Sscan(blocks, &allowance.Period)
+	if err != nil {
+		die("Could not parse period:", err)
+	}
 	if len(args) > 2 {
-		_, err = strconv.Atoi(args[2])
+		hosts, err := strconv.Atoi(args[2])
 		if err != nil {
 			die("Could not parse host count")
 		}
-		queryString += fmt.Sprintf("&hosts=%s", args[2])
+		allowance.Hosts = uint64(hosts)
 	}
 	if len(args) > 3 {
 		renewWindow, err := parsePeriod(args[3])
 		if err != nil {
 			die("Could not parse renew window")
 		}
-		queryString += fmt.Sprintf("&renewwindow=%s", renewWindow)
+		_, err = fmt.Sscan(renewWindow, &allowance.RenewWindow)
+		if err != nil {
+			die("Could not parse renew window:", err)
+		}
 	}
-	err = post("/renter", queryString)
+	err = httpClient.RenterPostAllowance(allowance)
 	if err != nil {
 		die("Could not set allowance:", err)
 	}
@@ -340,8 +348,7 @@ func (s byValue) Less(i, j int) bool {
 // rentercontractscmd is the handler for the comand `siac renter contracts`.
 // It lists the Renter's contracts.
 func rentercontractscmd() {
-	var rc api.RenterContracts
-	err := getAPI("/renter/contracts", &rc)
+	rc, err := httpClient.RenterContractsGet()
 	if err != nil {
 		die("Could not get contracts:", err)
 	}
@@ -371,16 +378,14 @@ func rentercontractscmd() {
 // rentercontractsviewcmd is the handler for the command `siac renter contracts <id>`.
 // It lists details of a specific contract.
 func rentercontractsviewcmd(cid string) {
-	var rc api.RenterContracts
-	err := getAPI("/renter/contracts", &rc)
+	rc, err := httpClient.RenterContractsGet()
 	if err != nil {
 		die("Could not get contract details: ", err)
 	}
 
 	for _, rc := range rc.Contracts {
 		if rc.ID.String() == cid {
-			var hostInfo api.HostdbHostsGET
-			err = getAPI("/hostdb/hosts/"+rc.HostPublicKey.String(), &hostInfo)
+			hostInfo, err := httpClient.HostDbHostsGet(rc.HostPublicKey)
 			if err != nil {
 				die("Could not fetch details of host: ", err)
 			}
@@ -420,7 +425,7 @@ Contract %v
 // renterfilesdeletecmd is the handler for the command `siac renter delete [path]`.
 // Removes the specified path from the Sia network.
 func renterfilesdeletecmd(path string) {
-	err := post("/renter/delete/"+path, "")
+	err := httpClient.RenterDeletePost(path)
 	if err != nil {
 		die("Could not delete file:", err)
 	}
@@ -434,7 +439,7 @@ func renterfilesdownloadcmd(path, destination string) {
 	done := make(chan struct{})
 	go downloadprogress(done, path)
 
-	err := get("/renter/download/" + path + "?destination=" + destination)
+	err := httpClient.RenterDownloadFullGet(path, destination, false)
 	close(done)
 	if err != nil {
 		die("Could not download file:", err)
@@ -451,8 +456,7 @@ func downloadprogress(done chan struct{}, siapath string) {
 
 		case <-time.Tick(time.Second):
 			// get download progress of file
-			var queue api.RenterDownloadQueue
-			err := getAPI("/renter/downloads", &queue)
+			queue, err := httpClient.RenterDownloadsGet()
 			if err != nil {
 				continue // benign
 			}
@@ -487,7 +491,7 @@ func (s bySiaPath) Less(i, j int) bool { return s[i].SiaPath < s[j].SiaPath }
 // Lists files known to the renter on the network.
 func renterfileslistcmd() {
 	var rf api.RenterFiles
-	err := getAPI("/renter/files", &rf)
+	rf, err := httpClient.RenterFilesGet()
 	if err != nil {
 		die("Could not get file list:", err)
 	}
@@ -528,7 +532,7 @@ func renterfileslistcmd() {
 // renterfilesrenamecmd is the handler for the command `siac renter rename [path] [newpath]`.
 // Renames a file on the Sia network.
 func renterfilesrenamecmd(path, newpath string) {
-	err := post("/renter/rename/"+path, "newsiapath="+newpath)
+	err := httpClient.RenterRenamePost(path, newpath)
 	if err != nil {
 		die("Could not rename file:", err)
 	}
@@ -568,7 +572,7 @@ func renterfilesuploadcmd(source, path string) {
 			fpath, _ := filepath.Rel(source, file)
 			fpath = filepath.Join(path, fpath)
 			fpath = filepath.ToSlash(fpath)
-			err = post("/renter/upload/"+fpath, "source="+abs(file))
+			err = httpClient.RenterUploadDefaultPost(abs(file), fpath)
 			if err != nil {
 				die("Could not upload file:", err)
 			}
@@ -576,7 +580,7 @@ func renterfilesuploadcmd(source, path string) {
 		fmt.Printf("Uploaded %d files into '%s'.\n", len(files), path)
 	} else {
 		// single file
-		err = post("/renter/upload/"+path, "source="+abs(source))
+		err = httpClient.RenterUploadDefaultPost(abs(source), path)
 		if err != nil {
 			die("Could not upload file:", err)
 		}
@@ -587,8 +591,7 @@ func renterfilesuploadcmd(source, path string) {
 // renterpricescmd is the handler for the command `siac renter prices`, which
 // displays the prices of various storage operations.
 func renterpricescmd() {
-	var rpg api.RenterPricesGET
-	err := getAPI("/renter/prices", &rpg)
+	rpg, err := httpClient.RenterPricesGet()
 	if err != nil {
 		die("Could not read the renter prices:", err)
 	}

--- a/cmd/siac/walletcmd.go
+++ b/cmd/siac/walletcmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"syscall"
@@ -11,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
 
@@ -206,8 +206,7 @@ func confirmPassword(prev string) error {
 // walletaddresscmd fetches a new address from the wallet that will be able to
 // receive coins.
 func walletaddresscmd() {
-	addr := new(api.WalletAddressGET)
-	err := getAPI("/wallet/address", addr)
+	addr, err := httpClient.WalletAddressGet()
 	if err != nil {
 		die("Could not generate new address:", err)
 	}
@@ -216,8 +215,7 @@ func walletaddresscmd() {
 
 // walletaddressescmd fetches the list of addresses that the wallet knows.
 func walletaddressescmd() {
-	addrs := new(api.WalletAddressesGET)
-	err := getAPI("/wallet/addresses", addrs)
+	addrs, err := httpClient.WalletAddressesGet()
 	if err != nil {
 		die("Failed to fetch addresses:", err)
 	}
@@ -238,8 +236,7 @@ func walletchangepasswordcmd() {
 	} else if err = confirmPassword(newPassword); err != nil {
 		die(err)
 	}
-	qs := fmt.Sprintf("newpassword=%s&encryptionpassword=%s", newPassword, currentPassword)
-	err = post("/wallet/changepassword", qs)
+	err = httpClient.WalletChangePasswordPost(currentPassword, newPassword)
 	if err != nil {
 		die("Changing the password failed:", err)
 	}
@@ -248,21 +245,17 @@ func walletchangepasswordcmd() {
 
 // walletinitcmd encrypts the wallet with the given password
 func walletinitcmd() {
-	var er api.WalletInitPOST
-	qs := fmt.Sprintf("dictionary=%s", "english")
+	var password string
+	var err error
 	if initPassword {
-		password, err := passwordPrompt("Wallet password: ")
+		password, err = passwordPrompt("Wallet password: ")
 		if err != nil {
 			die("Reading password failed:", err)
 		} else if err = confirmPassword(password); err != nil {
 			die(err)
 		}
-		qs += fmt.Sprintf("&encryptionpassword=%s", password)
 	}
-	if initForce {
-		qs += "&force=true"
-	}
-	err := postResp("/wallet/init", qs, &er)
+	er, err := httpClient.WalletInitPost(password, initForce)
 	if err != nil {
 		die("Error when encrypting wallet:", err)
 	}
@@ -280,20 +273,16 @@ func walletinitseedcmd() {
 	if err != nil {
 		die("Reading seed failed:", err)
 	}
-	qs := fmt.Sprintf("&seed=%s&dictionary=%s", seed, "english")
+	var password string
 	if initPassword {
-		password, err := passwordPrompt("Wallet password: ")
+		password, err = passwordPrompt("Wallet password: ")
 		if err != nil {
 			die("Reading password failed:", err)
 		} else if err = confirmPassword(password); err != nil {
 			die(err)
 		}
-		qs += fmt.Sprintf("&encryptionpassword=%s", password)
 	}
-	if initForce {
-		qs += "&force=true"
-	}
-	err = post("/wallet/init/seed", qs)
+	err = httpClient.WalletInitSeedPost(seed, password, initForce)
 	if err != nil {
 		die("Could not initialize wallet from seed:", err)
 	}
@@ -310,8 +299,7 @@ func walletload033xcmd(source string) {
 	if err != nil {
 		die("Reading password failed:", err)
 	}
-	qs := fmt.Sprintf("source=%s&encryptionpassword=%s", abs(source), password)
-	err = post("/wallet/033x", qs)
+	err = httpClient.Wallet033xPost(abs(source), password)
 	if err != nil {
 		die("Loading wallet failed:", err)
 	}
@@ -328,8 +316,7 @@ func walletloadseedcmd() {
 	if err != nil {
 		die("Reading password failed:", err)
 	}
-	qs := fmt.Sprintf("encryptionpassword=%s&seed=%s&dictionary=%s", password, seed, "english")
-	err = post("/wallet/seed", qs)
+	err = httpClient.WalletSeedPost(seed, password)
 	if err != nil {
 		die("Could not add seed:", err)
 	}
@@ -342,8 +329,7 @@ func walletloadsiagcmd(keyfiles string) {
 	if err != nil {
 		die("Reading password failed:", err)
 	}
-	qs := fmt.Sprintf("keyfiles=%s&encryptionpassword=%s", keyfiles, password)
-	err = post("/wallet/siagkey", qs)
+	err = httpClient.WalletSiagKeyPost(keyfiles, password)
 	if err != nil {
 		die("Loading siag key failed:", err)
 	}
@@ -352,7 +338,7 @@ func walletloadsiagcmd(keyfiles string) {
 
 // walletlockcmd locks the wallet
 func walletlockcmd() {
-	err := post("/wallet/lock", "")
+	err := httpClient.WalletLockPost()
 	if err != nil {
 		die("Could not lock wallet:", err)
 	}
@@ -360,8 +346,7 @@ func walletlockcmd() {
 
 // walletseedcmd returns the current seed {
 func walletseedscmd() {
-	var seedInfo api.WalletSeedsGET
-	err := getAPI("/wallet/seeds", &seedInfo)
+	seedInfo, err := httpClient.WalletSeedsGet()
 	if err != nil {
 		die("Error retrieving the current seed:", err)
 	}
@@ -388,7 +373,15 @@ func walletsendsiacoinscmd(amount, dest string) {
 	if err != nil {
 		die("Could not parse amount:", err)
 	}
-	err = post("/wallet/siacoins", fmt.Sprintf("amount=%s&destination=%s", hastings, dest))
+	var value types.Currency
+	if _, err := fmt.Sscan(hastings, &value); err != nil {
+		die("Failed to parse amount", err)
+	}
+	var hash types.UnlockHash
+	if _, err := fmt.Sscan(dest, &hash); err != nil {
+		die("Failed to parse destination address", err)
+	}
+	_, err = httpClient.WalletSiacoinsPost(value, hash)
 	if err != nil {
 		die("Could not send siacoins:", err)
 	}
@@ -397,7 +390,15 @@ func walletsendsiacoinscmd(amount, dest string) {
 
 // walletsendsiafundscmd sends siafunds to a destination address.
 func walletsendsiafundscmd(amount, dest string) {
-	err := post("/wallet/siafunds", fmt.Sprintf("amount=%s&destination=%s", amount, dest))
+	var value types.Currency
+	if _, err := fmt.Sscan(amount, &value); err != nil {
+		die("Failed to parse amount", err)
+	}
+	var hash types.UnlockHash
+	if _, err := fmt.Sscan(dest, &hash); err != nil {
+		die("Failed to parse destination address", err)
+	}
+	_, err := httpClient.WalletSiafundsPost(value, hash)
 	if err != nil {
 		die("Could not send siafunds:", err)
 	}
@@ -406,13 +407,11 @@ func walletsendsiafundscmd(amount, dest string) {
 
 // walletbalancecmd retrieves and displays information about the wallet.
 func walletbalancecmd() {
-	status := new(api.WalletGET)
-	err := getAPI("/wallet", status)
+	status, err := httpClient.WalletGet()
 	if err != nil {
 		die("Could not get wallet status:", err)
 	}
-	var fees api.TpoolFeeGET
-	err = getAPI("/tpool/fee", &fees)
+	fees, err := httpClient.TransactionPoolFeeGet()
 	if err != nil {
 		die("Could not get fee estimation:", err)
 	}
@@ -458,8 +457,7 @@ func walletsweepcmd() {
 		die("Reading seed failed:", err)
 	}
 
-	var swept api.WalletSweepPOST
-	err = postResp("/wallet/sweep/seed", fmt.Sprintf("seed=%s&dictionary=%s", seed, "english"), &swept)
+	swept, err := httpClient.WalletSweepPost(seed)
 	if err != nil {
 		die("Could not sweep seed:", err)
 	}
@@ -469,8 +467,7 @@ func walletsweepcmd() {
 // wallettransactionscmd lists all of the transactions related to the wallet,
 // providing a net flow of siacoins and siafunds for each.
 func wallettransactionscmd() {
-	wtg := new(api.WalletTransactionsGET)
-	err := getAPI("/wallet/transactions?startheight=0&endheight=10000000", wtg)
+	wtg, err := httpClient.WalletTransactionsGet(0, math.MaxUint64)
 	if err != nil {
 		die("Could not fetch transaction history:", err)
 	}
@@ -536,8 +533,7 @@ func walletunlockcmd() {
 	password := os.Getenv("SIA_WALLET_PASSWORD")
 	if password != "" && !initPassword {
 		fmt.Println("Using SIA_WALLET_PASSWORD environment variable")
-		qs := fmt.Sprintf("encryptionpassword=%s&dictonary=%s", password, "english")
-		err := post("/wallet/unlock", qs)
+		err := httpClient.WalletUnlockPost(password)
 		if err != nil {
 			fmt.Println("Automatic unlock failed!")
 		} else {
@@ -549,8 +545,7 @@ func walletunlockcmd() {
 	if err != nil {
 		die("Reading password failed:", err)
 	}
-	qs := fmt.Sprintf("encryptionpassword=%s&dictonary=%s", password, "english")
-	err = post("/wallet/unlock", qs)
+	err = httpClient.WalletUnlockPost(password)
 	if err != nil {
 		die("Could not unlock wallet:", err)
 	}

--- a/doc/Contributors.md
+++ b/doc/Contributors.md
@@ -7,13 +7,14 @@
 ### List of contributors
 * DavidVorick (Owner)
 * lukechampine (Lead Developer)
+* ChrisSchinnerl (Nebulous Developer)
+* Msevey (Nebulous Developer)
 * VoidingWarranties
 * avahowell
 * seveibar
 * triazo
 * mnsl
 * mtlynch
-* ChrisSchinnerl
 * Mingling94
 * marcinja
 * RNabel
@@ -52,6 +53,7 @@
 * huetsch
 * mjmay08
 * jfcg
+* pachisi456
 * Google Inc.
 
 

--- a/doc/Guide to Contributing to Sia.md
+++ b/doc/Guide to Contributing to Sia.md
@@ -29,19 +29,6 @@ You should install the latest [official Go binary][binary] for your system (if
 not available, [install from source][source]).  If you plan to cross compile 
 Sia, see [Cross Compilation with Go 1.5][cross] by Dave Cheney.  
 
-Now make a workspace directory in which you will store source code and 
-dependencies.  You can choose any filepath except where you installed Go (don't 
-choose `/usr/local`).
-
-```bash
-# make a working directory called golang in your home directory
-$ mkdir $HOME/golang
-# store base path in an environmental variable
-$ echo 'export GOPATH=$HOME/golang' >> $HOME/.profile
-# add bin subdirectory to PATH environmental variable
-$ echo 'export PATH=$PATH:$GOPATH/bin' >> $HOME/.profile
-```
-
 <a name="learn-go"/>
 
 ### Learn Go
@@ -67,13 +54,19 @@ $ cd $GOPATH/src/github.com/NebulousLabs/Sia
 
 # You have three Sia builds to choose from.
 # To build the standard release binary:
-$ make release-std
+$ make release
 # Or to build the release binary with race detection and an array debugging 
 # asserts:
-$ make release
+$ make release-race
 # Or to build the developer binary (with a different genesis block, faster 
 # block times, and other changes):
-$ make
+$ make dev
+# Or build the developer binary with race detection:
+$ make dev-race
+# Build the debugger binary:
+$ make debug
+# Or build debugger binary with race detection:
+$ make debug-race
 ```
 
 <a name="contribute"/>
@@ -117,6 +110,8 @@ $ cd $GOPATH/src/github.com/NebulousLabs/Sia
 # Add your fork as a remote.  Name it whatever is convenient,
 # e.g your GitHub username
 $ git remote add <remote name> https://github.com/<username>/Sia.git
+# Or if you use an SSH key, create the remote with the following
+$ git remote add <remote name> git@github.com:<username>/Sia.git
 ```
 
 <a name="write"/>

--- a/modules/gateway/conn.go
+++ b/modules/gateway/conn.go
@@ -19,10 +19,10 @@ func (pc peerConn) RPCAddr() modules.NetAddress {
 	return pc.dialbackAddr
 }
 
-// dial will dial the input address and return a connection. dial appropriately
+// staticDial will staticDial the input address and return a connection. staticDial appropriately
 // handles things like clean shutdown, fast shutdown, and chooses the correct
 // communication protocol.
-func (g *Gateway) dial(addr modules.NetAddress) (net.Conn, error) {
+func (g *Gateway) staticDial(addr modules.NetAddress) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Cancel:  g.threads.StopChan(),
 		Timeout: dialTimeout,

--- a/modules/gateway/gateway.go
+++ b/modules/gateway/gateway.go
@@ -152,7 +152,7 @@ type Gateway struct {
 	threads    siasync.ThreadGroup
 
 	// Unique ID
-	id gatewayID
+	staticId gatewayID
 }
 
 type gatewayID [8]byte
@@ -205,7 +205,7 @@ func New(addr string, bootstrap bool, persistDir string) (*Gateway, error) {
 	}
 
 	// Set Unique GatewayID
-	fastrand.Read(g.id[:])
+	fastrand.Read(g.staticId[:])
 
 	// Create the logger.
 	g.log, err = persist.NewFileLogger(filepath.Join(g.persistDir, logFile))

--- a/modules/gateway/peers.go
+++ b/modules/gateway/peers.go
@@ -174,7 +174,7 @@ func (g *Gateway) managedAcceptConnPeer(conn net.Conn, remoteVersion string) err
 	g.mu.RLock()
 	ourHeader := sessionHeader{
 		GenesisID:  types.GenesisID,
-		UniqueID:   g.id,
+		UniqueID:   g.staticId,
 		NetAddress: g.myAddr,
 	}
 	g.mu.RUnlock()
@@ -217,7 +217,7 @@ func (g *Gateway) managedAcceptConnPeer(conn net.Conn, remoteVersion string) err
 	// do this in a goroutine so that we can begin communicating with the peer
 	// immediately.
 	go func() {
-		err := g.pingNode(remoteAddr)
+		err := g.staticPingNode(remoteAddr)
 		if err == nil {
 			g.mu.Lock()
 			g.addNode(remoteAddr)
@@ -370,7 +370,7 @@ func (g *Gateway) managedConnectPeer(conn net.Conn, remoteVersion string, remote
 	g.mu.RLock()
 	ourHeader := sessionHeader{
 		GenesisID:  types.GenesisID,
-		UniqueID:   g.id,
+		UniqueID:   g.staticId,
 		NetAddress: g.myAddr,
 	}
 	g.mu.RUnlock()
@@ -407,7 +407,7 @@ func (g *Gateway) managedConnect(addr modules.NetAddress) error {
 	}
 
 	// Dial the peer and perform peer initialization.
-	conn, err := g.dial(addr)
+	conn, err := g.staticDial(addr)
 	if err != nil {
 		return err
 	}

--- a/modules/gateway/peers_test.go
+++ b/modules/gateway/peers_test.go
@@ -600,7 +600,7 @@ func TestConnectRejectsVersions(t *testing.T) {
 		{
 			version:         minimumAcceptablePeerVersion,
 			msg:             "Connect should not succeed when peer is connecting to itself",
-			uniqueID:        g.id,
+			uniqueID:        g.staticId,
 			genesisID:       types.GenesisID,
 			errWant:         errOurAddress.Error(),
 			localErrWant:    errOurAddress.Error(),

--- a/modules/renter/contractor/consts.go
+++ b/modules/renter/contractor/consts.go
@@ -1,8 +1,6 @@
 package contractor
 
 import (
-	"time"
-
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
@@ -10,22 +8,14 @@ import (
 
 // Constants related to contract formation parameters.
 var (
-	// To alleviate potential block propagation issues, the contractor sleeps
-	// between each contract formation.
-	contractFormationInterval = build.Select(build.Var{
-		Dev:      10 * time.Second,
-		Standard: 60 * time.Second,
-		Testing:  10 * time.Millisecond,
-	}).(time.Duration)
-
 	// minContractFundRenewalThreshold defines the ratio of remaining funds to
 	// total contract cost below which the contractor will prematurely renew a
 	// contract.
 	minContractFundRenewalThreshold = float64(0.03) // 3%
 
-	// minScoreHostBuffer defines how many extra hosts are queried when trying
+	// randomHostsBufferForScore defines how many extra hosts are queried when trying
 	// to figure out an appropriate minimum score for the hosts that we have.
-	minScoreHostBuffer = build.Select(build.Var{
+	randomHostsBufferForScore = build.Select(build.Var{
 		Dev:      2,
 		Standard: 10,
 		Testing:  1,

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -65,8 +65,8 @@ type Contractor struct {
 	renewedIDs   map[types.FileContractID]types.FileContractID
 }
 
-// resolveID returns the ID of the most recent renewal of id.
-func (c *Contractor) resolveID(id types.FileContractID) types.FileContractID {
+// readlockResolveID returns the ID of the most recent renewal of id.
+func (c *Contractor) readlockResolveID(id types.FileContractID) types.FileContractID {
 	newID, exists := c.renewedIDs[id]
 	for exists {
 		id = newID
@@ -126,7 +126,7 @@ func (c *Contractor) PeriodSpending() modules.ContractorSpending {
 func (c *Contractor) ContractByID(id types.FileContractID) (modules.RenterContract, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.contracts.View(c.resolveID(id))
+	return c.contracts.View(c.readlockResolveID(id))
 }
 
 // Contracts returns the contracts formed by the contractor in the current
@@ -140,7 +140,9 @@ func (c *Contractor) Contracts() []modules.RenterContract {
 
 // ContractUtility returns the utility fields for the given contract.
 func (c *Contractor) ContractUtility(id types.FileContractID) (modules.ContractUtility, bool) {
-	return c.staticContractUtility(id)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.readlockContractUtility(id)
 }
 
 // CurrentPeriod returns the height at which the current allowance period
@@ -154,7 +156,7 @@ func (c *Contractor) CurrentPeriod() types.BlockHeight {
 // ResolveID returns the ID of the most recent renewal of id.
 func (c *Contractor) ResolveID(id types.FileContractID) types.FileContractID {
 	c.mu.RLock()
-	newID := c.resolveID(id)
+	newID := c.readlockResolveID(id)
 	c.mu.RUnlock()
 	return newID
 }
@@ -247,9 +249,6 @@ func NewCustomContractor(cs consensusSet, w wallet, tp transactionPool, hdb host
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-
-	// Mark contract utility.
-	c.managedMarkContractsUtility()
 
 	// Subscribe to the consensus set.
 	err = cs.ConsensusSetSubscribe(c, c.lastChange, c.tg.StopChan())

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -38,6 +38,7 @@ type (
 		Drop()
 		FundSiacoins(types.Currency) error
 		Sign(bool) ([]types.Transaction, error)
+		UnconfirmedParents() ([]types.Transaction, error)
 		View() (types.Transaction, []types.Transaction)
 		ViewAdded() (parents, coins, funds, signatures []int)
 	}
@@ -52,7 +53,7 @@ type (
 		Host(types.SiaPublicKey) (modules.HostDBEntry, bool)
 		IncrementSuccessfulInteractions(key types.SiaPublicKey)
 		IncrementFailedInteractions(key types.SiaPublicKey)
-		RandomHosts(n int, exclude []types.SiaPublicKey) []modules.HostDBEntry
+		RandomHosts(n int, exclude []types.SiaPublicKey) ([]modules.HostDBEntry, error)
 		ScoreBreakdown(modules.HostDBEntry) modules.HostScoreBreakdown
 	}
 

--- a/modules/renter/hostdb/consts.go
+++ b/modules/renter/hostdb/consts.go
@@ -46,6 +46,10 @@ const (
 	// saveFrequency defines how frequently the hostdb will save to disk. Hostdb
 	// will also save immediately prior to shutdown.
 	saveFrequency = 2 * time.Minute
+
+	// scanCheckInterval is the interval used when waiting for the scanList to
+	// empty itself and for waiting on the consensus set to be synced.
+	scanCheckInterval = time.Second
 )
 
 var (

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -19,8 +19,11 @@ import (
 )
 
 var (
-	errNilCS      = errors.New("cannot create hostdb with nil consensus set")
-	errNilGateway = errors.New("cannot create hostdb with nil gateway")
+	// ErrInitialScanIncomplete is returned whenever an operation is not
+	// allowed to be executed before the initial host scan has finished.
+	ErrInitialScanIncomplete = errors.New("initial hostdb scan is not yet completed")
+	errNilCS                 = errors.New("cannot create hostdb with nil consensus set")
+	errNilGateway            = errors.New("cannot create hostdb with nil gateway")
 )
 
 // The HostDB is a database of potential hosts. It assigns a weight to each
@@ -45,10 +48,11 @@ type HostDB struct {
 	// handful of goroutines constantly waiting on the channel for hosts to
 	// scan. The scan map is used to prevent duplicates from entering the scan
 	// pool.
-	scanList        []modules.HostDBEntry
-	scanMap         map[string]struct{}
-	scanWait        bool
-	scanningThreads int
+	initialScanComplete bool
+	scanList            []modules.HostDBEntry
+	scanMap             map[string]struct{}
+	scanWait            bool
+	scanningThreads     int
 
 	blockHeight types.BlockHeight
 	lastChange  modules.ConsensusChangeID
@@ -161,6 +165,8 @@ func NewCustomHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir stri
 	// fake hosts and not have them marked as offline as the scanloop operates.
 	if !hdb.deps.Disrupt("disableScanLoop") {
 		go hdb.threadedScan()
+	} else {
+		hdb.initialScanComplete = true
 	}
 
 	return hdb, nil
@@ -225,6 +231,12 @@ func (hdb *HostDB) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) {
 // RandomHosts implements the HostDB interface's RandomHosts() method. It takes
 // a number of hosts to return, and a slice of netaddresses to ignore, and
 // returns a slice of entries.
-func (hdb *HostDB) RandomHosts(n int, excludeKeys []types.SiaPublicKey) []modules.HostDBEntry {
-	return hdb.hostTree.SelectRandom(n, excludeKeys)
+func (hdb *HostDB) RandomHosts(n int, excludeKeys []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
+	hdb.mu.RLock()
+	initialScanComplete := hdb.initialScanComplete
+	hdb.mu.RUnlock()
+	if !initialScanComplete {
+		return []modules.HostDBEntry{}, ErrInitialScanIncomplete
+	}
+	return hdb.hostTree.SelectRandom(n, excludeKeys), nil
 }

--- a/modules/renter/hostdb/hostdb_test.go
+++ b/modules/renter/hostdb/hostdb_test.go
@@ -234,7 +234,10 @@ func TestRandomHosts(t *testing.T) {
 
 	// Check that all hosts can be queried.
 	for i := 0; i < 25; i++ {
-		hosts := hdbt.hdb.RandomHosts(nEntries, nil)
+		hosts, err := hdbt.hdb.RandomHosts(nEntries, nil)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		if len(hosts) != nEntries {
 			t.Errorf("RandomHosts returned few entries. got %v wanted %v\n", len(hosts), nEntries)
 		}
@@ -254,7 +257,10 @@ func TestRandomHosts(t *testing.T) {
 
 	// Base case, fill out a map exposing hosts from a single RH query.
 	dupCheck1 := make(map[string]modules.HostDBEntry)
-	hosts := hdbt.hdb.RandomHosts(nEntries/2, nil)
+	hosts, err := hdbt.hdb.RandomHosts(nEntries/2, nil)
+	if err != nil {
+		t.Fatal("Failed to get hosts", err)
+	}
 	if len(hosts) != nEntries/2 {
 		t.Fatalf("RandomHosts returned few entries. got %v wanted %v\n", len(hosts), nEntries/2)
 	}
@@ -275,7 +281,10 @@ func TestRandomHosts(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		dupCheck2 := make(map[string]modules.HostDBEntry)
 		var overlap, disjoint bool
-		hosts = hdbt.hdb.RandomHosts(nEntries/2, nil)
+		hosts, err = hdbt.hdb.RandomHosts(nEntries/2, nil)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		if len(hosts) != nEntries/2 {
 			t.Fatalf("RandomHosts returned few entries. got %v wanted %v\n", len(hosts), nEntries/2)
 		}
@@ -306,12 +315,18 @@ func TestRandomHosts(t *testing.T) {
 	// Try exclude list by excluding every host except for the last one, and
 	// doing a random select.
 	for i := 0; i < 25; i++ {
-		hosts := hdbt.hdb.RandomHosts(nEntries, nil)
+		hosts, err := hdbt.hdb.RandomHosts(nEntries, nil)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		var exclude []types.SiaPublicKey
 		for j := 1; j < len(hosts); j++ {
 			exclude = append(exclude, hosts[j].PublicKey)
 		}
-		rand := hdbt.hdb.RandomHosts(1, exclude)
+		rand, err := hdbt.hdb.RandomHosts(1, exclude)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		if len(rand) != 1 {
 			t.Fatal("wrong number of hosts returned")
 		}
@@ -320,7 +335,10 @@ func TestRandomHosts(t *testing.T) {
 		}
 
 		// Try again but request more hosts than are available.
-		rand = hdbt.hdb.RandomHosts(5, exclude)
+		rand, err = hdbt.hdb.RandomHosts(5, exclude)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		if len(rand) != 1 {
 			t.Fatal("wrong number of hosts returned")
 		}
@@ -339,7 +357,10 @@ func TestRandomHosts(t *testing.T) {
 
 		// Select only 20 hosts.
 		dupCheck := make(map[string]struct{})
-		rand = hdbt.hdb.RandomHosts(20, exclude)
+		rand, err = hdbt.hdb.RandomHosts(20, exclude)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		if len(rand) != 20 {
 			t.Error("random hosts is returning the wrong number of hosts")
 		}
@@ -357,7 +378,10 @@ func TestRandomHosts(t *testing.T) {
 
 		// Select exactly 50 hosts.
 		dupCheck = make(map[string]struct{})
-		rand = hdbt.hdb.RandomHosts(50, exclude)
+		rand, err = hdbt.hdb.RandomHosts(50, exclude)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		if len(rand) != 50 {
 			t.Error("random hosts is returning the wrong number of hosts")
 		}
@@ -375,7 +399,10 @@ func TestRandomHosts(t *testing.T) {
 
 		// Select 100 hosts.
 		dupCheck = make(map[string]struct{})
-		rand = hdbt.hdb.RandomHosts(100, exclude)
+		rand, err = hdbt.hdb.RandomHosts(100, exclude)
+		if err != nil {
+			t.Fatal("Failed to get hosts", err)
+		}
 		if len(rand) != 50 {
 			t.Error("random hosts is returning the wrong number of hosts")
 		}

--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -290,6 +290,23 @@ func (hdb *HostDB) managedScanHost(entry modules.HostDBEntry) {
 	hdb.mu.Unlock()
 }
 
+// waitForScans is a helper function that blocks until the hostDB's scanList is
+// empty.
+func (hdb *HostDB) managedWaitForScans() {
+	for {
+		hdb.mu.Lock()
+		length := len(hdb.scanList)
+		hdb.mu.Unlock()
+		if length == 0 {
+			break
+		}
+		select {
+		case <-hdb.tg.StopChan():
+		case <-time.After(scanCheckInterval):
+		}
+	}
+}
+
 // threadedProbeHosts pulls hosts from the thread pool and runs a scan on them.
 func (hdb *HostDB) threadedProbeHosts(scanPool <-chan modules.HostDBEntry) {
 	err := hdb.tg.Add()
@@ -328,6 +345,37 @@ func (hdb *HostDB) threadedScan() {
 		return
 	}
 	defer hdb.tg.Done()
+
+	// Wait until the consensus set is synced. Only then we can be sure that
+	// the initial scan covers the whole network.
+	for {
+		if hdb.cs.Synced() {
+			break
+		}
+		select {
+		case <-hdb.tg.StopChan():
+			return
+		case <-time.After(scanCheckInterval):
+		}
+	}
+
+	// The initial scan might have been interrupted. Queue one scan for every
+	// announced host that was missed by the initial scan and wait for the
+	// scans to finish before starting the scan loop.
+	allHosts := hdb.hostTree.All()
+	hdb.mu.Lock()
+	for _, host := range allHosts {
+		if len(host.ScanHistory) == 0 && host.HistoricUptime == 0 && host.HistoricDowntime == 0 {
+			hdb.queueScan(host)
+		}
+	}
+	hdb.mu.Unlock()
+	hdb.managedWaitForScans()
+
+	// Set the flag to indicate that the initial scan is complete.
+	hdb.mu.Lock()
+	hdb.initialScanComplete = true
+	hdb.mu.Unlock()
 
 	for {
 		// Set up a scan for the hostCheckupQuanity most valuable hosts in the

--- a/modules/renter/proto/contract.go
+++ b/modules/renter/proto/contract.go
@@ -29,6 +29,14 @@ type updateSetHeader struct {
 	Header contractHeader
 }
 
+// v132UpdateHeader was introduced due to backwards compatibility reasons after
+// changing the format of the contractHeader. It contains the legacy
+// v132ContractHeader.
+type v132UpdateSetHeader struct {
+	ID     types.FileContractID
+	Header v132ContractHeader
+}
+
 type updateSetRoot struct {
 	ID    types.FileContractID
 	Root  crypto.Hash
@@ -54,6 +62,28 @@ type contractHeader struct {
 	TxnFee           types.Currency
 	SiafundFee       types.Currency
 	Utility          modules.ContractUtility
+}
+
+// v132ContractHeader is a contractHeader without the Utility field. This field
+// was added after v132 to be able to persist contract utilities.
+type v132ContractHeader struct {
+	// transaction is the signed transaction containing the most recent
+	// revision of the file contract.
+	Transaction types.Transaction
+
+	// secretKey is the key used by the renter to sign the file contract
+	// transaction.
+	SecretKey crypto.SecretKey
+
+	// Same as modules.RenterContract.
+	StartHeight      types.BlockHeight
+	DownloadSpending types.Currency
+	StorageSpending  types.Currency
+	UploadSpending   types.Currency
+	TotalCost        types.Currency
+	ContractFee      types.Currency
+	TxnFee           types.Currency
+	SiafundFee       types.Currency
 }
 
 // validate returns an error if the contractHeader is invalid.
@@ -329,7 +359,7 @@ func (c *SafeContract) commitTxns() error {
 			switch update.Name {
 			case updateNameSetHeader:
 				var u updateSetHeader
-				if err := encoding.Unmarshal(update.Instructions, &u); err != nil {
+				if err := unmarshalHeader(update.Instructions, &u); err != nil {
 					return err
 				}
 				if err := c.applySetHeader(u.Header); err != nil {
@@ -363,7 +393,7 @@ func (c *SafeContract) unappliedHeader() (h contractHeader) {
 		for _, update := range t.Updates {
 			if update.Name == updateNameSetHeader {
 				var u updateSetHeader
-				if err := encoding.Unmarshal(update.Instructions, &u); err != nil {
+				if err := unmarshalHeader(update.Instructions, &u); err != nil {
 					continue
 				}
 				h = u.Header
@@ -450,7 +480,7 @@ func (cs *ContractSet) loadSafeContract(filename string, walTxns []*writeaheadlo
 		switch update := t.Updates[0]; update.Name {
 		case updateNameSetHeader:
 			var u updateSetHeader
-			if err := encoding.Unmarshal(update.Instructions, &u); err != nil {
+			if err := unmarshalHeader(update.Instructions, &u); err != nil {
 				return err
 			}
 			id = u.ID
@@ -588,5 +618,33 @@ func (mrs *MerkleRootSet) UnmarshalJSON(b []byte) error {
 		copy(umrs[i][:], fullBytes[i*crypto.HashSize:(i+1)*crypto.HashSize])
 	}
 	*mrs = umrs
+	return nil
+}
+
+func unmarshalHeader(b []byte, u *updateSetHeader) error {
+	// Try unmarshaling the header.
+	if err := encoding.Unmarshal(b, u); err != nil {
+		// COMPATv132 try unmarshaling the header the old way.
+		var oldHeader v132UpdateSetHeader
+		if err2 := encoding.Unmarshal(b, &oldHeader); err2 != nil {
+			// If unmarshaling the header the old way also doesn't work we
+			// return the original error.
+			return err
+		}
+		// If unmarshaling it the old way was successful we convert it to a new
+		// header.
+		u.Header = contractHeader{
+			Transaction:      oldHeader.Header.Transaction,
+			SecretKey:        oldHeader.Header.SecretKey,
+			StartHeight:      oldHeader.Header.StartHeight,
+			DownloadSpending: oldHeader.Header.DownloadSpending,
+			StorageSpending:  oldHeader.Header.StorageSpending,
+			UploadSpending:   oldHeader.Header.UploadSpending,
+			TotalCost:        oldHeader.Header.TotalCost,
+			ContractFee:      oldHeader.Header.ContractFee,
+			TxnFee:           oldHeader.Header.TxnFee,
+			SiafundFee:       oldHeader.Header.SiafundFee,
+		}
+	}
 	return nil
 }

--- a/modules/renter/proto/formcontract.go
+++ b/modules/renter/proto/formcontract.go
@@ -98,7 +98,11 @@ func (cs *ContractSet) FormContract(params ContractParams, txnBuilder transactio
 
 	// Create initial transaction set.
 	txn, parentTxns := txnBuilder.View()
-	txnSet := append(parentTxns, txn)
+	unconfirmedParents, err := txnBuilder.UnconfirmedParents()
+	if err != nil {
+		return modules.RenterContract{}, err
+	}
+	txnSet := append(unconfirmedParents, append(parentTxns, txn)...)
 
 	// Increase Successful/Failed interactions accordingly
 	defer func() {

--- a/modules/renter/proto/proto.go
+++ b/modules/renter/proto/proto.go
@@ -19,6 +19,7 @@ type (
 		AddTransactionSignature(types.TransactionSignature) uint64
 		FundSiacoins(types.Currency) error
 		Sign(bool) ([]types.Transaction, error)
+		UnconfirmedParents() ([]types.Transaction, error)
 		View() (types.Transaction, []types.Transaction)
 		ViewAdded() (parents, coins, funds, signatures []int)
 	}

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -97,9 +97,13 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 	// add miner fee
 	txnBuilder.AddMinerFee(txnFee)
 
-	// create initial transaction set
+	// Create initial transaction set.
 	txn, parentTxns := txnBuilder.View()
-	txnSet := append(parentTxns, txn)
+	unconfirmedParents, err := txnBuilder.UnconfirmedParents()
+	if err != nil {
+		return modules.RenterContract{}, err
+	}
+	txnSet := append(unconfirmedParents, append(parentTxns, txn)...)
 
 	// Increase Successful/Failed interactions accordingly
 	defer func() {

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -75,7 +75,7 @@ type hostDB interface {
 	// RandomHosts returns a set of random hosts, weighted by their estimated
 	// usefulness / attractiveness to the renter. RandomHosts will not return
 	// any offline or inactive hosts.
-	RandomHosts(int, []types.SiaPublicKey) []modules.HostDBEntry
+	RandomHosts(int, []types.SiaPublicKey) ([]modules.HostDBEntry, error)
 
 	// ScoreBreakdown returns a detailed explanation of the various properties
 	// of the host.
@@ -224,7 +224,10 @@ func (r *Renter) PriceEstimation() modules.RenterPriceEstimation {
 	}
 
 	// Grab hosts to perform the estimation.
-	hosts := r.hostDB.RandomHosts(priceEstimationScope, nil)
+	hosts, err := r.hostDB.RandomHosts(priceEstimationScope, nil)
+	if err != nil {
+		return modules.RenterPriceEstimation{}
+	}
 
 	// Check if there are zero hosts, which means no estimation can be made.
 	if len(hosts) == 0 {

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -107,8 +107,8 @@ func (stubHostDB) AllHosts() []modules.HostDBEntry      { return nil }
 func (stubHostDB) AverageContractPrice() types.Currency { return types.Currency{} }
 func (stubHostDB) Close() error                         { return nil }
 func (stubHostDB) IsOffline(modules.NetAddress) bool    { return true }
-func (stubHostDB) RandomHosts(int, []types.SiaPublicKey) []modules.HostDBEntry {
-	return []modules.HostDBEntry{}
+func (stubHostDB) RandomHosts(int, []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
+	return []modules.HostDBEntry{}, nil
 }
 func (stubHostDB) EstimateHostScore(modules.HostDBEntry) modules.HostScoreBreakdown {
 	return modules.HostScoreBreakdown{}
@@ -143,8 +143,8 @@ type pricesStub struct {
 	dbEntries []modules.HostDBEntry
 }
 
-func (ps pricesStub) RandomHosts(n int, exclude []types.SiaPublicKey) []modules.HostDBEntry {
-	return ps.dbEntries
+func (ps pricesStub) RandomHosts(n int, exclude []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
+	return ps.dbEntries, nil
 }
 
 // TestRenterPricesVolatility verifies that the renter caches its price

--- a/modules/renter/uploadheap.go
+++ b/modules/renter/uploadheap.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 )
 
@@ -167,6 +168,10 @@ func (r *Renter) buildUnfinishedChunks(f *file, hosts map[string]struct{}) []*un
 	for fcid, fileContract := range f.contracts {
 		recentContract, exists := r.hostContractor.ContractByID(fcid)
 		contractUtility, exists2 := r.hostContractor.ContractUtility(fcid)
+		if exists != exists2 {
+			build.Critical("got a contract without utility or vice versa which shouldn't happen",
+				exists, exists2)
+		}
 		if !exists || !exists2 {
 			// File contract does not seem to be part of the host anymore.
 			// Delete this contract and mark the file to be saved.

--- a/modules/transactionpool.go
+++ b/modules/transactionpool.go
@@ -143,6 +143,10 @@ type (
 		// transaction pool changes, and should not subscribe to both.
 		TransactionPoolSubscribe(TransactionPoolSubscriber)
 
+		// TransactionSet returns the transaction set the provided object
+		// appears in.
+		TransactionSet(crypto.Hash) []types.Transaction
+
 		// Unsubscribe removes a subscriber from the transaction pool.
 		// This is necessary for clean shutdown of the miner.
 		Unsubscribe(TransactionPoolSubscriber)

--- a/modules/transactionpool/transactionpool.go
+++ b/modules/transactionpool/transactionpool.go
@@ -256,6 +256,24 @@ func (tp *TransactionPool) Transaction(id types.TransactionID) (types.Transactio
 	return txn, necessaryParents, exists
 }
 
+// TransactionSet returns the transaction set the provided object
+// appears in.
+func (tp *TransactionPool) TransactionSet(oid crypto.Hash) []types.Transaction {
+	tp.mu.RLock()
+	defer tp.mu.RUnlock()
+	var parents []types.Transaction
+	tSetID, exists := tp.knownObjects[ObjectID(oid)]
+	if !exists {
+		return nil
+	}
+	tSet, exists := tp.transactionSets[tSetID]
+	if !exists {
+		return nil
+	}
+	parents = append(parents, tSet...)
+	return parents
+}
+
 // Broadcast broadcasts a transaction set to all of the transaction pool's
 // peers.
 func (tp *TransactionPool) Broadcast(ts []types.Transaction) {

--- a/modules/transactionpool/update.go
+++ b/modules/transactionpool/update.go
@@ -2,6 +2,7 @@ package transactionpool
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 
 	"github.com/NebulousLabs/Sia/crypto"
@@ -185,7 +186,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 		tp.log.Println("NOTE: Upgrading tpool database to support consensus change verification.")
 		resetSanityCheck = true
 	} else if err != nil {
-		tp.log.Println("ERROR: Could not access recentID from tpool.")
+		tp.log.Critical("ERROR: Could not access recentID from tpool:", err)
 	}
 
 	// Update the database of confirmed transactions.
@@ -193,7 +194,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 		// Sanity check - the id of each reverted block should match the recent
 		// parent id.
 		if block.ID() != recentID && !resetSanityCheck {
-			panic("Consensus change series appears to be inconsistent - we are reverting the wrong block.")
+			panic(fmt.Sprintf("Consensus change series appears to be inconsistent - we are reverting the wrong block. bid: %v recent: %v", block.ID(), recentID))
 		}
 		recentID = block.ParentID
 
@@ -220,7 +221,7 @@ func (tp *TransactionPool) ProcessConsensusChange(cc modules.ConsensusChange) {
 		// Sanity check - the parent id of each block should match the current
 		// block id.
 		if block.ParentID != recentID && !resetSanityCheck {
-			panic("Consensus change series appears to be inconsistent - we are applying the wrong block.")
+			panic(fmt.Sprintf("Consensus change series appears to be inconsistent - we are applying the wrong block. pid: %v recent: %v", block.ParentID, recentID))
 		}
 		recentID = block.ID()
 

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -198,6 +198,10 @@ type (
 		// transaction should be dropped.
 		Sign(wholeTransaction bool) ([]types.Transaction, error)
 
+		// UnconfirmedParents returns any unconfirmed parents the transaction set that
+		// is being built by the transaction builder could have.
+		UnconfirmedParents() ([]types.Transaction, error)
+
 		// View returns the incomplete transaction along with all of its
 		// parents.
 		View() (txn types.Transaction, parents []types.Transaction)

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -382,6 +382,43 @@ func (tb *transactionBuilder) FundSiafunds(amount types.Currency) error {
 	return nil
 }
 
+// UnconfirmedParents returns the unconfirmed parents of the transaction set
+// that is being constructed by the transaction builder.
+func (tb *transactionBuilder) UnconfirmedParents() (parents []types.Transaction, err error) {
+	// Currently we don't need to call UnconfirmedParents after the transaction
+	// was signed so we don't allow doing that. If for some reason our
+	// requirements change, we can remove this check. The only downside is,
+	// that it might lead to transactions being returned that are not actually
+	// parents in case the signed transaction already has child transactions.
+	if tb.signed {
+		return nil, errBuilderAlreadySigned
+	}
+	addedParents := make(map[types.TransactionID]struct{})
+	for _, p := range tb.parents {
+		for _, sci := range p.SiacoinInputs {
+			tSet := tb.wallet.tpool.TransactionSet(crypto.Hash(sci.ParentID))
+			for _, txn := range tSet {
+				// Add the transaction to the parents.
+				txnID := txn.ID()
+				if _, exists := addedParents[txnID]; exists {
+					continue
+				}
+				addedParents[txnID] = struct{}{}
+				parents = append(parents, txn)
+
+				// When we found the transaction that contains the output that
+				// is spent by sci we stop to avoid adding child transactions.
+				for i := range txn.SiacoinOutputs {
+					if txn.SiacoinOutputID(uint64(i)) == sci.ParentID {
+						break
+					}
+				}
+			}
+		}
+	}
+	return
+}
+
 // AddParents adds a set of parents to the transaction.
 func (tb *transactionBuilder) AddParents(newParents []types.Transaction) {
 	tb.parents = append(tb.parents, newParents...)

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -450,3 +450,52 @@ func TestParallelBuilders(t *testing.T) {
 		t.Fatal("did not get the expected ending balance", expected, endingSCConfirmed, startingSCConfirmed)
 	}
 }
+
+// TestUnconfirmedParents tests the functionality of the transaction builder's
+// UnconfirmedParents method.
+func TestUnconfirmedParents(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	wt, err := createWalletTester(t.Name(), &modules.ProductionDependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	// Send all of the wallet's available balance to itself.
+	uc, err := wt.wallet.NextAddress()
+	if err != nil {
+		t.Fatal("Failed to get address", err)
+	}
+	siacoins, _, _ := wt.wallet.ConfirmedBalance()
+	tSet, err := wt.wallet.SendSiacoins(siacoins.Sub(types.SiacoinPrecision), uc.UnlockHash())
+	if err != nil {
+		t.Fatal("Failed to send coins", err)
+	}
+
+	// Create a transaction. That transaction should use siacoin outputs from
+	// the unconfirmed transactions in tSet as inputs and is therefore a child
+	// of tSet.
+	b := wt.wallet.StartTransaction()
+	txnFund := types.NewCurrency64(1e3)
+	err = b.FundSiacoins(txnFund)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// UnconfirmedParents should return the transactions of the transaction set
+	// we used to send money to ourselves.
+	parents, err := b.UnconfirmedParents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tSet) != len(parents) {
+		t.Fatal("parents should have same length as unconfirmed transaction set")
+	}
+	for i := 0; i < len(tSet); i++ {
+		if tSet[i].ID() != parents[i].ID() {
+			t.Error("returned parent doesn't match transaction of transaction set")
+		}
+	}
+}

--- a/node/api/client/daemon.go
+++ b/node/api/client/daemon.go
@@ -13,3 +13,15 @@ func (c *Client) DaemonStopGet() (err error) {
 	err = c.get("/daemon/stop", nil)
 	return
 }
+
+// DaemonUpdateGet checks for an available daemon update.
+func (c *Client) DaemonUpdateGet() (dig api.DaemonUpdateGet, err error) {
+	err = c.get("/daemon/update", nil)
+	return
+}
+
+// DaemonUpdatePost updates the daemon.
+func (c *Client) DaemonUpdatePost() (err error) {
+	err = c.post("/daemon/update", "", nil)
+	return
+}

--- a/node/api/client/gateway.go
+++ b/node/api/client/gateway.go
@@ -23,6 +23,13 @@ func (c *Client) GatewayConnectPost(address modules.NetAddress) (err error) {
 	return
 }
 
+// GatewayDisconnectPost uses the /gateway/disconnect/:address endpoint to
+// disconnect the gateway from a peer.
+func (c *Client) GatewayDisconnectPost(address modules.NetAddress) (err error) {
+	err = c.post("/gateway/disconnect/"+string(address), "", nil)
+	return
+}
+
 // GatewayGet requests the /gateway api resource
 func (c *Client) GatewayGet() (gwg api.GatewayGET, err error) {
 	err = c.get("/gateway", &gwg)

--- a/node/api/client/host.go
+++ b/node/api/client/host.go
@@ -63,6 +63,8 @@ func (c *Client) HostAnnounceAddrPost(address modules.NetAddress) (err error) {
 	return
 }
 
+// HostContractInfoGet uses the /host/contracts endpoint to get information
+// about contracts on the host.
 func (c *Client) HostContractInfoGet() (cg api.ContractInfoGET, err error) {
 	err = c.get("/host/contracts", &cg)
 	return

--- a/node/api/client/host.go
+++ b/node/api/client/host.go
@@ -63,6 +63,11 @@ func (c *Client) HostAnnounceAddrPost(address modules.NetAddress) (err error) {
 	return
 }
 
+func (c *Client) HostContractInfoGet() (cg api.ContractInfoGET, err error) {
+	err = c.get("/host/contracts", &cg)
+	return
+}
+
 // HostEstimateScoreGet requests the /host/estimatescore endpoint.
 func (c *Client) HostEstimateScoreGet(param, value string) (eg api.HostEstimateScoreGET, err error) {
 	err = c.get(fmt.Sprintf("/host/estimatescore?%v=%v", param, value), &eg)

--- a/node/api/client/host.go
+++ b/node/api/client/host.go
@@ -1,10 +1,52 @@
 package client
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/node/api"
+)
+
+// HostParam is a parameter in the host's settings that can be changed via the
+// API. It is primarily used as a helper struct to ensure type safety.
+type HostParam string
+
+const (
+	// HostParamCollateralBudget is the collateral budget of the host in
+	// hastings.
+	HostParamCollateralBudget = HostParam("collateralbudget")
+	// HostParamMaxCollateral is the max collateral of the host in hastings.
+	HostParamMaxCollateral = HostParam("maxcollateral")
+	// HostParamMinContractPrice is the min contract price in hastings.
+	HostParamMinContractPrice = HostParam("mincontractprice")
+	// HostParamMinDownloadBandwidthPrice is the min download bandwidth price
+	// in hastings/byte.
+	HostParamMinDownloadBandwidthPrice = HostParam("mindownloadbandwidthprice")
+	// HostParamMinUploadBandwidthPrice is the min upload bandwidth price in
+	// hastings/byte.
+	HostParamMinUploadBandwidthPrice = HostParam("minuploadbandwidthprice")
+	// HostParamCollateral is the host's collateral in hastings/byte/block.
+	HostParamCollateral = HostParam("collateral")
+	// HostParamMinStoragePrice is the minimum storage price in
+	// hastings/byte/block.
+	HostParamMinStoragePrice = HostParam("minstorageprice")
+	// HostParamAcceptingContracts indicates if the host is accepting new
+	// contracts.
+	HostParamAcceptingContracts = HostParam("acceptingcontracts")
+	// HostParamMaxDuration is the max duration of a contract in blocks.
+	HostParamMaxDuration = HostParam("maxduration")
+	// HostParamWindowSize is the size of the proof window in blocks.
+	HostParamWindowSize = HostParam("windowsize")
+	// HostParamMaxDownloadBatchSize is the maximum size of the download batch
+	// size in bytes.
+	HostParamMaxDownloadBatchSize = HostParam("maxdownloadbatchsize")
+	// HostParamMaxReviseBatchSize is the maximum size of the revise batch size.
+	HostParamMaxReviseBatchSize = HostParam("maxrevisebatchsize")
+	// HostParamNetAddress is the announced netaddress of the host.
+	HostParamNetAddress = HostParam("netaddress")
 )
 
 // HostAnnouncePost uses the /host/announce endpoint to announce the host to
@@ -14,11 +56,29 @@ func (c *Client) HostAnnouncePost() (err error) {
 	return
 }
 
-// HostAcceptingContractsPost uses the /host endpoint to change the acceptingcontracts field of the host's settings
-func (c *Client) HostAcceptingContractsPost(acceptingContracts bool) (err error) {
-	values := url.Values{}
-	values.Set("acceptingcontracts", strconv.FormatBool(acceptingContracts))
-	err = c.post("/host", values.Encode(), nil)
+// HostAnnounceAddrPost uses the /host/anounce endpoint to announce the host to
+// the network using the provided address.
+func (c *Client) HostAnnounceAddrPost(address modules.NetAddress) (err error) {
+	err = c.post("/host/announce", "netaddress="+string(address), nil)
+	return
+}
+
+// HostEstimateScoreGet requests the /host/estimatescore endpoint.
+func (c *Client) HostEstimateScoreGet(param, value string) (eg api.HostEstimateScoreGET, err error) {
+	err = c.get(fmt.Sprintf("/host/estimatescore?%v=%v", param, value), &eg)
+	return
+}
+
+// HostGet requests the /host endpoint.
+func (c *Client) HostGet() (hg api.HostGET, err error) {
+	err = c.get("/host", &hg)
+	return
+}
+
+// HostModifySettingPost uses the /host endpoint to change a param of the host
+// settings to a certain value.
+func (c *Client) HostModifySettingPost(param HostParam, value interface{}) (err error) {
+	err = c.post("/host", string(param)+"="+fmt.Sprint(value), nil)
 	return
 }
 
@@ -32,8 +92,34 @@ func (c *Client) HostStorageFoldersAddPost(path string, size uint64) (err error)
 	return
 }
 
-// HostGet requests the /host endpoint.
-func (c *Client) HostGet() (hg api.HostGET, err error) {
-	err = c.get("/host", &hg)
+// HostStorageFoldersRemovePost uses the /host/storage/folders/remove api
+// endpoint to remove a storage folder from a host.
+func (c *Client) HostStorageFoldersRemovePost(path string) (err error) {
+	values := url.Values{}
+	values.Set("path", path)
+	err = c.post("/host/storage/folders/remove", values.Encode(), nil)
+	return
+}
+
+// HostStorageFoldersResizePost uses the /host/storage/folders/resize api
+// endpoint to resize an existing storage folder.
+func (c *Client) HostStorageFoldersResizePost(path string, size uint64) (err error) {
+	values := url.Values{}
+	values.Set("path", path)
+	values.Set("newsize", strconv.FormatUint(size, 10))
+	err = c.post("/host/storage/folders/resize", values.Encode(), nil)
+	return
+}
+
+// HostStorageGet requests the /host/storage endpoint.
+func (c *Client) HostStorageGet() (sg api.StorageGET, err error) {
+	err = c.get("/host/storage", &sg)
+	return
+}
+
+// HostStorageSectorsDeletePost uses the /host/storage/sectors/delete endpoint
+// to delete a sector from the host.
+func (c *Client) HostStorageSectorsDeletePost(root crypto.Hash) (err error) {
+	err = c.post("/host/storage/sectors/delete/"+root.String(), "", nil)
 	return
 }

--- a/node/api/client/hostdb.go
+++ b/node/api/client/hostdb.go
@@ -1,9 +1,24 @@
 package client
 
-import "github.com/NebulousLabs/Sia/node/api"
+import (
+	"github.com/NebulousLabs/Sia/node/api"
+	"github.com/NebulousLabs/Sia/types"
+)
 
-// HostDbActiveGet requests the /hostdb/active endpoint's resources
+// HostDbActiveGet requests the /hostdb/active endpoint's resources.
 func (c *Client) HostDbActiveGet() (hdag api.HostdbActiveGET, err error) {
 	err = c.get("/hostdb/active", &hdag)
+	return
+}
+
+// HostDbAllGet requests the /hostdb/all endpoint's resources.
+func (c *Client) HostDbAllGet() (hdag api.HostdbAllGET, err error) {
+	err = c.get("/hostdb/all", &hdag)
+	return
+}
+
+// HostDbHostsGet request the /hostdb/hosts/:pubkey endpoint's resources.
+func (c *Client) HostDbHostsGet(pk types.SiaPublicKey) (hhg api.HostdbHostsGET, err error) {
+	err = c.get("/hostdb/hosts/"+pk.String(), &hhg)
 	return
 }

--- a/node/api/client/miner.go
+++ b/node/api/client/miner.go
@@ -2,8 +2,15 @@ package client
 
 import (
 	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/node/api"
 	"github.com/NebulousLabs/Sia/types"
 )
+
+// MinerGet requests the /miner endpoint's resources.
+func (c *Client) MinerGet() (mg api.MinerGET, err error) {
+	err = c.get("/miner", &mg)
+	return
+}
 
 // MinerHeaderGet uses the /miner/header endpoint to get a header for work.
 func (c *Client) MinerHeaderGet() (target types.Target, bh types.BlockHeader, err error) {

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -30,6 +30,15 @@ func (c *Client) RenterDownloadGet(siaPath, destination string, offset, length u
 	return
 }
 
+// RenterDownloadFullGet uses the /renter/download endpoint to download a full
+// file.
+func (c *Client) RenterDownloadFullGet(siaPath, destination string, async bool) (err error) {
+	query := fmt.Sprintf("%s?destination=%s&httpresp=false&async=%v",
+		siaPath, destination, async)
+	err = c.get("/renter/download/"+query, nil)
+	return
+}
+
 // RenterDownloadsGet requests the /renter/downloads resource
 func (c *Client) RenterDownloadsGet() (rdq api.RenterDownloadQueue, err error) {
 	err = c.get("/renter/downloads", &rdq)
@@ -44,9 +53,15 @@ func (c *Client) RenterDownloadHTTPResponseGet(siaPath string, offset, length ui
 	return
 }
 
-// RenterFilesGet requests the /renter/files resource
+// RenterFilesGet requests the /renter/files resource.
 func (c *Client) RenterFilesGet() (rf api.RenterFiles, err error) {
 	err = c.get("/renter/files", &rf)
+	return
+}
+
+// RenterGet requests the /renter resource.
+func (c *Client) RenterGet() (rg api.RenterGET, err error) {
+	err = c.get("/renter", &rg)
 	return
 }
 
@@ -61,6 +76,18 @@ func (c *Client) RenterPostAllowance(allowance modules.Allowance) (err error) {
 	return
 }
 
+// RenterCancelAllowance uses the /renter endpoint to cancel the allowance.
+func (c *Client) RenterCancelAllowance() (err error) {
+	err = c.RenterPostAllowance(modules.Allowance{})
+	return
+}
+
+// RenterPricesGet requests the /renter/prices endpoint's resources.
+func (c *Client) RenterPricesGet() (rpg api.RenterPricesGET, err error) {
+	err = c.get("/renter/prices", &rpg)
+	return
+}
+
 // RenterPostRateLimit uses the /renter endpoint to change the renter's bandwidth rate
 // limit.
 func (c *Client) RenterPostRateLimit(readBPS, writeBPS int64) (err error) {
@@ -68,6 +95,12 @@ func (c *Client) RenterPostRateLimit(readBPS, writeBPS int64) (err error) {
 	values.Set("maxdownloadspeed", strconv.FormatInt(readBPS, 10))
 	values.Set("maxuploadspeed", strconv.FormatInt(writeBPS, 10))
 	err = c.post("/renter", values.Encode(), nil)
+	return
+}
+
+// RenterRenamePost uses the /renter/rename/:siapath endpoint to rename a file.
+func (c *Client) RenterRenamePost(siaPathOld, siaPathNew string) (err error) {
+	err = c.post("/renter/rename/"+siaPathOld, "newsiapath="+siaPathNew, nil)
 	return
 }
 
@@ -85,12 +118,21 @@ func (c *Client) RenterStreamPartialGet(siaPath string, start, end uint64) (resp
 	return
 }
 
-// RenterUploadPost uses the /renter/upload endpoin to upload a file
+// RenterUploadPost uses the /renter/upload endpoint to upload a file
 func (c *Client) RenterUploadPost(path, siaPath string, dataPieces, parityPieces uint64) (err error) {
 	values := url.Values{}
 	values.Set("source", path)
 	values.Set("datapieces", strconv.FormatUint(dataPieces, 10))
 	values.Set("paritypieces", strconv.FormatUint(parityPieces, 10))
+	err = c.post(fmt.Sprintf("/renter/upload%v", siaPath), values.Encode(), nil)
+	return
+}
+
+// RenterUploadDefaultPost uses the /renter/upload endpoint with default
+// redundancy settings to upload a file.
+func (c *Client) RenterUploadDefaultPost(path, siaPath string) (err error) {
+	values := url.Values{}
+	values.Set("source", path)
 	err = c.post(fmt.Sprintf("/renter/upload%v", siaPath), values.Encode(), nil)
 	return
 }

--- a/node/api/client/transactionpool.go
+++ b/node/api/client/transactionpool.go
@@ -1,0 +1,9 @@
+package client
+
+import "github.com/NebulousLabs/Sia/node/api"
+
+// TransactionPoolFeeGet uses the /tpool/fee endpoint to get a fee estimation.
+func (c *Client) TransactionPoolFeeGet() (tfg api.TpoolFeeGET, err error) {
+	err = c.get("/tpool/fee", &tfg)
+	return
+}

--- a/node/api/client/wallet.go
+++ b/node/api/client/wallet.go
@@ -16,6 +16,23 @@ func (c *Client) WalletAddressGet() (wag api.WalletAddressGET, err error) {
 	return
 }
 
+// WalletAddressesGet requests the wallets known addresses from the
+// /wallet/addresses endpoint.
+func (c *Client) WalletAddressesGet() (wag api.WalletAddressesGET, err error) {
+	err = c.get("/wallet/addresses", &wag)
+	return
+}
+
+// WalletChangePasswordPost uses the /wallet/changepassword endpoint to change
+// the wallet's password.
+func (c *Client) WalletChangePasswordPost(currentPassword, newPassword string) (err error) {
+	values := url.Values{}
+	values.Set("newpassword", newPassword)
+	values.Set("encryptionpassword", currentPassword)
+	err = c.post("/wallet/changepassword", values.Encode(), nil)
+	return
+}
+
 // WalletInitPost uses the /wallet/init endpoint to initialize and encrypt a
 // wallet
 func (c *Client) WalletInitPost(password string, force bool) (wip api.WalletInitPOST, err error) {
@@ -26,9 +43,43 @@ func (c *Client) WalletInitPost(password string, force bool) (wip api.WalletInit
 	return
 }
 
+// WalletInitSeedPost uses the /wallet/init/seed endpoint to initialize and
+// encrypt a wallet using a given seed.
+func (c *Client) WalletInitSeedPost(seed, password string, force bool) (err error) {
+	values := url.Values{}
+	values.Set("seed", seed)
+	values.Set("encryptionpassword", password)
+	values.Set("force", strconv.FormatBool(force))
+	err = c.post("/wallet/init/seed", values.Encode(), nil)
+	return
+}
+
 // WalletGet requests the /wallet api resource
 func (c *Client) WalletGet() (wg api.WalletGET, err error) {
 	err = c.get("/wallet", &wg)
+	return
+}
+
+// WalletLockPost uses the /wallet/lock endpoint to lock the wallet.
+func (c *Client) WalletLockPost() (err error) {
+	err = c.post("/wallet/lock", "", nil)
+	return
+}
+
+// WalletSeedPost uses the /wallet/seed endpoint to add a seed to the wallet's list
+// of seeds.
+func (c *Client) WalletSeedPost(seed, password string) (err error) {
+	values := url.Values{}
+	values.Set("seed", seed)
+	values.Set("encryptionpassword", password)
+	err = c.post("/wallet/seed", values.Encode(), nil)
+	return
+}
+
+// WalletSeedsGet uses the /wallet/seeds endpoint to return the wallet's
+// current seeds.
+func (c *Client) WalletSeedsGet() (wsg api.WalletSeedsGET, err error) {
+	err = c.get("/wallet/seeds", &wsg)
 	return
 }
 
@@ -55,6 +106,35 @@ func (c *Client) WalletSiacoinsPost(amount types.Currency, destination types.Unl
 	return
 }
 
+// WalletSiafundsPost uses the /wallet/siafunds api endpoint to send siafunds
+// to a single address.
+func (c *Client) WalletSiafundsPost(amount types.Currency, destination types.UnlockHash) (wsp api.WalletSiafundsPOST, err error) {
+	values := url.Values{}
+	values.Set("amount", amount.String())
+	values.Set("destination", destination.String())
+	err = c.post("/wallet/siafunds", values.Encode(), &wsp)
+	return
+}
+
+// WalletSiagKeyPost uses the /wallet/siagkey endpoint to load a siag key into
+// the wallet.
+func (c *Client) WalletSiagKeyPost(keyfiles, password string) (err error) {
+	values := url.Values{}
+	values.Set("keyfiles", keyfiles)
+	values.Set("encryptionpassword", password)
+	err = c.post("/wallet/siagkey", values.Encode(), nil)
+	return
+}
+
+// WalletSweepPost uses the /wallet/sweep/seed endpoint to sweep a seed into
+// the current wallet.
+func (c *Client) WalletSweepPost(seed string) (wsp api.WalletSweepPOST, err error) {
+	values := url.Values{}
+	values.Set("seed", seed)
+	err = c.post("/wallet/sweep/seed", values.Encode(), &wsp)
+	return
+}
+
 // WalletTransactionsGet requests the/wallet/transactions api resource for a
 // certain startheight and endheight
 func (c *Client) WalletTransactionsGet(startHeight types.BlockHeight, endHeight types.BlockHeight) (wtg api.WalletTransactionsGET, err error) {
@@ -69,5 +149,15 @@ func (c *Client) WalletUnlockPost(password string) (err error) {
 	values := url.Values{}
 	values.Set("encryptionpassword", password)
 	err = c.post("/wallet/unlock", values.Encode(), nil)
+	return
+}
+
+// Wallet033xPost uses the /wallet/033x endpoint to load a v0.3.3.x wallet into
+// the current wallet.
+func (c *Client) Wallet033xPost(path, password string) (err error) {
+	values := url.Values{}
+	values.Set("source", path)
+	values.Set("encryptionpassword", password)
+	err = c.post("/wallet/033x", values.Encode(), nil)
 	return
 }

--- a/node/api/daemon.go
+++ b/node/api/daemon.go
@@ -6,3 +6,10 @@ type DaemonVersionGet struct {
 	GitRevision string
 	BuildTime   string
 }
+
+// DaemonUpdateGet contains information about a potential available update for
+// the daemon.
+type DaemonUpdateGet struct {
+	Available bool   `json:"available"`
+	Version   string `json:"version"`
+}

--- a/node/api/wallet.go
+++ b/node/api/wallet.go
@@ -504,12 +504,12 @@ func (api *API) walletTransactionsHandler(w http.ResponseWriter, req *http.Reque
 		return
 	}
 	// Get the start and end blocks.
-	start, err := strconv.Atoi(startheightStr)
+	start, err := strconv.ParseUint(startheightStr, 10, 64)
 	if err != nil {
 		WriteError(w, Error{"parsing integer value for parameter `startheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
-	end, err := strconv.Atoi(endheightStr)
+	end, err := strconv.ParseUint(endheightStr, 10, 64)
 	if err != nil {
 		WriteError(w, Error{"parsing integer value for parameter `endheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return

--- a/siatest/renter.go
+++ b/siatest/renter.go
@@ -119,7 +119,7 @@ func (tn *TestNode) DownloadInfo(lf *LocalFile, rf *RemoteFile) (*api.DownloadIn
 	if di.Length != di.Filesize {
 		err = errors.AddContext(err, "filesize != length")
 	}
-	// Received data can't be larger than transfered data
+	// Received data can't be larger than transferred data
 	if di.Received > di.TotalDataTransferred {
 		err = errors.AddContext(err, "received > TotalDataTransfered")
 	}

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -177,7 +177,7 @@ func testRenterLocalRepair(t *testing.T, tg *siatest.TestGroup) {
 		t.Fatal(err)
 	}
 	// Get the file info of the fully uploaded file. Tha way we can compare the
-	// redundancieslater.
+	// redundancies later.
 	fi, err := renter.FileInfo(remoteFile)
 	if err != nil {
 		t.Fatal("failed to get file info", err)

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -170,7 +170,7 @@ func addStorageFolderToHosts(hosts map[*TestNode]struct{}) error {
 // announceHosts adds storage to each host and announces them to the group
 func announceHosts(hosts map[*TestNode]struct{}) error {
 	for host := range hosts {
-		if err := host.HostAcceptingContractsPost(true); err != nil {
+		if err := host.HostModifySettingPost(client.HostParamAcceptingContracts, true); err != nil {
 			return errors.AddContext(err, "failed to set host to accepting contracts")
 		}
 		if err := host.HostAnnouncePost(); err != nil {

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -1,6 +1,7 @@
 package siatest
 
 import (
+	"fmt"
 	"math"
 	"strconv"
 	"sync"
@@ -89,7 +90,7 @@ func NewGroup(nodeParams ...node.NodeParams) (*TestGroup, error) {
 		return nil, errors.New("cannot fund group without miners")
 	}
 	miner := tg.Miners()[0]
-	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
+	for i := types.BlockHeight(0); i <= types.MaturityDelay+types.TaxHardforkHeight; i++ {
 		if err := miner.MineBlock(); err != nil {
 			return nil, errors.AddContext(err, "failed to mine block for funding")
 		}
@@ -185,15 +186,23 @@ func fullyConnectNodes(nodes []*TestNode) error {
 	// Fully connect the nodes
 	for i, nodeA := range nodes {
 		for _, nodeB := range nodes[i+1:] {
-			isPeer, err := nodeA.hasPeer(nodeB)
+			err := build.Retry(100, 100*time.Millisecond, func() error {
+				if err := nodeA.GatewayConnectPost(nodeB.GatewayAddress()); err != nil && err != client.ErrPeerExists {
+					return errors.AddContext(err, "failed to connect to peer")
+				}
+				isPeer1, err1 := nodeA.hasPeer(nodeB)
+				isPeer2, err2 := nodeB.hasPeer(nodeA)
+				if err1 != nil || err2 != nil {
+					return build.ExtendErr("couldn't determine if nodeA and nodeB are connected",
+						errors.Compose(err1, err2))
+				}
+				if isPeer1 && isPeer2 {
+					return nil
+				}
+				return errors.New("nodeA and nodeB are not peers of each other")
+			})
 			if err != nil {
-				return build.ExtendErr("couldn't determine if nodeB is a peer of nodeA", err)
-			}
-			if isPeer {
-				continue
-			}
-			if err := nodeA.GatewayConnectPost(nodeB.GatewayAddress()); err != nil && err != client.ErrPeerExists {
-				return errors.AddContext(err, "failed to connect to peer")
+				return err
 			}
 		}
 	}
@@ -315,16 +324,33 @@ func synchronizationCheck(miner *TestNode, nodes map[*TestNode]struct{}) error {
 	if err != nil {
 		return err
 	}
+	// Loop until all the blocks have the same CurrentBlock. If we need to mine
+	// a new block in between we need to repeat the check until no block was
+	// mined.
 	for node := range nodes {
 		err := Retry(600, 100*time.Millisecond, func() error {
 			ncg, err := node.ConsensusGet()
 			if err != nil {
 				return err
 			}
-			if mcg.CurrentBlock != ncg.CurrentBlock {
-				return errors.New("the node's current block doesn't equal the miner's")
+			// If the CurrentBlock's match we are done.
+			if mcg.CurrentBlock == ncg.CurrentBlock {
+				return nil
 			}
-			return nil
+			// If the miner's height is greater than the node's we need to
+			// wait a bit longer for them to sync.
+			if mcg.Height > ncg.Height {
+				return fmt.Errorf("the node didn't catch up to the miner's height %v %v",
+					mcg.Height, ncg.Height)
+			}
+			// If the miner's height is smaller than the node's we need a
+			// bit longer for them to sync.
+			if mcg.Height < ncg.Height {
+				return errors.New("the miner didn't catch up to the node's height")
+			}
+			// If the miner's height is equal to the node's but still
+			// doesn't match, it needs to mine a block.
+			return errors.New("the node's current block's id does not equal the miner's")
 		})
 		if err != nil {
 			return err

--- a/siatest/testnode.go
+++ b/siatest/testnode.go
@@ -29,7 +29,7 @@ func NewNode(nodeParams node.NodeParams) (*TestNode, error) {
 		return nil, err
 	}
 	// Fund the node
-	for i := types.BlockHeight(0); i <= types.MaturityDelay; i++ {
+	for i := types.BlockHeight(0); i <= types.MaturityDelay+types.TaxHardforkHeight; i++ {
 		if err := tn.MineBlock(); err != nil {
 			return nil, err
 		}

--- a/sync/trymutex.go
+++ b/sync/trymutex.go
@@ -43,10 +43,12 @@ func (tm *TryMutex) TryLock() bool {
 func (tm *TryMutex) TryLockTimed(t time.Duration) bool {
 	tm.once.Do(tm.init)
 
+	timer := time.NewTimer(t)
 	select {
 	case <-tm.lock:
+		timer.Stop()
 		return true
-	case <-time.After(t):
+	case <-timer.C:
 		return false
 	}
 }

--- a/types/constants.go
+++ b/types/constants.go
@@ -124,6 +124,15 @@ var (
 	TargetWindow BlockHeight
 )
 
+var (
+	// TaxHardforkHeight is the height at which the tax hardfork occured.
+	TaxHardforkHeight = build.Select(build.Var{
+		Dev:      BlockHeight(10),
+		Standard: BlockHeight(21e3),
+		Testing:  BlockHeight(10),
+	}).(BlockHeight)
+)
+
 // init checks which build constant is in place and initializes the variables
 // accordingly.
 func init() {

--- a/types/filecontracts.go
+++ b/types/filecontracts.go
@@ -4,7 +4,6 @@ package types
 // contracts.
 
 import (
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
 )
 
@@ -123,7 +122,7 @@ func PostTax(height BlockHeight, payout Currency) Currency {
 func Tax(height BlockHeight, payout Currency) Currency {
 	// COMPATv0.4.0 - until the first 20,000 blocks have been archived, they
 	// will need to be handled in a special way.
-	if (height < 21e3 && build.Release == "standard") || (height < 10 && build.Release == "testing") {
+	if height < TaxHardforkHeight {
 		return payout.MulFloat(0.039).RoundDown(SiafundCount)
 	}
 	return payout.MulTax().RoundDown(SiafundCount)


### PR DESCRIPTION
This PR introduces a new `siac` command to display contract information on the host.
The command uses 2 formats to display the data:

1. `value`: shows information about the financial values of the obligation
2. `status`: shows information about the status of the obligation

A filter is used to specify what data should should be shown based on the obligation status.

Examples: 
`siac host contracts value rejected` shows financial information about all rejected obligations
`siac host contracts status all` shows status information about all obligations

Data is always sorted by expiration height.

Closes issues #2416 and #2465 