### PR TITLE
Catch SIGTERM signal to do a clean shutdown

### DIFF
--- a/cmd/siad/daemon.go
+++ b/cmd/siad/daemon.go
@@ -192,7 +192,7 @@ func startDaemon(config Config) (err error) {
 
 	// listen for kill signals
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, os.Interrupt, os.Kill, syscall.SIGTERM)
 
 	// Print a 'startup complete' message.
 	startupTime := time.Since(loadStart)


### PR DESCRIPTION
On Linux systems background daemons are usually terminated with SIGTERM, because Sia was not configured to catch this signal it caused an unclean shutdown any time someone runs `systemctl stop siad` for instance.

This PR adds SIGTERM to the shutdown signals so Sia doesn't get killed unexpectedly when running as daemon. I've confirmed that this works as expected on my system.

I considered adding SIGQUIT too, but it's already being used by the Go runtime to print a full execution stack dump, and it doesn't allow the program to catch it too.