### PR TITLE
Add id fields to /consensus/blocks endpoint

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -212,13 +212,14 @@ The JSON formatted block or a standard error response.
     "parentid": "0000000000009615e8db750eb1226aa5e629bfa7badbfe0b79607ec8b918a44c",
     "timestamp": 1444516982,
     "transactions": [
-	{
+        {
 	    // ...
-	}
+        },
         {
             "arbitrarydata": [],
             "filecontractrevisions": [],
             "filecontracts": [],
+            "id": "3c98ec79b990461f353c22bb06bcfb10e702f529ad7d27a43c4448273553d90a",
             "minerfees": [],
             "siacoininputs": [
                 {
@@ -237,10 +238,12 @@ The JSON formatted block or a standard error response.
             ],
             "siacoinoutputs": [
                 {
+                    "id": "1f9da81e23522f79590ac67ac0b668828c52b341cbf04df4959bb7040c072f29",
                     "unlockhash": "d54f500f6c1774d518538dbe87114fe6f7e6c76b5bc8373a890b12ce4b8909a336106a4cd6db",
                     "value": "1010000000000000000000000000"
                 },
                 {
+                    "id": "14978a4c54f5ebd910ea41537de014f8423574c13d132e8713fab5af09ec08ca",
                     "unlockhash": "48a56b19bd0be4f24190640acbd0bed9669ea9c18823da2645ec1ad9652f10b06c5d4210f971",
                     "value": "5780000000000000000000000000"
                 }

--- a/doc/api/Consensus.md
+++ b/doc/api/Consensus.md
@@ -82,13 +82,14 @@ The JSON formatted block or a standard error response.
     "parentid": "0000000000009615e8db750eb1226aa5e629bfa7badbfe0b79607ec8b918a44c",
     "timestamp": 1444516982,
     "transactions": [
-	{
+        {
 	    // ...
-	}
+        },
         {
             "arbitrarydata": [],
             "filecontractrevisions": [],
             "filecontracts": [],
+            "id": "3c98ec79b990461f353c22bb06bcfb10e702f529ad7d27a43c4448273553d90a",
             "minerfees": [],
             "siacoininputs": [
                 {
@@ -107,10 +108,12 @@ The JSON formatted block or a standard error response.
             ],
             "siacoinoutputs": [
                 {
+                    "id": "1f9da81e23522f79590ac67ac0b668828c52b341cbf04df4959bb7040c072f29",
                     "unlockhash": "d54f500f6c1774d518538dbe87114fe6f7e6c76b5bc8373a890b12ce4b8909a336106a4cd6db",
                     "value": "1010000000000000000000000000"
                 },
                 {
+                    "id": "14978a4c54f5ebd910ea41537de014f8423574c13d132e8713fab5af09ec08ca",
                     "unlockhash": "48a56b19bd0be4f24190640acbd0bed9669ea9c18823da2645ec1ad9652f10b06c5d4210f971",
                     "value": "5780000000000000000000000000"
                 }

--- a/node/api/client/wallet.go
+++ b/node/api/client/wallet.go
@@ -143,6 +143,13 @@ func (c *Client) WalletTransactionsGet(startHeight types.BlockHeight, endHeight 
 	return
 }
 
+// WalletTransactionGet requests the /wallet/transaction/:id api resource for a
+// certain TransactionID.
+func (c *Client) WalletTransactionGet(id types.TransactionID) (wtg api.WalletTransactionGETid, err error) {
+	err = c.get("/wallet/transaction/"+id.String(), wtg)
+	return
+}
+
 // WalletUnlockPost uses the /wallet/unlock endpoint to unlock the wallet with
 // a given encryption key. Per default this key is the seed.
 func (c *Client) WalletUnlockPost(password string) (err error) {

--- a/node/api/consensus.go
+++ b/node/api/consensus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/Sia/types"
 
 	"github.com/julienschmidt/httprouter"
@@ -25,15 +26,146 @@ type ConsensusHeadersGET struct {
 	BlockID types.BlockID `json:"blockid"`
 }
 
-// ConsensusBlocksGet wraps a types.Block and adds an id field.
+// ConsensusBlocksGet contains all fields of a types.Block and additional
+// fields for ID and Height.
 type ConsensusBlocksGet struct {
-	ID           types.BlockID         `json:"id"`
-	Height       types.BlockHeight     `json:"height"`
-	ParentID     types.BlockID         `json:"parentid"`
-	Nonce        types.BlockNonce      `json:"nonce"`
-	Timestamp    types.Timestamp       `json:"timestamp"`
-	MinerPayouts []types.SiacoinOutput `json:"minerpayouts"`
-	Transactions []types.Transaction   `json:"transactions"`
+	ID           types.BlockID           `json:"id"`
+	Height       types.BlockHeight       `json:"height"`
+	ParentID     types.BlockID           `json:"parentid"`
+	Nonce        types.BlockNonce        `json:"nonce"`
+	Timestamp    types.Timestamp         `json:"timestamp"`
+	MinerPayouts []types.SiacoinOutput   `json:"minerpayouts"`
+	Transactions []ConsensusBlocksGetTxn `json:"transactions"`
+}
+
+// ConsensusBlocksGetTxn contains all fields of a types.Transaction and an
+// additional ID field.
+type ConsensusBlocksGetTxn struct {
+	ID                    types.TransactionID               `json:"id"`
+	SiacoinInputs         []types.SiacoinInput              `json:"siacoininputs"`
+	SiacoinOutputs        []ConsensusBlocksGetSiacoinOutput `json:"siacoinoutputs"`
+	FileContracts         []ConsensusBlocksGetFileContract  `json:"filecontracts"`
+	FileContractRevisions []types.FileContractRevision      `json:"filecontractrevisions"`
+	StorageProofs         []types.StorageProof              `json:"storageproofs"`
+	SiafundInputs         []types.SiafundInput              `json:"siafundinputs"`
+	SiafundOutputs        []ConsensusBlocksGetSiafundOutput `json:"siafundoutputs"`
+	MinerFees             []types.Currency                  `json:"minerfees"`
+	ArbitraryData         [][]byte                          `json:"arbitrarydata"`
+	TransactionSignatures []types.TransactionSignature      `json:"transactionsignatures"`
+}
+
+// ConsensusBlocksGetFileContract contains all fields of a types.FileContract
+// and an additional ID field.
+type ConsensusBlocksGetFileContract struct {
+	ID                 types.FileContractID              `json:"id"`
+	FileSize           uint64                            `json:"filesize"`
+	FileMerkleRoot     crypto.Hash                       `json:"filemerkleroot"`
+	WindowStart        types.BlockHeight                 `json:"windowstart"`
+	WindowEnd          types.BlockHeight                 `json:"windowend"`
+	Payout             types.Currency                    `json:"payout"`
+	ValidProofOutputs  []ConsensusBlocksGetSiacoinOutput `json:"validproofoutputs"`
+	MissedProofOutputs []ConsensusBlocksGetSiacoinOutput `json:"missedproofoutputs"`
+	UnlockHash         types.UnlockHash                  `json:"unlockhash"`
+	RevisionNumber     uint64                            `json:"revisionnumber"`
+}
+
+// ConsensusBlocksGetSiacoinOutput contains all fields of a types.SiacoinOutput
+// and an additional ID field.
+type ConsensusBlocksGetSiacoinOutput struct {
+	ID         types.SiacoinOutputID `json:"id"`
+	Value      types.Currency        `json:"value"`
+	UnlockHash types.UnlockHash      `json:"unlockhash"`
+}
+
+// ConsensusBlocksGetSiafundOutput contains all fields of a types.SiafundOutput
+// and an additional ID field.
+type ConsensusBlocksGetSiafundOutput struct {
+	ID         types.SiafundOutputID `json:"id"`
+	Value      types.Currency        `json:"value"`
+	UnlockHash types.UnlockHash      `json:"unlockhash"`
+}
+
+// ConsensusBlocksGetFromBlock is a helper method that uses a types.Block and
+// types.BlockHeight to create a ConsensusBlocksGet object.
+func consensusBlocksGetFromBlock(b types.Block, h types.BlockHeight) ConsensusBlocksGet {
+	txns := make([]ConsensusBlocksGetTxn, 0, len(b.Transactions))
+	for _, t := range b.Transactions {
+		// Get the transaction's SiacoinOutputs.
+		scos := make([]ConsensusBlocksGetSiacoinOutput, 0, len(t.SiacoinOutputs))
+		for i, sco := range t.SiacoinOutputs {
+			scos = append(scos, ConsensusBlocksGetSiacoinOutput{
+				ID:         t.SiacoinOutputID(uint64(i)),
+				Value:      sco.Value,
+				UnlockHash: sco.UnlockHash,
+			})
+		}
+		// Get the transaction's SiafundOutputs.
+		sfos := make([]ConsensusBlocksGetSiafundOutput, 0, len(t.SiafundOutputs))
+		for i, sfo := range t.SiafundOutputs {
+			sfos = append(sfos, ConsensusBlocksGetSiafundOutput{
+				ID:         t.SiafundOutputID(uint64(i)),
+				Value:      sfo.Value,
+				UnlockHash: sfo.UnlockHash,
+			})
+		}
+		// Get the transaction's FileContracts.
+		fcos := make([]ConsensusBlocksGetFileContract, 0, len(t.FileContracts))
+		for i, fc := range t.FileContracts {
+			// Get the FileContract's valid proof outputs.
+			fcid := t.FileContractID(uint64(i))
+			vpos := make([]ConsensusBlocksGetSiacoinOutput, 0, len(fc.ValidProofOutputs))
+			for j, vpo := range fc.ValidProofOutputs {
+				vpos = append(vpos, ConsensusBlocksGetSiacoinOutput{
+					ID:         fcid.StorageProofOutputID(types.ProofValid, uint64(j)),
+					Value:      vpo.Value,
+					UnlockHash: vpo.UnlockHash,
+				})
+			}
+			// Get the FileContract's missed proof outputs.
+			mpos := make([]ConsensusBlocksGetSiacoinOutput, 0, len(fc.MissedProofOutputs))
+			for j, mpo := range fc.MissedProofOutputs {
+				mpos = append(mpos, ConsensusBlocksGetSiacoinOutput{
+					ID:         fcid.StorageProofOutputID(types.ProofMissed, uint64(j)),
+					Value:      mpo.Value,
+					UnlockHash: mpo.UnlockHash,
+				})
+			}
+			fcos = append(fcos, ConsensusBlocksGetFileContract{
+				ID:                 fcid,
+				FileSize:           fc.FileSize,
+				FileMerkleRoot:     fc.FileMerkleRoot,
+				WindowStart:        fc.WindowStart,
+				WindowEnd:          fc.WindowEnd,
+				Payout:             fc.Payout,
+				ValidProofOutputs:  vpos,
+				MissedProofOutputs: mpos,
+				UnlockHash:         fc.UnlockHash,
+				RevisionNumber:     fc.RevisionNumber,
+			})
+		}
+		txns = append(txns, ConsensusBlocksGetTxn{
+			ID:                    t.ID(),
+			SiacoinInputs:         t.SiacoinInputs,
+			SiacoinOutputs:        scos,
+			FileContracts:         fcos,
+			FileContractRevisions: t.FileContractRevisions,
+			StorageProofs:         t.StorageProofs,
+			SiafundInputs:         t.SiafundInputs,
+			SiafundOutputs:        sfos,
+			MinerFees:             t.MinerFees,
+			ArbitraryData:         t.ArbitraryData,
+			TransactionSignatures: t.TransactionSignatures,
+		})
+	}
+	return ConsensusBlocksGet{
+		ID:           b.ID(),
+		Height:       h,
+		ParentID:     b.ParentID,
+		Nonce:        b.Nonce,
+		Timestamp:    b.Timestamp,
+		MinerPayouts: b.MinerPayouts,
+		Transactions: txns,
+	}
 }
 
 // consensusHandler handles the API calls to /consensus.
@@ -88,15 +220,7 @@ func (api *API) consensusBlocksHandler(w http.ResponseWriter, req *http.Request,
 		return
 	}
 	// Write response
-	WriteJSON(w, ConsensusBlocksGet{
-		ID:           b.ID(),
-		Height:       h,
-		ParentID:     b.ParentID,
-		Nonce:        b.Nonce,
-		Timestamp:    b.Timestamp,
-		MinerPayouts: b.MinerPayouts,
-		Transactions: b.Transactions,
-	})
+	WriteJSON(w, consensusBlocksGetFromBlock(b, h))
 }
 
 // consensusValidateTransactionsetHandler handles the API calls to


### PR DESCRIPTION
This PR adds various `ID` fields to the JSON block returned by the `/consensus/blocks/...` endpoint.