### PR TITLE
i3009 renter settings

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -877,7 +877,10 @@ returns the current settings along with metrics on the renter's spending.
       "hosts":       24,
       "period":      6048, // blocks
       "renewwindow": 3024  // blocks
-    }
+    },
+    "maxuploadspeed":     1234, // BPS
+    "maxdownloadspeed":   1234, // BPS
+    "downloadcachesize":  4    
   },
   "financialmetrics": {
     "contractfees":     "1234", // hastings

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -64,14 +64,15 @@ returns the current settings along with metrics on the renter's spending.
     }, 
     // MaxUploadSpeed by defaul is unlimited but can be set by the user to 
     // manage bandwidth
-    "maxuploadspeed":     1234, // BPS
+    "maxuploadspeed":     1234, // bytes per second
 
     // MaxDownloadSpeed by defaul is unlimited but can be set by the user to 
     // manage bandwidth
-    "maxdownloadspeed":   1234, // BPS
+    "maxdownloadspeed":   1234, // bytes per second
 
-    // The DownloadCacheSize is 
-    "downloadcachesize":  4   
+    // The DownloadCacheSize is the number of data chunks that will be cached during
+    // streaming
+    "downloadcachesize":  4  
   },
 
   // Metrics about how much the Renter has spent on storage, uploads, and

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -61,7 +61,17 @@ returns the current settings along with metrics on the renter's spending.
       // contract is scheduled to end, the contract is renewed automatically.
       // Is always nonzero.
       "renewwindow": 3024 // blocks
-    }
+    }, 
+    // MaxUploadSpeed by defaul is unlimited but can be set by the user to 
+    // manage bandwidth
+    "maxuploadspeed":     1234, // BPS
+
+    // MaxDownloadSpeed by defaul is unlimited but can be set by the user to 
+    // manage bandwidth
+    "maxdownloadspeed":   1234, // BPS
+
+    // The DownloadCacheSize is 
+    "downloadcachesize":  4   
   },
 
   // Metrics about how much the Renter has spent on storage, uploads, and

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -157,6 +157,13 @@ func (c *Contractor) ResolveID(id types.FileContractID) types.FileContractID {
 	return newID
 }
 
