### PR TITLE
Remove unnecessary lock

### DIFF
--- a/modules/gateway/ip.go
+++ b/modules/gateway/ip.go
@@ -37,9 +37,7 @@ func (g *Gateway) managedIPFromPeers() (string, error) {
 		default:
 		}
 		// Get peers
-		g.mu.RLock()
 		peers := g.Peers()
-		g.mu.RUnlock()
 		// Check if there are enough peers. Otherwise wait.
 		if len(peers) < minPeersForIPDiscovery {
 			g.managedSleep(peerDiscoveryRetryInterval)


### PR DESCRIPTION
In the `Peers()` function, the read lock is already acquired, so this lock is unnecessary.