### PR TITLE
Change host duration check to use startheight vs endheight of window

### DIFF
--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -238,9 +238,9 @@ func (h *Host) managedVerifyNewContract(txnSet []types.Transaction, renterPK cry
 	if fc.WindowEnd < fc.WindowStart+eSettings.WindowSize {
 		return errSmallWindow
 	}
-	// WindowEnd must not be more than settings.MaxDuration blocks into the
+	// WindowStart must not be more than settings.MaxDuration blocks into the
 	// future.
-	if fc.WindowEnd > blockHeight+eSettings.MaxDuration {
+	if fc.WindowStart > blockHeight+eSettings.MaxDuration {
 		return errLongDuration
 	}
 

--- a/modules/host/negotiaterenewcontract.go
+++ b/modules/host/negotiaterenewcontract.go
@@ -251,6 +251,11 @@ func (h *Host) managedVerifyRenewedContract(so storageObligation, txnSet []types
 	if fc.WindowEnd < fc.WindowStart+externalSettings.WindowSize {
 		return errSmallWindow
 	}
+	// WindowStart must not be more than settings.MaxDuration blocks into the
+	// future.
+	if fc.WindowStart > blockHeight+externalSettings.MaxDuration {
+		return errLongDuration
+	}
 
 	// ValidProofOutputs shoud have 2 outputs (renter + host) and missed
 	// outputs should have 3 (renter + host + void)


### PR DESCRIPTION
This PR changes the duration check in the host module to use the window's startheight instead of the endheight.
From a renter's perspective the host can't be expected to hold on to the file after the window start since the host might just broadcast the proof and delete the files afterwards. That's why the duration of a contract is defined as the number of blocks between the startHeight of the contract and the start of the proof window.