### PR TITLE
Fix archived contracts being revived on Windows after restart

### DIFF
--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -265,6 +265,10 @@ func (c *Contractor) threadedContractMaintenance() {
 		return
 	}
 	defer c.tg.Done()
+
+	// Archive contracts that need to be archived before doing additional maintenance.
+	c.managedArchiveContracts()
+
 	// Nothing to do if there are no hosts.
 	c.mu.RLock()
 	wantedHosts := c.allowance.Hosts

--- a/modules/renter/contractor/persist.go
+++ b/modules/renter/contractor/persist.go
@@ -9,6 +9,8 @@ import (
 	"github.com/NebulousLabs/Sia/modules/renter/proto"
 	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
+
+	"github.com/NebulousLabs/errors"
 )
 
 // contractorPersist defines what Contractor data persists across sessions.
@@ -141,6 +143,5 @@ func convertPersist(dir string) error {
 	}
 
 	// delete the journal file
-	os.RemoveAll(journalPath)
-	return nil
+	return errors.AddContext(os.Remove(journalPath), "failed to remove journal file")
 }

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -7,17 +7,7 @@ import (
 
 // managedArchiveContracts will figure out which contracts are no longer needed
 // and move them to the historic set of contracts.
-//
-// TODO: This function should be performed by threadedContractMaintenance.
-// threadedContractMaintenance will currently quit if there are no hosts, but it
-// should at least run this code before quitting.
 func (c *Contractor) managedArchiveContracts() {
-	err := c.tg.Add()
-	if err != nil {
-		return
-	}
-	defer c.tg.Done()
-
 	// Determine the current block height.
 	c.mu.RLock()
 	currentHeight := c.blockHeight
@@ -90,6 +80,5 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	// maintenance.
 	if cc.Synced {
 		go c.threadedContractMaintenance()
-		go c.managedArchiveContracts()
 	}
 }

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -1,7 +1,6 @@
 package proto
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/ratelimit"
 
+	"github.com/NebulousLabs/errors"
 	"github.com/NebulousLabs/writeaheadlog"
 )
 
@@ -64,7 +64,8 @@ func (cs *ContractSet) Delete(c *SafeContract) {
 	cs.mu.Unlock()
 	safeContract.mu.Unlock()
 	// delete contract file
-	err := os.Remove(filepath.Join(cs.dir, c.header.ID().String()+contractExtension))
+	path := filepath.Join(cs.dir, c.header.ID().String()+contractExtension)
+	err := errors.Compose(safeContract.headerFile.Close(), os.Remove(path))
 	if err != nil {
 		build.Critical("Failed to delete SafeContract from disk:", err)
 	}

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -64,7 +64,10 @@ func (cs *ContractSet) Delete(c *SafeContract) {
 	cs.mu.Unlock()
 	safeContract.mu.Unlock()
 	// delete contract file
-	os.Remove(filepath.Join(cs.dir, c.header.ID().String()+contractExtension))
+	err := os.Remove(filepath.Join(cs.dir, c.header.ID().String()+contractExtension))
+	if err != nil {
+		build.Critical("Failed to delete SafeContract from disk:", err)
+	}
 }
 
 // IDs returns the FileContractID of each contract in the set. The contracts

--- a/modules/renter/proto/contractset_test.go
+++ b/modules/renter/proto/contractset_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/NebulousLabs/fastrand"
@@ -24,7 +27,12 @@ func (cs *ContractSet) mustAcquire(t *testing.T, id types.FileContractID) *SafeC
 // TestContractSet tests that the ContractSet type is safe for concurrent use.
 func TestContractSet(t *testing.T) {
 	// create contract set
-	c1 := &SafeContract{header: contractHeader{Transaction: types.Transaction{
+	testDir := build.TempDir(t.Name())
+	cs, err := NewContractSet(testDir, modules.ProdDependencies)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header1 := contractHeader{Transaction: types.Transaction{
 		FileContractRevisions: []types.FileContractRevision{{
 			ParentID:             types.FileContractID{1},
 			NewValidProofOutputs: []types.SiacoinOutput{{}, {}},
@@ -32,9 +40,8 @@ func TestContractSet(t *testing.T) {
 				PublicKeys: []types.SiaPublicKey{{}, {}},
 			},
 		}},
-	}}}
-	id1 := c1.header.ID()
-	c2 := &SafeContract{header: contractHeader{Transaction: types.Transaction{
+	}}
+	header2 := contractHeader{Transaction: types.Transaction{
 		FileContractRevisions: []types.FileContractRevision{{
 			ParentID:             types.FileContractID{2},
 			NewValidProofOutputs: []types.SiacoinOutput{{}, {}},
@@ -42,17 +49,21 @@ func TestContractSet(t *testing.T) {
 				PublicKeys: []types.SiaPublicKey{{}, {}},
 			},
 		}},
-	}}}
-	id2 := c2.header.ID()
-	cs := &ContractSet{
-		contracts: map[types.FileContractID]*SafeContract{
-			id1: c1,
-			id2: c2,
-		},
+	}}
+	id1 := header1.ID()
+	id2 := header2.ID()
+
+	_, err = cs.managedInsertContract(header1, []crypto.Hash{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cs.managedInsertContract(header2, []crypto.Hash{})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// uncontested acquire/release
-	c1 = cs.mustAcquire(t, id1)
+	c1 := cs.mustAcquire(t, id1)
 	cs.Return(c1)
 
 	// 100 concurrent serialized mutations
@@ -84,11 +95,13 @@ func TestContractSet(t *testing.T) {
 	cs.Return(c1)
 
 	// delete and reinsert id2
-	c2 = cs.mustAcquire(t, id2)
+	c2 := cs.mustAcquire(t, id2)
 	cs.Delete(c2)
-	cs.mu.Lock()
-	cs.contracts[id2] = c2
-	cs.mu.Unlock()
+	roots, err := c2.merkleRoots.merkleRoots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs.managedInsertContract(c2.header, roots)
 
 	// call all the methods in parallel haphazardly
 	funcs := []func(){
@@ -99,7 +112,7 @@ func TestContractSet(t *testing.T) {
 		func() { cs.Return(cs.mustAcquire(t, id1)) },
 		func() { cs.Return(cs.mustAcquire(t, id2)) },
 		func() {
-			c3 := &SafeContract{header: contractHeader{
+			header3 := contractHeader{
 				Transaction: types.Transaction{
 					FileContractRevisions: []types.FileContractRevision{{
 						ParentID:             types.FileContractID{3},
@@ -109,12 +122,13 @@ func TestContractSet(t *testing.T) {
 						},
 					}},
 				},
-			}}
-			id3 := c3.header.ID()
-			cs.mu.Lock()
-			cs.contracts[id3] = c3
-			cs.mu.Unlock()
-			cs.mustAcquire(t, id3)
+			}
+			id3 := header3.ID()
+			_, err := cs.managedInsertContract(header3, []crypto.Hash{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c3 := cs.mustAcquire(t, id3)
 			cs.Delete(c3)
 		},
 	}


### PR DESCRIPTION
This PR implements a `TODO` in the contract archival code, adds some logging in case of a failed `SafeContract` deletion and hopefully fixes an issue that caused the contracts of Windows users to be "revived" after being archived.