### PR TITLE
Fix -1 Integer Parsing

### DIFF
--- a/node/api/wallet.go
+++ b/node/api/wallet.go
@@ -556,13 +556,13 @@ func (api *API) walletTransactionsHandler(w http.ResponseWriter, req *http.Reque
 	// negative, explicitly set var end to MaxUint64.
 	var end uint64
 	endInt, err := strconv.ParseInt(endheightStr, 10, 64)
-	end = uint64(endInt)
-	if endInt < 0 {
-		end = math.MaxUint64
-	}
 	if err != nil {
 		WriteError(w, Error{"parsing integer value for parameter `endheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
+	}
+	end = uint64(endInt)
+	if endInt < 0 {
+		end = math.MaxUint64
 	}
 	confirmedTxns, err := api.wallet.Transactions(types.BlockHeight(start), types.BlockHeight(end))
 	if err != nil {

--- a/node/api/wallet.go
+++ b/node/api/wallet.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -551,7 +552,14 @@ func (api *API) walletTransactionsHandler(w http.ResponseWriter, req *http.Reque
 		WriteError(w, Error{"parsing integer value for parameter `startheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
-	end, err := strconv.ParseInt(endheightStr, 10, 64)
+	// Parse endheightStr as an Int to account for negative numbers. If endInt is
+	// negative, explicitly set var end to MaxUint64.
+	var end uint64
+	endInt, err := strconv.ParseInt(endheightStr, 10, 64)
+	end = uint64(endInt)
+	if endInt < 0 {
+		end = math.MaxUint64
+	}
 	if err != nil {
 		WriteError(w, Error{"parsing integer value for parameter `endheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return

--- a/node/api/wallet.go
+++ b/node/api/wallet.go
@@ -551,7 +551,7 @@ func (api *API) walletTransactionsHandler(w http.ResponseWriter, req *http.Reque
 		WriteError(w, Error{"parsing integer value for parameter `startheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return
 	}
-	end, err := strconv.ParseUint(endheightStr, 10, 64)
+	end, err := strconv.ParseInt(endheightStr, 10, 64)
 	if err != nil {
 		WriteError(w, Error{"parsing integer value for parameter `endheight` failed: " + err.Error()}, http.StatusBadRequest)
 		return

--- a/node/api/wallet_test.go
+++ b/node/api/wallet_test.go
@@ -677,6 +677,15 @@ func TestWalletTransactionGETid(t *testing.T) {
 	if len(wtg.UnconfirmedTransactions) != 2 {
 		t.Fatal("expecting two unconfirmed transactions in sender wallet")
 	}
+	// Check that undocumented API behaviour used in Sia-UI still works with
+	// current API.
+	err = st.getAPI("/wallet/transactions?startheight=0&endheight=-1", &wtg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wtg.UnconfirmedTransactions) != 2 {
+		t.Fatal("expecting two unconfirmed transactions in sender wallet")
+	}
 	// Get the id of the non-change output sent to the receiving wallet.
 	expectedOutputID := wtg.UnconfirmedTransactions[1].Outputs[0].ID
 


### PR DESCRIPTION
Sia-UI is currently not able to fetch the transactions from siad. It uses the following api call: `/wallet/transactions?startheight=0&endheight=-1`

When `strconv.ParseUint` attempts to parse -1, an error is returned to Sia-UI, rather then the intended behaviour, which is to return all wallet transactions from height 0 to max height.

This fix uses the `ParseInt` method instead. When the -1 is casted to the BlockHeight type, we get an arbitrarily large number `18446744073709551615`.

Another way we could fix this bug is to call the current block height from consensus, and set that to the `end` variable, if the argument sent back is less than 0.