### PR TITLE
Add hostdb endpoint to indicate intial scan status and queued scans

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -656,12 +656,27 @@ Host DB
 
 | Route                                                   | HTTP verb |
 | ------------------------------------------------------- | --------- |
+| [/hostdb](#hostdb-get-example)                          | GET       |
 | [/hostdb/active](#hostdbactive-get-example)             | GET       |
 | [/hostdb/all](#hostdball-get-example)                   | GET       |
 | [/hostdb/hosts/:___pubkey___](#hostdbhostspubkey-get-example) | GET       |
 
 For examples and detailed descriptions of request and response parameters,
 refer to [HostDB.md](/doc/api/HostDB.md).
+
+#### /hostdb [GET] [(example)](/doc/api/HostDB.md#hostdb-get)
+
+shows some general information about the state of the hostdb.
+
+###### JSON Response [(with comments)](/doc/api/HostDB.md#json-response)
+
+Either the following JSON struct or an error response. See [#standard-responses](#standard-responses).
+
+```javascript
+{
+    "initialscancomplete": false
+}
+```
 
 #### /hostdb/active [GET] [(example)](/doc/api/HostDB.md#active-hosts)
 
@@ -672,7 +687,7 @@ lists all of the active hosts known to the renter, sorted by preference.
 numhosts // Optional
 ```
 
-###### JSON Response [(with comments)](/doc/api/HostDB.md#json-response)
+###### JSON Response [(with comments)](/doc/api/HostDB.md#json-response-1)
 ```javascript
 {
   "hosts": [
@@ -702,7 +717,7 @@ numhosts // Optional
 lists all of the hosts known to the renter. Hosts are not guaranteed to be in
 any particular order, and the order may change in subsequent calls.
 
-###### JSON Response [(with comments)](/doc/api/HostDB.md#json-response-1)
+###### JSON Response [(with comments)](/doc/api/HostDB.md#json-response-2)
 ```javascript
 {
   "hosts": [
@@ -740,7 +755,7 @@ overall.
 :pubkey
 ```
 
-###### JSON Response [(with comments)](/doc/api/HostDB.md#json-response-2)
+###### JSON Response [(with comments)](/doc/api/HostDB.md#json-response-3)
 ```javascript
 {
   "entry": {

--- a/doc/api/HostDB.md
+++ b/doc/api/HostDB.md
@@ -20,9 +20,24 @@ Index
 
 | Request                                                 | HTTP Verb | Examples                      |
 | ------------------------------------------------------- | --------- | ----------------------------- |
+| [/hostdb](#hostdb-get-example)                          | GET       | [HostDB Get](#hostdb-get)     |
 | [/hostdb/active](#hostdbactive-get-example)             | GET       | [Active hosts](#active-hosts) |
 | [/hostdb/all](#hostdball-get-example)                   | GET       | [All hosts](#all-hosts)       |
 | [/hostdb/hosts/___:pubkey___](#hostdbhosts-get-example) | GET       | [Hosts](#hosts)               |
+
+#### /hostdb [GET] [(example)](#hostdb-get)
+
+shows some general information about the state of the hostdb.
+
+###### JSON Response 
+
+Either the following JSON struct or an error response. See [#standard-responses](#standard-responses).
+
+```javascript
+{
+    "initialscancomplete": false // indicates if all known hosts have been scanned at least once.
+}
+```
 
 #### /hostdb/active [GET] [(example)](#active-hosts)
 
@@ -310,6 +325,25 @@ overall.
 
 Examples
 --------
+
+#### HostDB Get
+
+###### Request
+```
+/hostdb
+```
+
+###### Expected Response Code
+```
+200 OK
+```
+
+###### Example JSON Response
+```javascript
+{
+    "initialscancomplete": false
+}
+```
 
 #### Active hosts
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -347,6 +347,10 @@ type Renter interface {
 	// Host provides the DB entry and score breakdown for the requested host.
 	Host(pk types.SiaPublicKey) (HostDBEntry, bool)
 
+	// InitialScanComplete returns a boolean indicating if the initial scan of the
+	// hostdb is completed.
+	InitialScanComplete() (bool, error)
+
 	// LoadSharedFiles loads a '.sia' file into the renter. A .sia file may
 	// contain multiple files. The paths of the added files are returned.
 	LoadSharedFiles(source string) ([]string, error)
@@ -386,6 +390,9 @@ type Renter interface {
 	// from the Sia network and also returns the fileName of the streamed
 	// resource.
 	Streamer(siaPath string) (string, io.ReadSeeker, error)
+
+	// QueuedScans returns the currently queued scans of the hostdb.
+	QueuedScans() ([]HostDBEntry, error)
 
 	// Upload uploads a file using the input parameters.
 	Upload(FileUploadParams) error

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -391,9 +391,6 @@ type Renter interface {
 	// resource.
 	Streamer(siaPath string) (string, io.ReadSeeker, error)
 
-	// QueuedScans returns the currently queued scans of the hostdb.
-	QueuedScans() ([]HostDBEntry, error)
-
 	// Upload uploads a file using the input parameters.
 	Upload(FileUploadParams) error
 }

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -15,8 +15,8 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/modules/renter/hostdb/hosttree"
 	"github.com/NebulousLabs/Sia/persist"
-	siasync "github.com/NebulousLabs/Sia/sync"
 	"github.com/NebulousLabs/Sia/types"
+	"github.com/NebulousLabs/threadgroup"
 )
 
 var (
@@ -38,7 +38,7 @@ type HostDB struct {
 	log        *persist.Logger
 	mu         sync.RWMutex
 	persistDir string
-	tg         siasync.ThreadGroup
+	tg         threadgroup.ThreadGroup
 
 	// The hostTree is the root node of the tree that organizes hosts by
 	// weight. The tree is necessary for selecting weighted hosts at
@@ -99,12 +99,17 @@ func NewCustomHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir stri
 		return nil, err
 	}
 	hdb.log = logger
-	hdb.tg.AfterStop(func() {
+	err = hdb.tg.AfterStop(func() error {
 		if err := hdb.log.Close(); err != nil {
 			// Resort to println as the logger is in an uncertain state.
 			fmt.Println("Failed to close the hostdb logger:", err)
+			return err
 		}
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// The host tree is used to manage hosts and query them at random.
 	hdb.hostTree = hosttree.New(hdb.calculateHostWeight)
@@ -116,14 +121,19 @@ func NewCustomHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir stri
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-	hdb.tg.AfterStop(func() {
+	err = hdb.tg.AfterStop(func() error {
 		hdb.mu.Lock()
 		err := hdb.saveSync()
 		hdb.mu.Unlock()
 		if err != nil {
 			hdb.log.Println("Unable to save the hostdb:", err)
+			return err
 		}
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Loading is complete, establish the save loop.
 	go hdb.threadedSaveLoop()
@@ -158,9 +168,13 @@ func NewCustomHostDB(g modules.Gateway, cs modules.ConsensusSet, persistDir stri
 	if err != nil {
 		return nil, errors.New("hostdb subscription failed: " + err.Error())
 	}
-	hdb.tg.OnStop(func() {
+	err = hdb.tg.OnStop(func() error {
 		cs.Unsubscribe(hdb)
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// Spawn the scan loop during production, but allow it to be disrupted
 	// during testing. Primary reason is so that we can fill the hostdb with
@@ -236,6 +250,7 @@ func (hdb *HostDB) InitialScanComplete() (complete bool, err error) {
 	if err = hdb.tg.Add(); err != nil {
 		return
 	}
+	defer hdb.tg.Done()
 	hdb.mu.Lock()
 	defer hdb.mu.Unlock()
 	complete = hdb.initialScanComplete

--- a/modules/renter/hostdb/hostdb.go
+++ b/modules/renter/hostdb/hostdb.go
@@ -254,16 +254,3 @@ func (hdb *HostDB) RandomHosts(n int, excludeKeys []types.SiaPublicKey) ([]modul
 	}
 	return hdb.hostTree.SelectRandom(n, excludeKeys), nil
 }
-
-// QueuedScans returns the currently queued scans of the hostdb.
-func (hdb *HostDB) QueuedScans() (hosts []modules.HostDBEntry, err error) {
-	if err = hdb.tg.Add(); err != nil {
-		return []modules.HostDBEntry{}, err
-	}
-	hdb.mu.Lock()
-	defer hdb.mu.Unlock()
-	for _, host := range hdb.scanList {
-		hosts = append(hosts, host)
-	}
-	return
-}

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -93,9 +93,6 @@ type hostDB interface {
 	// EstimateHostScore returns the estimated score breakdown of a host with the
 	// provided settings.
 	EstimateHostScore(modules.HostDBEntry) modules.HostScoreBreakdown
-
-	// QueuedScans returns the currently queued scans of the hostdb.
-	QueuedScans() ([]modules.HostDBEntry, error)
 }
 
 // A hostContractor negotiates, revises, renews, and provides access to file
@@ -373,9 +370,6 @@ func (r *Renter) AllHosts() []modules.HostDBEntry { return r.hostDB.AllHosts() }
 
 // Host returns the host associated with the given public key
 func (r *Renter) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) { return r.hostDB.Host(spk) }
-
-// QueuedScans returns the currently queued scans of the hostdb.
-func (r *Renter) QueuedScans() ([]modules.HostDBEntry, error) { return r.hostDB.QueuedScans() }
 
 // InitialScanComplete returns a boolean indicating if the initial scan of the
 // hostdb is completed.

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -77,6 +77,10 @@ type hostDB interface {
 	// Host returns the HostDBEntry for a given host.
 	Host(types.SiaPublicKey) (modules.HostDBEntry, bool)
 
+	// initialScanComplete returns a boolean indicating if the initial scan of the
+	// hostdb is completed.
+	InitialScanComplete() (bool, error)
+
 	// RandomHosts returns a set of random hosts, weighted by their estimated
 	// usefulness / attractiveness to the renter. RandomHosts will not return
 	// any offline or inactive hosts.
@@ -89,6 +93,9 @@ type hostDB interface {
 	// EstimateHostScore returns the estimated score breakdown of a host with the
 	// provided settings.
 	EstimateHostScore(modules.HostDBEntry) modules.HostScoreBreakdown
+
+	// QueuedScans returns the currently queued scans of the hostdb.
+	QueuedScans() ([]modules.HostDBEntry, error)
 }
 
 // A hostContractor negotiates, revises, renews, and provides access to file
@@ -366,6 +373,13 @@ func (r *Renter) AllHosts() []modules.HostDBEntry { return r.hostDB.AllHosts() }
 
 // Host returns the host associated with the given public key
 func (r *Renter) Host(spk types.SiaPublicKey) (modules.HostDBEntry, bool) { return r.hostDB.Host(spk) }
+
+// QueuedScans returns the currently queued scans of the hostdb.
+func (r *Renter) QueuedScans() ([]modules.HostDBEntry, error) { return r.hostDB.QueuedScans() }
+
+// InitialScanComplete returns a boolean indicating if the initial scan of the
+// hostdb is completed.
+func (r *Renter) InitialScanComplete() (bool, error) { return r.hostDB.InitialScanComplete() }
 
 // ScoreBreakdown returns the score breakdown
 func (r *Renter) ScoreBreakdown(e modules.HostDBEntry) modules.HostScoreBreakdown {

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -150,7 +150,6 @@ func (pricesStub) InitialScanComplete() (bool, error) { return true, nil }
 func (ps pricesStub) RandomHosts(n int, exclude []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
 	return ps.dbEntries, nil
 }
-func (pricesStub) QueuedScans() ([]modules.HostDBEntry, error) { return nil, nil }
 
 // TestRenterPricesVolatility verifies that the renter caches its price
 // estimation, and subsequent calls result in non-volatile results.

--- a/modules/renter/renter_test.go
+++ b/modules/renter/renter_test.go
@@ -145,9 +145,12 @@ type pricesStub struct {
 	dbEntries []modules.HostDBEntry
 }
 
+func (pricesStub) InitialScanComplete() (bool, error) { return true, nil }
+
 func (ps pricesStub) RandomHosts(n int, exclude []types.SiaPublicKey) ([]modules.HostDBEntry, error) {
 	return ps.dbEntries, nil
 }
+func (pricesStub) QueuedScans() ([]modules.HostDBEntry, error) { return nil, nil }
 
 // TestRenterPricesVolatility verifies that the renter caches its price
 // estimation, and subsequent calls result in non-volatile results.

--- a/node/api/client/hostdb.go
+++ b/node/api/client/hostdb.go
@@ -5,6 +5,12 @@ import (
 	"github.com/NebulousLabs/Sia/types"
 )
 
+// HostDbGet requests the /hostdb endpoint's resources.
+func (c *Client) HostDbGet() (hdg api.HostdbGet, err error) {
+	err = c.get("/hostdb", &hdg)
+	return
+}
+
 // HostDbActiveGet requests the /hostdb/active endpoint's resources.
 func (c *Client) HostDbActiveGet() (hdag api.HostdbActiveGET, err error) {
 	err = c.get("/hostdb/active", &hdag)

--- a/node/api/host.go
+++ b/node/api/host.go
@@ -73,7 +73,6 @@ func (api *API) hostContractInfoHandler(w http.ResponseWriter, req *http.Request
 	cg := ContractInfoGET{
 		Contracts: api.host.StorageObligations(),
 	}
-
 	WriteJSON(w, cg)
 }
 

--- a/node/api/host.go
+++ b/node/api/host.go
@@ -73,6 +73,7 @@ func (api *API) hostContractInfoHandler(w http.ResponseWriter, req *http.Request
 	cg := ContractInfoGET{
 		Contracts: api.host.StorageObligations(),
 	}
+
 	WriteJSON(w, cg)
 }
 

--- a/node/api/hostdb.go
+++ b/node/api/hostdb.go
@@ -36,8 +36,8 @@ type (
 		ScoreBreakdown modules.HostScoreBreakdown `json:"scorebreakdown"`
 	}
 
-	// HostDBGet holds information about the hostdb.
-	HostDBGet struct {
+	// HostdbGet holds information about the hostdb.
+	HostdbGet struct {
 		InitialScanComplete bool `json:"initialscancomplete"`
 	}
 )
@@ -50,7 +50,7 @@ func (api *API) hostdbHandler(w http.ResponseWriter, req *http.Request, _ httpro
 		WriteError(w, Error{"Failed to get initial scan status" + err.Error()}, http.StatusInternalServerError)
 		return
 	}
-	WriteJSON(w, HostDBGet{
+	WriteJSON(w, HostdbGet{
 		InitialScanComplete: isc,
 	})
 }

--- a/node/api/hostdb.go
+++ b/node/api/hostdb.go
@@ -38,8 +38,7 @@ type (
 
 	// HostDBGet holds information about the hostdb.
 	HostDBGet struct {
-		InitialScanComplete bool                  `json:"initialscancomplete"`
-		QueuedScans         []modules.HostDBEntry `json:"queuedscans"`
+		InitialScanComplete bool `json:"initialscancomplete"`
 	}
 )
 
@@ -51,14 +50,8 @@ func (api *API) hostdbHandler(w http.ResponseWriter, req *http.Request, _ httpro
 		WriteError(w, Error{"Failed to get initial scan status" + err.Error()}, http.StatusInternalServerError)
 		return
 	}
-	scans, err := api.renter.QueuedScans()
-	if err != nil {
-		WriteError(w, Error{"Failed to get queued scans" + err.Error()}, http.StatusInternalServerError)
-		return
-	}
 	WriteJSON(w, HostDBGet{
 		InitialScanComplete: isc,
-		QueuedScans:         scans,
 	})
 }
 

--- a/node/api/hostdb.go
+++ b/node/api/hostdb.go
@@ -35,7 +35,32 @@ type (
 		Entry          ExtendedHostDBEntry        `json:"entry"`
 		ScoreBreakdown modules.HostScoreBreakdown `json:"scorebreakdown"`
 	}
+
+	// HostDBGet holds information about the hostdb.
+	HostDBGet struct {
+		InitialScanComplete bool                  `json:"initialscancomplete"`
+		QueuedScans         []modules.HostDBEntry `json:"queuedscans"`
+	}
 )
+
+// hostdbHandler handles the API call asking for the list of active
+// hosts.
+func (api *API) hostdbHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	isc, err := api.renter.InitialScanComplete()
+	if err != nil {
+		WriteError(w, Error{"Failed to get initial scan status" + err.Error()}, http.StatusInternalServerError)
+		return
+	}
+	scans, err := api.renter.QueuedScans()
+	if err != nil {
+		WriteError(w, Error{"Failed to get queued scans" + err.Error()}, http.StatusInternalServerError)
+		return
+	}
+	WriteJSON(w, HostDBGet{
+		InitialScanComplete: isc,
+		QueuedScans:         scans,
+	})
+}
 
 // hostdbActiveHandler handles the API call asking for the list of active
 // hosts.

--- a/node/api/routes.go
+++ b/node/api/routes.go
@@ -90,6 +90,7 @@ func (api *API) buildHTTPRoutes(requiredUserAgent string, requiredPassword strin
 		router.POST("/renter/upload/*siapath", RequirePassword(api.renterUploadHandler, requiredPassword))
 
 		// HostDB endpoints.
+		router.GET("/hostdb", api.hostdbHandler)
 		router.GET("/hostdb/active", api.hostdbActiveHandler)
 		router.GET("/hostdb/all", api.hostdbAllHandler)
 		router.GET("/hostdb/hosts/:pubkey", api.hostdbHostsHandler)

--- a/node/node.go
+++ b/node/node.go
@@ -86,7 +86,8 @@ type NodeParams struct {
 	Allowance modules.Allowance
 
 	// The following fields are used to skip parts of the node set up
-	SkipSetAllowance bool
+	SkipSetAllowance  bool
+	SkipHostDiscovery bool
 
 	// The high level directory where all the persistence gets stored for the
 	// moudles.

--- a/siatest/renter/dependencies.go
+++ b/siatest/renter/dependencies.go
@@ -1,6 +1,38 @@
 package renter
 
-import "github.com/NebulousLabs/Sia/siatest"
+import (
+	"github.com/NebulousLabs/Sia/modules"
+	"github.com/NebulousLabs/Sia/siatest"
+)
+
+// dependencyBlockScan blocks the scan progress of the hostdb until Scan is
+// called on the dependency.
+type dependencyBlockScan struct {
+	modules.ProductionDependencies
+	closed bool
+	c      chan struct{}
+}
+
+// Disrupt will block the scan progress of the hostdb. The scan can be started
+// by calling Scan on the dependency.
+func (d *dependencyBlockScan) Disrupt(s string) bool {
+	if d.c == nil {
+		d.c = make(chan struct{})
+	}
+	if s == "BlockScan" {
+		<-d.c
+	}
+	return false
+}
+
+// Scan resumes the blocked scan.
+func (d *dependencyBlockScan) Scan() {
+	if d.closed {
+		return
+	}
+	close(d.c)
+	d.closed = true
+}
 
 // newDependencyInterruptDownloadBeforeSendingRevision creates a new dependency
 // that interrupts the download on the renter side before sending the signed

--- a/siatest/renter/hostdb_test.go
+++ b/siatest/renter/hostdb_test.go
@@ -1,0 +1,93 @@
+package renter
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NebulousLabs/Sia/build"
+	"github.com/NebulousLabs/Sia/node"
+	"github.com/NebulousLabs/Sia/siatest"
+)
+
+// TestInitialScanComplete tests if the initialScanComplete field is set
+// correctly.
+func TestInitialScanComplete(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Get a directory for testing.
+	testDir, err := siatest.TestDir(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDir = filepath.Join(testDir, t.Name())
+
+	// Create a group. The renter should block the scanning thread using a
+	// dependency.
+	deps := &dependencyBlockScan{}
+	renterTemplate := node.Renter(filepath.Join(testDir, "renter"))
+	renterTemplate.SkipSetAllowance = true
+	renterTemplate.SkipHostDiscovery = true
+	renterTemplate.HostDBDeps = deps
+
+	tg, err := siatest.NewGroup(renterTemplate, node.Host(filepath.Join(testDir, "host")),
+		siatest.Miner(filepath.Join(testDir, "miner")))
+	if err != nil {
+		t.Fatal("Failed to create group: ", err)
+	}
+	defer func() {
+		deps.Scan()
+		if err := tg.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// The renter should have 1 offline host in its database and
+	// initialScanComplete should be false.
+	renter := tg.Renters()[0]
+	hdag, err := renter.HostDbAllGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hdg, err := renter.HostDbGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hdag.Hosts) != 1 {
+		t.Fatalf("HostDB should have 1 host but had %v", len(hdag.Hosts))
+	}
+	if hdag.Hosts[0].ScanHistory.Len() > 0 {
+		t.Fatalf("Host should have 0 scans but had %v", hdag.Hosts[0].ScanHistory.Len())
+	}
+	if hdg.InitialScanComplete {
+		t.Fatal("Initial scan is complete even though it shouldn't")
+	}
+
+	deps.Scan()
+	err = build.Retry(600, 100*time.Millisecond, func() error {
+		hdag, err := renter.HostDbAllGet()
+		if err != nil {
+			t.Fatal(err)
+		}
+		hdg, err := renter.HostDbGet()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !hdg.InitialScanComplete {
+			return fmt.Errorf("Initial scan is not complete even though it should be")
+		}
+		if len(hdag.Hosts) != 1 {
+			return fmt.Errorf("HostDB should have 1 host but had %v", len(hdag.Hosts))
+		}
+		if hdag.Hosts[0].ScanHistory.Len() == 0 {
+			return fmt.Errorf("Host should have >0 scans but had %v", hdag.Hosts[0].ScanHistory.Len())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -229,6 +229,9 @@ func fundNodes(miner *TestNode, nodes map[*TestNode]struct{}) error {
 // database.
 func hostsInRenterDBCheck(miner *TestNode, renters map[*TestNode]struct{}, hosts map[*TestNode]struct{}) error {
 	for renter := range renters {
+		if renter.params.SkipHostDiscovery {
+			continue
+		}
 		for host := range hosts {
 			numRetries := 0
 			err := Retry(100, 100*time.Millisecond, func() error {


### PR DESCRIPTION
This Pr adds a new endpoint that lets the user retrieve information about the hostdb.
At this point it contains the list of hosts that are being scanned at the moment and the a flag indicating if the initial scan of the hostdb is complete.
That is useful since we currently block uploads and contract formation/renewals until the initial scan is done.
Once this endpoint is reviewed and after I've received some feedback I'll update the documentation and add an automated test for it. 