### PR TITLE
Detect when local file is lost before 1x redundancy

### DIFF
--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -541,7 +541,7 @@ func renterfileslistcmd() {
 	fmt.Printf("Total uploaded: %9s\n", filesizeUnits(int64(totalStored)))
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	if renterListVerbose {
-		fmt.Fprintln(w, "File size\tAvailable\tUploaded\tProgress\tRedundancy\tRenewing\tSia path")
+		fmt.Fprintln(w, "File size\tAvailable\tUploaded\tProgress\tRedundancy\tRenewing\tOn Disk\tRecoverable\tSia path")
 	}
 	sort.Sort(bySiaPath(rf.Files))
 	for _, file := range rf.Files {
@@ -554,13 +554,13 @@ func renterfileslistcmd() {
 				redundancyStr = "-"
 			}
 			uploadProgressStr := fmt.Sprintf("%.2f%%", file.UploadProgress)
-			if _, err := os.Stat(file.LocalPath); os.IsNotExist(err) && file.Redundancy < 1 {
-				uploadProgressStr = fmt.Sprintf("Local File Lost")
-			}
+			_, err := os.Stat(file.LocalPath)
+			onDiskStr := yesNo(!os.IsNotExist(err))
+			recoverableStr := yesNo(!(file.Redundancy < 1))
 			if file.UploadProgress == -1 {
 				uploadProgressStr = "-"
 			}
-			fmt.Fprintf(w, "\t%s\t%9s\t%8s\t%10s\t%s", availableStr, filesizeUnits(int64(file.UploadedBytes)), uploadProgressStr, redundancyStr, renewingStr)
+			fmt.Fprintf(w, "\t%s\t%9s\t%8s\t%10s\t%s\t%s\t%s", availableStr, filesizeUnits(int64(file.UploadedBytes)), uploadProgressStr, redundancyStr, renewingStr, onDiskStr, recoverableStr)
 		}
 		fmt.Fprintf(w, "\t%s", file.SiaPath)
 		if !renterListVerbose && !file.Available {

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -554,6 +554,9 @@ func renterfileslistcmd() {
 				redundancyStr = "-"
 			}
 			uploadProgressStr := fmt.Sprintf("%.2f%%", file.UploadProgress)
+			if _, err := os.Stat(file.LocalPath); os.IsNotExist(err) && file.Redundancy < 1 {
+				uploadProgressStr = fmt.Sprintf("Local File Lost")
+			}
 			if file.UploadProgress == -1 {
 				uploadProgressStr = "-"
 			}

--- a/modules/renter/download.go
+++ b/modules/renter/download.go
@@ -104,7 +104,7 @@ package renter
 // That's going to need to be changed to a partial sector. This is probably
 // going to result in downloading that's 64-byte aligned instead of perfectly
 // byte-aligned. Further, the encryption and erasure coding may also have
-// alignment requirements which interefere with how the call to Sector can work.
+// alignment requirements which interfere with how the call to Sector can work.
 // So you need to make sure that in 'managedDownload' you download at least
 // enough data to fit the alignment requirements of all 3 steps (download from
 // host, encryption, erasure coding). After the logical data has been recovered,

--- a/modules/renter/downloadchunk.go
+++ b/modules/renter/downloadchunk.go
@@ -48,7 +48,7 @@ type unfinishedDownloadChunk struct {
 	staticFetchLength uint64 // Length within the logical chunk to fetch.
 	staticFetchOffset uint64 // Offset within the logical chunk that is being downloaded.
 	staticPieceSize   uint64
-	staticWriteOffset int64 // Offet within the writer to write the completed data.
+	staticWriteOffset int64 // Offset within the writer to write the completed data.
 
 	// Fetch + Write instructions - read only or otherwise thread safe.
 	staticLatencyTarget time.Duration
@@ -154,7 +154,7 @@ func (udc *unfinishedDownloadChunk) returnMemory() {
 	if udc.piecesCompleted >= udc.erasureCode.MinPieces() {
 		// udc.piecesRegistered is guaranteed to be at most equal to the number
 		// of overdrive pieces, meaning it will be equal to or less than
-		// initalMemory.
+		// initialMemory.
 		maxMemory = uint64(udc.piecesCompleted+udc.piecesRegistered) * udc.staticPieceSize
 	}
 	// If the chunk recovery has completed, the maximum number of pieces is the

--- a/modules/renter/downloaddestination.go
+++ b/modules/renter/downloaddestination.go
@@ -23,7 +23,7 @@ import (
 )
 
 // downloadDestination is a wrapper for the different types of writing that we
-// can do when reovering and writing the logical data of a file. The wrapper
+// can do when recovering and writing the logical data of a file. The wrapper
 // needs to convert the various write-at calls into writes that make sense to
 // the underlying file, buffer, or stream.
 //

--- a/modules/renter/uploadheap.go
+++ b/modules/renter/uploadheap.go
@@ -242,13 +242,7 @@ func (r *Renter) managedBuildChunkHeap(hosts map[string]struct{}) {
 	offline := make(map[types.FileContractID]bool)
 	for _, file := range r.files {
 		file.mu.RLock()
-		// Build maps that map contract id to its offline and goodForRenew
-		// status
-		contractIDs := make(map[types.FileContractID]struct{})
 		for cid := range file.contracts {
-			contractIDs[cid] = struct{}{}
-		}
-		for cid := range contractIDs {
 			resolvedID := r.hostContractor.ResolveIDToPubKey(cid)
 			cu, ok := r.hostContractor.ContractUtility(resolvedID)
 			goodForRenew[cid] = ok && cu.GoodForRenew

--- a/modules/renter/uploadheap.go
+++ b/modules/renter/uploadheap.go
@@ -237,38 +237,44 @@ func (r *Renter) buildUnfinishedChunks(f *file, hosts map[string]struct{}) []*un
 func (r *Renter) managedBuildChunkHeap(hosts map[string]struct{}) {
 	// Loop through the whole set of files and get a list of chunks to add to
 	// the heap.
-	id := r.mu.Lock()
+	id := r.mu.RLock()
+	goodForRenew := make(map[types.FileContractID]bool)
+	offline := make(map[types.FileContractID]bool)
 	for _, file := range r.files {
-		// check for local file
-		tf, exists := r.persist.Tracking[file.name]
-		if exists {
-			// Build maps that map contract id to its offline and goodForRenew
-			// status
-			contractIDs := make(map[types.FileContractID]struct{})
-			for cid := range file.contracts {
-				contractIDs[cid] = struct{}{}
-			}
-			goodForRenew := make(map[types.FileContractID]bool)
-			offline := make(map[types.FileContractID]bool)
-			for cid := range contractIDs {
-				resolvedID := r.hostContractor.ResolveID(cid)
-				cu, ok := r.hostContractor.ContractUtility(resolvedID)
-				goodForRenew[cid] = ok && cu.GoodForRenew
-				offline[cid] = r.hostContractor.IsOffline(resolvedID)
-			}
-			// Check if local file is missing and redundancy is less than 1
-			// log warning to renter log
-			if _, err := os.Stat(tf.RepairPath); os.IsNotExist(err) && file.redundancy(offline, goodForRenew) < 1 {
-				r.log.Println("File not found on disk:", tf.RepairPath)
-			}
+		file.mu.RLock()
+		// Build maps that map contract id to its offline and goodForRenew
+		// status
+		contractIDs := make(map[types.FileContractID]struct{})
+		for cid := range file.contracts {
+			contractIDs[cid] = struct{}{}
 		}
+		for cid := range contractIDs {
+			resolvedID := r.hostContractor.ResolveIDToPubKey(cid)
+			cu, ok := r.hostContractor.ContractUtility(resolvedID)
+			goodForRenew[cid] = ok && cu.GoodForRenew
+			offline[cid] = r.hostContractor.IsOffline(resolvedID)
+		}
+		file.mu.RUnlock()
 
 		unfinishedUploadChunks := r.buildUnfinishedChunks(file, hosts)
 		for i := 0; i < len(unfinishedUploadChunks); i++ {
 			r.uploadHeap.managedPush(unfinishedUploadChunks[i])
 		}
 	}
-	r.mu.Unlock(id)
+	for _, file := range r.files {
+		file.mu.RLock()
+		// check for local file
+		tf, exists := r.persist.Tracking[file.name]
+		if exists {
+			// Check if local file is missing and redundancy is less than 1
+			// log warning to renter log
+			if _, err := os.Stat(tf.RepairPath); os.IsNotExist(err) && file.redundancy(offline, goodForRenew) < 1 {
+				r.log.Println("File not found on disk and possibly unrecoverable:", tf.RepairPath)
+			}
+		}
+		file.mu.RUnlock()
+	}
+	r.mu.RUnlock(id)
 }
 
 // managedPrepareNextChunk takes the next chunk from the chunk heap and prepares

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -575,7 +575,7 @@ func (api *API) renterUploadHandler(w http.ResponseWriter, req *http.Request, ps
 	if req.FormValue("datapieces") != "" || req.FormValue("paritypieces") != "" {
 		// Check that both values have been supplied.
 		if req.FormValue("datapieces") == "" || req.FormValue("paritypieces") == "" {
-			WriteError(w, Error{"must provide both the datapieces paramaeter and the paritypieces parameter if specifying erasure coding parameters"}, http.StatusBadRequest)
+			WriteError(w, Error{"must provide both the datapieces parameter and the paritypieces parameter if specifying erasure coding parameters"}, http.StatusBadRequest)
 			return
 		}
 


### PR DESCRIPTION
@DavidVorick @ChrisSchinnerl I want to check and see if I was going down the right path with this one.

So far I added a message in `siac renter -v` under the upload progress to notify the user that the local file was not found before 1x redundancy was reached.  I also added a log in `managedBuildChunkHeap()` noting that the local file was lost.

Couple questions:
1. Are there other locations, or better locations to capture this?
2. Are there additional steps that we should take when we identify this?  Or should we just notify the user and leave it up to them to decide what to do?

@mtlynch  This PR is to resolve #2488 