### PR TITLE
Fix contractor locking violation

### DIFF
--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -145,9 +145,7 @@ func (c *Contractor) managedMarkContractsUtility() error {
 		}()
 
 		// Apply changes.
-		c.mu.Lock()
-		err := c.updateContractUtility(contract.ID, utility)
-		c.mu.Unlock()
+		err := c.managedUpdateContractUtility(contract.ID, utility)
 		if err != nil {
 			return err
 		}
@@ -509,12 +507,11 @@ func (c *Contractor) threadedContractMaintenance() {
 
 			// Update the utility values for the new contract, and for the old
 			// contract.
-			c.mu.Lock()
 			newUtility := modules.ContractUtility{
 				GoodForUpload: true,
 				GoodForRenew:  true,
 			}
-			if err := c.updateContractUtility(newContract.ID, newUtility); err != nil {
+			if err := c.managedUpdateContractUtility(newContract.ID, newUtility); err != nil {
 				c.log.Println("Failed to update the contract utilities", err)
 				return
 			}
@@ -524,7 +521,6 @@ func (c *Contractor) threadedContractMaintenance() {
 				c.log.Println("Failed to update the contract utilities", err)
 				return
 			}
-			c.mu.Unlock()
 			// If the contract is a mid-cycle renew, add the contract line to
 			// the new contract. The contract line is not included/extended if
 			// we are just renewing because the contract is expiring.
@@ -617,8 +613,7 @@ func (c *Contractor) threadedContractMaintenance() {
 		}
 
 		// Add this contract to the contractor and save.
-		c.mu.Lock()
-		err = c.updateContractUtility(newContract.ID, modules.ContractUtility{
+		err = c.managedUpdateContractUtility(newContract.ID, modules.ContractUtility{
 			GoodForUpload: true,
 			GoodForRenew:  true,
 		})
@@ -626,6 +621,7 @@ func (c *Contractor) threadedContractMaintenance() {
 			c.log.Println("Failed to update the contract utilities", err)
 			return
 		}
+		c.mu.Lock()
 		err = c.saveSync()
 		c.mu.Unlock()
 		if err != nil {
@@ -649,9 +645,9 @@ func (c *Contractor) threadedContractMaintenance() {
 	}
 }
 
-// updateContractUtility is a helper function that acquires a contract, updates
+// managedUpdateContractUtility is a helper function that acquires a contract, updates
 // its ContractUtility and returns the contract again.
-func (c *Contractor) updateContractUtility(id types.FileContractID, utility modules.ContractUtility) error {
+func (c *Contractor) managedUpdateContractUtility(id types.FileContractID, utility modules.ContractUtility) error {
 	safeContract, ok := c.staticContracts.Acquire(id)
 	if !ok {
 		return errors.New("failed to acquire contract for update")

--- a/modules/renter/contractor/host_integration_test.go
+++ b/modules/renter/contractor/host_integration_test.go
@@ -348,12 +348,10 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 
 	// renew the contract
-	c.mu.Lock()
-	err = c.updateContractUtility(contract.ID, modules.ContractUtility{GoodForRenew: true})
+	err = c.managedUpdateContractUtility(contract.ID, modules.ContractUtility{GoodForRenew: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.mu.Unlock()
 	oldContract, _ := c.staticContracts.Acquire(contract.ID)
 	contract, err = c.managedRenew(oldContract, types.SiacoinPrecision.Mul64(50), c.blockHeight+200)
 	if err != nil {
@@ -384,12 +382,10 @@ func TestIntegrationRenew(t *testing.T) {
 	}
 
 	// renew to a lower height
-	c.mu.Lock()
-	err = c.updateContractUtility(contract.ID, modules.ContractUtility{GoodForRenew: true})
+	err = c.managedUpdateContractUtility(contract.ID, modules.ContractUtility{GoodForRenew: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.mu.Unlock()
 	oldContract, _ = c.staticContracts.Acquire(contract.ID)
 	contract, err = c.managedRenew(oldContract, types.SiacoinPrecision.Mul64(50), c.blockHeight+100)
 	if err != nil {


### PR DESCRIPTION
`updateContractUtility` held the `contractor` lock while calling `Acquire` on the `staticContracts`. That's a violation of our locking conventions and might cause the contractor lock to be held for a long time during slow uploads. This results in delays within API calls that need to acquire the `contractor` lock.