### PR TITLE
Implement fmt.Scanner for UnlockHash

### DIFF
--- a/types/encoding.go
+++ b/types/encoding.go
@@ -1158,3 +1158,14 @@ func (uh *UnlockHash) LoadString(strUH string) error {
 	copy(uh[:], byteUnlockHash[:])
 	return nil
 }
+
+// Scan implements the fmt.Scanner interface, allowing UnlockHash values to be
+// scanned from text.
+func (uh *UnlockHash) Scan(s fmt.ScanState, ch rune) error {
+	s.SkipSpace()
+	tok, err := s.Token(false, nil)
+	if err != nil {
+		return err
+	}
+	return uh.LoadString(string(tok))
+}

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -723,13 +723,11 @@ func TestTransactionMarshalSiaSize(t *testing.T) {
 // works as expected.
 func TestUnlockHashScan(t *testing.T) {
 	// Create a random unlock hash.
-	uh := UnlockHash{}
-	copy(uh[:], fastrand.Bytes(crypto.HashSize))
-	// Convert it to a string.
-	uhStr := uh.String()
-	// Scan the hash from the string.
-	scannedHash := UnlockHash{}
-	fmt.Sscan(uhStr, &scannedHash)
+	var uh UnlockHash
+	fastrand.Read(uh[:])
+	// Convert it to a string and parse the string using Sscan.
+	var scannedHash UnlockHash
+	fmt.Sscan(uh.String(), &scannedHash)
 	// Check if they are equal.
 	if !bytes.Equal(uh[:], scannedHash[:]) {
 		t.Fatal("scanned hash is not equal to original hash")

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -718,3 +718,20 @@ func TestTransactionMarshalSiaSize(t *testing.T) {
 		t.Errorf("sizes do not match: expected %v, got %v", len(encoding.Marshal(txn)), txn.MarshalSiaSize())
 	}
 }
+
+// TestUnlockHashScan checks if the fmt.Scanner implementation of UnlockHash
+// works as expected.
+func TestUnlockHashScan(t *testing.T) {
+	// Create a random unlock hash.
+	uh := UnlockHash{}
+	copy(uh[:], fastrand.Bytes(crypto.HashSize))
+	// Convert it to a string.
+	uhStr := uh.String()
+	// Scan the hash from the string.
+	scannedHash := UnlockHash{}
+	fmt.Sscan(uhStr, &scannedHash)
+	// Check if they are equal.
+	if !bytes.Equal(uh[:], scannedHash[:]) {
+		t.Fatal("scanned hash is not equal to original hash")
+	}
+}


### PR DESCRIPTION
This PR implements the `fmt.Scanner` interface for the `UnlockHash` struct.