### PR TITLE
stop timer early if lock acquired

### DIFF
--- a/sync/trymutex.go
+++ b/sync/trymutex.go
@@ -43,10 +43,12 @@ func (tm *TryMutex) TryLock() bool {
 func (tm *TryMutex) TryLockTimed(t time.Duration) bool {
 	tm.once.Do(tm.init)
 
+	timer := time.NewTimer(t)
 	select {
 	case <-tm.lock:
+		timer.Stop()
 		return true
-	case <-time.After(t):
+	case <-timer.C:
 		return false
 	}
 }


### PR DESCRIPTION
Previously, `TryLockTimed` would leave the timer running until the duration elapsed.
The only use of `TryLockTimed` is in the host, where it is used with a duration of 1 minute in `managedTryLockStorageObligation`. This is unlikely to cause problems in practice, but in theory, calling `managedTryLockStorageObligation` too frequently will eventually exhaust available memory due to the accumulating timers.