+// RateLimits sets the bandwidth limits for connections created by the
+// contractSet.
+func (c *Contractor) RateLimits() (int64, int64) {
+	download, upload := c.staticContracts.RateLimits()
+	return download, upload
+}
+
 // SetRateLimits sets the bandwidth limits for connections created by the
 // contractSet.
 func (c *Contractor) SetRateLimits(readBPS, writeBPS int64, packetSize uint64) {

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -159,14 +159,13 @@ func (c *Contractor) ResolveID(id types.FileContractID) types.FileContractID {
 
 // RateLimits sets the bandwidth limits for connections created by the
 // contractSet.
-func (c *Contractor) RateLimits() (int64, int64, uint64) {
-	download, upload, packetSize := c.staticContracts.RateLimits()
-	return download, upload, packetSize
+func (c *Contractor) RateLimits() (readBPW int64, writeBPS int64, packetSize uint64) {
+	return c.staticContracts.RateLimits()
 }
 
 // SetRateLimits sets the bandwidth limits for connections created by the
 // contractSet.
-func (c *Contractor) SetRateLimits(readBPS, writeBPS int64, packetSize uint64) {
+func (c *Contractor) SetRateLimits(readBPS int64, writeBPS int64, packetSize uint64) {
 	c.staticContracts.SetRateLimits(readBPS, writeBPS, packetSize)
 }
 

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -159,9 +159,9 @@ func (c *Contractor) ResolveID(id types.FileContractID) types.FileContractID {
 
 // RateLimits sets the bandwidth limits for connections created by the
 // contractSet.
-func (c *Contractor) RateLimits() (int64, int64) {
-	download, upload := c.staticContracts.RateLimits()
-	return download, upload
+func (c *Contractor) RateLimits() (int64, int64, uint64) {
+	download, upload, packetSize := c.staticContracts.RateLimits()
+	return download, upload, packetSize
 }
 
 // SetRateLimits sets the bandwidth limits for connections created by the

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -106,14 +106,13 @@ func (cs *ContractSet) Return(c *SafeContract) {
 
 // RateLimits sets the bandwidth limits for connections created by the
 // contractSet.
-func (cs *ContractSet) RateLimits() (int64, int64, uint64) {
-	download, upload, packetSize := cs.rl.Limits()
-	return download, upload, packetSize
+func (cs *ContractSet) RateLimits() (readBPS int64, writeBPS int64, packetSize uint64) {
+	return cs.rl.Limits()
 }
 
 // SetRateLimits sets the bandwidth limits for connections created by the
 // contractSet.
-func (cs *ContractSet) SetRateLimits(readBPS, writeBPS int64, packetSize uint64) {
+func (cs *ContractSet) SetRateLimits(readBPS int64, writeBPS int64, packetSize uint64) {
 	cs.rl.SetLimits(readBPS, writeBPS, packetSize)
 }
 

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -107,7 +107,8 @@ func (cs *ContractSet) Return(c *SafeContract) {
 // RateLimits sets the bandwidth limits for connections created by the
 // contractSet.
 func (cs *ContractSet) RateLimits() (int64, int64) {
-	return cs.rl.GetLimits()
+	download, upload := cs.rl.GetLimits()
+	return download, upload
 }
 
 // SetRateLimits sets the bandwidth limits for connections created by the

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -107,7 +107,7 @@ func (cs *ContractSet) Return(c *SafeContract) {
 // RateLimits sets the bandwidth limits for connections created by the
 // contractSet.
 func (cs *ContractSet) RateLimits() (int64, int64, uint64) {
-	download, upload, packetSize := cs.rl.GetLimits()
+	download, upload, packetSize := cs.rl.Limits()
 	return download, upload, packetSize
 }
 

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -104,6 +104,12 @@ func (cs *ContractSet) Return(c *SafeContract) {
 	safeContract.mu.Unlock()
 }
 
+// RateLimits sets the bandwidth limits for connections created by the
+// contractSet.
+func (cs *ContractSet) RateLimits() (int64, int64) {
+	return cs.rl.GetLimits()
+}
+
 // SetRateLimits sets the bandwidth limits for connections created by the
 // contractSet.
 func (cs *ContractSet) SetRateLimits(readBPS, writeBPS int64, packetSize uint64) {

--- a/modules/renter/proto/contractset.go
+++ b/modules/renter/proto/contractset.go
@@ -106,9 +106,9 @@ func (cs *ContractSet) Return(c *SafeContract) {
 
 // RateLimits sets the bandwidth limits for connections created by the
 // contractSet.
-func (cs *ContractSet) RateLimits() (int64, int64) {
-	download, upload := cs.rl.GetLimits()
-	return download, upload
+func (cs *ContractSet) RateLimits() (int64, int64, uint64) {
+	download, upload, packetSize := cs.rl.GetLimits()
+	return download, upload, packetSize
 }
 
 // SetRateLimits sets the bandwidth limits for connections created by the

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -135,7 +135,7 @@ type hostContractor interface {
 
 	// RateLimits Gets the bandwidth limits for connections created by the
 	// contractor and its submodules.
-	RateLimits() (int64, int64)
+	RateLimits() (int64, int64, uint64)
 
 	// SetRateLimits sets the bandwidth limits for connections created by the
 	// contractor and its submodules.
@@ -347,7 +347,7 @@ func (r *Renter) PeriodSpending() modules.ContractorSpending { return r.hostCont
 
 // Settings returns the host contractor's allowance
 func (r *Renter) Settings() modules.RenterSettings {
-	download, upload := r.hostContractor.RateLimits()
+	download, upload, _ := r.hostContractor.RateLimits()
 	return modules.RenterSettings{
 		Allowance:        r.hostContractor.Allowance(),
 		MaxDownloadSpeed: download,

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -135,7 +135,7 @@ type hostContractor interface {
 
 	// RateLimits Gets the bandwidth limits for connections created by the
 	// contractor and its submodules.
-	RateLimits() (int64, int64, uint64)
+	RateLimits() (readBPS int64, writeBPS int64, packetSize uint64)
 
 	// SetRateLimits sets the bandwidth limits for connections created by the
 	// contractor and its submodules.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -133,6 +133,10 @@ type hostContractor interface {
 	// ResolveID returns the most recent renewal of the specified ID.
 	ResolveID(types.FileContractID) types.FileContractID
 
+	// RateLimits Gets the bandwidth limits for connections created by the
+	// contractor and its submodules.
+	RateLimits() (int64, int64)
+
 	// SetRateLimits sets the bandwidth limits for connections created by the
 	// contractor and its submodules.
 	SetRateLimits(int64, int64, uint64)
@@ -343,8 +347,11 @@ func (r *Renter) PeriodSpending() modules.ContractorSpending { return r.hostCont
 
 // Settings returns the host contractor's allowance
 func (r *Renter) Settings() modules.RenterSettings {
+	download, upload := r.hostContractor.RateLimits()
 	return modules.RenterSettings{
-		Allowance: r.hostContractor.Allowance(),
+		Allowance:        r.hostContractor.Allowance(),
+		MaxDownloadSpeed: download,
+		MaxUploadSpeed:   upload,
 	}
 }
 

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1,6 +1,7 @@
 package renter
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -319,6 +320,17 @@ func testRenterStreamingCache(t *testing.T, tg *siatest.TestGroup) {
 	chunkSize := int64(pieceSize * dataPieces)
 	if err := r.RenterPostRateLimit(chunkSize, chunkSize); err != nil {
 		t.Fatal(err)
+	}
+
+	rg, err := r.RenterGet()
+	if err != nil {
+		t.Fatal(err, "Could not request RenterGe()")
+	}
+	if rg.Settings.MaxDownloadSpeed != chunkSize {
+		t.Fatal(errors.New("MaxDownloadSpeed doesn't match value set through RenterPostRateLimit"))
+	}
+	if rg.Settings.MaxUploadSpeed != chunkSize {
+		t.Fatal(errors.New("MaxUploadSpeed doesn't match value set through RenterPostRateLimit"))
 	}
 
 	// Upload a file that is a single chunk big.


### PR DESCRIPTION
resolves #3009 
upload and download speeds were being reset to defaults as they were not being returned when Settings() was called on the renter