### PR TITLE
Heap cache sort

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -908,6 +908,9 @@ funds // hastings
 hosts
 period      // block height
 renewwindow // block height
+maxdownloadspeed
+maxuploadspeed
+downloadcachesize // Greater than zero
 ```
 
 ###### Response

--- a/doc/API.md
+++ b/doc/API.md
@@ -908,8 +908,8 @@ funds // hastings
 hosts
 period      // block height
 renewwindow // block height
-maxdownloadspeed
-maxuploadspeed
+maxdownloadspeed  // bytes per second, not persisted and will be reset by a shutdown
+maxuploadspeed  // bytes per second, not persisted and will be reset by a shutdown
 downloadcachesize // Greater than zero
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -910,7 +910,7 @@ period      // block height
 renewwindow // block height
 maxdownloadspeed  // bytes per second, not persisted and will be reset by a shutdown
 maxuploadspeed  // bytes per second, not persisted and will be reset by a shutdown
-streamcachesize // Greater than zero, not persisted and will be reset by a shutdown
+streamcachesize // number of data chunks cached when streaming, not persisted and will be reset by a shutdown
 ```
 
 ###### Response

--- a/doc/API.md
+++ b/doc/API.md
@@ -883,7 +883,7 @@ returns the current settings along with metrics on the renter's spending.
     },
     "maxuploadspeed":     1234, // BPS
     "maxdownloadspeed":   1234, // BPS
