### PR TITLE
Change MaxUint64 to MaxInt64 in wallettransactionscmd

### DIFF
--- a/cmd/siac/walletcmd.go
+++ b/cmd/siac/walletcmd.go
@@ -467,7 +467,7 @@ func walletsweepcmd() {
 // wallettransactionscmd lists all of the transactions related to the wallet,
 // providing a net flow of siacoins and siafunds for each.
 func wallettransactionscmd() {
-	wtg, err := httpClient.WalletTransactionsGet(0, math.MaxUint64)
+	wtg, err := httpClient.WalletTransactionsGet(0, math.MaxInt64)
 	if err != nil {
 		die("Could not fetch transaction history:", err)
 	}


### PR DESCRIPTION
Changes `math.MaxUint64` to `math.MaxInt64` so that the handler does not overflow when running parseInt on the end height.

This bug showed up due to merging PR #3097 - which is a necessary modification to maintain `-1` api compatibility with older versions of Sia-UI.