### PR TITLE
Improve BucketProcessedTransactions usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ pkgs = ./build ./cmd/siac ./cmd/siad ./compatibility ./crypto ./encoding ./modul
        ./modules/gateway ./modules/host ./modules/host/contractmanager ./modules/renter ./modules/renter/contractor       \
        ./modules/renter/hostdb ./modules/renter/hostdb/hosttree ./modules/renter/proto ./modules/miner ./modules/wallet   \
        ./modules/transactionpool ./node ./node/api ./persist ./siatest ./siatest/consensus ./siatest/renter               \
-       ./node/api/server ./sync ./types
+       ./siatest/wallet ./node/api/server ./sync ./types
 
 # fmt calls go fmt on all packages.
 fmt:

--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -295,6 +295,9 @@ func decodeProcessedTransaction(ptBytes []byte, pt *modules.ProcessedTransaction
 	return err
 }
 
+func dbDeleteTransactionIndex(tx *bolt.Tx, txid types.TransactionID) error {
+	return dbDelete(tx.Bucket(bucketProcessedTxnIndex), txid)
+}
 func dbPutTransactionIndex(tx *bolt.Tx, txid types.TransactionID, key []byte) error {
 	return dbPut(tx.Bucket(bucketProcessedTxnIndex), txid, key)
 }
