### PR TITLE
Don't accept scan results if we lost connectivity during the scan

### DIFF
--- a/modules/renter/hostdb/scan.go
+++ b/modules/renter/hostdb/scan.go
@@ -314,6 +314,11 @@ func (hdb *HostDB) managedScanHost(entry modules.HostDBEntry) {
 	}
 	success := err == nil
 
+	// The scan result is not reliable if we went offline during the scan.
+	if !hdb.gateway.Online() {
+		return
+	}
+
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
 	// Update the host tree to have a new entry, including the new error. Then


### PR DESCRIPTION
We should not accept scan results if we lost our internet connection during the scan since it might mess up the redundancy of our files.