-    "downloadcachesize":  4    
+    "streamcachesize":  4    
   },
   "financialmetrics": {
     "contractfees":     "1234", // hastings
@@ -910,7 +910,7 @@ period      // block height
 renewwindow // block height
 maxdownloadspeed  // bytes per second, not persisted and will be reset by a shutdown
 maxuploadspeed  // bytes per second, not persisted and will be reset by a shutdown
-downloadcachesize // Greater than zero
+streamcachesize // Greater than zero, not persisted and will be reset by a shutdown
 ```
 
 ###### Response

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -70,9 +70,9 @@ returns the current settings along with metrics on the renter's spending.
     // manage bandwidth
     "maxdownloadspeed":   1234, // bytes per second
 
-    // The DownloadCacheSize is the number of data chunks that will be cached during
+    // The StreamCacheSize is the number of data chunks that will be cached during
     // streaming
-    "downloadcachesize":  4  
+    "streamcachesize":  4  
   },
 
   // Metrics about how much the Renter has spent on storage, uploads, and
@@ -138,9 +138,9 @@ maxdownloadspeed
 // setting is not persisted and will be reset by a shutdown
 maxuploadspeed
 
-// Download cache size specifies how many data chunks will be cached while 
+// Stream cache size specifies how many data chunks will be cached while 
 // streaming.  Must be greater than 0
-downloadcachesize
+streamcachesize
 ```
 
 ###### Response

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -129,6 +129,16 @@ period // block height
 // fewer total transaction fees. Storage spending is not affected by the renew
 // window size.
 renewwindow // block height
+
+// Max download speed permitted
+maxdownloadspeed
+
+// Max upload speed permitted
+maxuploadspeed
+
+// Download cache size specifies how many data chunks will be cached while 
+// streaming.  Must be greater than 0
+downloadcachesize
 ```
 
 ###### Response

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -130,10 +130,12 @@ period // block height
 // window size.
 renewwindow // block height
 
-// Max download speed permitted
+// Max download speed permitted, speed provide in bytes per second
+// setting is not persisted and will be reset by a shutdown
 maxdownloadspeed
 
-// Max upload speed permitted
+// Max upload speed permitted, speed provide in bytes per second
+// setting is not persisted and will be reset by a shutdown
 maxuploadspeed
 
 // Download cache size specifies how many data chunks will be cached while 

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -139,7 +139,7 @@ maxdownloadspeed
 maxuploadspeed
 
 // Stream cache size specifies how many data chunks will be cached while 
-// streaming.  Must be greater than 0
+// streaming.  
 streamcachesize
 ```
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -167,10 +167,10 @@ type RenterPriceEstimation struct {
 
 // RenterSettings control the behavior of the Renter.
 type RenterSettings struct {
-	Allowance         Allowance `json:"allowance"`
-	DownloadCacheSize uint64    `json:"downloadcachesize"`
-	MaxUploadSpeed    int64     `json:"maxuploadspeed"`
-	MaxDownloadSpeed  int64     `json:"maxdownloadspeed"`
+	Allowance        Allowance `json:"allowance"`
+	MaxUploadSpeed   int64     `json:"maxuploadspeed"`
+	MaxDownloadSpeed int64     `json:"maxdownloadspeed"`
+	StreamCacheSize  uint64    `json:"streamcachesize"`
 }
 
 // HostDBScans represents a sortable slice of scans.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -168,9 +168,9 @@ type RenterPriceEstimation struct {
 // RenterSettings control the behavior of the Renter.
 type RenterSettings struct {
 	Allowance         Allowance `json:"allowance"`
+	DownloadCacheSize uint64    `json:"downloadcachesize"`
 	MaxUploadSpeed    int64     `json:"maxuploadspeed"`
 	MaxDownloadSpeed  int64     `json:"maxdownloadspeed"`
-	DownloadCacheSize uint64    `json:"downloadcachesize"`
 }
 
 // HostDBScans represents a sortable slice of scans.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -170,7 +170,7 @@ type RenterSettings struct {
 	Allowance         Allowance `json:"allowance"`
 	MaxUploadSpeed    int64     `json:"maxuploadspeed"`
 	MaxDownloadSpeed  int64     `json:"maxdownloadspeed"`
-	DownloadCacheSize int       `json:"downloadcachesize"`
+	DownloadCacheSize uint64    `json:"downloadcachesize"`
 }
 
 // HostDBScans represents a sortable slice of scans.

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -167,9 +167,10 @@ type RenterPriceEstimation struct {
 
 // RenterSettings control the behavior of the Renter.
 type RenterSettings struct {
-	Allowance        Allowance `json:"allowance"`
-	MaxUploadSpeed   int64     `json:"maxuploadspeed"`
-	MaxDownloadSpeed int64     `json:"maxdownloadspeed"`
+	Allowance         Allowance `json:"allowance"`
+	MaxUploadSpeed    int64     `json:"maxuploadspeed"`
+	MaxDownloadSpeed  int64     `json:"maxdownloadspeed"`
+	DownloadCacheSize int       `json:"downloadcachesize"`
 }
 
 // HostDBScans represents a sortable slice of scans.

--- a/modules/renter/consts.go
+++ b/modules/renter/consts.go
@@ -71,9 +71,9 @@ const (
 	// from the /renter/stream endpoint.
 	destinationTypeSeekStream = "httpseekstream"
 
-	// downloadCacheSize is the cache size of the /renter/stream cache in
-	// chunks.
-	downloadCacheSize = 2
+	// defaultDownloadCacheSize is the default cache size of the /renter/stream cache in
+	// chunks, the user can change this through the API
+	defaultDownloadCacheSize = 2
 )
 
 var (

--- a/modules/renter/consts.go
+++ b/modules/renter/consts.go
@@ -71,9 +71,9 @@ const (
 	// from the /renter/stream endpoint.
 	destinationTypeSeekStream = "httpseekstream"
 
-	// defaultDownloadCacheSize is the default cache size of the /renter/stream cache in
+	// defaultStreamCacheSize is the default cache size of the /renter/stream cache in
 	// chunks, the user can set a custom cache size through the API
-	defaultDownloadCacheSize = 2
+	defaultStreamCacheSize = 2
 )
 
 var (

--- a/modules/renter/consts.go
+++ b/modules/renter/consts.go
@@ -72,7 +72,7 @@ const (
 	destinationTypeSeekStream = "httpseekstream"
 
 	// defaultDownloadCacheSize is the default cache size of the /renter/stream cache in
-	// chunks, the user can change this through the API
+	// chunks, the user can set a custom cache size through the API
 	defaultDownloadCacheSize = 2
 )
 

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -437,8 +437,8 @@ func (r *Renter) managedNewDownload(params downloadParams) (*download, error) {
 			physicalChunkData: make([][]byte, params.file.erasureCode.NumPieces()),
 			pieceUsage:        make([]bool, params.file.erasureCode.NumPieces()),
 
-			download:           d,
-			downloadChunkCache: r.downloadChunkCache,
+			download:    d,
+			streamCache: r.streamCache,
 		}
 
 		// Set the fetchOffset - the offset within the chunk that we start

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -437,9 +437,10 @@ func (r *Renter) managedNewDownload(params downloadParams) (*download, error) {
 			physicalChunkData: make([][]byte, params.file.erasureCode.NumPieces()),
 			pieceUsage:        make([]bool, params.file.erasureCode.NumPieces()),
 
-			download:   d,
-			chunkCache: r.chunkCache,
-			cacheMu:    r.cmu,
+			download:       d,
+			chunkCacheMap:  r.chunkCacheMap,
+			chunkCacheHeap: r.chunkCacheHeap,
+			cacheMu:        r.cmu,
 		}
 
 		// Set the fetchOffset - the offset within the chunk that we start

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -437,8 +437,8 @@ func (r *Renter) managedNewDownload(params downloadParams) (*download, error) {
 			physicalChunkData: make([][]byte, params.file.erasureCode.NumPieces()),
 			pieceUsage:        make([]bool, params.file.erasureCode.NumPieces()),
 
-			download:    d,
-			streamCache: r.streamCache,
+			download:          d,
+			staticStreamCache: r.staticStreamCache,
 		}
 
 		// Set the fetchOffset - the offset within the chunk that we start

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -437,10 +437,9 @@ func (r *Renter) managedNewDownload(params downloadParams) (*download, error) {
 			physicalChunkData: make([][]byte, params.file.erasureCode.NumPieces()),
 			pieceUsage:        make([]bool, params.file.erasureCode.NumPieces()),
 
-			download:       d,
-			chunkCacheMap:  r.chunkCacheMap,
-			chunkCacheHeap: r.chunkCacheHeap,
-			cacheMu:        r.cmu,
+			download:           d,
+			downloadChunkCache: r.downloadChunkCache,
+			cacheMu:            r.cmu,
 		}
 
 		// Set the fetchOffset - the offset within the chunk that we start

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -439,7 +439,6 @@ func (r *Renter) managedNewDownload(params downloadParams) (*download, error) {
 
 			download:           d,
 			downloadChunkCache: r.downloadChunkCache,
-			cacheMu:            r.cmu,
 		}
 
 		// Set the fetchOffset - the offset within the chunk that we start

--- a/modules/renter/downloadcache.go
+++ b/modules/renter/downloadcache.go
@@ -64,7 +64,7 @@ func (cch *chunkCacheHeap) Pop() interface{} {
 	return chunkData
 }
 
-// update, updates the heap and reorders
+// update updates the heap and reorders
 func (cch *chunkCacheHeap) update(cd *chunkData, id string, data []byte, lastAccess time.Time) {
 	cd.id = id
 	cd.data = data
@@ -86,6 +86,11 @@ func (dcc *downloadChunkCache) add(data []byte, cacheID string, destinationType 
 	defer dcc.mu.Unlock()
 
 	// Prune cache if necessary.
+	if dcc.cacheSize == 0 {
+		build.Critical("DownloadCacheSize is set to zero")
+		return
+	}
+
 	for len(dcc.chunkCacheMap) >= int(dcc.cacheSize) {
 		// Remove from Heap
 		cd := heap.Pop(&dcc.chunkCacheHeap).(*chunkData)

--- a/modules/renter/downloadcache.go
+++ b/modules/renter/downloadcache.go
@@ -126,8 +126,6 @@ func (dcc *downloadChunkCache) Init() {
 // TODO: in the future we might need cache invalidation. At the
 // moment this doesn't worry us since our files are static.
 func (dcc *downloadChunkCache) Retrieve(udc *unfinishedDownloadChunk) bool {
-	// If staticFetchOffset and Length are part of the dcc then the only inputs would be
-	// download and destination
 	udc.mu.Lock()
 	defer udc.mu.Unlock()
 	dcc.mu.Lock()

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -16,6 +16,7 @@ func TestAdd(t *testing.T) {
 		},
 		downloadChunkCache: new(downloadChunkCache),
 	}
+	// TODO: Pass modules.RenterSettings
 	udc.downloadChunkCache.init()
 
 	// Testing Push to Heap

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -10,29 +10,29 @@ import (
 // TestHeapImplementation tests that the downloadChunkCache heap functions properly
 func TestHeapImplementation(t *testing.T) {
 	// Initializing minimum variables
-	downloadChunkCache := new(downloadChunkCache)
-	downloadChunkCache.Init()
+	dcc := new(downloadChunkCache)
+	dcc.Init()
 
 	// Testing Push to Heap
-	old := len(downloadChunkCache.chunkCacheHeap)
-	heap.Push(&downloadChunkCache.chunkCacheHeap, &chunkData{
+	length := len(dcc.chunkCacheHeap)
+	heap.Push(&dcc.chunkCacheHeap, &chunkData{
 		id:         "Push",
 		data:       []byte{},
 		lastAccess: time.Now(),
 	})
 
 	// Confirming the length of the heap increased by 1
-	if len(downloadChunkCache.chunkCacheHeap) != old+1 {
-		t.Error("Length of heap did not change, chunkData was not pushed onto Heap. Length of heap is still ", len(downloadChunkCache.chunkCacheHeap))
+	if len(dcc.chunkCacheHeap) != length+1 {
+		t.Error("Length of heap did not change, chunkData was not pushed onto Heap. Length of heap is still ", len(dcc.chunkCacheHeap))
 	}
 	// Confirming the chunk added was the one expected
-	if downloadChunkCache.chunkCacheHeap[0].id != "Push" {
-		t.Error("Chunk on top of heap is not the chunk that was just pushed on, chunkData.id =", downloadChunkCache.chunkCacheHeap[0].id)
+	if dcc.chunkCacheHeap[0].id != "Push" {
+		t.Error("Chunk on top of heap is not the chunk that was just pushed on, chunkData.id =", dcc.chunkCacheHeap[0].id)
 	}
 
 	// Add more chunks to heap
 	for i := 0; i < 3; i++ {
-		heap.Push(&downloadChunkCache.chunkCacheHeap, &chunkData{
+		heap.Push(&dcc.chunkCacheHeap, &chunkData{
 			id:         strconv.Itoa(i),
 			data:       []byte{},
 			lastAccess: time.Now(),
@@ -42,33 +42,33 @@ func TestHeapImplementation(t *testing.T) {
 
 	// Testing Heap update
 	// Confirming recently accessed elements get moved to the bottom of Heap
-	cd := downloadChunkCache.chunkCacheHeap[0]
-	downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now())
-	if downloadChunkCache.chunkCacheHeap[len(downloadChunkCache.chunkCacheHeap)-1] != cd {
+	cd := dcc.chunkCacheHeap[0]
+	dcc.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now())
+	if dcc.chunkCacheHeap[len(dcc.chunkCacheHeap)-1] != cd {
 		t.Error("Heap order was not updated. Recently accessed element not at bottom of heap")
 	}
 	// Confirming least recently accessed element is moved to the top of Heap
-	cd = downloadChunkCache.chunkCacheHeap[len(downloadChunkCache.chunkCacheHeap)-1]
-	downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
-	if downloadChunkCache.chunkCacheHeap[0] != cd {
+	cd = dcc.chunkCacheHeap[len(dcc.chunkCacheHeap)-1]
+	dcc.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
+	if dcc.chunkCacheHeap[0] != cd {
 		t.Error("Heap order was not updated. Least recently accessed element is not at top of heap")
 	}
 
 	// Testing Pop of Heap
 	// Confirming element at the top of heap is removed
-	cd = downloadChunkCache.chunkCacheHeap[0]
-	length := len(downloadChunkCache.chunkCacheHeap)
-	if pop := heap.Pop(&downloadChunkCache.chunkCacheHeap).(*chunkData); pop != cd {
+	cd = dcc.chunkCacheHeap[0]
+	length = len(dcc.chunkCacheHeap)
+	if pop := heap.Pop(&dcc.chunkCacheHeap).(*chunkData); pop != cd {
 		t.Error("Element at the top of the Heap was not popped off")
 	}
-	if len(downloadChunkCache.chunkCacheHeap) != length-1 {
+	if len(dcc.chunkCacheHeap) != length-1 {
 		t.Error("Heap length was not reduced by 1")
 	}
 }
 
 // TestStreamCache tests that when Add() is called, chunks are added and removed
 // from both the Heap and the Map
-// Retrieve() is tested through the Streaming tests in the siatest pacakges
+// Retrieve() is tested through the Streaming tests in the siatest packages
 // SetStreamingCacheSize() is tested through the API endpoint tests in the
 // siatest packages
 func TestStreamCache(t *testing.T) {
@@ -77,7 +77,7 @@ func TestStreamCache(t *testing.T) {
 	dcc.Init()
 
 	// Fill Cache
-	// Purposefully trying to fill to a value larger than cacheSize to confirm Add
+	// Purposefully trying to fill to a value larger than cacheSize to confirm Add()
 	// keeps pruning cache
 	for i := 0; i < int(dcc.cacheSize)+5; i++ {
 		dcc.Add(strconv.Itoa(i), []byte{})
@@ -111,7 +111,7 @@ func TestStreamCache(t *testing.T) {
 	// Add additional chunk to force deletion of a chunk
 	dcc.Add("chunk2", []byte{})
 
-	// check if the chunk was removed from Map
+	// check if chunk1 was removed from Map
 	if _, ok := dcc.chunkCacheMap["chunk1"]; ok {
 		t.Error("chunk1 wasn't removed from the map")
 	}

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -3,81 +3,117 @@ package renter
 import (
 	"container/heap"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
 
-// TestAdd tests that the oldest chunk is removed
-func TestAdd(t *testing.T) {
+// TestHeapImplementation tests that the downloadChunkCache heap functions properly
+func TestHeapImplementation(t *testing.T) {
 	// Initializing minimum variables
-	udc := &unfinishedDownloadChunk{
-		download: &download{
-			staticDestinationType: destinationTypeSeekStream,
-		},
-		downloadChunkCache: new(downloadChunkCache),
-	}
-
-	udc.downloadChunkCache.init()
+	downloadChunkCache := new(downloadChunkCache)
+	downloadChunkCache.Init()
 
 	// Testing Push to Heap
-	old := len(udc.downloadChunkCache.chunkCacheHeap)
-	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, &chunkData{
+	old := len(downloadChunkCache.chunkCacheHeap)
+	heap.Push(&downloadChunkCache.chunkCacheHeap, &chunkData{
 		id:         "Push",
 		data:       []byte{},
 		lastAccess: time.Now(),
 	})
-	if len(udc.downloadChunkCache.chunkCacheHeap) <= old {
-		t.Error("chunkData was not pushed onto Heap.")
+
+	// Confirming the length of the heap increased by 1
+	if len(downloadChunkCache.chunkCacheHeap) != old+1 {
+		t.Error("Length of heap did not change, chunkData was not pushed onto Heap. Length of heap is still ", len(downloadChunkCache.chunkCacheHeap))
+	}
+	// Confirming the chunk added was the one expected
+	if downloadChunkCache.chunkCacheHeap[0].id != "Push" {
+		t.Error("Chunk on top of heap is not the chunk that was just pushed on, chunkData.id =", downloadChunkCache.chunkCacheHeap[0].id)
 	}
 
-	// Popping chunkData back off Heap to work with empty Heap
-	cd := heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData)
-
-	udc.downloadChunkCache.init()
-
-	// Testing Push to Heap
-	old = len(udc.downloadChunkCache.chunkCacheHeap)
-	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, &chunkData{
-		id:         "Push",
-		data:       []byte{},
-		lastAccess: time.Now(),
-	})
-	if len(udc.downloadChunkCache.chunkCacheHeap) <= old {
-		t.Error("chunkData was not pushed onto Heap.")
-	}
-
-	// Popping chunkData back off Heap to work with empty Heap
-	cd = heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData)
-
-	// Fill Cache
-	for i := 0; i < int(udc.downloadChunkCache.cacheSize); i++ {
-		udc.staticCacheID = strconv.Itoa(i)
-		udc.downloadChunkCache.add([]byte{}, udc.staticCacheID, udc.download.staticDestinationType)
-		time.Sleep(1 * time.Millisecond)
+	// Add more chunks to heap
+	for i := 0; i < 3; i++ {
+		heap.Push(&downloadChunkCache.chunkCacheHeap, &chunkData{
+			id:         strconv.Itoa(i),
+			data:       []byte{},
+			lastAccess: time.Now(),
+		})
+		time.Sleep(1 * time.Second)
 	}
 
 	// Testing Heap update
-	cd = udc.downloadChunkCache.chunkCacheMap[strconv.FormatUint(udc.downloadChunkCache.cacheSize-1, 10)] // this should have been the last element added and be at the bottom
-	udc.downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().AddDate(0, -1, 0))        // updating it so it is at the top of Heap
-	if udc.downloadChunkCache.chunkCacheHeap[0] != cd {
-		t.Error("Heap order was not updated.")
+	// Confirming recently accessed elements get moved to the bottom of Heap
+	cd := downloadChunkCache.chunkCacheHeap[0]
+	downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now())
+	if downloadChunkCache.chunkCacheHeap[len(downloadChunkCache.chunkCacheHeap)-1] != cd {
+		t.Error("Heap order was not updated. Recently accessed element not at bottom of heap")
+	}
+	// Confirming least recently accessed element is moved to the top of Heap
+	cd = downloadChunkCache.chunkCacheHeap[len(downloadChunkCache.chunkCacheHeap)-1]
+	downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
+	if downloadChunkCache.chunkCacheHeap[0] != cd {
+		t.Error("Heap order was not updated. Least recently accessed element is not at top of heap")
 	}
 
-	// test pop
-	cd = udc.downloadChunkCache.chunkCacheHeap[0]
-	if pop := heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData); pop != cd {
-		t.Error("Least recently accessed chunk was not removed from the heap.")
+	// Testing Pop of Heap
+	// Confirming element at the top of heap is removed
+	cd = downloadChunkCache.chunkCacheHeap[0]
+	length := len(downloadChunkCache.chunkCacheHeap)
+	if pop := heap.Pop(&downloadChunkCache.chunkCacheHeap).(*chunkData); pop != cd {
+		t.Error("Element at the top of the Heap was not popped off")
+	}
+	if len(downloadChunkCache.chunkCacheHeap) != length-1 {
+		t.Error("Heap length was not reduced by 1")
+	}
+}
+
+// TestStreamCache tests that the oldest chunk is removed
+func TestStreamCache(t *testing.T) {
+	// Initializing minimum required variables
+	udc := &unfinishedDownloadChunk{
+		mu:                 new(sync.Mutex),
+		downloadChunkCache: new(downloadChunkCache),
+	}
+	udc.downloadChunkCache.Init()
+
+	// call Add
+	// 		length of downloadChunkCache Heap should never exceed cacheSize (DONE)
+	//		when Heap is full, top element should be removed to add a new element (IN PROGRESS)
+	//		Top element should be least recently accessed
+
+	// Fill Cache
+	// Purposefully trying to fill to a value large to cacheSize to confirm Add
+	// keeps pruning cache
+	for i := 0; i < int(udc.downloadChunkCache.cacheSize)+5; i++ {
+		udc.downloadChunkCache.Add(strconv.Itoa(i), []byte{})
+		time.Sleep(1 * time.Second)
+	}
+	// Confirm that the chunkCacheHeap didn't exceed the cacheSize
+	if len(udc.downloadChunkCache.chunkCacheHeap) > int(udc.downloadChunkCache.cacheSize) {
+		t.Error("Heap is larger than set cacheSize")
 	}
 
-	// Pushing back on as to not cause error with addChunkToCache()
-	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, cd)
+	// Making the least recently accessed element the most recently accessed element
+	cd := udc.downloadChunkCache.chunkCacheHeap[0]
+	// udc.downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now())
+
+	udc.downloadChunkCache.Add("New", []byte{})
+	if udc.downloadChunkCache.chunkCacheHeap[0] == cd {
+		t.Error("Least recently accessed element still at the top of the heap")
+	}
 
 	// Add additional chunk to force deletion of a chunk
-	udc.staticCacheID = strconv.FormatUint(udc.downloadChunkCache.cacheSize, 10)
-	udc.downloadChunkCache.add([]byte{}, udc.staticCacheID, udc.download.staticDestinationType)
+	staticCacheID = strconv.FormatUint(udc.downloadChunkCache.cacheSize, 10)
+	udc.downloadChunkCache.Add(staticCacheID, []byte{})
 
 	// check if the chunk was removed from Map
 	if _, ok := udc.downloadChunkCache.chunkCacheMap[cd.id]; ok {
 		t.Error("The least recently accessed chunk wasn't pruned from the cache")
 	}
+	// test Retrieve
+	// 		should updated the element making it the most recently accessed
+	//		element should be at the bottom of the Heap
+	udc.downloadChunkCache.Retrieve(udc)
+
+	// don't need to test setStreaming cacheSize, that is tested through the API endpoint testing in siaTest
 }

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -1,6 +1,7 @@
 package renter
 
 import (
+	"container/heap"
 	"strconv"
 	"sync"
 	"testing"
@@ -9,13 +10,29 @@ import (
 
 // TestAddChunkToCache tests that the oldest chunk is removed
 func TestAddChunkToCache(t *testing.T) {
+	// Initializing minimum variables
 	udc := &unfinishedDownloadChunk{
 		download: &download{
 			staticDestinationType: destinationTypeSeekStream,
 		},
-		chunkCacheMap: make(map[string]*cacheData),
-		cacheMu:       new(sync.Mutex),
+		downloadChunkCache: new(downloadChunkCache),
+		cacheMu:            new(sync.Mutex),
 	}
+	udc.downloadChunkCache.init()
+
+	// Testing Push to Heap
+	old := len(udc.downloadChunkCache.chunkCacheHeap)
+	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, &chunkData{
+		id:         "Push",
+		data:       []byte{},
+		lastAccess: time.Now(),
+	})
+	if len(udc.downloadChunkCache.chunkCacheHeap) <= old {
+		t.Error("chunkData was not pushed onto Heap.")
+	}
+
+	// Popping chunkData back off Heap to work with empty Heap
+	cd := heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData)
 
 	// Fill Cache
 	for i := 0; i < downloadCacheSize; i++ {
@@ -24,13 +41,28 @@ func TestAddChunkToCache(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 	}
 
+	// Testing Heap update
+	cd = udc.downloadChunkCache.chunkCacheMap[strconv.Itoa(downloadCacheSize-1)]                   // this should have been the last element added and be at the bottom
+	udc.downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().AddDate(0, -1, 0)) // updating it so it is at the top of Heap
+	if udc.downloadChunkCache.chunkCacheHeap[0] != cd {
+		t.Error("Heap order was not updated.")
+	}
+
+	// test pop
+	cd = udc.downloadChunkCache.chunkCacheHeap[0]
+	if pop := heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData); pop != cd {
+		t.Error("Least recently accessed chunk was not removed from the heap.")
+	}
+
+	// Pushing back on as to not cause error with addChunkToCache()
+	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, cd)
+
 	// Add additional chunk to force deletion of a chunk
 	udc.staticCacheID = strconv.Itoa(downloadCacheSize)
 	udc.addChunkToCache([]byte{})
 
-	// check if the chunk with staticCacheID = "0" was removed
-	// as that would have been the first to be added
-	if _, ok := udc.chunkCacheMap["0"]; ok {
+	// check if the chunk was removed from Map
+	if _, ok := udc.downloadChunkCache.chunkCacheMap[cd.id]; ok {
 		t.Error("The least recently accessed chunk wasn't pruned from the cache")
 	}
 }

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -36,7 +36,7 @@ func TestAdd(t *testing.T) {
 	// Fill Cache
 	for i := 0; i < int(udc.downloadChunkCache.cacheSize); i++ {
 		udc.staticCacheID = strconv.Itoa(i)
-		udc.downloadChunkCache.add([]byte{}, udc)
+		udc.downloadChunkCache.add([]byte{}, udc.staticCacheID, udc.download.staticDestinationType)
 		time.Sleep(1 * time.Millisecond)
 	}
 
@@ -58,7 +58,7 @@ func TestAdd(t *testing.T) {
 
 	// Add additional chunk to force deletion of a chunk
 	udc.staticCacheID = strconv.FormatUint(udc.downloadChunkCache.cacheSize, 10)
-	udc.downloadChunkCache.add([]byte{}, udc)
+	udc.downloadChunkCache.add([]byte{}, udc.staticCacheID, udc.download.staticDestinationType)
 
 	// check if the chunk was removed from Map
 	if _, ok := udc.downloadChunkCache.chunkCacheMap[cd.id]; ok {

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -13,8 +13,8 @@ func TestAddChunkToCache(t *testing.T) {
 		download: &download{
 			staticDestinationType: destinationTypeSeekStream,
 		},
-		chunkCache: make(map[string]*cacheData),
-		cacheMu:    new(sync.Mutex),
+		chunkCacheMap: make(map[string]*cacheData),
+		cacheMu:       new(sync.Mutex),
 	}
 
 	// Fill Cache
@@ -30,7 +30,7 @@ func TestAddChunkToCache(t *testing.T) {
 
 	// check if the chunk with staticCacheID = "0" was removed
 	// as that would have been the first to be added
-	if _, ok := udc.chunkCache["0"]; ok {
+	if _, ok := udc.chunkCacheMap["0"]; ok {
 		t.Error("The least recently accessed chunk wasn't pruned from the cache")
 	}
 }

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -16,7 +16,6 @@ func TestAdd(t *testing.T) {
 		},
 		downloadChunkCache: new(downloadChunkCache),
 	}
-
 	udc.downloadChunkCache.init()
 
 	// Testing Push to Heap
@@ -32,6 +31,22 @@ func TestAdd(t *testing.T) {
 
 	// Popping chunkData back off Heap to work with empty Heap
 	cd := heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData)
+
+	udc.downloadChunkCache.init()
+
+	// Testing Push to Heap
+	old = len(udc.downloadChunkCache.chunkCacheHeap)
+	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, &chunkData{
+		id:         "Push",
+		data:       []byte{},
+		lastAccess: time.Now(),
+	})
+	if len(udc.downloadChunkCache.chunkCacheHeap) <= old {
+		t.Error("chunkData was not pushed onto Heap.")
+	}
+
+	// Popping chunkData back off Heap to work with empty Heap
+	cd = heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData)
 
 	// Fill Cache
 	for i := 0; i < int(udc.downloadChunkCache.cacheSize); i++ {

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -16,7 +16,7 @@ func TestAdd(t *testing.T) {
 		},
 		downloadChunkCache: new(downloadChunkCache),
 	}
-	// TODO: Pass modules.RenterSettings
+
 	udc.downloadChunkCache.init()
 
 	// Testing Push to Heap

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -3,12 +3,13 @@ package renter
 import (
 	"container/heap"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 )
 
 // TestAddChunkToCache tests that the oldest chunk is removed
+// TODO: Access modules.RenterSettings
+//    rs := api.renter.Settings()
 func TestAddChunkToCache(t *testing.T) {
 	// Initializing minimum variables
 	udc := &unfinishedDownloadChunk{
@@ -16,8 +17,8 @@ func TestAddChunkToCache(t *testing.T) {
 			staticDestinationType: destinationTypeSeekStream,
 		},
 		downloadChunkCache: new(downloadChunkCache),
-		cacheMu:            new(sync.Mutex),
 	}
+	// TODO: Pass modules.RenterSettings
 	udc.downloadChunkCache.init()
 
 	// Testing Push to Heap
@@ -35,6 +36,7 @@ func TestAddChunkToCache(t *testing.T) {
 	cd := heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData)
 
 	// Fill Cache
+	// TODO: parss modules.TenterSettings into addChunkToCache
 	for i := 0; i < downloadCacheSize; i++ {
 		udc.staticCacheID = strconv.Itoa(i)
 		udc.addChunkToCache([]byte{})
@@ -58,6 +60,7 @@ func TestAddChunkToCache(t *testing.T) {
 	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, cd)
 
 	// Add additional chunk to force deletion of a chunk
+	// TODO: parss modules.TenterSettings into addChunkToCache
 	udc.staticCacheID = strconv.Itoa(downloadCacheSize)
 	udc.addChunkToCache([]byte{})
 

--- a/modules/renter/downloadcache_test.go
+++ b/modules/renter/downloadcache_test.go
@@ -7,10 +7,8 @@ import (
 	"time"
 )
 
-// TestAddChunkToCache tests that the oldest chunk is removed
-// TODO: Access modules.RenterSettings
-//    rs := api.renter.Settings()
-func TestAddChunkToCache(t *testing.T) {
+// TestAdd tests that the oldest chunk is removed
+func TestAdd(t *testing.T) {
 	// Initializing minimum variables
 	udc := &unfinishedDownloadChunk{
 		download: &download{
@@ -18,7 +16,7 @@ func TestAddChunkToCache(t *testing.T) {
 		},
 		downloadChunkCache: new(downloadChunkCache),
 	}
-	// TODO: Pass modules.RenterSettings
+
 	udc.downloadChunkCache.init()
 
 	// Testing Push to Heap
@@ -36,16 +34,15 @@ func TestAddChunkToCache(t *testing.T) {
 	cd := heap.Pop(&udc.downloadChunkCache.chunkCacheHeap).(*chunkData)
 
 	// Fill Cache
-	// TODO: parss modules.TenterSettings into addChunkToCache
-	for i := 0; i < downloadCacheSize; i++ {
+	for i := 0; i < int(udc.downloadChunkCache.cacheSize); i++ {
 		udc.staticCacheID = strconv.Itoa(i)
-		udc.addChunkToCache([]byte{})
+		udc.downloadChunkCache.add([]byte{}, udc)
 		time.Sleep(1 * time.Millisecond)
 	}
 
 	// Testing Heap update
-	cd = udc.downloadChunkCache.chunkCacheMap[strconv.Itoa(downloadCacheSize-1)]                   // this should have been the last element added and be at the bottom
-	udc.downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().AddDate(0, -1, 0)) // updating it so it is at the top of Heap
+	cd = udc.downloadChunkCache.chunkCacheMap[strconv.FormatUint(udc.downloadChunkCache.cacheSize-1, 10)] // this should have been the last element added and be at the bottom
+	udc.downloadChunkCache.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().AddDate(0, -1, 0))        // updating it so it is at the top of Heap
 	if udc.downloadChunkCache.chunkCacheHeap[0] != cd {
 		t.Error("Heap order was not updated.")
 	}
@@ -60,9 +57,8 @@ func TestAddChunkToCache(t *testing.T) {
 	heap.Push(&udc.downloadChunkCache.chunkCacheHeap, cd)
 
 	// Add additional chunk to force deletion of a chunk
-	// TODO: parss modules.TenterSettings into addChunkToCache
-	udc.staticCacheID = strconv.Itoa(downloadCacheSize)
-	udc.addChunkToCache([]byte{})
+	udc.staticCacheID = strconv.FormatUint(udc.downloadChunkCache.cacheSize, 10)
+	udc.downloadChunkCache.add([]byte{}, udc)
 
 	// check if the chunk was removed from Map
 	if _, ok := udc.downloadChunkCache.chunkCacheMap[cd.id]; ok {

--- a/modules/renter/downloadchunk.go
+++ b/modules/renter/downloadchunk.go
@@ -15,6 +15,8 @@ import (
 	"github.com/NebulousLabs/errors"
 )
 
+// downloadChunkCache contains a chunkCacheMap for quick look up and a chunkCacheHeap for
+// quick removal of old chunks
 type downloadChunkCache struct {
 	chunkCacheMap  map[string]*chunkData
 	chunkCacheHeap chunkCacheHeap
@@ -22,7 +24,7 @@ type downloadChunkCache struct {
 
 func (dcc *downloadChunkCache) init() {
 	dcc.chunkCacheMap = make(map[string]*chunkData)
-	dcc.chunkCacheHeap = make(chunkCacheHeap, downloadCacheSize)
+	dcc.chunkCacheHeap = make(chunkCacheHeap, 0, downloadCacheSize)
 	heap.Init(&dcc.chunkCacheHeap)
 }
 

--- a/modules/renter/downloadchunk.go
+++ b/modules/renter/downloadchunk.go
@@ -75,7 +75,7 @@ type unfinishedDownloadChunk struct {
 	mu       sync.Mutex
 
 	// Caching related fields
-	downloadChunkCache *downloadChunkCache
+	streamCache *streamCache
 }
 
 // fail will set the chunk status to failed. The physical chunk memory will be
@@ -223,7 +223,7 @@ func (udc *unfinishedDownloadChunk) threadedRecoverLogicalData() error {
 		// We only cache streaming chunks since browsers and media players tend
 		// to only request a few kib at once when streaming data. That way we can
 		// prevent scheduling the same chunk for download over and over.
-		udc.downloadChunkCache.Add(udc.staticCacheID, recoveredData)
+		udc.streamCache.Add(udc.staticCacheID, recoveredData)
 	}
 
 	// Write the bytes to the requested output.

--- a/modules/renter/downloadchunk.go
+++ b/modules/renter/downloadchunk.go
@@ -75,7 +75,7 @@ type unfinishedDownloadChunk struct {
 	mu       sync.Mutex
 
 	// Caching related fields
-	streamCache *streamCache
+	staticStreamCache *streamCache
 }
 
 // fail will set the chunk status to failed. The physical chunk memory will be
@@ -223,7 +223,7 @@ func (udc *unfinishedDownloadChunk) threadedRecoverLogicalData() error {
 		// We only cache streaming chunks since browsers and media players tend
 		// to only request a few kib at once when streaming data. That way we can
 		// prevent scheduling the same chunk for download over and over.
-		udc.streamCache.Add(udc.staticCacheID, recoveredData)
+		udc.staticStreamCache.Add(udc.staticCacheID, recoveredData)
 	}
 
 	// Write the bytes to the requested output.

--- a/modules/renter/downloadchunk.go
+++ b/modules/renter/downloadchunk.go
@@ -16,26 +16,27 @@ import (
 )
 
 type downloadChunkCache struct {
-	chunkCacheMap  map[string]*cacheData
+	chunkCacheMap  map[string]*chunkData
 	chunkCacheHeap chunkCacheHeap
 }
 
 func (dcc *downloadChunkCache) init() {
-	dcc.chunkCacheMap = make(map[string]*cacheData)
+	dcc.chunkCacheMap = make(map[string]*chunkData)
 	dcc.chunkCacheHeap = make(chunkCacheHeap, downloadCacheSize)
 	heap.Init(&dcc.chunkCacheHeap)
 }
 
-// cacheData contatins the data and the timestamp for the unfinished
+// chunkData contatins the data and the timestamp for the unfinished
 // download chunks
-type cacheData struct {
+type chunkData struct {
+	id         string
 	data       []byte
-	lastAccess int64
+	lastAccess time.Time
 	index      int
 }
 
-// chunkCacheHeap is a priority queue and implements heap.Interface and holds cacheData
-type chunkCacheHeap []*cacheData
+// chunkCacheHeap is a priority queue and implements heap.Interface and holds chunkData
+type chunkCacheHeap []*chunkData
 
 // downloadPieceInfo contains all the information required to download and
 // recover a piece of a chunk from a host. It is a value in a map where the key

--- a/modules/renter/downloadchunk.go
+++ b/modules/renter/downloadchunk.go
@@ -219,7 +219,7 @@ func (udc *unfinishedDownloadChunk) threadedRecoverLogicalData() error {
 	recoveredData := recoverWriter.Bytes()
 
 	// Add the chunk to the cache.
-	udc.downloadChunkCache.add(recoveredData, udc)
+	udc.downloadChunkCache.add(recoveredData, udc.staticCacheID, udc.download.staticDestinationType)
 
 	// Write the bytes to the requested output.
 	start := udc.staticFetchOffset

--- a/modules/renter/downloadchunk.go
+++ b/modules/renter/downloadchunk.go
@@ -219,7 +219,12 @@ func (udc *unfinishedDownloadChunk) threadedRecoverLogicalData() error {
 	recoveredData := recoverWriter.Bytes()
 
 	// Add the chunk to the cache.
-	udc.downloadChunkCache.add(recoveredData, udc.staticCacheID, udc.download.staticDestinationType)
+	if udc.download.staticDestinationType == destinationTypeSeekStream {
+		// We only cache streaming chunks since browsers and media players tend
+		// to only request a few kib at once when streaming data. That way we can
+		// prevent scheduling the same chunk for download over and over.
+		udc.downloadChunkCache.Add(udc.staticCacheID, recoveredData)
+	}
 
 	// Write the bytes to the requested output.
 	start := udc.staticFetchOffset

--- a/modules/renter/downloadheap.go
+++ b/modules/renter/downloadheap.go
@@ -196,7 +196,7 @@ LOOP:
 			}
 
 			// Check if we got the chunk cached already.
-			if r.streamCache.Retrieve(nextChunk) {
+			if r.staticStreamCache.Retrieve(nextChunk) {
 				continue
 			}
 

--- a/modules/renter/downloadheap.go
+++ b/modules/renter/downloadheap.go
@@ -196,7 +196,7 @@ LOOP:
 			}
 
 			// Check if we got the chunk cached already.
-			if r.managedTryCache(nextChunk) {
+			if r.downloadChunkCache.retreive(nextChunk) {
 				continue
 			}
 

--- a/modules/renter/downloadheap.go
+++ b/modules/renter/downloadheap.go
@@ -196,7 +196,7 @@ LOOP:
 			}
 
 			// Check if we got the chunk cached already.
-			if r.downloadChunkCache.Retrieve(nextChunk) {
+			if r.streamCache.Retrieve(nextChunk) {
 				continue
 			}
 

--- a/modules/renter/downloadheap.go
+++ b/modules/renter/downloadheap.go
@@ -196,7 +196,7 @@ LOOP:
 			}
 
 			// Check if we got the chunk cached already.
-			if r.downloadChunkCache.retreive(nextChunk) {
+			if r.downloadChunkCache.retrieve(nextChunk) {
 				continue
 			}
 

--- a/modules/renter/downloadheap.go
+++ b/modules/renter/downloadheap.go
@@ -196,7 +196,7 @@ LOOP:
 			}
 
 			// Check if we got the chunk cached already.
-			if r.downloadChunkCache.retrieve(nextChunk) {
+			if r.downloadChunkCache.Retrieve(nextChunk) {
 				continue
 			}
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -193,18 +193,18 @@ type Renter struct {
 	lastEstimation modules.RenterPriceEstimation
 
 	// Utilities.
-	downloadChunkCache *downloadChunkCache
-	cmu                *sync.Mutex
-	cs                 modules.ConsensusSet
-	deps               modules.Dependencies
-	g                  modules.Gateway
-	hostContractor     hostContractor
-	hostDB             hostDB
-	log                *persist.Logger
-	persistDir         string
-	mu                 *siasync.RWMutex
-	tg                 threadgroup.ThreadGroup
-	tpool              modules.TransactionPool
+	streamCache    *streamCache
+	cmu            *sync.Mutex
+	cs             modules.ConsensusSet
+	deps           modules.Dependencies
+	g              modules.Gateway
+	hostContractor hostContractor
+	hostDB         hostDB
+	log            *persist.Logger
+	persistDir     string
+	mu             *siasync.RWMutex
+	tg             threadgroup.ThreadGroup
+	tpool          modules.TransactionPool
 }
 
 // Close closes the Renter and its dependencies
@@ -351,7 +351,7 @@ func (r *Renter) Settings() modules.RenterSettings {
 	download, upload, _ := r.hostContractor.RateLimits()
 	return modules.RenterSettings{
 		Allowance:         r.hostContractor.Allowance(),
-		DownloadCacheSize: r.downloadChunkCache.cacheSize,
+		DownloadCacheSize: r.streamCache.cacheSize,
 		MaxDownloadSpeed:  download,
 		MaxUploadSpeed:    upload,
 	}
@@ -435,18 +435,18 @@ func NewCustomRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.T
 
 		workerPool: make(map[types.FileContractID]*worker),
 
-		downloadChunkCache: new(downloadChunkCache),
-		cmu:                new(sync.Mutex),
-		cs:                 cs,
-		deps:               deps,
-		g:                  g,
-		hostDB:             hdb,
-		hostContractor:     hc,
-		persistDir:         persistDir,
-		mu:                 siasync.New(modules.SafeMutexDelay, 1),
-		tpool:              tpool,
+		streamCache:    new(streamCache),
+		cmu:            new(sync.Mutex),
+		cs:             cs,
+		deps:           deps,
+		g:              g,
+		hostDB:         hdb,
+		hostContractor: hc,
+		persistDir:     persistDir,
+		mu:             siasync.New(modules.SafeMutexDelay, 1),
+		tpool:          tpool,
 	}
-	r.downloadChunkCache.Init()
+	r.streamCache.Init()
 	r.memoryManager = newMemoryManager(defaultMemory, r.tg.StopChan())
 
 	// Load all saved data.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -288,6 +288,7 @@ func (r *Renter) PriceEstimation() modules.RenterPriceEstimation {
 }
 
 // SetSettings will update the settings for the renter.
+// TODO: Add downloadcachesize
 func (r *Renter) SetSettings(s modules.RenterSettings) error {
 	// Set allowance.
 	err := r.hostContractor.SetAllowance(s.Allowance)
@@ -305,6 +306,10 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 		// the packetSize using the API. For now the sane default is 16kib if
 		// the user wants to limit the connection.
 		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
+	}
+	// TODO: confirm downloadcachesize is set correctly
+	if s.DownloadCacheSize <= 0 {
+		s.DownloadCacheSize = 2
 	}
 
 	r.managedUpdateWorkerPool()
@@ -444,7 +449,7 @@ func NewCustomRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.T
 		mu:                 siasync.New(modules.SafeMutexDelay, 1),
 		tpool:              tpool,
 	}
-	r.downloadChunkCache.init()
+	r.downloadChunkCache.init(RenterSettings.DownloadCacheSize)
 	r.memoryManager = newMemoryManager(defaultMemory, r.tg.StopChan())
 
 	// Load all saved data.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -307,10 +307,6 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 		// the user wants to limit the connection.
 		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
 	}
-	// TODO: confirm downloadcachesize is set correctly
-	if s.DownloadCacheSize <= 0 {
-		s.DownloadCacheSize = 2
-	}
 
 	r.setStreamingCacheSize(s.DownloadCacheSize)
 	r.managedUpdateWorkerPool()

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -288,6 +288,7 @@ func (r *Renter) PriceEstimation() modules.RenterPriceEstimation {
 }
 
 // SetSettings will update the settings for the renter.
+// TODO: Add downloadcachesize
 func (r *Renter) SetSettings(s modules.RenterSettings) error {
 	// Set allowance.
 	err := r.hostContractor.SetAllowance(s.Allowance)
@@ -305,6 +306,10 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 		// the packetSize using the API. For now the sane default is 16kib if
 		// the user wants to limit the connection.
 		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
+	}
+	// TODO: confirm downloadcachesize is set correctly
+	if s.DownloadCacheSize <= 0 {
+		s.DownloadCacheSize = 2
 	}
 
 	r.setStreamingCacheSize(s.DownloadCacheSize)

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -350,9 +350,10 @@ func (r *Renter) PeriodSpending() modules.ContractorSpending { return r.hostCont
 func (r *Renter) Settings() modules.RenterSettings {
 	download, upload, _ := r.hostContractor.RateLimits()
 	return modules.RenterSettings{
-		Allowance:        r.hostContractor.Allowance(),
-		MaxDownloadSpeed: download,
-		MaxUploadSpeed:   upload,
+		Allowance:         r.hostContractor.Allowance(),
+		DownloadCacheSize: r.downloadChunkCache.cacheSize,
+		MaxDownloadSpeed:  download,
+		MaxUploadSpeed:    upload,
 	}
 }
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -307,7 +307,7 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
 	}
 
-	r.SetStreamingCacheSize(s.DownloadCacheSize)
+	r.SetStreamingCacheSize(s.StreamCacheSize)
 	r.managedUpdateWorkerPool()
 	return nil
 }
@@ -350,10 +350,10 @@ func (r *Renter) PeriodSpending() modules.ContractorSpending { return r.hostCont
 func (r *Renter) Settings() modules.RenterSettings {
 	download, upload, _ := r.hostContractor.RateLimits()
 	return modules.RenterSettings{
-		Allowance:         r.hostContractor.Allowance(),
-		DownloadCacheSize: r.streamCache.cacheSize,
-		MaxDownloadSpeed:  download,
-		MaxUploadSpeed:    upload,
+		Allowance:        r.hostContractor.Allowance(),
+		MaxDownloadSpeed: download,
+		MaxUploadSpeed:   upload,
+		StreamCacheSize:  r.streamCache.cacheSize,
 	}
 }
 

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -307,11 +307,8 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 		// the user wants to limit the connection.
 		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
 	}
-	// TODO: confirm downloadcachesize is set correctly
-	if s.DownloadCacheSize <= 0 {
-		s.DownloadCacheSize = 2
-	}
 
+	r.setStreamingCacheSize(s.DownloadCacheSize)
 	r.managedUpdateWorkerPool()
 	return nil
 }
@@ -449,7 +446,7 @@ func NewCustomRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.T
 		mu:                 siasync.New(modules.SafeMutexDelay, 1),
 		tpool:              tpool,
 	}
-	r.downloadChunkCache.init(RenterSettings.DownloadCacheSize)
+	r.downloadChunkCache.init()
 	r.memoryManager = newMemoryManager(defaultMemory, r.tg.StopChan())
 
 	// Load all saved data.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -307,7 +307,7 @@ func (r *Renter) SetSettings(s modules.RenterSettings) error {
 		r.hostContractor.SetRateLimits(s.MaxDownloadSpeed, s.MaxUploadSpeed, 4*4096)
 	}
 
-	r.setStreamingCacheSize(s.DownloadCacheSize)
+	r.SetStreamingCacheSize(s.DownloadCacheSize)
 	r.managedUpdateWorkerPool()
 	return nil
 }
@@ -446,7 +446,7 @@ func NewCustomRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.T
 		mu:                 siasync.New(modules.SafeMutexDelay, 1),
 		tpool:              tpool,
 	}
-	r.downloadChunkCache.init()
+	r.downloadChunkCache.Init()
 	r.memoryManager = newMemoryManager(defaultMemory, r.tg.StopChan())
 
 	// Load all saved data.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -288,7 +288,6 @@ func (r *Renter) PriceEstimation() modules.RenterPriceEstimation {
 }
 
 // SetSettings will update the settings for the renter.
-// TODO: Add downloadcachesize
 func (r *Renter) SetSettings(s modules.RenterSettings) error {
 	// Set allowance.
 	err := r.hostContractor.SetAllowance(s.Allowance)

--- a/modules/renter/streamcache.go
+++ b/modules/renter/streamcache.go
@@ -163,10 +163,10 @@ func (sc *streamCache) Retrieve(udc *unfinishedDownloadChunk) bool {
 // SetStreamingCacheSize confirms that the cache size is being set
 // to a value greater than zero.  Otherwise it will remain the default
 // value set during the initialization of the streamCache
-func (r *Renter) SetStreamingCacheSize(cacheSize uint64) {
-	r.streamCache.mu.Lock()
-	defer r.streamCache.mu.Unlock()
+func (sc *streamCache) SetStreamingCacheSize(cacheSize uint64) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
 	if cacheSize > 0 {
-		r.streamCache.cacheSize = cacheSize
+		sc.cacheSize = cacheSize
 	}
 }

--- a/modules/renter/streamcache.go
+++ b/modules/renter/streamcache.go
@@ -105,7 +105,7 @@ func (sc *streamCache) Init() {
 	heap.Init(&sc.streamHeap)
 }
 
-// pruneCache prunes the cache until it is the length of cacheSize
+// pruneCache prunes the cache until it is the length of size
 func (sc *streamCache) pruneCache(size uint64) {
 	for len(sc.streamMap) > int(size) {
 		// Remove from Heap

--- a/modules/renter/streamcache.go
+++ b/modules/renter/streamcache.go
@@ -1,8 +1,5 @@
 package renter
 
-// TODO expose the downloadCacheSize as a variable and allow users to set it
-// via the API.
-
 import (
 	"container/heap"
 	"sync"
@@ -111,8 +108,8 @@ func (sc *streamCache) Init() {
 	}
 
 	sc.streamMap = make(map[string]*chunkData)
-	sc.streamHeap = make(streamHeap, 0, defaultDownloadCacheSize)
-	sc.cacheSize = defaultDownloadCacheSize
+	sc.streamHeap = make(streamHeap, 0, defaultStreamCacheSize)
+	sc.cacheSize = defaultStreamCacheSize
 	heap.Init(&sc.streamHeap)
 }
 

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -80,6 +80,9 @@ func TestStreamCache(t *testing.T) {
 	sc := new(streamCache)
 	sc.Init()
 
+	// Setting cacheSize to large value so reducing it can be tested
+	sc.cacheSize = 10
+
 	// Fill Cache
 	// Purposefully trying to fill to a value larger than cacheSize to confirm Add()
 	// keeps pruning cache
@@ -89,6 +92,14 @@ func TestStreamCache(t *testing.T) {
 	// Confirm that the streamHeap didn't exceed the cacheSize
 	if len(sc.streamHeap) > int(sc.cacheSize) {
 		t.Error("Heap is larger than set cacheSize")
+	}
+
+	// Reduce cacheSize and call Add() to confirm cache is pruned
+	sc.cacheSize = 2
+	sc.Add("", []byte{})
+	// Confirm that the length of streamHeap is the cacheSize
+	if len(sc.streamHeap) != int(sc.cacheSize) {
+		t.Error("Heap is not equal to the cacheSize")
 	}
 
 	// Add new chunk with known staticCacheID

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -45,7 +45,7 @@ func TestHeapImplementation(t *testing.T) {
 	// Confirming recently accessed elements get moved to the bottom of Heap
 	cd = sc.streamHeap[0]
 	sc.streamHeap.update(cd, cd.id, cd.data, time.Now())
-	if !reflect.DeepEqual(cd, sc.streamHeap[len(sc.streamHeap)-1]) {
+	if reflect.DeepEqual(cd, sc.streamHeap[0]) {
 		t.Error("Heap order was not updated. Recently accessed element not at bottom of heap")
 	}
 	// Confirming least recently accessed element is moved to the top of Heap

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -11,8 +11,7 @@ import (
 // TestHeapImplementation tests that the streamCache heap functions properly
 func TestHeapImplementation(t *testing.T) {
 	// Initializing minimum variables
-	sc := new(streamCache)
-	sc.Init()
+	sc := newStreamCache()
 
 	// Testing Push to Heap
 	length := len(sc.streamHeap)
@@ -37,7 +36,7 @@ func TestHeapImplementation(t *testing.T) {
 		heap.Push(&sc.streamHeap, &chunkData{
 			id:         strconv.Itoa(i),
 			data:       []byte{},
-			lastAccess: time.Now(),
+			lastAccess: time.Now().Add(-1 * time.Minute),
 		})
 	}
 
@@ -77,8 +76,7 @@ func TestStreamCache(t *testing.T) {
 		t.SkipNow()
 	}
 	// Initializing minimum required variables
-	sc := new(streamCache)
-	sc.Init()
+	sc := newStreamCache()
 
 	// Setting cacheSize to large value so reducing it can be tested
 	sc.cacheSize = 10

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -2,6 +2,7 @@ package renter
 
 import (
 	"container/heap"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -15,18 +16,19 @@ func TestHeapImplementation(t *testing.T) {
 
 	// Testing Push to Heap
 	length := len(sc.streamHeap)
-	heap.Push(&sc.streamHeap, &chunkData{
+	cd := &chunkData{
 		id:         "Push",
 		data:       []byte{},
 		lastAccess: time.Now(),
-	})
+	}
+	heap.Push(&sc.streamHeap, cd)
 
 	// Confirming the length of the heap increased by 1
 	if len(sc.streamHeap) != length+1 {
 		t.Error("Length of heap did not change, chunkData was not pushed onto Heap. Length of heap is still ", len(sc.streamHeap))
 	}
 	// Confirming the chunk added was the one expected
-	if sc.streamHeap[0].id != "Push" {
+	if !reflect.DeepEqual(cd, sc.streamHeap[0]) {
 		t.Error("Chunk on top of heap is not the chunk that was just pushed on, chunkData.id =", sc.streamHeap[0].id)
 	}
 
@@ -37,20 +39,19 @@ func TestHeapImplementation(t *testing.T) {
 			data:       []byte{},
 			lastAccess: time.Now(),
 		})
-		time.Sleep(1 * time.Second)
 	}
 
 	// Testing Heap update
 	// Confirming recently accessed elements get moved to the bottom of Heap
-	cd := sc.streamHeap[0]
+	cd = sc.streamHeap[0]
 	sc.streamHeap.update(cd, cd.id, cd.data, time.Now())
-	if sc.streamHeap[len(sc.streamHeap)-1] != cd {
+	if !reflect.DeepEqual(cd, sc.streamHeap[len(sc.streamHeap)-1]) {
 		t.Error("Heap order was not updated. Recently accessed element not at bottom of heap")
 	}
 	// Confirming least recently accessed element is moved to the top of Heap
 	cd = sc.streamHeap[len(sc.streamHeap)-1]
 	sc.streamHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
-	if sc.streamHeap[0] != cd {
+	if !reflect.DeepEqual(cd, sc.streamHeap[0]) {
 		t.Error("Heap order was not updated. Least recently accessed element is not at top of heap")
 	}
 
@@ -58,7 +59,7 @@ func TestHeapImplementation(t *testing.T) {
 	// Confirming element at the top of heap is removed
 	cd = sc.streamHeap[0]
 	length = len(sc.streamHeap)
-	if pop := heap.Pop(&sc.streamHeap).(*chunkData); pop != cd {
+	if pop := heap.Pop(&sc.streamHeap).(*chunkData); !reflect.DeepEqual(cd, pop) {
 		t.Error("Element at the top of the Heap was not popped off")
 	}
 	if len(sc.streamHeap) != length-1 {
@@ -98,7 +99,7 @@ func TestStreamCache(t *testing.T) {
 	if !ok {
 		t.Error("The chunk1 was not added to the Map")
 	}
-	if cd != sc.streamHeap[len(sc.streamHeap)-1] {
+	if !reflect.DeepEqual(cd, sc.streamHeap[len(sc.streamHeap)-1]) {
 		t.Error("The chunk1 is not at the bottom of the Heap")
 	}
 
@@ -106,7 +107,7 @@ func TestStreamCache(t *testing.T) {
 	sc.streamHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
 
 	// Confirm chunk1 is at the top of the heap
-	if sc.streamHeap[0] != cd {
+	if !reflect.DeepEqual(cd, sc.streamHeap[0]) {
 		t.Error("Chunk1 is not at the top of the heap")
 	}
 
@@ -117,7 +118,7 @@ func TestStreamCache(t *testing.T) {
 	if _, ok := sc.streamMap["chunk1"]; ok {
 		t.Error("chunk1 wasn't removed from the map")
 	}
-	if sc.streamHeap[0] == cd {
+	if reflect.DeepEqual(cd, sc.streamHeap[0]) {
 		t.Error("chunk1 wasn't removed from the heap")
 	}
 }

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -7,32 +7,32 @@ import (
 	"time"
 )
 
-// TestHeapImplementation tests that the downloadChunkCache heap functions properly
+// TestHeapImplementation tests that the streamCache heap functions properly
 func TestHeapImplementation(t *testing.T) {
 	// Initializing minimum variables
-	dcc := new(downloadChunkCache)
-	dcc.Init()
+	sc := new(streamCache)
+	sc.Init()
 
 	// Testing Push to Heap
-	length := len(dcc.chunkCacheHeap)
-	heap.Push(&dcc.chunkCacheHeap, &chunkData{
+	length := len(sc.streamHeap)
+	heap.Push(&sc.streamHeap, &chunkData{
 		id:         "Push",
 		data:       []byte{},
 		lastAccess: time.Now(),
 	})
 
 	// Confirming the length of the heap increased by 1
-	if len(dcc.chunkCacheHeap) != length+1 {
-		t.Error("Length of heap did not change, chunkData was not pushed onto Heap. Length of heap is still ", len(dcc.chunkCacheHeap))
+	if len(sc.streamHeap) != length+1 {
+		t.Error("Length of heap did not change, chunkData was not pushed onto Heap. Length of heap is still ", len(sc.streamHeap))
 	}
 	// Confirming the chunk added was the one expected
-	if dcc.chunkCacheHeap[0].id != "Push" {
-		t.Error("Chunk on top of heap is not the chunk that was just pushed on, chunkData.id =", dcc.chunkCacheHeap[0].id)
+	if sc.streamHeap[0].id != "Push" {
+		t.Error("Chunk on top of heap is not the chunk that was just pushed on, chunkData.id =", sc.streamHeap[0].id)
 	}
 
 	// Add more chunks to heap
 	for i := 0; i < 3; i++ {
-		heap.Push(&dcc.chunkCacheHeap, &chunkData{
+		heap.Push(&sc.streamHeap, &chunkData{
 			id:         strconv.Itoa(i),
 			data:       []byte{},
 			lastAccess: time.Now(),
@@ -42,26 +42,26 @@ func TestHeapImplementation(t *testing.T) {
 
 	// Testing Heap update
 	// Confirming recently accessed elements get moved to the bottom of Heap
-	cd := dcc.chunkCacheHeap[0]
-	dcc.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now())
-	if dcc.chunkCacheHeap[len(dcc.chunkCacheHeap)-1] != cd {
+	cd := sc.streamHeap[0]
+	sc.streamHeap.update(cd, cd.id, cd.data, time.Now())
+	if sc.streamHeap[len(sc.streamHeap)-1] != cd {
 		t.Error("Heap order was not updated. Recently accessed element not at bottom of heap")
 	}
 	// Confirming least recently accessed element is moved to the top of Heap
-	cd = dcc.chunkCacheHeap[len(dcc.chunkCacheHeap)-1]
-	dcc.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
-	if dcc.chunkCacheHeap[0] != cd {
+	cd = sc.streamHeap[len(sc.streamHeap)-1]
+	sc.streamHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
+	if sc.streamHeap[0] != cd {
 		t.Error("Heap order was not updated. Least recently accessed element is not at top of heap")
 	}
 
 	// Testing Pop of Heap
 	// Confirming element at the top of heap is removed
-	cd = dcc.chunkCacheHeap[0]
-	length = len(dcc.chunkCacheHeap)
-	if pop := heap.Pop(&dcc.chunkCacheHeap).(*chunkData); pop != cd {
+	cd = sc.streamHeap[0]
+	length = len(sc.streamHeap)
+	if pop := heap.Pop(&sc.streamHeap).(*chunkData); pop != cd {
 		t.Error("Element at the top of the Heap was not popped off")
 	}
-	if len(dcc.chunkCacheHeap) != length-1 {
+	if len(sc.streamHeap) != length-1 {
 		t.Error("Heap length was not reduced by 1")
 	}
 }
@@ -73,49 +73,49 @@ func TestHeapImplementation(t *testing.T) {
 // siatest packages
 func TestStreamCache(t *testing.T) {
 	// Initializing minimum required variables
-	dcc := new(downloadChunkCache)
-	dcc.Init()
+	sc := new(streamCache)
+	sc.Init()
 
 	// Fill Cache
 	// Purposefully trying to fill to a value larger than cacheSize to confirm Add()
 	// keeps pruning cache
-	for i := 0; i < int(dcc.cacheSize)+5; i++ {
-		dcc.Add(strconv.Itoa(i), []byte{})
+	for i := 0; i < int(sc.cacheSize)+5; i++ {
+		sc.Add(strconv.Itoa(i), []byte{})
 		time.Sleep(1 * time.Second)
 	}
-	// Confirm that the chunkCacheHeap didn't exceed the cacheSize
-	if len(dcc.chunkCacheHeap) > int(dcc.cacheSize) {
+	// Confirm that the streamHeap didn't exceed the cacheSize
+	if len(sc.streamHeap) > int(sc.cacheSize) {
 		t.Error("Heap is larger than set cacheSize")
 	}
 
 	// Add new chunk with known staticCacheID
-	dcc.Add("chunk1", []byte{}) // "chunk1" should be at the bottom of the Heap
+	sc.Add("chunk1", []byte{}) // "chunk1" should be at the bottom of the Heap
 
 	// Confirm chunk is in the Map and at the bottom of the Heap
-	cd, ok := dcc.chunkCacheMap["chunk1"]
+	cd, ok := sc.streamMap["chunk1"]
 	if !ok {
 		t.Error("The chunk1 was not added to the Map")
 	}
-	if cd != dcc.chunkCacheHeap[len(dcc.chunkCacheHeap)-1] {
+	if cd != sc.streamHeap[len(sc.streamHeap)-1] {
 		t.Error("The chunk1 is not at the bottom of the Heap")
 	}
 
 	// Make chunk1 least recently accessed element, so it is at the top
-	dcc.chunkCacheHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
+	sc.streamHeap.update(cd, cd.id, cd.data, time.Now().Add(-1*time.Hour))
 
 	// Confirm chunk1 is at the top of the heap
-	if dcc.chunkCacheHeap[0] != cd {
+	if sc.streamHeap[0] != cd {
 		t.Error("Chunk1 is not at the top of the heap")
 	}
 
 	// Add additional chunk to force deletion of a chunk
-	dcc.Add("chunk2", []byte{})
+	sc.Add("chunk2", []byte{})
 
 	// check if chunk1 was removed from Map
-	if _, ok := dcc.chunkCacheMap["chunk1"]; ok {
+	if _, ok := sc.streamMap["chunk1"]; ok {
 		t.Error("chunk1 wasn't removed from the map")
 	}
-	if dcc.chunkCacheHeap[0] == cd {
+	if sc.streamHeap[0] == cd {
 		t.Error("chunk1 wasn't removed from the heap")
 	}
 }

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -72,6 +72,9 @@ func TestHeapImplementation(t *testing.T) {
 // SetStreamingCacheSize() is tested through the API endpoint tests in the
 // siatest packages
 func TestStreamCache(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
 	// Initializing minimum required variables
 	sc := new(streamCache)
 	sc.Init()
@@ -81,7 +84,6 @@ func TestStreamCache(t *testing.T) {
 	// keeps pruning cache
 	for i := 0; i < int(sc.cacheSize)+5; i++ {
 		sc.Add(strconv.Itoa(i), []byte{})
-		time.Sleep(1 * time.Second)
 	}
 	// Confirm that the streamHeap didn't exceed the cacheSize
 	if len(sc.streamHeap) > int(sc.cacheSize) {

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -42,11 +42,11 @@ func TestHeapImplementation(t *testing.T) {
 	}
 
 	// Testing Heap update
-	// Confirming recently accessed elements get moved to the bottom of Heap
+	// Confirming recently accessed elements gets removed from the top of Heap
 	cd = sc.streamHeap[0]
 	sc.streamHeap.update(cd, cd.id, cd.data, time.Now())
 	if reflect.DeepEqual(cd, sc.streamHeap[0]) {
-		t.Error("Heap order was not updated. Recently accessed element not at bottom of heap")
+		t.Error("Heap order was not updated. Recently accessed element at top of heap")
 	}
 	// Confirming least recently accessed element is moved to the top of Heap
 	cd = sc.streamHeap[len(sc.streamHeap)-1]

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/node/api"
+	"github.com/NebulousLabs/errors"
 )
 
 // RenterContractsGet requests the /renter/contracts resource
@@ -97,6 +98,18 @@ func (c *Client) RenterCancelAllowance() (err error) {
 // RenterPricesGet requests the /renter/prices endpoint's resources.
 func (c *Client) RenterPricesGet() (rpg api.RenterPricesGET, err error) {
 	err = c.get("/renter/prices", &rpg)
+	return
+}
+
+// RenterPostDownloadCacheSize uses the /renter endpoint to change the renter's
+// downloadCacheSize for streaming
+func (c *Client) RenterPostDownloadCacheSize(cacheSize uint64) (err error) {
+	if cacheSize <= 0 {
+		return errors.New("Download Cache Size must be greater than 0")
+	}
+	values := url.Values{}
+	values.Set("downloadCacheSize", strconv.FormatUint(cacheSize, 10))
+	err = c.post("/renter", values.Encode(), nil)
 	return
 }
 

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/node/api"
-	"github.com/NebulousLabs/errors"
 )
 
 // RenterContractsGet requests the /renter/contracts resource
@@ -101,18 +100,6 @@ func (c *Client) RenterPricesGet() (rpg api.RenterPricesGET, err error) {
 	return
 }
 
-// RenterPostDownloadCacheSize uses the /renter endpoint to change the renter's
-// downloadCacheSize for streaming
-func (c *Client) RenterPostDownloadCacheSize(cacheSize uint64) (err error) {
-	if cacheSize <= 0 {
-		return errors.New("Download Cache Size must be greater than 0")
-	}
-	values := url.Values{}
-	values.Set("downloadCacheSize", strconv.FormatUint(cacheSize, 10))
-	err = c.post("/renter", values.Encode(), nil)
-	return
-}
-
 // RenterPostRateLimit uses the /renter endpoint to change the renter's bandwidth rate
 // limit.
 func (c *Client) RenterPostRateLimit(readBPS, writeBPS int64) (err error) {
@@ -128,6 +115,15 @@ func (c *Client) RenterRenamePost(siaPathOld, siaPathNew string) (err error) {
 	siaPathOld = strings.TrimPrefix(siaPathOld, "/")
 	siaPathNew = strings.TrimPrefix(siaPathNew, "/")
 	err = c.post("/renter/rename/"+siaPathOld, "newsiapath=/"+siaPathNew, nil)
+	return
+}
+
+// RenterSetStreamCacheSizePost uses the /renter endpoint to change the renter's
+// downloadCacheSize for streaming
+func (c *Client) RenterSetStreamCacheSizePost(cacheSize uint64) (err error) {
+	values := url.Values{}
+	values.Set("downloadcachesize", strconv.FormatUint(cacheSize, 10))
+	err = c.post("/renter", values.Encode(), nil)
 	return
 }
 

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -119,10 +119,10 @@ func (c *Client) RenterRenamePost(siaPathOld, siaPathNew string) (err error) {
 }
 
 // RenterSetStreamCacheSizePost uses the /renter endpoint to change the renter's
-// downloadCacheSize for streaming
+// streamCacheSize for streaming
 func (c *Client) RenterSetStreamCacheSizePost(cacheSize uint64) (err error) {
 	values := url.Values{}
-	values.Set("downloadcachesize", strconv.FormatUint(cacheSize, 10))
+	values.Set("streamcachesize", strconv.FormatUint(cacheSize, 10))
 	err = c.post("/renter", values.Encode(), nil)
 	return
 }

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -254,6 +254,7 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		settings.MaxUploadSpeed = uploadSpeed
 	}
 	// Scan the download cache size. (optional parameter)
+<<<<<<< 0ee5798cc36ae3a031a079cc492f9dbb16e434b7
 	if dcs := req.FormValue("downloadcachesize"); dcs != "" {
 		var downloadCacheSize uint64
 		if _, err := fmt.Sscan(dcs, &downloadCacheSize); err != nil {
@@ -261,6 +262,16 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 			return
 		}
 		settings.DownloadCacheSize = downloadCacheSize
+=======
+	if dc := req.FormValue("downloadcachesize"); dc != "" {
+		// TODO: Does this need to be update for downloadcache??
+		// var uploadSpeed int
+		// if _, err := fmt.Sscan(u, &uploadSpeed); err != nil {
+		// 	WriteError(w, Error{"unable to parse uploadspeed: " + err.Error()}, http.StatusBadRequest)
+		// 	return
+		// }
+		settings.DownloadCacheSize = downloadcachesize
+>>>>>>> Change addChunkToCache and manageTryCache methods to add and retreive methods called on the downloadChunkCache
 	}
 	// Set the settings in the renter.
 	err := api.renter.SetSettings(settings)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -254,14 +254,20 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		settings.MaxUploadSpeed = uploadSpeed
 	}
 	// Scan the download cache size. (optional parameter)
+<<<<<<< 4f76f71a907e18e6aeb2af5013eb212b708b573a
 <<<<<<< 0ee5798cc36ae3a031a079cc492f9dbb16e434b7
 	if dcs := req.FormValue("downloadcachesize"); dcs != "" {
 		var downloadCacheSize uint64
+=======
+	if dcs := req.FormValue("downloadcachesize"); dc != "" {
+		var downloadCacheSize int
+>>>>>>> Create SetStreamingCacheSize() to update cacheSize from API /renter call
 		if _, err := fmt.Sscan(dcs, &downloadCacheSize); err != nil {
 			WriteError(w, Error{"unable to parse downloadcachesize: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 		settings.DownloadCacheSize = downloadCacheSize
+<<<<<<< 4f76f71a907e18e6aeb2af5013eb212b708b573a
 =======
 	if dc := req.FormValue("downloadcachesize"); dc != "" {
 		// TODO: Does this need to be update for downloadcache??
@@ -272,6 +278,10 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		// }
 		settings.DownloadCacheSize = downloadcachesize
 >>>>>>> Change addChunkToCache and manageTryCache methods to add and retreive methods called on the downloadChunkCache
+=======
+	} else {
+		settings.DownloadCacheSize = DefaultDownloadCacheSize
+>>>>>>> Create SetStreamingCacheSize() to update cacheSize from API /renter call
 	}
 	// Set the settings in the renter.
 	err := api.renter.SetSettings(settings)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -254,14 +254,15 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		settings.MaxUploadSpeed = uploadSpeed
 	}
 	// Scan the download cache size. (optional parameter)
-	if dc := req.FormValue("downloadcachesize"); dc != "" {
-		// TODO: Does this need to be update for downloadcache??
-		// var uploadSpeed int
-		// if _, err := fmt.Sscan(u, &uploadSpeed); err != nil {
-		// 	WriteError(w, Error{"unable to parse uploadspeed: " + err.Error()}, http.StatusBadRequest)
-		// 	return
-		// }
-		settings.DownloadCacheSize = downloadcachesize
+	if dcs := req.FormValue("downloadcachesize"); dc != "" {
+		var downloadCacheSize int
+		if _, err := fmt.Sscan(dcs, &downloadCacheSize); err != nil {
+			WriteError(w, Error{"unable to parse downloadcachesize: " + err.Error()}, http.StatusBadRequest)
+			return
+		}
+		settings.DownloadCacheSize = downloadCacheSize
+	} else {
+		settings.DownloadCacheSize = DefaultDownloadCacheSize
 	}
 	// Set the settings in the renter.
 	err := api.renter.SetSettings(settings)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -254,34 +254,13 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		settings.MaxUploadSpeed = uploadSpeed
 	}
 	// Scan the download cache size. (optional parameter)
-<<<<<<< 4f76f71a907e18e6aeb2af5013eb212b708b573a
-<<<<<<< 0ee5798cc36ae3a031a079cc492f9dbb16e434b7
 	if dcs := req.FormValue("downloadcachesize"); dcs != "" {
 		var downloadCacheSize uint64
-=======
-	if dcs := req.FormValue("downloadcachesize"); dc != "" {
-		var downloadCacheSize int
->>>>>>> Create SetStreamingCacheSize() to update cacheSize from API /renter call
 		if _, err := fmt.Sscan(dcs, &downloadCacheSize); err != nil {
 			WriteError(w, Error{"unable to parse downloadcachesize: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 		settings.DownloadCacheSize = downloadCacheSize
-<<<<<<< 4f76f71a907e18e6aeb2af5013eb212b708b573a
-=======
-	if dc := req.FormValue("downloadcachesize"); dc != "" {
-		// TODO: Does this need to be update for downloadcache??
-		// var uploadSpeed int
-		// if _, err := fmt.Sscan(u, &uploadSpeed); err != nil {
-		// 	WriteError(w, Error{"unable to parse uploadspeed: " + err.Error()}, http.StatusBadRequest)
-		// 	return
-		// }
-		settings.DownloadCacheSize = downloadcachesize
->>>>>>> Change addChunkToCache and manageTryCache methods to add and retreive methods called on the downloadChunkCache
-=======
-	} else {
-		settings.DownloadCacheSize = DefaultDownloadCacheSize
->>>>>>> Create SetStreamingCacheSize() to update cacheSize from API /renter call
 	}
 	// Set the settings in the renter.
 	err := api.renter.SetSettings(settings)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -253,6 +253,16 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		}
 		settings.MaxUploadSpeed = uploadSpeed
 	}
+	// Scan the download cache size. (optional parameter)
+	if dc := req.FormValue("downloadcachesize"); dc != "" {
+		// TODO: Does this need to be update for downloadcache??
+		// var uploadSpeed int
+		// if _, err := fmt.Sscan(u, &uploadSpeed); err != nil {
+		// 	WriteError(w, Error{"unable to parse uploadspeed: " + err.Error()}, http.StatusBadRequest)
+		// 	return
+		// }
+		settings.DownloadCacheSize = downloadcachesize
+	}
 	// Set the settings in the renter.
 	err := api.renter.SetSettings(settings)
 	if err != nil {

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -254,15 +254,13 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		settings.MaxUploadSpeed = uploadSpeed
 	}
 	// Scan the download cache size. (optional parameter)
-	if dcs := req.FormValue("downloadcachesize"); dc != "" {
-		var downloadCacheSize int
+	if dcs := req.FormValue("downloadcachesize"); dcs != "" {
+		var downloadCacheSize uint64
 		if _, err := fmt.Sscan(dcs, &downloadCacheSize); err != nil {
 			WriteError(w, Error{"unable to parse downloadcachesize: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
 		settings.DownloadCacheSize = downloadCacheSize
-	} else {
-		settings.DownloadCacheSize = DefaultDownloadCacheSize
 	}
 	// Set the settings in the renter.
 	err := api.renter.SetSettings(settings)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -253,14 +253,14 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 		}
 		settings.MaxUploadSpeed = uploadSpeed
 	}
-	// Scan the download cache size. (optional parameter)
-	if dcs := req.FormValue("downloadcachesize"); dcs != "" {
-		var downloadCacheSize uint64
-		if _, err := fmt.Sscan(dcs, &downloadCacheSize); err != nil {
-			WriteError(w, Error{"unable to parse downloadcachesize: " + err.Error()}, http.StatusBadRequest)
+	// Scan the stream cache size. (optional parameter)
+	if dcs := req.FormValue("streamcachesize"); dcs != "" {
+		var streamCacheSize uint64
+		if _, err := fmt.Sscan(dcs, &streamCacheSize); err != nil {
+			WriteError(w, Error{"unable to parse streamcachesize: " + err.Error()}, http.StatusBadRequest)
 			return
 		}
-		settings.DownloadCacheSize = downloadCacheSize
+		settings.StreamCacheSize = streamCacheSize
 	}
 	// Set the settings in the renter.
 	err := api.renter.SetSettings(settings)

--- a/node/api/renterhost_test.go
+++ b/node/api/renterhost_test.go
@@ -1810,7 +1810,7 @@ func TestRedundancyReporting(t *testing.T) {
 			t.Fatal(err)
 		}
 		if len(ah.Hosts) != 2 {
-			return errors.New("not enough hosts in hostdb")
+			return fmt.Errorf("not enough hosts in hostdb, number of hosts is: %v", len(ah.Hosts))
 		}
 		for _, host := range ah.Hosts {
 			if len(host.ScanHistory) < 2 {

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -313,6 +313,22 @@ func testRenterStreamingCache(t *testing.T, tg *siatest.TestGroup) {
 	// Grab the first of the group's renters
 	r := tg.Renters()[0]
 
+	// Testing setting downloadCacheSize for streaming
+	// Test setting it to larger than the defaultCacheSize
+	if err := r.RenterPostDownloadCacheSize(4); err != nil {
+		t.Fatal(err, "Could not set DownloadCacheSize to 4")
+	}
+
+	// Test resetting to the value of defaultDownloadCacheSize (2)
+	if err := r.RenterPostDownloadCacheSize(2); err != nil {
+		t.Fatal(err, "Could not set DownloadCacheSize to 2")
+	}
+
+	// Test setting to 0
+	if err := r.RenterPostDownloadCacheSize(0); err == nil {
+		t.Fatal(errors.New("Download Cache Set to 0, should have caused an error"))
+	}
+
 	// Set fileSize and redundancy for upload
 	dataPieces := uint64(1)
 	parityPieces := uint64(len(tg.Hosts())) - dataPieces

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1,7 +1,6 @@
 package renter
 
 import (
-	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -315,18 +314,41 @@ func testRenterStreamingCache(t *testing.T, tg *siatest.TestGroup) {
 
 	// Testing setting downloadCacheSize for streaming
 	// Test setting it to larger than the defaultCacheSize
-	if err := r.RenterPostDownloadCacheSize(4); err != nil {
+	if err := r.RenterSetStreamCacheSizePost(4); err != nil {
 		t.Fatal(err, "Could not set DownloadCacheSize to 4")
+	}
+	rg, err := r.RenterGet()
+	if err != nil {
+		t.Fatal(err, "Could not get Renter through RenterGet()")
+	}
+	if rg.Settings.DownloadCacheSize != 4 {
+		t.Fatal("DownloadCacheSize not set to 4, set to", rg.Settings.DownloadCacheSize)
 	}
 
 	// Test resetting to the value of defaultDownloadCacheSize (2)
-	if err := r.RenterPostDownloadCacheSize(2); err != nil {
+	if err := r.RenterSetStreamCacheSizePost(2); err != nil {
 		t.Fatal(err, "Could not set DownloadCacheSize to 2")
 	}
+	rg, err = r.RenterGet()
+	if err != nil {
+		t.Fatal(err, "Could not get Renter through RenterGet()")
+	}
+	if rg.Settings.DownloadCacheSize != 2 {
+		t.Fatal("DownloadCacheSize not set to 2, set to", rg.Settings.DownloadCacheSize)
+	}
+
+	prev := rg.Settings.DownloadCacheSize
 
 	// Test setting to 0
-	if err := r.RenterPostDownloadCacheSize(0); err == nil {
-		t.Fatal(errors.New("Download Cache Set to 0, should have caused an error"))
+	if err := r.RenterSetStreamCacheSizePost(0); err != nil {
+		t.Fatal(err, "Error in calling RenterSetStreamCacheSizePost(0)")
+	}
+	rg, err = r.RenterGet()
+	if err != nil {
+		t.Fatal(err, "Could not get Renter through RenterGet()")
+	}
+	if rg.Settings.DownloadCacheSize == 0 {
+		t.Fatal("DownloadCacheSize set to 0, should have stayed as previous value or", prev)
 	}
 
 	// Set fileSize and redundancy for upload

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1,6 +1,7 @@
 package renter
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -362,7 +363,7 @@ func testRenterStreamingCache(t *testing.T, tg *siatest.TestGroup) {
 		t.Fatal(err)
 	}
 
-	rg, err := r.RenterGet()
+	rg, err = r.RenterGet()
 	if err != nil {
 		t.Fatal(err, "Could not request RenterGe()")
 	}

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -313,32 +313,32 @@ func testRenterStreamingCache(t *testing.T, tg *siatest.TestGroup) {
 	// Grab the first of the group's renters
 	r := tg.Renters()[0]
 
-	// Testing setting downloadCacheSize for streaming
+	// Testing setting StreamCacheSize for streaming
 	// Test setting it to larger than the defaultCacheSize
 	if err := r.RenterSetStreamCacheSizePost(4); err != nil {
-		t.Fatal(err, "Could not set DownloadCacheSize to 4")
+		t.Fatal(err, "Could not set StreamCacheSize to 4")
 	}
 	rg, err := r.RenterGet()
 	if err != nil {
 		t.Fatal(err, "Could not get Renter through RenterGet()")
 	}
-	if rg.Settings.DownloadCacheSize != 4 {
-		t.Fatal("DownloadCacheSize not set to 4, set to", rg.Settings.DownloadCacheSize)
+	if rg.Settings.StreamCacheSize != 4 {
+		t.Fatal("StreamCacheSize not set to 4, set to", rg.Settings.StreamCacheSize)
 	}
 
-	// Test resetting to the value of defaultDownloadCacheSize (2)
+	// Test resetting to the value of defaultStreamCacheSize (2)
 	if err := r.RenterSetStreamCacheSizePost(2); err != nil {
-		t.Fatal(err, "Could not set DownloadCacheSize to 2")
+		t.Fatal(err, "Could not set StreamCacheSize to 2")
 	}
 	rg, err = r.RenterGet()
 	if err != nil {
 		t.Fatal(err, "Could not get Renter through RenterGet()")
 	}
-	if rg.Settings.DownloadCacheSize != 2 {
-		t.Fatal("DownloadCacheSize not set to 2, set to", rg.Settings.DownloadCacheSize)
+	if rg.Settings.StreamCacheSize != 2 {
+		t.Fatal("StreamCacheSize not set to 2, set to", rg.Settings.StreamCacheSize)
 	}
 
-	prev := rg.Settings.DownloadCacheSize
+	prev := rg.Settings.StreamCacheSize
 
 	// Test setting to 0
 	if err := r.RenterSetStreamCacheSizePost(0); err != nil {
@@ -348,8 +348,8 @@ func testRenterStreamingCache(t *testing.T, tg *siatest.TestGroup) {
 	if err != nil {
 		t.Fatal(err, "Could not get Renter through RenterGet()")
 	}
-	if rg.Settings.DownloadCacheSize == 0 {
-		t.Fatal("DownloadCacheSize set to 0, should have stayed as previous value or", prev)
+	if rg.Settings.StreamCacheSize == 0 {
+		t.Fatal("StreamCacheSize set to 0, should have stayed as previous value or", prev)
 	}
 
 	// Set fileSize and redundancy for upload


### PR DESCRIPTION
Implemented heap for the download cache for deleting least recently accessed chunk.  Added API endpoint to be able to manually set the download cache size.  Added Siatest to confirm API endpoint is working.  Updated API documentation