### PR TITLE
don't hold lock when calling initPersist

### DIFF
--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -491,8 +491,7 @@ func NewCustomRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.T
 	}
 	r.memoryManager = newMemoryManager(defaultMemory, r.tg.StopChan())
 
-	// Load all saved data. We are still in the renter's constructor so it
-	// should be fine to call an unexported method without holding the lock.
+	// Load all saved data.
 	if err := r.initPersist(); err != nil {
 		return nil, err
 	}

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -491,13 +491,11 @@ func NewCustomRenter(g modules.Gateway, cs modules.ConsensusSet, tpool modules.T
 	}
 	r.memoryManager = newMemoryManager(defaultMemory, r.tg.StopChan())
 
-	// Load all saved data.
-	id := r.mu.Lock()
+	// Load all saved data. We are still in the renter's constructor so it
+	// should be fine to call an unexported method without holding the lock.
 	if err := r.initPersist(); err != nil {
-		r.mu.Unlock(id)
 		return nil, err
 	}
-	r.mu.Unlock(id)
 
 	// Set the bandwidth limits, sincce the contractor doesn't persist them.
 	//


### PR DESCRIPTION
Seems like for very large numbers of files the safe lock around `initPersist` reports a deadlock. Since we don't actually to hold that lock within the constructor of the renter I removed that lock.