### PR TITLE
add allowance cancel warning

### DIFF
--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -272,6 +273,19 @@ func renterallowancecmd() {
 
 // renterallowancecancelcmd cancels the current allowance.
 func renterallowancecancelcmd() {
+	fmt.Println("Canceling your allowance will destroy all contracts and uploaded files immediately.")
+again:
+	fmt.Print("Do you want to continue? [y/n] ")
+	var resp string
+	fmt.Scanln(&resp)
+	switch strings.ToLower(resp) {
+	case "y", "yes":
+		// continue below
+	case "n", "no":
+		return
+	default:
+		goto again
+	}
 	err := httpClient.RenterCancelAllowance()
 	if err != nil {
 		die("error canceling allowance:", err)


### PR DESCRIPTION
Add warning to allowance cancel.

This PR replaces #3021 since it appears that dev has lost interest.
This PR resolves #3017 and is a short-term fix for #3013 until a core dev can update the renter allowance API endpoint as discussed in #3013.