### PR TITLE
Update stream cache to prevent duplicate chunks being added

### DIFF
--- a/modules/renter/contractor/contractor_test.go
+++ b/modules/renter/contractor/contractor_test.go
@@ -360,7 +360,7 @@ func TestAllowanceSpending(t *testing.T) {
 		}
 	}
 
-	// Retry to give the threadedMaintenenace some time to finish
+	// Retry to give the threadedMaintenance some time to finish
 	var newReportedSpending modules.ContractorSpending
 	err = build.Retry(100, 100*time.Millisecond, func() error {
 		newReportedSpending = c.PeriodSpending()

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/NebulousLabs/fastrand"
 )
 
-// TestIntegrationAutoRenew tests that contracts are automatically renwed at
+// TestIntegrationAutoRenew tests that contracts are automatically renewed at
 // the expected block height.
 func TestIntegrationAutoRenew(t *testing.T) {
 	if testing.Short() {

--- a/modules/renter/streamcache.go
+++ b/modules/renter/streamcache.go
@@ -105,7 +105,7 @@ func (sc *streamCache) pruneCache(size uint64) {
 
 	// Sanity check to confirm the Map and Heap where both pruned
 	if len(sc.streamHeap) != len(sc.streamMap) {
-		build.Critical("streamHeap and streamMap are not the same length")
+		build.Critical("streamHeap and streamMap are not the same length, %v and %v", len(sc.streamHeap), len(sc.streamMap))
 	}
 }
 
@@ -113,7 +113,7 @@ func (sc *streamCache) pruneCache(size uint64) {
 // successful it will write the data to the destination and stop the download
 // if it was the last missing chunk. The function returns true if the chunk was
 // in the cache.
-// Using the entire unfisihedDownloadChunk as the argument as there are seven different fields
+// Using the entire unfinishedDownloadChunk as the argument as there are seven different fields
 // used from unfinishedDownloadChunk and it allows using udc.fail()
 //
 // TODO: in the future we might need cache invalidation. At the

--- a/modules/renter/streamcache.go
+++ b/modules/renter/streamcache.go
@@ -76,6 +76,11 @@ func (sc *streamCache) Add(cacheID string, data []byte) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
+	// Check to make sure chuck has not already been added
+	if _, ok := sc.streamMap[cacheID]; ok {
+		return
+	}
+
 	// pruning cache to cacheSize - 1 to make room to add the new chunk
 	sc.pruneCache(sc.cacheSize - 1)
 
@@ -105,7 +110,7 @@ func (sc *streamCache) pruneCache(size uint64) {
 
 	// Sanity check to confirm the Map and Heap where both pruned
 	if len(sc.streamHeap) != len(sc.streamMap) {
-		build.Critical("streamHeap and streamMap are not the same length, %v and %v", len(sc.streamHeap), len(sc.streamMap))
+		build.Critical("streamHeap and streamMap are not the same length,", len(sc.streamHeap), "and", len(sc.streamMap))
 	}
 }
 

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -103,29 +103,13 @@ func TestPruneCache(t *testing.T) {
 	}
 
 	// Confirm the same chunk won't be added if already added
-	id := sc.streamHeap[0].id
+	sc.pruneCache(0)
+	id := "test"
 	for i := 0; i < 5; i++ {
 		sc.Add(id, []byte{})
 	}
-
-	// Manually remove ID and confirm it no longer exists in the Heap of Cache
-	cd := heap.Pop(&sc.streamHeap).(*chunkData)
-	if cd.id != id {
-		t.Fatal("Wrong chunk popped from Heap")
-	}
-	delete(sc.streamMap, cd.id)
-
-	// Check for any duplicate chunks
-	for len(sc.streamHeap) > 0 {
-		cd = heap.Pop(&sc.streamHeap).(*chunkData)
-		if cd.id == id {
-			t.Fatal("Duplicate ID found")
-		}
-	}
-	for k := range sc.streamMap {
-		if k == id {
-			t.Fatal("Duplicate ID found")
-		}
+	if len(sc.streamHeap) != 1 || len(sc.streamMap) != 1 {
+		t.Fatalf("Chunk added more the once.\nHeap length: %v\nMap length: %v\n", len(sc.streamHeap), len(sc.streamMap))
 	}
 }
 

--- a/modules/renter/streamcache_test.go
+++ b/modules/renter/streamcache_test.go
@@ -102,6 +102,31 @@ func TestPruneCache(t *testing.T) {
 		t.Error("Cache size was changed by pruning to larger value")
 	}
 
+	// Confirm the same chunk won't be added if already added
+	id := sc.streamHeap[0].id
+	for i := 0; i < 5; i++ {
+		sc.Add(id, []byte{})
+	}
+
+	// Manually remove ID and confirm it no longer exists in the Heap of Cache
+	cd := heap.Pop(&sc.streamHeap).(*chunkData)
+	if cd.id != id {
+		t.Fatal("Wrong chunk popped from Heap")
+	}
+	delete(sc.streamMap, cd.id)
+
+	// Check for any duplicate chunks
+	for len(sc.streamHeap) > 0 {
+		cd = heap.Pop(&sc.streamHeap).(*chunkData)
+		if cd.id == id {
+			t.Fatal("Duplicate ID found")
+		}
+	}
+	for k := range sc.streamMap {
+		if k == id {
+			t.Fatal("Duplicate ID found")
+		}
+	}
 }
 
 // TestStreamCache tests that when Add() is called, chunks are added and removed

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -114,7 +114,7 @@ func testUploadDownload(t *testing.T, tg *siatest.TestGroup) {
 }
 
 // testSingleFileGet is a subtest that uses an existing TestGroup to test if
-// using the signle file API endpoint works
+// using the single file API endpoint works
 func testSingleFileGet(t *testing.T, tg *siatest.TestGroup) {
 	// Grab the first of the group's renters
 	renter := tg.Renters()[0]
@@ -404,7 +404,7 @@ func testDownloadInterrupted(t *testing.T, deps *siatest.DependencyInterruptOnce
 	// Try downloading the file 5 times.
 	for i := 0; i < 5; i++ {
 		if _, err := renter.DownloadByStream(remoteFile); err == nil {
-			t.Fatal("Download shouldn't suceed since it was interrupted")
+			t.Fatal("Download shouldn't succeed since it was interrupted")
 		}
 	}
 	// Stop calling fail on the dependency.
@@ -805,7 +805,7 @@ func TestRenterPersistData(t *testing.T) {
 		t.Fatalf("%v: Could not set StreamCacheSize to %v", err, cacheSize)
 	}
 	if err := r.RenterPostRateLimit(ds, us); err != nil {
-		t.Fatalf("%v: Could not set RateLimts to %v and %v", err, ds, us)
+		t.Fatalf("%v: Could not set RateLimits to %v and %v", err, ds, us)
 	}
 
 	// Confirm Settings were updated
@@ -859,7 +859,7 @@ func testRenterDownloadAfterRenew(t *testing.T, tg *siatest.TestGroup) {
 		t.Fatal("Failed to upload a file for testing: ", err)
 	}
 	// Mine enough blocks for the next period to start. This means the
-	// contracts should be renewed and the data should still be availeble for
+	// contracts should be renewed and the data should still be available for
 	// download.
 	miner := tg.Miners()[0]
 	for i := types.BlockHeight(0); i < siatest.DefaultAllowance.Period; i++ {


### PR DESCRIPTION
Current code allowed the same chunk to be added to the Heap but it would not be added to the Map.  Updated so chunks can only be added once and updated unit test.

Resolves #3094 