### PR TITLE
Remove siapath Prefix in client library before using it

### DIFF
--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/node/api"
@@ -17,6 +18,7 @@ func (c *Client) RenterContractsGet() (rc api.RenterContracts, err error) {
 
 // RenterDeletePost uses the /renter/delete endpoint to delete a file.
 func (c *Client) RenterDeletePost(siaPath string) (err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	err = c.post(fmt.Sprintf("/renter/delete/%s", siaPath), "", nil)
 	return err
 }
@@ -24,6 +26,7 @@ func (c *Client) RenterDeletePost(siaPath string) (err error) {
 // RenterDownloadGet uses the /renter/download endpoint to download a file to a
 // destination on disk.
 func (c *Client) RenterDownloadGet(siaPath, destination string, offset, length uint64, async bool) (err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	query := fmt.Sprintf("%s?destination=%s&offset=%d&length=%d&httpresp=false&async=%v",
 		siaPath, destination, offset, length, async)
 	err = c.get("/renter/download/"+query, nil)
@@ -33,6 +36,7 @@ func (c *Client) RenterDownloadGet(siaPath, destination string, offset, length u
 // RenterDownloadFullGet uses the /renter/download endpoint to download a full
 // file.
 func (c *Client) RenterDownloadFullGet(siaPath, destination string, async bool) (err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	query := fmt.Sprintf("%s?destination=%s&httpresp=false&async=%v",
 		siaPath, destination, async)
 	err = c.get("/renter/download/"+query, nil)
@@ -48,6 +52,7 @@ func (c *Client) RenterDownloadsGet() (rdq api.RenterDownloadQueue, err error) {
 // RenterDownloadHTTPResponseGet uses the /renter/download endpoint to download
 // a file and return its data.
 func (c *Client) RenterDownloadHTTPResponseGet(siaPath string, offset, length uint64) (resp []byte, err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	query := fmt.Sprintf("%s?offset=%d&length=%d&httpresp=true", siaPath, offset, length)
 	resp, err = c.getRawResponse("/renter/download/" + query)
 	return
@@ -100,13 +105,16 @@ func (c *Client) RenterPostRateLimit(readBPS, writeBPS int64) (err error) {
 
 // RenterRenamePost uses the /renter/rename/:siapath endpoint to rename a file.
 func (c *Client) RenterRenamePost(siaPathOld, siaPathNew string) (err error) {
-	err = c.post("/renter/rename/"+siaPathOld, "newsiapath="+siaPathNew, nil)
+	siaPathOld = strings.TrimPrefix(siaPathOld, "/")
+	siaPathNew = strings.TrimPrefix(siaPathNew, "/")
+	err = c.post("/renter/rename/"+siaPathOld, "newsiapath=/"+siaPathNew, nil)
 	return
 }
 
 // RenterStreamGet uses the /renter/stream endpoint to download data as a
 // stream.
 func (c *Client) RenterStreamGet(siaPath string) (resp []byte, err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	resp, err = c.getRawResponse("/renter/stream/" + siaPath)
 	return
 }
@@ -114,25 +122,28 @@ func (c *Client) RenterStreamGet(siaPath string) (resp []byte, err error) {
 // RenterStreamPartialGet uses the /renter/stream endpoint to download a part
 // of data as a stream.
 func (c *Client) RenterStreamPartialGet(siaPath string, start, end uint64) (resp []byte, err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	resp, err = c.getRawPartialResponse("/renter/stream/"+siaPath, start, end)
 	return
 }
 
 // RenterUploadPost uses the /renter/upload endpoint to upload a file
 func (c *Client) RenterUploadPost(path, siaPath string, dataPieces, parityPieces uint64) (err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	values := url.Values{}
 	values.Set("source", path)
 	values.Set("datapieces", strconv.FormatUint(dataPieces, 10))
 	values.Set("paritypieces", strconv.FormatUint(parityPieces, 10))
-	err = c.post(fmt.Sprintf("/renter/upload%v", siaPath), values.Encode(), nil)
+	err = c.post(fmt.Sprintf("/renter/upload/%v", siaPath), values.Encode(), nil)
 	return
 }
 
 // RenterUploadDefaultPost uses the /renter/upload endpoint with default
 // redundancy settings to upload a file.
 func (c *Client) RenterUploadDefaultPost(path, siaPath string) (err error) {
+	siaPath = strings.TrimPrefix(siaPath, "/")
 	values := url.Values{}
 	values.Set("source", path)
-	err = c.post(fmt.Sprintf("/renter/upload%v", siaPath), values.Encode(), nil)
+	err = c.post(fmt.Sprintf("/renter/upload/%v", siaPath), values.Encode(), nil)
 	return
 }


### PR DESCRIPTION
This guarantees that it doesn't matter if the `siaPath` we upload from has a leading `/` or not. If there is a leading `/` it will just be removed.