### PR TITLE
Add tg.Add to exported wallet methods

### DIFF
--- a/modules/consensus/accept_bench_test.go
+++ b/modules/consensus/accept_bench_test.go
@@ -129,7 +129,10 @@ func BenchmarkAcceptSmallBlocks(b *testing.B) {
 	for j := 0; j < b.N; j++ {
 		// Create a transaction with a miner fee, a normal siacoin output, and
 		// a funded file contract.
-		txnBuilder := cst.wallet.StartTransaction()
+		txnBuilder, err := cst.wallet.StartTransaction()
+		if err != nil {
+			b.Fatal(err)
+		}
 		err = txnBuilder.FundSiacoins(types.NewCurrency64(125e6))
 		if err != nil {
 			b.Fatal(err)

--- a/modules/consensus/accept_test.go
+++ b/modules/consensus/accept_test.go
@@ -504,7 +504,10 @@ func TestIntegrationDoSBlockHandling(t *testing.T) {
 
 	// Mine a block that is valid except for containing a buried invalid
 	// transaction. The transaction has more siacoin inputs than outputs.
-	txnBuilder := cst.wallet.StartTransaction()
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(types.NewCurrency64(50))
 	if err != nil {
 		t.Fatal(err)
@@ -794,7 +797,10 @@ func TestBuriedBadTransaction(t *testing.T) {
 
 	// Create a good transaction using the wallet.
 	txnValue := types.NewCurrency64(1200)
-	txnBuilder := cst.wallet.StartTransaction()
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(txnValue)
 	if err != nil {
 		t.Fatal(err)
@@ -890,7 +896,10 @@ func TestTaxHardfork(t *testing.T) {
 	}
 
 	// Create and fund a transaction with a file contract.
-	txnBuilder := cst.wallet.StartTransaction()
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(payout)
 	if err != nil {
 		t.Fatal(err)
@@ -937,7 +946,10 @@ func TestTaxHardfork(t *testing.T) {
 		NewValidProofOutputs:  fc.ValidProofOutputs,
 		NewMissedProofOutputs: fc.MissedProofOutputs,
 	}
-	txnBuilder = cst.wallet.StartTransaction()
+	txnBuilder, err = cst.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	txnBuilder.AddFileContractRevision(fcr)
 	txnSet, err = txnBuilder.Sign(true)
 	if err != nil {

--- a/modules/consensus/accept_txntypes_test.go
+++ b/modules/consensus/accept_txntypes_test.go
@@ -107,8 +107,11 @@ func (cst *consensusSetTester) testSpendSiacoinsBlock() {
 
 	// Create a block containing a transaction with a valid siacoin output.
 	txnValue := types.NewCurrency64(1200)
-	txnBuilder := cst.wallet.StartTransaction()
-	err := txnBuilder.FundSiacoins(txnValue)
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		panic(err)
+	}
+	err = txnBuilder.FundSiacoins(txnValue)
 	if err != nil {
 		panic(err)
 	}
@@ -197,8 +200,11 @@ func (cst *consensusSetTester) testValidStorageProofBlocks() {
 
 	// Submit a transaction with the file contract.
 	oldSiafundPool := cst.cs.dbGetSiafundPool()
-	txnBuilder := cst.wallet.StartTransaction()
-	err := txnBuilder.FundSiacoins(payout)
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		panic(err)
+	}
+	err = txnBuilder.FundSiacoins(payout)
 	if err != nil {
 		panic(err)
 	}
@@ -241,7 +247,10 @@ func (cst *consensusSetTester) testValidStorageProofBlocks() {
 		HashSet:  hashSet,
 	}
 	copy(sp.Segment[:], segment)
-	txnBuilder = cst.wallet.StartTransaction()
+	txnBuilder, err = cst.wallet.StartTransaction()
+	if err != nil {
+		panic(err)
+	}
 	txnBuilder.AddStorageProof(sp)
 	txnSet, err = txnBuilder.Sign(true)
 	if err != nil {
@@ -322,8 +331,11 @@ func (cst *consensusSetTester) testMissedStorageProofBlocks() {
 
 	// Submit a transaction with the file contract.
 	oldSiafundPool := cst.cs.dbGetSiafundPool()
-	txnBuilder := cst.wallet.StartTransaction()
-	err := txnBuilder.FundSiacoins(payout)
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		panic(err)
+	}
+	err = txnBuilder.FundSiacoins(payout)
 	if err != nil {
 		panic(err)
 	}
@@ -452,8 +464,11 @@ func (cst *consensusSetTester) testFileContractRevision() {
 	}
 
 	// Submit a transaction with the file contract.
-	txnBuilder := cst.wallet.StartTransaction()
-	err := txnBuilder.FundSiacoins(payout)
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		panic(err)
+	}
+	err = txnBuilder.FundSiacoins(payout)
 	if err != nil {
 		panic(err)
 	}
@@ -518,7 +533,10 @@ func (cst *consensusSetTester) testFileContractRevision() {
 		HashSet:  hashSet,
 	}
 	copy(sp.Segment[:], segment)
-	txnBuilder = cst.wallet.StartTransaction()
+	txnBuilder, err = cst.wallet.StartTransaction()
+	if err != nil {
+		panic(err)
+	}
 	txnBuilder.AddStorageProof(sp)
 	txnSet, err = txnBuilder.Sign(true)
 	if err != nil {
@@ -562,8 +580,11 @@ func (cst *consensusSetTester) testSpendSiafunds() {
 
 	// Create a block containing a transaction with a valid siafund output.
 	txnValue := types.NewCurrency64(3)
-	txnBuilder := cst.wallet.StartTransaction()
-	err := txnBuilder.FundSiafunds(txnValue)
+	txnBuilder, err := cst.wallet.StartTransaction()
+	if err != nil {
+		panic(err)
+	}
+	err = txnBuilder.FundSiafunds(txnValue)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/consensus/consensusset_test.go
+++ b/modules/consensus/consensusset_test.go
@@ -69,7 +69,10 @@ func (cst *consensusSetTester) addSiafunds() {
 	}
 
 	// Check that the siafunds made it to the wallet.
-	_, siafundBalance, _ := cst.wallet.ConfirmedBalance()
+	_, siafundBalance, _, err := cst.wallet.ConfirmedBalance()
+	if err != nil {
+		panic(err)
+	}
 	if !siafundBalance.Equals64(1e3) {
 		panic("wallet does not have the siafunds")
 	}

--- a/modules/consensus/validtransaction_test.go
+++ b/modules/consensus/validtransaction_test.go
@@ -126,7 +126,10 @@ func TestStorageProofBoundaries(t *testing.T) {
 
 			// Create a transaction around the file contract and add it to the
 			// transaction pool.
-			b := cst.wallet.StartTransaction()
+			b, err := cst.wallet.StartTransaction()
+			if err != nil {
+				t.Fatal(err)
+			}
 			err = b.FundSiacoins(types.NewCurrency64(500))
 			if err != nil {
 				t.Fatal(err)
@@ -255,7 +258,10 @@ func TestEmptyStorageProof(t *testing.T) {
 
 			// Create a transaction around the file contract and add it to the
 			// transaction pool.
-			b := cst.wallet.StartTransaction()
+			b, err := cst.wallet.StartTransaction()
+			if err != nil {
+				t.Fatal(err)
+			}
 			err = b.FundSiacoins(types.NewCurrency64(500))
 			if err != nil {
 				t.Fatal(err)

--- a/modules/explorer/info_test.go
+++ b/modules/explorer/info_test.go
@@ -87,7 +87,10 @@ func TestFileContractPayoutsMissingProof(t *testing.T) {
 	}
 
 	// Create and fund valid file contracts.
-	builder := et.wallet.StartTransaction()
+	builder, err := et.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	payout := types.NewCurrency64(1e9)
 	err = builder.FundSiacoins(payout)
 	if err != nil {
@@ -189,7 +192,10 @@ func TestFileContractsPayoutValidProof(t *testing.T) {
 
 	// Submit a transaction with the file contract.
 	//oldSiafundPool := cst.cs.dbGetSiafundPool()
-	builder := et.wallet.StartTransaction()
+	builder, err := et.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = builder.FundSiacoins(payout)
 	if err != nil {
 		t.Fatal(err)
@@ -224,7 +230,10 @@ func TestFileContractsPayoutValidProof(t *testing.T) {
 		HashSet:  hashSet,
 	}
 	copy(sp.Segment[:], segment)
-	builder = et.wallet.StartTransaction()
+	builder, err = et.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	builder.AddStorageProof(sp)
 	tSet, err = builder.Sign(true)
 	if err != nil {

--- a/modules/explorer/update_test.go
+++ b/modules/explorer/update_test.go
@@ -51,7 +51,10 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 
 	// Put a file contract into the chain, and check that the explorer
 	// correctly does all of the counting.
-	builder := et.wallet.StartTransaction()
+	builder, err := et.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	builder.FundSiacoins(types.NewCurrency64(5e9))
 	fcOutputs := []types.SiacoinOutput{{Value: types.NewCurrency64(4805e6)}}
 	fc := types.FileContract{
@@ -102,7 +105,10 @@ func TestIntegrationExplorerFileContractMetrics(t *testing.T) {
 
 	// Put a second file into the explorer to check that multiple files are
 	// handled well.
-	builder = et.wallet.StartTransaction()
+	builder, err = et.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	builder.FundSiacoins(types.NewCurrency64(1e9))
 	fcOutputs = []types.SiacoinOutput{{Value: types.NewCurrency64(961e6)}}
 	fc = types.FileContract{

--- a/modules/host/announce_test.go
+++ b/modules/host/announce_test.go
@@ -183,7 +183,11 @@ func TestHostAnnounceCheckUnlockHash(t *testing.T) {
 		t.Fatal("host did not set a new unlock hash after announce with reset wallet")
 	}
 	hasAddr := false
-	for _, addr := range ht.wallet.AllAddresses() {
+	addrs, err := ht.wallet.AllAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
 		if addr == newUnlockHash {
 			hasAddr = true
 			break

--- a/modules/host/host.go
+++ b/modules/host/host.go
@@ -180,7 +180,10 @@ type Host struct {
 // from the wallet. That may fail due to the wallet being locked, in which case
 // an error is returned.
 func (h *Host) checkUnlockHash() error {
-	addrs := h.wallet.AllAddresses()
+	addrs, err := h.wallet.AllAddresses()
+	if err != nil {
+		return err
+	}
 	hasAddr := false
 	for _, addr := range addrs {
 		if h.unlockHash == addr {

--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -38,10 +38,17 @@ func (h *Host) managedAddCollateral(settings modules.HostExternalSettings, txnSe
 	parents := txnSet[:len(txnSet)-1]
 	fc := txn.FileContracts[0]
 	hostPortion := contractCollateral(settings, fc)
-	builder = h.wallet.RegisterTransaction(txn, parents)
+	builder, err = h.wallet.RegisterTransaction(txn, parents)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			builder.Drop()
+		}
+	}()
 	err = builder.FundSiacoins(hostPortion)
 	if err != nil {
-		builder.Drop()
 		return nil, nil, nil, nil, extendErr("could not add collateral: ", ErrorInternal(err.Error()))
 	}
 

--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -51,10 +51,17 @@ func (h *Host) managedAddRenewCollateral(so storageObligation, settings modules.
 	parents := txnSet[:len(txnSet)-1]
 	fc := txn.FileContracts[0]
 	hostPortion := renewContractCollateral(so, settings, fc)
-	builder = h.wallet.RegisterTransaction(txn, parents)
+	builder, err = h.wallet.RegisterTransaction(txn, parents)
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			builder.Drop()
+		}
+	}()
 	err = builder.FundSiacoins(hostPortion)
 	if err != nil {
-		builder.Drop()
 		return nil, nil, nil, nil, extendErr("could not add collateral: ", ErrorInternal(err.Error()))
 	}
 

--- a/modules/host/storageobligations_smoke_test.go
+++ b/modules/host/storageobligations_smoke_test.go
@@ -31,12 +31,15 @@ func randSector() (crypto.Hash, []byte) {
 // contract that will form the foundation of a storage obligation.
 func (ht *hostTester) newTesterStorageObligation() (storageObligation, error) {
 	// Create the file contract that will be used in the obligation.
-	builder := ht.wallet.StartTransaction()
+	builder, err := ht.wallet.StartTransaction()
+	if err != nil {
+		return storageObligation{}, err
+	}
 	// Fund the file contract with a payout. The payout needs to be big enough
 	// that the expected revenue is larger than the fee that the host may end
 	// up paying.
 	payout := types.SiacoinPrecision.Mul64(1e3)
-	err := builder.FundSiacoins(payout)
+	err = builder.FundSiacoins(payout)
 	if err != nil {
 		return storageObligation{}, err
 	}

--- a/modules/host/update_test.go
+++ b/modules/host/update_test.go
@@ -32,7 +32,10 @@ func TestStorageProof(t *testing.T) {
 		ValidProofOutputs:  []types.SiacoinOutput{{Value: types.NewCurrency64(1)}, {Value: types.NewCurrency64(0)}},
 		MissedProofOutputs: []types.SiacoinOutput{{Value: types.NewCurrency64(1)}, {Value: types.NewCurrency64(0)}},
 	}
-	txnBuilder := ht.wallet.StartTransaction()
+	txnBuilder, err := ht.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(fc.Payout)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/miner/blockmanager.go
+++ b/modules/miner/blockmanager.go
@@ -81,13 +81,17 @@ func (m *Miner) HeaderForWork() (types.BlockHeader, types.Target, error) {
 	defer m.mu.Unlock()
 
 	// Return a blank header with an error if the wallet is locked.
-	if !m.wallet.Unlocked() {
+	unlocked, err := m.wallet.Unlocked()
+	if err != nil {
+		return types.BlockHeader{}, types.Target{}, err
+	}
+	if !unlocked {
 		return types.BlockHeader{}, types.Target{}, modules.ErrLockedWallet
 	}
 
 	// Check that the wallet has been initialized, and that the miner has
 	// successfully fetched an address.
-	err := m.checkAddress()
+	err = m.checkAddress()
 	if err != nil {
 		return types.BlockHeader{}, types.Target{}, err
 	}

--- a/modules/miner/miner.go
+++ b/modules/miner/miner.go
@@ -249,7 +249,10 @@ func (m *Miner) Close() error {
 // checkAddress checks that the miner has an address, fetching an address from
 // the wallet if not.
 func (m *Miner) checkAddress() error {
-	addrs := m.wallet.AllAddresses()
+	addrs, err := m.wallet.AllAddresses()
+	if err != nil {
+		return err
+	}
 	hasAddr := false
 	for _, addr := range addrs {
 		if m.persist.Address == addr {

--- a/modules/miner/miner_test.go
+++ b/modules/miner/miner_test.go
@@ -104,7 +104,10 @@ func TestIntegrationMiner(t *testing.T) {
 	}
 
 	// Check that the wallet has money.
-	siacoins, _, _ := mt.wallet.ConfirmedBalance()
+	siacoins, _, _, err := mt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Error(err)
+	}
 	if siacoins.IsZero() {
 		t.Error("expecting mining full balance to not be zero")
 	}
@@ -117,7 +120,10 @@ func TestIntegrationMiner(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	morecoins, _, _ := mt.wallet.ConfirmedBalance()
+	morecoins, _, _, err := mt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Error(err)
+	}
 	if siacoins.Cmp(morecoins) >= 0 {
 		t.Error("wallet is not gaining balance while mining")
 	}

--- a/modules/miner/testminer.go
+++ b/modules/miner/testminer.go
@@ -49,7 +49,11 @@ func solveBlock(b types.Block, target types.Target) (types.Block, bool) {
 func (m *Miner) BlockForWork() (b types.Block, t types.Target, err error) {
 	// Check if the wallet is unlocked. If the wallet is unlocked, make sure
 	// that the miner has a recent address.
-	if !m.wallet.Unlocked() {
+	unlocked, err := m.wallet.Unlocked()
+	if err != nil {
+		return types.Block{}, types.Target{}, err
+	}
+	if !unlocked {
 		err = modules.ErrLockedWallet
 		return
 	}
@@ -85,10 +89,14 @@ func (m *Miner) FindBlock() (types.Block, error) {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 
-		if !m.wallet.Unlocked() {
+		unlocked, err := m.wallet.Unlocked()
+		if err != nil {
+			return err
+		}
+		if !unlocked {
 			return modules.ErrLockedWallet
 		}
-		err := m.checkAddress()
+		err = m.checkAddress()
 		if err != nil {
 			return err
 		}

--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -24,8 +24,8 @@ func (newStub) Synced() bool                               { return true }
 func (newStub) Unsubscribe(modules.ConsensusSetSubscriber) { return }
 
 // wallet stubs
-func (newStub) NextAddress() (uc types.UnlockConditions, err error) { return }
-func (newStub) StartTransaction() modules.TransactionBuilder        { return nil }
+func (newStub) NextAddress() (uc types.UnlockConditions, err error)          { return }
+func (newStub) StartTransaction() (tb modules.TransactionBuilder, err error) { return }
 
 // transaction pool stubs
 func (newStub) AcceptTransactionSet([]types.Transaction) error      { return nil }
@@ -310,7 +310,10 @@ func TestAllowanceSpending(t *testing.T) {
 			}
 		}
 	}
-	balance, _, _ := w.ConfirmedBalance()
+	balance, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	spent := minerRewards.Sub(balance)
 	if spent.Cmp(testAllowance.Funds) > 0 {
 		t.Fatal("contractor spent too much money: spent", spent.HumanString(), "allowance funds:", testAllowance.Funds.HumanString())
@@ -535,9 +538,9 @@ func (ws *testWalletShim) NextAddress() (types.UnlockConditions, error) {
 	ws.nextAddressCalled = true
 	return types.UnlockConditions{}, nil
 }
-func (ws *testWalletShim) StartTransaction() modules.TransactionBuilder {
+func (ws *testWalletShim) StartTransaction() (modules.TransactionBuilder, error) {
 	ws.startTxnCalled = true
-	return nil
+	return nil, nil
 }
 
 // TestWalletBridge tests the walletBridge type.

--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -185,7 +185,10 @@ func (c *Contractor) managedNewContract(host modules.HostDBEntry, contractFundin
 	c.mu.RUnlock()
 
 	// create transaction builder
-	txnBuilder := c.wallet.StartTransaction()
+	txnBuilder, err := c.wallet.StartTransaction()
+	if err != nil {
+		return modules.RenterContract{}, err
+	}
 
 	contract, err := c.staticContracts.FormContract(params, txnBuilder, c.tpool, c.hdb, c.tg.StopChan())
 	if err != nil {
@@ -241,7 +244,10 @@ func (c *Contractor) managedRenew(sc *proto.SafeContract, contractFunding types.
 	c.mu.RUnlock()
 
 	// execute negotiation protocol
-	txnBuilder := c.wallet.StartTransaction()
+	txnBuilder, err := c.wallet.StartTransaction()
+	if err != nil {
+		return modules.RenterContract{}, err
+	}
 	newContract, err := c.staticContracts.Renew(sc, params, txnBuilder, c.tpool, c.hdb, c.tg.StopChan())
 	if err != nil {
 		txnBuilder.Drop() // return unused outputs to wallet

--- a/modules/renter/contractor/dependencies.go
+++ b/modules/renter/contractor/dependencies.go
@@ -21,11 +21,11 @@ type (
 	// transactionBuilder.
 	walletShim interface {
 		NextAddress() (types.UnlockConditions, error)
-		StartTransaction() modules.TransactionBuilder
+		StartTransaction() (modules.TransactionBuilder, error)
 	}
 	wallet interface {
 		NextAddress() (types.UnlockConditions, error)
-		StartTransaction() transactionBuilder
+		StartTransaction() (transactionBuilder, error)
 	}
 	transactionBuilder interface {
 		AddArbitraryData([]byte) uint64
@@ -75,7 +75,7 @@ func (ws *WalletBridge) NextAddress() (types.UnlockConditions, error) { return w
 
 // StartTransaction creates a new transactionBuilder that can be used to create
 // and sign a transaction.
-func (ws *WalletBridge) StartTransaction() transactionBuilder { return ws.W.StartTransaction() }
+func (ws *WalletBridge) StartTransaction() (transactionBuilder, error) { return ws.W.StartTransaction() }
 
 // stdPersist implements the persister interface. The filename required by
 // these functions is internal to stdPersist.

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -32,7 +32,11 @@ func newTestingWallet(testdir string, cs modules.ConsensusSet, tp modules.Transa
 		return nil, err
 	}
 	key := crypto.GenerateTwofishKey()
-	if !w.Encrypted() {
+	encrypted, err := w.Encrypted()
+	if err != nil {
+		return nil, err
+	}
+	if !encrypted {
 		_, err = w.Encrypt(key)
 		if err != nil {
 			return nil, err
@@ -126,7 +130,11 @@ func newTestingTrio(name string) (modules.Host, *Contractor, modules.TestMiner, 
 		return nil, nil, nil, err
 	}
 	key := crypto.GenerateTwofishKey()
-	if !w.Encrypted() {
+	encrypted, err := w.Encrypted()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if !encrypted {
 		_, err = w.Encrypt(key)
 		if err != nil {
 			return nil, nil, nil, err

--- a/modules/renter/contractor/negotiate_test.go
+++ b/modules/renter/contractor/negotiate_test.go
@@ -139,7 +139,10 @@ func TestNegotiateContract(t *testing.T) {
 		RevisionNumber: 0,
 	}
 
-	txnBuilder := ct.wallet.StartTransaction()
+	txnBuilder, err := ct.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(fc.Payout)
 	if err != nil {
 		t.Fatal(err)
@@ -210,7 +213,10 @@ func TestReviseContract(t *testing.T) {
 		{Value: types.ZeroCurrency, UnlockHash: types.UnlockHash{}},
 	}
 
-	txnBuilder := ct.wallet.StartTransaction()
+	txnBuilder, err := ct.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(fc.Payout)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/transactionpool/accept_test.go
+++ b/modules/transactionpool/accept_test.go
@@ -74,7 +74,10 @@ func TestConflictingTransactionSets(t *testing.T) {
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
-	txnBuilder := tpt.wallet.StartTransaction()
+	txnBuilder, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(fund)
 	if err != nil {
 		t.Fatal(err)
@@ -335,7 +338,10 @@ func TestTransactionSuperset(t *testing.T) {
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
-	txnBuilder := tpt.wallet.StartTransaction()
+	txnBuilder, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(fund)
 	if err != nil {
 		t.Fatal(err)
@@ -394,7 +400,10 @@ func TestTransactionSubset(t *testing.T) {
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
-	txnBuilder := tpt.wallet.StartTransaction()
+	txnBuilder, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(fund)
 	if err != nil {
 		t.Fatal(err)
@@ -441,7 +450,10 @@ func TestTransactionChild(t *testing.T) {
 
 	// Fund a partial transaction.
 	fund := types.NewCurrency64(30e6)
-	txnBuilder := tpt.wallet.StartTransaction()
+	txnBuilder, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(fund)
 	if err != nil {
 		t.Fatal(err)
@@ -510,7 +522,10 @@ func TestAcceptFCAndConflictingRevision(t *testing.T) {
 	defer tpt.Close()
 
 	// Create and fund a valid file contract.
-	builder := tpt.wallet.StartTransaction()
+	builder, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	payout := types.NewCurrency64(1e9)
 	err = builder.FundSiacoins(payout)
 	if err != nil {
@@ -566,7 +581,10 @@ func TestPartialConfirmation(t *testing.T) {
 	defer tpt.Close()
 
 	// Create and fund a valid file contract.
-	builder := tpt.wallet.StartTransaction()
+	builder, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	payout := types.NewCurrency64(1e9)
 	err = builder.FundSiacoins(payout)
 	if err != nil {
@@ -644,7 +662,10 @@ func TestPartialConfirmationWeave(t *testing.T) {
 
 	// Create a transaction with a single output to a fully controlled address.
 	emptyUH := types.UnlockConditions{}.UnlockHash()
-	builder1 := tpt.wallet.StartTransaction()
+	builder1, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	funding1 := types.NewCurrency64(1e9)
 	err = builder1.FundSiacoins(funding1)
 	if err != nil {
@@ -672,7 +693,10 @@ func TestPartialConfirmationWeave(t *testing.T) {
 
 	// Create a second output to the fully controlled address, to fund the
 	// second transaction in the weave.
-	builder2 := tpt.wallet.StartTransaction()
+	builder2, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	funding2 := types.NewCurrency64(2e9)
 	err = builder2.FundSiacoins(funding2)
 	if err != nil {

--- a/modules/transactionpool/transactionpool_test.go
+++ b/modules/transactionpool/transactionpool_test.go
@@ -161,7 +161,10 @@ func TestGetTransaction(t *testing.T) {
 	value := types.NewCurrency64(35e6)
 	fee := types.NewCurrency64(3e2)
 	emptyUH := types.UnlockConditions{}.UnlockHash()
-	txnBuilder := tpt.wallet.StartTransaction()
+	txnBuilder, err := tpt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = txnBuilder.FundSiacoins(value)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -41,6 +41,10 @@ var (
 	// ErrLowBalance is returned if the wallet does not have enough funds to
 	// complete the desired action.
 	ErrLowBalance = errors.New("insufficient balance")
+
+	// ErrWalletShutdown is returned when a method can't continue execution due
+	// to the wallet shutting down.
+	ErrWalletShutdown = errors.New("wallet is shutting down")
 )
 
 type (
@@ -239,7 +243,7 @@ type (
 		// Encrypted returns whether or not the wallet has been encrypted yet.
 		// After being encrypted for the first time, the wallet can only be
 		// unlocked using the encryption password.
-		Encrypted() bool
+		Encrypted() (bool, error)
 
 		// InitFromSeed functions like Encrypt, but using a specified seed.
 		// Unlike Encrypt, the blockchain will be scanned to determine the
@@ -266,7 +270,7 @@ type (
 
 		// Unlocked returns true if the wallet is currently unlocked, false
 		// otherwise.
-		Unlocked() bool
+		Unlocked() (bool, error)
 	}
 
 	// KeyManager manages wallet keys, including the use of seeds, creating and
@@ -276,7 +280,7 @@ type (
 		// AllAddresses returns all addresses that the wallet is able to spend
 		// from, including unseeded addresses. Addresses are returned sorted in
 		// byte-order.
-		AllAddresses() []types.UnlockHash
+		AllAddresses() ([]types.UnlockHash, error)
 
 		// AllSeeds returns all of the seeds that are being tracked by the
 		// wallet, including the primary seed. Only the primary seed is used to
@@ -342,30 +346,30 @@ type (
 		// ConfirmedBalance returns the confirmed balance of the wallet, minus
 		// any outgoing transactions. ConfirmedBalance will include unconfirmed
 		// refund transactions.
-		ConfirmedBalance() (siacoinBalance types.Currency, siafundBalance types.Currency, siacoinClaimBalance types.Currency)
+		ConfirmedBalance() (siacoinBalance types.Currency, siafundBalance types.Currency, siacoinClaimBalance types.Currency, err error)
 
 		// UnconfirmedBalance returns the unconfirmed balance of the wallet.
 		// Outgoing funds and incoming funds are reported separately. Refund
 		// outputs are included, meaning that sending a single coin to
 		// someone could result in 'outgoing: 12, incoming: 11'. Siafunds are
 		// not considered in the unconfirmed balance.
-		UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency)
+		UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency, err error)
 
 		// Height returns the wallet's internal processed consensus height
-		Height() types.BlockHeight
+		Height() (types.BlockHeight, error)
 
 		// AddressTransactions returns all of the transactions that are related
 		// to a given address.
-		AddressTransactions(types.UnlockHash) []ProcessedTransaction
+		AddressTransactions(types.UnlockHash) ([]ProcessedTransaction, error)
 
 		// AddressUnconfirmedHistory returns all of the unconfirmed
 		// transactions related to a given address.
-		AddressUnconfirmedTransactions(types.UnlockHash) []ProcessedTransaction
+		AddressUnconfirmedTransactions(types.UnlockHash) ([]ProcessedTransaction, error)
 
 		// Transaction returns the transaction with the given id. The bool
 		// indicates whether the transaction is in the wallet database. The
 		// wallet only stores transactions that are related to the wallet.
-		Transaction(types.TransactionID) (ProcessedTransaction, bool)
+		Transaction(types.TransactionID) (ProcessedTransaction, bool, error)
 
 		// Transactions returns all of the transactions that were confirmed at
 		// heights [startHeight, endHeight]. Unconfirmed transactions are not
@@ -374,25 +378,25 @@ type (
 
 		// UnconfirmedTransactions returns all unconfirmed transactions
 		// relative to the wallet.
-		UnconfirmedTransactions() []ProcessedTransaction
+		UnconfirmedTransactions() ([]ProcessedTransaction, error)
 
 		// RegisterTransaction takes a transaction and its parents and returns
 		// a TransactionBuilder which can be used to expand the transaction.
-		RegisterTransaction(t types.Transaction, parents []types.Transaction) TransactionBuilder
+		RegisterTransaction(t types.Transaction, parents []types.Transaction) (TransactionBuilder, error)
 
 		// Rescanning reports whether the wallet is currently rescanning the
 		// blockchain.
-		Rescanning() bool
+		Rescanning() (bool, error)
 
 		// Settings returns the Wallet's current settings.
-		Settings() WalletSettings
+		Settings() (WalletSettings, error)
 
 		// SetSettings sets the Wallet's settings.
-		SetSettings(WalletSettings)
+		SetSettings(WalletSettings) error
 
 		// StartTransaction is a convenience method that calls
 		// RegisterTransaction(types.Transaction{}, nil)
-		StartTransaction() TransactionBuilder
+		StartTransaction() (TransactionBuilder, error)
 
 		// SendSiacoins is a tool for sending siacoins from the wallet to an
 		// address. Sending money usually results in multiple transactions. The
@@ -411,7 +415,7 @@ type (
 
 		// DustThreshold returns the quantity per byte below which a Currency is
 		// considered to be Dust.
-		DustThreshold() types.Currency
+		DustThreshold() (types.Currency, error)
 	}
 
 	// WalletSettings control the behavior of the Wallet.

--- a/modules/wallet/defrag.go
+++ b/modules/wallet/defrag.go
@@ -16,7 +16,10 @@ var (
 // wallet outputs into a single new address.
 func (w *Wallet) managedCreateDefragTransaction() ([]types.Transaction, error) {
 	// dustThreshold and minFee have to be obtained separate from the lock
-	dustThreshold := w.DustThreshold()
+	dustThreshold, err := w.DustThreshold()
+	if err != nil {
+		return nil, err
+	}
 	minFee, _ := w.tpool.FeeEstimation()
 
 	w.mu.Lock()

--- a/modules/wallet/defrag_test.go
+++ b/modules/wallet/defrag_test.go
@@ -71,7 +71,10 @@ func TestDefragWalletDust(t *testing.T) {
 	dustOutputValue := types.NewCurrency64(10000)
 	noutputs := defragThreshold + 1
 
-	tbuilder := wt.wallet.StartTransaction()
+	tbuilder, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = tbuilder.FundSiacoins(dustOutputValue.Mul64(uint64(noutputs)))
 	if err != nil {
 		t.Fatal(err)
@@ -164,7 +167,11 @@ func TestDefragOutputExhaustion(t *testing.T) {
 				fee := types.SiacoinPrecision.Mul64(10)
 				numOutputs := defragThreshold + 1
 
-				tbuilder := wt.wallet.StartTransaction()
+				tbuilder, err := wt.wallet.StartTransaction()
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				tbuilder.FundSiacoins(txnValue.Mul64(uint64(numOutputs)).Add(fee))
 
 				for i := 0; i < numOutputs; i++ {

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -274,13 +274,16 @@ func (w *Wallet) wipeSecrets() {
 }
 
 // Encrypted returns whether or not the wallet has been encrypted.
-func (w *Wallet) Encrypted() bool {
+func (w *Wallet) Encrypted() (bool, error) {
+	if err := w.tg.Add(); err != nil {
+		return false, err
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if build.DEBUG && w.unlocked && !w.encrypted {
 		panic("wallet is both unlocked and unencrypted")
 	}
-	return w.encrypted
+	return w.encrypted, nil
 }
 
 // Encrypt will create a primary seed for the wallet and encrypt it using
@@ -391,15 +394,21 @@ func (w *Wallet) InitFromSeed(masterKey crypto.TwofishKey, seed modules.Seed) er
 }
 
 // Unlocked indicates whether the wallet is locked or unlocked.
-func (w *Wallet) Unlocked() bool {
+func (w *Wallet) Unlocked() (bool, error) {
+	if err := w.tg.Add(); err != nil {
+		return false, err
+	}
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	return w.unlocked
+	return w.unlocked, nil
 }
 
 // Lock will erase all keys from memory and prevent the wallet from spending
 // coins until it is unlocked.
 func (w *Wallet) Lock() error {
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if !w.unlocked {

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -278,6 +278,7 @@ func (w *Wallet) Encrypted() (bool, error) {
 	if err := w.tg.Add(); err != nil {
 		return false, err
 	}
+	w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if build.DEBUG && w.unlocked && !w.encrypted {
@@ -398,6 +399,7 @@ func (w *Wallet) Unlocked() (bool, error) {
 	if err := w.tg.Add(); err != nil {
 		return false, err
 	}
+	defer w.tg.Done()
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.unlocked, nil
@@ -409,6 +411,7 @@ func (w *Wallet) Lock() error {
 	if err := w.tg.Add(); err != nil {
 		return err
 	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if !w.unlocked {

--- a/modules/wallet/encrypt.go
+++ b/modules/wallet/encrypt.go
@@ -278,7 +278,7 @@ func (w *Wallet) Encrypted() (bool, error) {
 	if err := w.tg.Add(); err != nil {
 		return false, err
 	}
-	w.tg.Done()
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if build.DEBUG && w.unlocked && !w.encrypted {
@@ -412,19 +412,43 @@ func (w *Wallet) Lock() error {
 		return err
 	}
 	defer w.tg.Done()
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if !w.unlocked {
-		return modules.ErrLockedWallet
-	}
-	w.log.Println("INFO: Locking wallet.")
+	return w.managedLock()
+}
 
-	// Wipe all of the seeds and secret keys. They will be replaced upon
-	// calling 'Unlock' again. Note that since the public keys are not wiped,
-	// we can continue processing blocks.
-	w.wipeSecrets()
-	w.unlocked = false
-	return nil
+// ChangeKey changes the wallet's encryption key from masterKey to newKey.
+func (w *Wallet) ChangeKey(masterKey crypto.TwofishKey, newKey crypto.TwofishKey) error {
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
+	defer w.tg.Done()
+
+	return w.managedChangeKey(masterKey, newKey)
+}
+
+// Unlock will decrypt the wallet seed and load all of the addresses into
+// memory.
+func (w *Wallet) Unlock(masterKey crypto.TwofishKey) error {
+	// By having the wallet's ThreadGroup track the Unlock method, we ensure
+	// that Unlock will never unlock the wallet once the ThreadGroup has been
+	// stopped. Without this precaution, the wallet's Close method would be
+	// unsafe because it would theoretically be possible for another function
+	// to Unlock the wallet in the short interval after Close calls w.Lock
+	// and before Close calls w.mu.Lock.
+	if err := w.tg.Add(); err != nil {
+		return err
+	}
+	defer w.tg.Done()
+
+	if !w.scanLock.TryLock() {
+		return errScanInProgress
+	}
+	defer w.scanLock.Unlock()
+
+	w.log.Println("INFO: Unlocking wallet.")
+
+	// Initialize all of the keys in the wallet under a lock. While holding the
+	// lock, also grab the subscriber status.
+	return w.managedUnlock(masterKey)
 }
 
 // managedChangeKey safely performs the database operations required to change
@@ -557,38 +581,27 @@ func (w *Wallet) managedChangeKey(masterKey crypto.TwofishKey, newKey crypto.Two
 	return nil
 }
 
-// ChangeKey changes the wallet's encryption key from masterKey to newKey.
-func (w *Wallet) ChangeKey(masterKey crypto.TwofishKey, newKey crypto.TwofishKey) error {
-	if err := w.tg.Add(); err != nil {
-		return err
+// managedLock will erase all keys from memory and prevent the wallet from
+// spending coins until it is unlocked.
+func (w *Wallet) managedLock() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.unlocked {
+		return modules.ErrLockedWallet
 	}
-	defer w.tg.Done()
+	w.log.Println("INFO: Locking wallet.")
 
-	return w.managedChangeKey(masterKey, newKey)
+	// Wipe all of the seeds and secret keys. They will be replaced upon
+	// calling 'Unlock' again. Note that since the public keys are not wiped,
+	// we can continue processing blocks.
+	w.wipeSecrets()
+	w.unlocked = false
+	return nil
 }
 
-// Unlock will decrypt the wallet seed and load all of the addresses into
-// memory.
-func (w *Wallet) Unlock(masterKey crypto.TwofishKey) error {
-	// By having the wallet's ThreadGroup track the Unlock method, we ensure
-	// that Unlock will never unlock the wallet once the ThreadGroup has been
-	// stopped. Without this precaution, the wallet's Close method would be
-	// unsafe because it would theoretically be possible for another function
-	// to Unlock the wallet in the short interval after Close calls w.Lock
-	// and before Close calls w.mu.Lock.
-	if err := w.tg.Add(); err != nil {
-		return err
-	}
-	defer w.tg.Done()
-
-	if !w.scanLock.TryLock() {
-		return errScanInProgress
-	}
-	defer w.scanLock.Unlock()
-
-	w.log.Println("INFO: Unlocking wallet.")
-
-	// Initialize all of the keys in the wallet under a lock. While holding the
-	// lock, also grab the subscriber status.
-	return w.managedUnlock(masterKey)
+// managedUnlocked indicates whether the wallet is locked or unlocked.
+func (w *Wallet) managedUnlocked() bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.unlocked
 }

--- a/modules/wallet/encrypt_test.go
+++ b/modules/wallet/encrypt_test.go
@@ -20,10 +20,18 @@ import (
 // unlocking are all happening in the correct order and returning the correct
 // errors.
 func postEncryptionTesting(m modules.TestMiner, w *Wallet, masterKey crypto.TwofishKey) {
-	if !w.Encrypted() {
+	encrypted, err := w.Encrypted()
+	if err != nil {
+		panic(err)
+	}
+	unlocked, err := w.Unlocked()
+	if err != nil {
+		panic(err)
+	}
+	if !encrypted {
 		panic("wallet is not encrypted when starting postEncryptionTesting")
 	}
-	if w.Unlocked() {
+	if unlocked {
 		panic("wallet is unlocked when starting postEncryptionTesting")
 	}
 	if len(w.seeds) != 0 {
@@ -31,7 +39,7 @@ func postEncryptionTesting(m modules.TestMiner, w *Wallet, masterKey crypto.Twof
 	}
 
 	// Try unlocking and using the wallet.
-	err := w.Unlock(masterKey)
+	err = w.Unlock(masterKey)
 	if err != nil {
 		panic(err)
 	}
@@ -47,7 +55,10 @@ func postEncryptionTesting(m modules.TestMiner, w *Wallet, masterKey crypto.Twof
 			panic(err)
 		}
 	}
-	siacoinBal, _, _ := w.ConfirmedBalance()
+	siacoinBal, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		panic(err)
+	}
 	if siacoinBal.IsZero() {
 		panic("wallet balance reported as 0 after maturing some mined blocks")
 	}
@@ -83,7 +94,10 @@ func postEncryptionTesting(m modules.TestMiner, w *Wallet, masterKey crypto.Twof
 	if err != nil {
 		panic(err)
 	}
-	siacoinBal2, _, _ := w.ConfirmedBalance()
+	siacoinBal2, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		panic(err)
+	}
 	if siacoinBal2.Cmp(siacoinBal) >= 0 {
 		panic("balance did not increase")
 	}
@@ -101,7 +115,11 @@ func TestIntegrationPreEncryption(t *testing.T) {
 	}
 
 	// Check that the wallet knows it's not encrypted.
-	if wt.wallet.Encrypted() {
+	encrypted, err := wt.wallet.Encrypted()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if encrypted {
 		t.Error("wallet is reporting that it has been encrypted")
 	}
 	err = wt.wallet.Lock()
@@ -120,10 +138,19 @@ func TestIntegrationPreEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if w1.Encrypted() {
+	encrypted, err = w1.Encrypted()
+	if encrypted {
 		t.Error("wallet is reporting that it has been encrypted when no such action has occurred")
 	}
-	if w1.Unlocked() {
+	unlocked, err := w1.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlocked, err = w1.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unlocked {
 		t.Error("new wallet is not being treated as locked")
 	}
 	w1.Close()
@@ -210,13 +237,19 @@ func TestLock(t *testing.T) {
 	}
 
 	// Lock the wallet.
-	siacoinBalance, _, _ := wt.wallet.ConfirmedBalance()
+	siacoinBalance, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Error(err)
+	}
 	err = wt.wallet.Lock()
 	if err != nil {
 		t.Error(err)
 	}
 	// Compare to the original balance.
-	siacoinBalance2, _, _ := wt.wallet.ConfirmedBalance()
+	siacoinBalance2, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Error(err)
+	}
 	if !siacoinBalance2.Equals(siacoinBalance) {
 		t.Error("siacoin balance reporting changed upon closing the wallet")
 	}
@@ -243,7 +276,10 @@ func TestLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	siacoinBalance3, _, _ := wt.wallet.ConfirmedBalance()
+	siacoinBalance3, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Error(err)
+	}
 	if siacoinBalance3.Cmp(siacoinBalance2) <= 0 {
 		t.Error("balance should increase after a block was mined")
 	}
@@ -266,7 +302,10 @@ func TestInitFromSeedConcurrentUnlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	origBal, _, _ := wt.wallet.ConfirmedBalance()
+	origBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// create a blank wallet
 	dir := filepath.Join(build.TempDir(modules.WalletDir, t.Name()+"-new"), modules.WalletDir)
@@ -296,7 +335,10 @@ func TestInitFromSeedConcurrentUnlock(t *testing.T) {
 	}
 
 	// starting balance should match the original wallet
-	newBal, _, _ := w.ConfirmedBalance()
+	newBal, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if newBal.Cmp(origBal) != 0 {
 		t.Log(w.UnconfirmedBalance())
 		t.Fatalf("wallet should have correct balance after loading seed: wanted %v, got %v", origBal, newBal)
@@ -358,7 +400,10 @@ func TestInitFromSeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	origBal, _, _ := wt.wallet.ConfirmedBalance()
+	origBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// create a blank wallet
 	dir := filepath.Join(build.TempDir(modules.WalletDir, "TestInitFromSeed1"), modules.WalletDir)
@@ -375,7 +420,10 @@ func TestInitFromSeed(t *testing.T) {
 		t.Fatal(err)
 	}
 	// starting balance should match the original wallet
-	newBal, _, _ := w.ConfirmedBalance()
+	newBal, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if newBal.Cmp(origBal) != 0 {
 		t.Log(w.UnconfirmedBalance())
 		t.Fatalf("wallet should have correct balance after loading seed: wanted %v, got %v", origBal, newBal)
@@ -447,7 +495,10 @@ func TestChangeKey(t *testing.T) {
 
 	var newKey crypto.TwofishKey
 	fastrand.Read(newKey[:])
-	origBal, _, _ := wt.wallet.ConfirmedBalance()
+	origBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = wt.wallet.ChangeKey(wt.walletMasterKey, newKey)
 	if err != nil {
@@ -468,7 +519,10 @@ func TestChangeKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	newBal, _, _ := wt.wallet.ConfirmedBalance()
+	newBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if newBal.Cmp(origBal) != 0 {
 		t.Fatal("wallet with changed key did not have the same balance")
 	}

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -18,6 +18,11 @@ type sortedOutputs struct {
 // DustThreshold returns the quantity per byte below which a Currency is
 // considered to be Dust.
 func (w *Wallet) DustThreshold() types.Currency {
+	if err := w.tg.Add(); err != nil {
+		return types.Currency{}
+	}
+	defer w.tg.Done()
+
 	minFee, _ := w.tpool.FeeEstimation()
 	return minFee.Mul64(3)
 }
@@ -25,6 +30,11 @@ func (w *Wallet) DustThreshold() types.Currency {
 // ConfirmedBalance returns the balance of the wallet according to all of the
 // confirmed transactions.
 func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalance types.Currency, siafundClaimBalance types.Currency) {
+	if err := w.tg.Add(); err != nil {
+		return
+	}
+	defer w.tg.Done()
+
 	// dustThreshold has to be obtained separate from the lock
 	dustThreshold := w.DustThreshold()
 
@@ -61,6 +71,11 @@ func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalan
 // the unconfirmed transaction set. Refund outputs are included in this
 // reporting.
 func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency) {
+	if err := w.tg.Add(); err != nil {
+		return
+	}
+	defer w.tg.Done()
+
 	// dustThreshold has to be obtained separate from the lock
 	dustThreshold := w.DustThreshold()
 

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -17,26 +17,29 @@ type sortedOutputs struct {
 
 // DustThreshold returns the quantity per byte below which a Currency is
 // considered to be Dust.
-func (w *Wallet) DustThreshold() types.Currency {
+func (w *Wallet) DustThreshold() (types.Currency, error) {
 	if err := w.tg.Add(); err != nil {
-		return types.Currency{}
+		return types.Currency{}, modules.ErrWalletShutdown
 	}
 	defer w.tg.Done()
 
 	minFee, _ := w.tpool.FeeEstimation()
-	return minFee.Mul64(3)
+	return minFee.Mul64(3), nil
 }
 
 // ConfirmedBalance returns the balance of the wallet according to all of the
 // confirmed transactions.
-func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalance types.Currency, siafundClaimBalance types.Currency) {
+func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalance types.Currency, siafundClaimBalance types.Currency, err error) {
 	if err := w.tg.Add(); err != nil {
-		return
+		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, modules.ErrWalletShutdown
 	}
 	defer w.tg.Done()
 
 	// dustThreshold has to be obtained separate from the lock
-	dustThreshold := w.DustThreshold()
+	dustThreshold, err := w.DustThreshold()
+	if err != nil {
+		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, modules.ErrWalletShutdown
+	}
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -70,14 +73,17 @@ func (w *Wallet) ConfirmedBalance() (siacoinBalance types.Currency, siafundBalan
 // UnconfirmedBalance returns the number of outgoing and incoming siacoins in
 // the unconfirmed transaction set. Refund outputs are included in this
 // reporting.
-func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency) {
+func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incomingSiacoins types.Currency, err error) {
 	if err := w.tg.Add(); err != nil {
-		return
+		return types.ZeroCurrency, types.ZeroCurrency, modules.ErrWalletShutdown
 	}
 	defer w.tg.Done()
 
 	// dustThreshold has to be obtained separate from the lock
-	dustThreshold := w.DustThreshold()
+	dustThreshold, err := w.DustThreshold()
+	if err != nil {
+		return types.ZeroCurrency, types.ZeroCurrency, modules.ErrWalletShutdown
+	}
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -101,6 +107,7 @@ func (w *Wallet) UnconfirmedBalance() (outgoingSiacoins types.Currency, incoming
 // is submitted to the transaction pool and is also returned.
 func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) (txns []types.Transaction, err error) {
 	if err := w.tg.Add(); err != nil {
+		err = modules.ErrWalletShutdown
 		return nil, err
 	}
 	defer w.tg.Done()
@@ -120,7 +127,10 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) (txn
 		UnlockHash: dest,
 	}
 
-	txnBuilder := w.StartTransaction()
+	txnBuilder, err := w.StartTransaction()
+	if err != nil {
+		return nil, err
+	}
 	defer func() {
 		if err != nil {
 			txnBuilder.Drop()
@@ -159,6 +169,7 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) (txn
 func (w *Wallet) SendSiacoinsMulti(outputs []types.SiacoinOutput) (txns []types.Transaction, err error) {
 	w.log.Println("Beginning call to SendSiacoinsMulti")
 	if err := w.tg.Add(); err != nil {
+		err = modules.ErrWalletShutdown
 		return nil, err
 	}
 	defer w.tg.Done()
@@ -170,7 +181,10 @@ func (w *Wallet) SendSiacoinsMulti(outputs []types.SiacoinOutput) (txns []types.
 		return nil, modules.ErrLockedWallet
 	}
 
-	txnBuilder := w.StartTransaction()
+	txnBuilder, err := w.StartTransaction()
+	if err != nil {
+		return nil, err
+	}
 	defer func() {
 		if err != nil {
 			txnBuilder.Drop()
@@ -229,6 +243,7 @@ func (w *Wallet) SendSiacoinsMulti(outputs []types.SiacoinOutput) (txns []types.
 // is submitted to the transaction pool and is also returned.
 func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]types.Transaction, error) {
 	if err := w.tg.Add(); err != nil {
+		err = modules.ErrWalletShutdown
 		return nil, err
 	}
 	defer w.tg.Done()
@@ -247,8 +262,11 @@ func (w *Wallet) SendSiafunds(amount types.Currency, dest types.UnlockHash) ([]t
 		UnlockHash: dest,
 	}
 
-	txnBuilder := w.StartTransaction()
-	err := txnBuilder.FundSiacoins(tpoolFee)
+	txnBuilder, err := w.StartTransaction()
+	if err != nil {
+		return nil, err
+	}
+	err = txnBuilder.FundSiacoins(tpoolFee)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/wallet/money_test.go
+++ b/modules/wallet/money_test.go
@@ -21,8 +21,14 @@ func TestSendSiacoins(t *testing.T) {
 
 	// Get the initial balance - should be 1 block. The unconfirmed balances
 	// should be 0.
-	confirmedBal, _, _ := wt.wallet.ConfirmedBalance()
-	unconfirmedOut, unconfirmedIn := wt.wallet.UnconfirmedBalance()
+	confirmedBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unconfirmedOut, unconfirmedIn, err := wt.wallet.UnconfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !confirmedBal.Equals(types.CalculateCoinbase(1)) {
 		t.Error("unexpected confirmed balance")
 	}
@@ -43,8 +49,14 @@ func TestSendSiacoins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	confirmedBal2, _, _ := wt.wallet.ConfirmedBalance()
-	unconfirmedOut2, unconfirmedIn2 := wt.wallet.UnconfirmedBalance()
+	confirmedBal2, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unconfirmedOut2, unconfirmedIn2, err := wt.wallet.UnconfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !confirmedBal2.Equals(confirmedBal) {
 		t.Error("confirmed balance changed without introduction of blocks")
 	}
@@ -58,8 +70,14 @@ func TestSendSiacoins(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	confirmedBal3, _, _ := wt.wallet.ConfirmedBalance()
-	unconfirmedOut3, unconfirmedIn3 := wt.wallet.UnconfirmedBalance()
+	confirmedBal3, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unconfirmedOut3, unconfirmedIn3, err := wt.wallet.UnconfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !confirmedBal3.Equals(confirmedBal2.Add(types.CalculateCoinbase(2)).Sub(sendValue).Sub(tpoolFee)) {
 		t.Error("confirmed balance did not adjust to the expected value")
 	}

--- a/modules/wallet/persist.go
+++ b/modules/wallet/persist.go
@@ -123,9 +123,7 @@ func (w *Wallet) initPersist() error {
 	if err != nil {
 		return err
 	}
-	w.tg.AfterStop(func() { w.db.Close() })
-
-	return nil
+	return w.tg.AfterStop(func() error { return w.db.Close() })
 }
 
 // createBackup copies the wallet database to dst.

--- a/modules/wallet/seed.go
+++ b/modules/wallet/seed.go
@@ -405,7 +405,11 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 		var txnCoins, txnFunds types.Currency
 
 		// construct a transaction that spends the outputs
-		tb := w.StartTransaction()
+		tb, err := w.StartTransaction()
+		if err != nil {
+			return types.ZeroCurrency, types.ZeroCurrency, err
+		}
+
 		var sweptCoins, sweptFunds types.Currency // total values of swept outputs
 		for _, output := range txnSiacoinOutputs {
 			// construct a siacoin input that spends the output
@@ -512,7 +516,7 @@ func (w *Wallet) SweepSeed(seed modules.Seed) (coins, funds types.Currency, err 
 		// submit the transactions
 		err = w.tpool.AcceptTransactionSet(txnSet)
 		if err != nil {
-			return
+			return types.ZeroCurrency, types.ZeroCurrency, err
 		}
 
 		w.log.Println("Creating a transaction set to sweep a seed, IDs:")

--- a/modules/wallet/seed_test.go
+++ b/modules/wallet/seed_test.go
@@ -125,7 +125,10 @@ func TestLoadSeed(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Balance of wallet should be 0.
-	siacoinBal, _, _ := w.ConfirmedBalance()
+	siacoinBal, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !siacoinBal.Equals64(0) {
 		t.Error("fresh wallet should not have a balance")
 	}
@@ -147,7 +150,10 @@ func TestLoadSeed(t *testing.T) {
 		t.Error("AllSeeds returned the wrong seed")
 	}
 
-	siacoinBal2, _, _ := w.ConfirmedBalance()
+	siacoinBal2, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if siacoinBal2.Cmp64(0) <= 0 {
 		t.Error("wallet failed to load a seed with money in it")
 	}
@@ -213,7 +219,10 @@ func TestSweepSeedCoins(t *testing.T) {
 		t.Fatal(err)
 	}
 	// starting balance should be 0.
-	siacoinBal, _, _ := w.ConfirmedBalance()
+	siacoinBal, _, _, err := w.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !siacoinBal.IsZero() {
 		t.Error("fresh wallet should not have a balance")
 	}
@@ -225,7 +234,10 @@ func TestSweepSeedCoins(t *testing.T) {
 	}
 
 	// new wallet should have exactly 'sweptCoins' coins
-	_, incoming := w.UnconfirmedBalance()
+	_, incoming, err := w.UnconfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if incoming.Cmp(sweptCoins) != 0 {
 		t.Fatalf("wallet should have correct balance after sweeping seed: wanted %v, got %v", sweptCoins, incoming)
 	}
@@ -250,7 +262,10 @@ func TestSweepSeedFunds(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	_, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if siafundBal.Cmp(types.NewCurrency64(2000)) != 0 {
 		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
 	}
@@ -279,7 +294,10 @@ func TestSweepSeedFunds(t *testing.T) {
 	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
 		wt.addBlockNoPayout()
 	}
-	oldCoinBalance, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	oldCoinBalance, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if siafundBal.Cmp(types.NewCurrency64(1988)) != 0 {
 		t.Errorf("expecting balance of %v after sending siafunds to the seed, got %v", 1988, siafundBal)
 	}
@@ -299,7 +317,10 @@ func TestSweepSeedFunds(t *testing.T) {
 	wt.addBlockNoPayout()
 
 	// Wallet balance should have decreased to pay for the sweep transaction.
-	newCoinBalance, _, _ := wt.wallet.ConfirmedBalance()
+	newCoinBalance, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if newCoinBalance.Cmp(oldCoinBalance) >= 0 {
 		t.Error("expecting balance to go down; instead, increased by", newCoinBalance.Sub(oldCoinBalance))
 	}
@@ -325,7 +346,10 @@ func TestSweepSeedSentFunds(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	_, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if siafundBal.Cmp(types.NewCurrency64(2000)) != 0 {
 		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
 	}
@@ -367,7 +391,10 @@ func TestSweepSeedSentFunds(t *testing.T) {
 	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
 		wt.addBlockNoPayout()
 	}
-	oldCoinBalance, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	oldCoinBalance, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if expected := 2000 - 12 - 10; siafundBal.Cmp(types.NewCurrency64(uint64(expected))) != 0 {
 		t.Errorf("expecting balance of %v after sending siafunds to the seed, got %v", expected, siafundBal)
 	}
@@ -387,7 +414,10 @@ func TestSweepSeedSentFunds(t *testing.T) {
 	wt.addBlockNoPayout()
 
 	// Wallet balance should have decreased to pay for the sweep transaction.
-	newCoinBalance, _, _ := wt.wallet.ConfirmedBalance()
+	newCoinBalance, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if newCoinBalance.Cmp(oldCoinBalance) >= 0 {
 		t.Error("expecting balance to go down; instead, increased by", newCoinBalance.Sub(oldCoinBalance))
 	}
@@ -412,7 +442,10 @@ func TestSweepSeedCoinsAndFunds(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	_, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if siafundBal.Cmp(types.NewCurrency64(2000)) != 0 {
 		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
 	}
@@ -442,7 +475,10 @@ func TestSweepSeedCoinsAndFunds(t *testing.T) {
 	for i := types.BlockHeight(0); i < types.MaturityDelay; i++ {
 		wt.addBlockNoPayout()
 	}
-	oldCoinBalance, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	oldCoinBalance, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if siafundBal.Cmp(types.NewCurrency64(1988)) != 0 {
 		t.Errorf("expecting balance of %v after sending siafunds to the seed, got %v", 1988, siafundBal)
 	}
@@ -462,7 +498,10 @@ func TestSweepSeedCoinsAndFunds(t *testing.T) {
 	wt.addBlockNoPayout()
 
 	// Wallet balance should have decreased to pay for the sweep transaction.
-	newCoinBalance, _, _ := wt.wallet.ConfirmedBalance()
+	newCoinBalance, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if newCoinBalance.Cmp(oldCoinBalance) <= 0 {
 		t.Error("expecting balance to go up; instead, decreased by", oldCoinBalance.Sub(newCoinBalance))
 	}

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -667,6 +667,7 @@ func (w *Wallet) RegisterTransaction(t types.Transaction, parents []types.Transa
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
+	defer w.tg.Done()
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.registerTransaction(t, parents), nil
@@ -678,5 +679,6 @@ func (w *Wallet) StartTransaction() (modules.TransactionBuilder, error) {
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
+	defer w.tg.Done()
 	return w.RegisterTransaction(types.Transaction{}, nil)
 }

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -54,7 +54,10 @@ func TestViewAdded(t *testing.T) {
 	// but do not sign the transaction. The format of this test mimics the way
 	// that the host-renter protocol behaves when building a file contract
 	// transaction.
-	b := wt.wallet.StartTransaction()
+	b, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	txnFund := types.NewCurrency64(100e9)
 	err = b.FundSiacoins(txnFund)
 	if err != nil {
@@ -67,7 +70,10 @@ func TestViewAdded(t *testing.T) {
 	// Create a second builder that extends the first, unsigned transaction. Do
 	// not sign the transaction, but do give the extensions to the original
 	// builder.
-	b2 := wt.wallet.RegisterTransaction(unfinishedTxn, unfinishedParents)
+	b2, err := wt.wallet.RegisterTransaction(unfinishedTxn, unfinishedParents)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = b2.FundSiacoins(txnFund)
 	if err != nil {
 		t.Fatal(err)
@@ -144,7 +150,10 @@ func TestDoubleSignError(t *testing.T) {
 	defer wt.closeWt()
 
 	// Create a transaction, add money to it, and then call sign twice.
-	b := wt.wallet.StartTransaction()
+	b, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	txnFund := types.NewCurrency64(100e9)
 	err = b.FundSiacoins(txnFund)
 	if err != nil {
@@ -191,8 +200,14 @@ func TestConcurrentBuilders(t *testing.T) {
 	}
 
 	// Get a baseline balance for the wallet.
-	startingSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
-	startingOutgoing, startingIncoming := wt.wallet.UnconfirmedBalance()
+	startingSCConfirmed, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	startingOutgoing, startingIncoming, err := wt.wallet.UnconfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !startingOutgoing.IsZero() {
 		t.Fatal(startingOutgoing)
 	}
@@ -201,8 +216,14 @@ func TestConcurrentBuilders(t *testing.T) {
 	}
 
 	// Create two builders at the same time, then add money to each.
-	builder1 := wt.wallet.StartTransaction()
-	builder2 := wt.wallet.StartTransaction()
+	builder1, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder2, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Fund each builder with a siacoin output that is smaller than all of the
 	// outputs that the wallet should currently have.
 	funding := types.NewCurrency64(10e3).Mul(types.SiacoinPrecision)
@@ -216,7 +237,10 @@ func TestConcurrentBuilders(t *testing.T) {
 	}
 
 	// Get a second reading on the wallet's balance.
-	fundedSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
+	fundedSCConfirmed, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !startingSCConfirmed.Equals(fundedSCConfirmed) {
 		t.Fatal("confirmed siacoin balance changed when no blocks have been mined", startingSCConfirmed, fundedSCConfirmed)
 	}
@@ -284,9 +308,15 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	scBal, _, _ := wt.wallet.ConfirmedBalance()
+	scBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Use a custom builder so that there is no transaction fee.
-	builder := wt.wallet.StartTransaction()
+	builder, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = builder.FundSiacoins(scBal)
 	if err != nil {
 		t.Fatal(err)
@@ -312,8 +342,14 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	}
 
 	// Get a baseline balance for the wallet.
-	startingSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
-	startingOutgoing, startingIncoming := wt.wallet.UnconfirmedBalance()
+	startingSCConfirmed, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	startingOutgoing, startingIncoming, err := wt.wallet.UnconfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !startingOutgoing.IsZero() {
 		t.Fatal(startingOutgoing)
 	}
@@ -322,8 +358,14 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	}
 
 	// Create two builders at the same time, then add money to each.
-	builder1 := wt.wallet.StartTransaction()
-	builder2 := wt.wallet.StartTransaction()
+	builder1, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder2, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Fund each builder with a siacoin output.
 	funding := types.NewCurrency64(10e3).Mul(types.SiacoinPrecision)
 	err = builder1.FundSiacoins(funding)
@@ -337,7 +379,10 @@ func TestConcurrentBuildersSingleOutput(t *testing.T) {
 	}
 
 	// Get a second reading on the wallet's balance.
-	fundedSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
+	fundedSCConfirmed, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !startingSCConfirmed.Equals(fundedSCConfirmed) {
 		t.Fatal("confirmed siacoin balance changed when no blocks have been mined", startingSCConfirmed, fundedSCConfirmed)
 	}
@@ -397,8 +442,14 @@ func TestParallelBuilders(t *testing.T) {
 	}
 
 	// Get a baseline balance for the wallet.
-	startingSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
-	startingOutgoing, startingIncoming := wt.wallet.UnconfirmedBalance()
+	startingSCConfirmed, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	startingOutgoing, startingIncoming, err := wt.wallet.UnconfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !startingOutgoing.IsZero() {
 		t.Fatal(startingOutgoing)
 	}
@@ -413,8 +464,11 @@ func TestParallelBuilders(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			// Create the builder and fund the transaction.
-			builder := wt.wallet.StartTransaction()
-			err := builder.FundSiacoins(funding)
+			builder, err := wt.wallet.StartTransaction()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = builder.FundSiacoins(funding)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -444,7 +498,10 @@ func TestParallelBuilders(t *testing.T) {
 	}
 
 	// Check the final balance.
-	endingSCConfirmed, _, _ := wt.wallet.ConfirmedBalance()
+	endingSCConfirmed, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	expected := startingSCConfirmed.Sub(funding.Mul(types.NewCurrency64(uint64(outputsDesired))))
 	if !expected.Equals(endingSCConfirmed) {
 		t.Fatal("did not get the expected ending balance", expected, endingSCConfirmed, startingSCConfirmed)
@@ -468,7 +525,10 @@ func TestUnconfirmedParents(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to get address", err)
 	}
-	siacoins, _, _ := wt.wallet.ConfirmedBalance()
+	siacoins, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	tSet, err := wt.wallet.SendSiacoins(siacoins.Sub(types.SiacoinPrecision), uc.UnlockHash())
 	if err != nil {
 		t.Fatal("Failed to send coins", err)
@@ -477,7 +537,10 @@ func TestUnconfirmedParents(t *testing.T) {
 	// Create a transaction. That transaction should use siacoin outputs from
 	// the unconfirmed transactions in tSet as inputs and is therefore a child
 	// of tSet.
-	b := wt.wallet.StartTransaction()
+	b, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	txnFund := types.NewCurrency64(1e3)
 	err = b.FundSiacoins(txnFund)
 	if err != nil {

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -22,6 +22,7 @@ func (w *Wallet) AddressTransactions(uh types.UnlockHash) (pts []modules.Process
 	if err := w.tg.Add(); err != nil {
 		return []modules.ProcessedTransaction{}, err
 	}
+	w.tg.Done()
 	// ensure durability of reported transactions
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -44,6 +45,7 @@ func (w *Wallet) AddressUnconfirmedTransactions(uh types.UnlockHash) (pts []modu
 	if err := w.tg.Add(); err != nil {
 		return []modules.ProcessedTransaction{}, err
 	}
+	w.tg.Done()
 	// ensure durability of reported transactions
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -78,6 +80,7 @@ func (w *Wallet) Transaction(txid types.TransactionID) (pt modules.ProcessedTran
 	if err := w.tg.Add(); err != nil {
 		return modules.ProcessedTransaction{}, false, err
 	}
+	w.tg.Done()
 	// ensure durability of reported transaction
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -100,6 +103,7 @@ func (w *Wallet) Transactions(startHeight, endHeight types.BlockHeight) (pts []m
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
+	w.tg.Done()
 	// ensure durability of reported transactions
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -201,6 +205,7 @@ func (w *Wallet) UnconfirmedTransactions() ([]modules.ProcessedTransaction, erro
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
+	w.tg.Done()
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.unconfirmedProcessedTransactions, nil

--- a/modules/wallet/transactions.go
+++ b/modules/wallet/transactions.go
@@ -22,7 +22,7 @@ func (w *Wallet) AddressTransactions(uh types.UnlockHash) (pts []modules.Process
 	if err := w.tg.Add(); err != nil {
 		return []modules.ProcessedTransaction{}, err
 	}
-	w.tg.Done()
+	defer w.tg.Done()
 	// ensure durability of reported transactions
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -45,7 +45,7 @@ func (w *Wallet) AddressUnconfirmedTransactions(uh types.UnlockHash) (pts []modu
 	if err := w.tg.Add(); err != nil {
 		return []modules.ProcessedTransaction{}, err
 	}
-	w.tg.Done()
+	defer w.tg.Done()
 	// ensure durability of reported transactions
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -80,7 +80,7 @@ func (w *Wallet) Transaction(txid types.TransactionID) (pt modules.ProcessedTran
 	if err := w.tg.Add(); err != nil {
 		return modules.ProcessedTransaction{}, false, err
 	}
-	w.tg.Done()
+	defer w.tg.Done()
 	// ensure durability of reported transaction
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -103,7 +103,7 @@ func (w *Wallet) Transactions(startHeight, endHeight types.BlockHeight) (pts []m
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
-	w.tg.Done()
+	defer w.tg.Done()
 	// ensure durability of reported transactions
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -205,7 +205,7 @@ func (w *Wallet) UnconfirmedTransactions() ([]modules.ProcessedTransaction, erro
 	if err := w.tg.Add(); err != nil {
 		return nil, err
 	}
-	w.tg.Done()
+	defer w.tg.Done()
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.unconfirmedProcessedTransactions, nil

--- a/modules/wallet/unseeded_test.go
+++ b/modules/wallet/unseeded_test.go
@@ -26,7 +26,10 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	_, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !siafundBal.Equals64(2000) {
 		t.Error("expecting a siafund balance of 2000 from the 1of1 key")
 	}
@@ -40,7 +43,10 @@ func TestIntegrationLoad1of1Siag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, siafundBal, _ = wt.wallet.ConfirmedBalance()
+	_, siafundBal, _, err = wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !siafundBal.Equals64(1988) {
 		t.Error("expecting balance of 1988 after sending siafunds to the void")
 	}
@@ -65,7 +71,10 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, siafundBal, _ := wt.wallet.ConfirmedBalance()
+	_, siafundBal, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !siafundBal.Equals64(7000) {
 		t.Error("expecting a siafund balance of 7000 from the 2of3 key")
 	}
@@ -79,7 +88,10 @@ func TestIntegrationLoad2of3Siag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, siafundBal, _ = wt.wallet.ConfirmedBalance()
+	_, siafundBal, _, err = wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !siafundBal.Equals64(6988) {
 		t.Error("expecting balance of 6988 after sending siafunds to the void")
 	}

--- a/modules/wallet/update_test.go
+++ b/modules/wallet/update_test.go
@@ -26,7 +26,10 @@ func TestUpdate(t *testing.T) {
 	}
 	// since the miner is mining into a wallet address, the wallet should have
 	// added a new transaction
-	_, ok := wt.wallet.Transaction(types.TransactionID(b.ID()))
+	_, ok, err := wt.wallet.Transaction(types.TransactionID(b.ID()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !ok {
 		t.Fatal("no record of miner transaction")
 	}
@@ -36,7 +39,10 @@ func TestUpdate(t *testing.T) {
 		RevertedBlocks: []types.Block{b},
 	})
 	// transaction should no longer be present
-	_, ok = wt.wallet.Transaction(types.TransactionID(b.ID()))
+	_, ok, err = wt.wallet.Transaction(types.TransactionID(b.ID()))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if ok {
 		t.Fatal("miner transaction was not removed after block was reverted")
 	}
@@ -59,14 +65,20 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// transaction should be present
-	_, ok = wt.wallet.Transaction(txnSet[0].ID())
+	_, ok, err = wt.wallet.Transaction(txnSet[0].ID())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !ok {
 		t.Fatal("no record of transaction")
 	}
 
 	// revert all the blocks
 	wt.wallet.ProcessConsensusChange(revertCC)
-	_, ok = wt.wallet.Transaction(txnSet[0].ID())
+	_, ok, err = wt.wallet.Transaction(txnSet[0].ID())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if ok {
 		t.Fatal("transaction was not removed")
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -113,9 +113,9 @@ type Wallet struct {
 }
 
 // Height return the internal processed consensus height of the wallet
-func (w *Wallet) Height() types.BlockHeight {
+func (w *Wallet) Height() (types.BlockHeight, error) {
 	if err := w.tg.Add(); err != nil {
-		return types.BlockHeight(0)
+		return types.BlockHeight(0), modules.ErrWalletShutdown
 	}
 	defer w.tg.Done()
 
@@ -127,9 +127,9 @@ func (w *Wallet) Height() types.BlockHeight {
 		return encoding.Unmarshal(tx.Bucket(bucketWallet).Get(keyConsensusHeight), &height)
 	})
 	if err != nil {
-		return types.BlockHeight(0)
+		return types.BlockHeight(0), err
 	}
-	return types.BlockHeight(height)
+	return types.BlockHeight(height), nil
 }
 
 // New creates a new wallet, loading any known addresses from the input file
@@ -210,7 +210,10 @@ func (w *Wallet) Close() error {
 	// Once the wallet is locked it cannot be unlocked except using the
 	// unexported unlock method (w.Unlock returns an error if the wallet's
 	// ThreadGroup is stopped).
-	if w.Unlocked() {
+	w.mu.RLock()
+	unlocked := w.unlocked
+	w.mu.RUnlock()
+	if unlocked {
 		if err := w.Lock(); err != nil {
 			errs = append(errs, err)
 		}
@@ -227,9 +230,9 @@ func (w *Wallet) Close() error {
 
 // AllAddresses returns all addresses that the wallet is able to spend from,
 // including unseeded addresses. Addresses are returned sorted in byte-order.
-func (w *Wallet) AllAddresses() []types.UnlockHash {
+func (w *Wallet) AllAddresses() ([]types.UnlockHash, error) {
 	if err := w.tg.Add(); err != nil {
-		return []types.UnlockHash{}
+		return []types.UnlockHash{}, modules.ErrWalletShutdown
 	}
 	defer w.tg.Done()
 
@@ -243,14 +246,14 @@ func (w *Wallet) AllAddresses() []types.UnlockHash {
 	sort.Slice(addrs, func(i, j int) bool {
 		return bytes.Compare(addrs[i][:], addrs[j][:]) < 0
 	})
-	return addrs
+	return addrs, nil
 }
 
 // Rescanning reports whether the wallet is currently rescanning the
 // blockchain.
-func (w *Wallet) Rescanning() bool {
+func (w *Wallet) Rescanning() (bool, error) {
 	if err := w.tg.Add(); err != nil {
-		return false
+		return false, modules.ErrWalletShutdown
 	}
 	defer w.tg.Done()
 
@@ -258,24 +261,29 @@ func (w *Wallet) Rescanning() bool {
 	if !rescanning {
 		w.scanLock.Unlock()
 	}
-	return rescanning
+	return rescanning, nil
 }
 
 // Settings returns the wallet's current settings
-func (w *Wallet) Settings() modules.WalletSettings {
+func (w *Wallet) Settings() (modules.WalletSettings, error) {
+	if err := w.tg.Add(); err != nil {
+		return modules.WalletSettings{}, modules.ErrWalletShutdown
+	}
+	defer w.tg.Done()
 	return modules.WalletSettings{
 		NoDefrag: w.defragDisabled,
-	}
+	}, nil
 }
 
 // SetSettings will update the settings for the wallet.
-func (w *Wallet) SetSettings(s modules.WalletSettings) {
+func (w *Wallet) SetSettings(s modules.WalletSettings) error {
 	if err := w.tg.Add(); err != nil {
-		return
+		return modules.ErrWalletShutdown
 	}
 	defer w.tg.Done()
 
 	w.mu.Lock()
 	w.defragDisabled = s.NoDefrag
 	w.mu.Unlock()
+	return nil
 }

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -210,11 +210,8 @@ func (w *Wallet) Close() error {
 	// Once the wallet is locked it cannot be unlocked except using the
 	// unexported unlock method (w.Unlock returns an error if the wallet's
 	// ThreadGroup is stopped).
-	w.mu.RLock()
-	unlocked := w.unlocked
-	w.mu.RUnlock()
-	if unlocked {
-		if err := w.Lock(); err != nil {
+	if w.managedUnlocked() {
+		if err := w.managedLock(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/modules/wallet/wallet.go
+++ b/modules/wallet/wallet.go
@@ -114,6 +114,11 @@ type Wallet struct {
 
 // Height return the internal processed consensus height of the wallet
 func (w *Wallet) Height() types.BlockHeight {
+	if err := w.tg.Add(); err != nil {
+		return types.BlockHeight(0)
+	}
+	defer w.tg.Done()
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -223,6 +228,11 @@ func (w *Wallet) Close() error {
 // AllAddresses returns all addresses that the wallet is able to spend from,
 // including unseeded addresses. Addresses are returned sorted in byte-order.
 func (w *Wallet) AllAddresses() []types.UnlockHash {
+	if err := w.tg.Add(); err != nil {
+		return []types.UnlockHash{}
+	}
+	defer w.tg.Done()
+
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
@@ -239,6 +249,11 @@ func (w *Wallet) AllAddresses() []types.UnlockHash {
 // Rescanning reports whether the wallet is currently rescanning the
 // blockchain.
 func (w *Wallet) Rescanning() bool {
+	if err := w.tg.Add(); err != nil {
+		return false
+	}
+	defer w.tg.Done()
+
 	rescanning := !w.scanLock.TryLock()
 	if !rescanning {
 		w.scanLock.Unlock()
@@ -255,6 +270,11 @@ func (w *Wallet) Settings() modules.WalletSettings {
 
 // SetSettings will update the settings for the wallet.
 func (w *Wallet) SetSettings(s modules.WalletSettings) {
+	if err := w.tg.Add(); err != nil {
+		return
+	}
+	defer w.tg.Done()
+
 	w.mu.Lock()
 	w.defragDisabled = s.NoDefrag
 	w.mu.Unlock()

--- a/modules/wallet/wallet_test.go
+++ b/modules/wallet/wallet_test.go
@@ -186,7 +186,10 @@ func TestAllAddresses(t *testing.T) {
 	wt.wallet.keys[types.UnlockHash{2}] = spendableKey{}
 	wt.wallet.keys[types.UnlockHash{4}] = spendableKey{}
 	wt.wallet.keys[types.UnlockHash{3}] = spendableKey{}
-	addrs := wt.wallet.AllAddresses()
+	addrs, err := wt.wallet.AllAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i := range addrs {
 		if addrs[i][0] != byte(i) {
 			t.Error("address sorting failed:", i, addrs[i][0])
@@ -235,7 +238,11 @@ func TestRescanning(t *testing.T) {
 	defer wt.closeWt()
 
 	// A fresh wallet should not be rescanning.
-	if wt.wallet.Rescanning() {
+	rescanning, err := wt.wallet.Rescanning()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rescanning {
 		t.Fatal("fresh wallet should not report that a scan is underway")
 	}
 
@@ -253,7 +260,11 @@ func TestRescanning(t *testing.T) {
 
 	// wait for goroutine to start, after which Rescanning should return true
 	time.Sleep(time.Millisecond * 10)
-	if !wt.wallet.Rescanning() {
+	rescanning, err = wt.wallet.Rescanning()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rescanning {
 		t.Fatal("wallet should report that a scan is underway")
 	}
 
@@ -264,7 +275,11 @@ func TestRescanning(t *testing.T) {
 	}
 
 	// Rescanning should now return false again
-	if wt.wallet.Rescanning() {
+	rescanning, err = wt.wallet.Rescanning()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rescanning {
 		t.Fatal("wallet should not report that a scan is underway")
 	}
 }
@@ -339,7 +354,10 @@ func TestAdvanceLookaheadNoRescan(t *testing.T) {
 	}
 	defer wt.closeWt()
 
-	builder := wt.wallet.StartTransaction()
+	builder, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	payout := types.ZeroCurrency
 
 	// Get the current progress
@@ -423,7 +441,10 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 	if err != nil {
 		t.Fatal("Couldn't fetch primary seed from db")
 	}
-	startBal, _, _ := wt.wallet.ConfirmedBalance()
+	startBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Send coins to an address with a high seed index, just outside the
 	// lookahead range. It will not be initially detected, but later the
@@ -432,7 +453,10 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 	farAddr := generateSpendableKey(wt.wallet.primarySeed, highIndex).UnlockConditions.UnlockHash()
 	farPayout := types.SiacoinPrecision.Mul64(8888)
 
-	builder := wt.wallet.StartTransaction()
+	builder, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	builder.AddSiacoinOutput(types.SiacoinOutput{
 		UnlockHash: farAddr,
 		Value:      farPayout,
@@ -452,12 +476,18 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 		t.Fatal(err)
 	}
 	wt.addBlockNoPayout()
-	newBal, _, _ := wt.wallet.ConfirmedBalance()
+	newBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !startBal.Sub(newBal).Equals(farPayout) {
 		t.Fatal("wallet should not recognize coins sent to very high seed index")
 	}
 
-	builder = wt.wallet.StartTransaction()
+	builder, err = wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	var payout types.Currency
 
 	// choose 10 keys in the lookahead and remember them
@@ -500,7 +530,10 @@ func TestAdvanceLookaheadForceRescan(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	// Check that high seed index txn was discovered in the rescan
-	rescanBal, _, _ := wt.wallet.ConfirmedBalance()
+	rescanBal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !rescanBal.Equals(startBal) {
 		t.Fatal("wallet did not discover txn after rescan")
 	}
@@ -557,8 +590,14 @@ func TestDistantWallets(t *testing.T) {
 	}
 
 	// The second wallet's balance should update accordingly.
-	w1bal, _, _ := wt.wallet.ConfirmedBalance()
-	w2bal, _, _ := w2.ConfirmedBalance()
+	w1bal, _, _, err := wt.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	w2bal, _, _, err := w2.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !w1bal.Equals(w2bal) {
 		t.Fatal("balances do not match:", w1bal, w2bal)
@@ -566,7 +605,10 @@ func TestDistantWallets(t *testing.T) {
 
 	// Send coins to an address with a very high seed index, outside the
 	// lookahead range. w2 should not detect it.
-	tbuilder := wt.wallet.StartTransaction()
+	tbuilder, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
 	farAddr := generateSpendableKey(wt.wallet.primarySeed, lookaheadBuffer*10).UnlockConditions.UnlockHash()
 	value := types.SiacoinPrecision.Mul64(1e3)
 	tbuilder.AddSiacoinOutput(types.SiacoinOutput{
@@ -587,7 +629,10 @@ func TestDistantWallets(t *testing.T) {
 	}
 	wt.addBlockNoPayout()
 
-	if newBal, _, _ := w2.ConfirmedBalance(); !newBal.Equals(w2bal.Sub(value)) {
+	if newBal, _, _, err := w2.ConfirmedBalance(); !newBal.Equals(w2bal.Sub(value)) {
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Fatal("wallet should not recognize coins sent to very high seed index")
 	}
 }

--- a/node/api/hostdb_test.go
+++ b/node/api/hostdb_test.go
@@ -262,7 +262,11 @@ func assembleHostPort(key crypto.TwofishKey, hostHostname string, testdir string
 	if err != nil {
 		return nil, err
 	}
-	if !w.Encrypted() {
+	encrypted, err := w.Encrypted()
+	if err != nil {
+		return nil, err
+	}
+	if !encrypted {
 		_, err = w.Encrypt(key)
 		if err != nil {
 			return nil, err

--- a/node/api/server_helpers_test.go
+++ b/node/api/server_helpers_test.go
@@ -165,7 +165,11 @@ func assembleServerTester(key crypto.TwofishKey, testdir string) (*serverTester,
 	if err != nil {
 		return nil, err
 	}
-	if !w.Encrypted() {
+	encrypted, err := w.Encrypted()
+	if err != nil {
+		return nil, err
+	}
+	if !encrypted {
 		_, err = w.Encrypt(key)
 		if err != nil {
 			return nil, err
@@ -245,7 +249,11 @@ func assembleAuthenticatedServerTester(requiredPassword string, key crypto.Twofi
 	if err != nil {
 		return nil, err
 	}
-	if !w.Encrypted() {
+	encrypted, err := w.Encrypted()
+	if err != nil {
+		return nil, err
+	}
+	if !encrypted {
 		_, err = w.Encrypt(key)
 		if err != nil {
 			return nil, err

--- a/node/api/server_helpers_test.go
+++ b/node/api/server_helpers_test.go
@@ -73,7 +73,7 @@ func (srv *Server) Close() error {
 	for _, mod := range mods {
 		if mod.c != nil {
 			if closeErr := mod.c.Close(); closeErr != nil {
-				err = errors.Extend(err, fmt.Errorf("%v.Close failed: %v", mod.name, err))
+				err = errors.Extend(err, fmt.Errorf("%v.Close failed: %v", mod.name, closeErr))
 			}
 		}
 	}

--- a/node/api/wallet_test.go
+++ b/node/api/wallet_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -19,6 +18,7 @@ import (
 	"github.com/NebulousLabs/Sia/modules/transactionpool"
 	"github.com/NebulousLabs/Sia/modules/wallet"
 	"github.com/NebulousLabs/Sia/types"
+	"github.com/NebulousLabs/errors"
 	"github.com/NebulousLabs/fastrand"
 )
 
@@ -119,7 +119,11 @@ func TestWalletEncrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !st.wallet.Unlocked() {
+	unlocked, err := st.wallet.Unlocked()
+	if err != nil {
+		t.Error(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 
@@ -147,7 +151,11 @@ func TestWalletEncrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !st2.wallet.Unlocked() {
+	unlocked, err = st2.wallet.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 }
@@ -213,7 +221,11 @@ func TestWalletBlankEncrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !w.Unlocked() {
+	unlocked, err := w.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 }
@@ -296,7 +308,11 @@ func TestIntegrationWalletInitSeed(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !w.Unlocked() {
+	unlocked, err := w.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 }
@@ -515,8 +531,11 @@ func TestIntegrationWalletLoadSeedPOST(t *testing.T) {
 	}
 
 	// Record starting balances.
-	oldBal, _, _ := st.wallet.ConfirmedBalance()
-	w2bal, _, _ := w2.ConfirmedBalance()
+	oldBal, _, _, err1 := st.wallet.ConfirmedBalance()
+	w2bal, _, _, err2 := w2.ConfirmedBalance()
+	if errs := errors.Compose(err1, err2); errs != nil {
+		t.Fatal(errs)
+	}
 	if w2bal.IsZero() {
 		t.Fatal("second wallet's balance should not be zero")
 	}
@@ -532,7 +551,10 @@ func TestIntegrationWalletLoadSeedPOST(t *testing.T) {
 		t.Fatal(err)
 	}
 	// First wallet should now have balance of both wallets
-	bal, _, _ := st.wallet.ConfirmedBalance()
+	bal, _, _, err := st.wallet.ConfirmedBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if exp := oldBal.Add(w2bal); !bal.Equals(exp) {
 		t.Fatalf("wallet did not load seed correctly: expected %v coins, got %v", exp, bal)
 	}
@@ -1017,7 +1039,11 @@ func TestWalletReset(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !st.wallet.Unlocked() {
+	unlocked, err := st.wallet.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 
@@ -1045,7 +1071,11 @@ func TestWalletReset(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !st2.wallet.Unlocked() {
+	unlocked, err = st2.wallet.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 }
@@ -1257,7 +1287,11 @@ func TestWalletChangePassword(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !st.wallet.Unlocked() {
+	unlocked, err := st.wallet.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 
@@ -1270,7 +1304,11 @@ func TestWalletChangePassword(t *testing.T) {
 		t.Fatal(err)
 	}
 	// wallet should still be unlocked
-	if !st.wallet.Unlocked() {
+	unlocked, err = st.wallet.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Fatal("changepassword locked the wallet")
 	}
 
@@ -1285,7 +1323,11 @@ func TestWalletChangePassword(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !st.wallet.Unlocked() {
+	unlocked, err = st.wallet.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 
@@ -1313,7 +1355,11 @@ func TestWalletChangePassword(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that the wallet actually unlocked.
-	if !st2.wallet.Unlocked() {
+	unlocked, err = st2.wallet.Unlocked()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unlocked {
 		t.Error("wallet is not unlocked")
 	}
 }
@@ -1471,7 +1517,10 @@ func TestWalletGETDust(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dt := st.wallet.DustThreshold()
+	dt, err := st.wallet.DustThreshold()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !dt.Equals(wg.DustThreshold) {
 		t.Fatal("dustThreshold mismatch")
 	}


### PR DESCRIPTION
Exported methods of top-level modules that are called by the API directly should always call `tg.Add`. Especially if those methods access closable resources. 
e.g. `wallet.ConfirmedBalance` can currently be called during a shutdown which results in a error since `ConfirmedBalance` calls `syncDB` on a closed database.