### PR TITLE
Unsubscribe explorer from the cs on close

### DIFF
--- a/modules/explorer/explorer.go
+++ b/modules/explorer/explorer.go
@@ -88,5 +88,6 @@ func New(cs modules.ConsensusSet, persistDir string) (*Explorer, error) {
 
 // Close closes the explorer.
 func (e *Explorer) Close() error {
+	e.cs.Unsubscribe(e)
 	return e.db.Close()
 }


### PR DESCRIPTION
Since the explorer gets closed before the cs, it's possible to still receive an update while the DB is already closed, resulting in some stack traces. Especially noticeable when stopping during IBD.