@@ -346,18 +349,29 @@ func dbAppendProcessedTransaction(tx *bolt.Tx, pt modules.ProcessedTransaction) 
 }
 
 func dbGetLastProcessedTransaction(tx *bolt.Tx) (pt modules.ProcessedTransaction, err error) {
-	_, val := tx.Bucket(bucketProcessedTransactions).Cursor().Last()
+	seq := tx.Bucket(bucketProcessedTransactions).Sequence()
+	keyBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(keyBytes, seq)
+	val := tx.Bucket(bucketProcessedTransactions).Get(keyBytes)
 	err = decodeProcessedTransaction(val, &pt)
 	return
 }
 
 func dbDeleteLastProcessedTransaction(tx *bolt.Tx) error {
-	// delete the last entry in the bucket. Note that we don't need to
-	// decrement the sequence integer; we only care that the next integer is
-	// larger than the previous one.
+	// Get the last processed txn.
+	pt, err := dbGetLastProcessedTransaction(tx)
+	if err != nil {
+		return errors.New("can't delete from empty bucket")
+	}
+	// Delete its txid from the index bucket.
+	if err := dbDeleteTransactionIndex(tx, pt.TransactionID); err != nil {
+		return errors.AddContext(err, "couldn't delete txn index")
+	}
+	// Delete the last processed txn and decrement the sequence.
 	b := tx.Bucket(bucketProcessedTransactions)
+	seq := b.Sequence()
 	key, _ := b.Cursor().Last()
-	return b.Delete(key)
+	return errors.Compose(b.SetSequence(seq-1), b.Delete(key))
 }
 
 func dbGetProcessedTransaction(tx *bolt.Tx, index uint64) (pt modules.ProcessedTransaction, err error) {

--- a/modules/wallet/database.go
+++ b/modules/wallet/database.go
@@ -370,8 +370,9 @@ func dbDeleteLastProcessedTransaction(tx *bolt.Tx) error {
 	// Delete the last processed txn and decrement the sequence.
 	b := tx.Bucket(bucketProcessedTransactions)
 	seq := b.Sequence()
-	key, _ := b.Cursor().Last()
-	return errors.Compose(b.SetSequence(seq-1), b.Delete(key))
+	keyBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(keyBytes, seq)
+	return errors.Compose(b.SetSequence(seq-1), b.Delete(keyBytes))
 }
 
 func dbGetProcessedTransaction(tx *bolt.Tx, index uint64) (pt modules.ProcessedTransaction, err error) {

--- a/modules/wallet/update.go
+++ b/modules/wallet/update.go
@@ -3,7 +3,6 @@ package wallet
 import (
 	"math"
 
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/errors"
@@ -170,7 +169,6 @@ func (w *Wallet) revertHistory(tx *bolt.Tx, reverted []types.Block) error {
 			txid := block.Transactions[i].ID()
 			pt, err := dbGetLastProcessedTransaction(tx)
 			if err != nil {
-				build.Critical("can't revert transaction because the bucket is empty")
 				break // bucket is empty
 			}
 			if txid == pt.TransactionID {
@@ -188,7 +186,6 @@ func (w *Wallet) revertHistory(tx *bolt.Tx, reverted []types.Block) error {
 			// most recent transaction in bucketProcessedTransactions.
 			pt, err := dbGetLastProcessedTransaction(tx)
 			if err != nil {
-				build.Critical("can't revert miner payout because the bucket is empty")
 				break // bucket is empty
 			}
 			if types.TransactionID(block.ID()) == pt.TransactionID {

--- a/node/api/client/transactionpool.go
+++ b/node/api/client/transactionpool.go
@@ -1,9 +1,25 @@
 package client
 
-import "github.com/NebulousLabs/Sia/node/api"
+import (
+	"net/url"
+
+	"github.com/NebulousLabs/Sia/encoding"
+	"github.com/NebulousLabs/Sia/node/api"
+	"github.com/NebulousLabs/Sia/types"
+)
 
 // TransactionPoolFeeGet uses the /tpool/fee endpoint to get a fee estimation.
 func (c *Client) TransactionPoolFeeGet() (tfg api.TpoolFeeGET, err error) {
 	err = c.get("/tpool/fee", &tfg)
+	return
+}
+
+// TransactionPoolRawPost uses the /tpool/raw endpoint to send a raw
+// transaction to the transaction pool.
+func (c *Client) TransactionPoolRawPost(txn types.Transaction, parents types.Transaction) (err error) {
+	values := url.Values{}
+	values.Set("transaction", string(encoding.Marshal(txn)))
+	values.Set("parents", string(encoding.Marshal(parents)))
+	err = c.post("/tpool/raw", values.Encode(), nil)
 	return
 }

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -340,8 +340,10 @@ func synchronizationCheck(miner *TestNode, nodes map[*TestNode]struct{}) error {
 			// If the miner's height is greater than the node's we need to
 			// wait a bit longer for them to sync.
 			if mcg.Height > ncg.Height {
-				return fmt.Errorf("the node didn't catch up to the miner's height %v %v",
-					mcg.Height, ncg.Height)
+				gwgMiner, errMiner := miner.GatewayGet()
+				gwgNode, errNode := node.GatewayGet()
+				return errors.Compose(fmt.Errorf("the node didn't catch up to the miner's height %v %v but have %v and %v peers respectively",
+					mcg.Height, ncg.Height, len(gwgNode.Peers), len(gwgMiner.Peers)), errMiner, errNode)
 			}
 			// If the miner's height is smaller than the node's we need a
 			// bit longer for them to sync.

--- a/siatest/wallet/wallet.go
+++ b/siatest/wallet/wallet.go
@@ -1,0 +1,1 @@
+package wallet

--- a/siatest/wallet/wallet_test.go
+++ b/siatest/wallet/wallet_test.go
@@ -1,0 +1,118 @@
+package wallet
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/siatest"
+	"github.com/NebulousLabs/Sia/types"
+)
+
+func TestTransactionReorg(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Create 2 miners
+	testdir, err := siatest.TestDir(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create two miners
+	miner1, err := siatest.NewNode(siatest.Miner(filepath.Join(testdir, "miner1")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := miner1.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	// miner1 sends a txn to itself and mines it.
+	uc, err := miner1.WalletAddressGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wsp, err := miner1.WalletSiacoinsPost(types.SiacoinPrecision, uc.Address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	println("\nTransactions sent")
+	for _, tid := range wsp.TransactionIDs {
+		println("    ", tid.String())
+	}
+	println("")
+	blocks := 1
+	for i := 0; i < blocks; i++ {
+		if err := miner1.MineBlock(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// wait until the transaction from before shows up as processed.
+	txn := wsp.TransactionIDs[len(wsp.TransactionIDs)-1]
+	err = build.Retry(100, 100*time.Millisecond, func() error {
+		cg, err := miner1.ConsensusGet()
+		if err != nil {
+			return err
+		}
+		wtg, err := miner1.WalletTransactionsGet(1, cg.Height)
+		if err != nil {
+			return err
+		}
+		for _, t := range wtg.ConfirmedTransactions {
+			if t.TransactionID == txn {
+				return nil
+			}
+		}
+		return errors.New("txn isn't processed yet")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	println("\ncreate node 2")
+	miner2, err := siatest.NewNode(siatest.Miner(filepath.Join(testdir, "miner2")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := miner2.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// miner2 mines 2 blocks now to create a longer chain than miner1.
+	for i := 0; i < blocks+1; i++ {
+		if err := miner2.MineBlock(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// miner1 and miner2 connect. This should cause a reorg that reverts the
+	// transaction from before.
+	println("\nconnecting")
+	if err := miner1.GatewayConnectPost(miner2.GatewayAddress()); err != nil {
+		t.Fatal(err)
+	}
+	err = build.Retry(100, 100*time.Millisecond, func() error {
+		cg, err := miner1.ConsensusGet()
+		if err != nil {
+			return err
+		}
+		wtg, err := miner1.WalletTransactionsGet(1, cg.Height)
+		if err != nil {
+			return err
+		}
+		for _, t := range wtg.ConfirmedTransactions {
+			if t.TransactionID == txn {
+				return errors.New("txn is still processed")
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/siatest/wallet/wallet_test.go
+++ b/siatest/wallet/wallet_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// TestTransactionReorg makes sure that a processedTransaction isn't returned
+// by the API after bein reverted.
 func TestTransactionReorg(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
 
-	// Create 2 miners
 	testdir, err := siatest.TestDir(t.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -41,11 +42,6 @@ func TestTransactionReorg(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	println("\nTransactions sent")
-	for _, tid := range wsp.TransactionIDs {
-		println("    ", tid.String())
-	}
-	println("")
 	blocks := 1
 	for i := 0; i < blocks; i++ {
 		if err := miner1.MineBlock(); err != nil {
@@ -73,7 +69,6 @@ func TestTransactionReorg(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	println("\ncreate node 2")
 	miner2, err := siatest.NewNode(siatest.Miner(filepath.Join(testdir, "miner2")))
 	if err != nil {
 		t.Fatal(err)
@@ -92,7 +87,6 @@ func TestTransactionReorg(t *testing.T) {
 	}
 	// miner1 and miner2 connect. This should cause a reorg that reverts the
 	// transaction from before.
-	println("\nconnecting")
 	if err := miner1.GatewayConnectPost(miner2.GatewayAddress()); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR fixes 3 potential issues in the wallet related to the processed transactions bucket.

1.) After deleting from the bucket we decrement the sequence number. This avoids gaps being created during a reorg which might lead to the binary search breaking.

2.) Whenever we remove a txn from `BucketProcessedTransactions` we also remove it from `BucketProcessedTxnIndex`. This way we can'tt run into issues with txnIDs pointing to nonexistent indices or even indices of the wrong transaction.

3.) Due to the changes in 1) we can now use the sequence number instead of `cursor.Last()` to find the last processed transaction. Apparently `cursor.Last()` is unrealiable when used before calling `txn.Commit()` on a bbolt transaction and might return `nil` instead of the last entry or even a wrong entry. This causes either no entry to be deleted or the wrong one during a reorg without anyone noticing.