### PR TITLE
Add `locked` field to contract utilities

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -65,6 +65,7 @@ type Allowance struct {
 type ContractUtility struct {
 	GoodForUpload bool
 	GoodForRenew  bool
+	Locked        bool // Locked utilities can only be set to false.
 }
 
 // DownloadInfo provides information about a file that has been requested for

--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -99,9 +99,12 @@ func (c *Contractor) managedMarkContractsUtility() error {
 	// Update utility fields for each contract.
 	for _, contract := range c.staticContracts.ViewAll() {
 		utility := func() (u modules.ContractUtility) {
-			// Start the contract in good standing.
-			u.GoodForUpload = true
-			u.GoodForRenew = true
+			// Start the contract in good standing if the utility wasn't
+			// locked.
+			if !u.Locked {
+				u.GoodForUpload = true
+				u.GoodForRenew = true
+			}
 
 			host, exists := c.hdb.Host(contract.HostPublicKey)
 			// Contract has no utility if the host is not in the database.
@@ -534,6 +537,8 @@ func (c *Contractor) threadedContractMaintenance() {
 				replace := numRenews >= consecutiveRenewalsBeforeReplacement
 				if failedBefore && secondHalfOfWindow && replace {
 					oldUtility.GoodForRenew = false
+					oldUtility.GoodForUpload = false
+					oldUtility.Locked = true
 					err := oldContract.UpdateUtility(oldUtility)
 					if err != nil {
 						c.log.Println("WARN: failed to mark contract as !goodForRenew:", err)

--- a/siatest/remotefile.go
+++ b/siatest/remotefile.go
@@ -12,3 +12,8 @@ type (
 		siaPath  string
 	}
 )
+
+// SiaPath returns the siaPath of a remote file.
+func (rf RemoteFile) SiaPath() string {
+	return rf.siaPath
+}

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1302,9 +1302,15 @@ func TestRenterCancelAllowance(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to get files")
 	}
-	if len(renterFiles.Files) != 2 || renterFiles.Files[1].UploadProgress > 0 || renterFiles.Files[1].Redundancy > 0 {
-		t.Fatal("uploading a file after cancelling allowance should fail",
-			renterFiles.Files[1].UploadProgress, renterFiles.Files[1].Redundancy)
+	if len(renterFiles.Files) != 2 {
+		t.Fatal("There should be exactly 2 tracked files")
+	}
+	fileInfo, err := renter.File(rf2.SiaPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileInfo.UploadProgress > 0 || fileInfo.UploadedBytes > 0 || fileInfo.Redundancy > 0 {
+		t.Fatal("Uploading a file after canceling the allowance should fail")
 	}
 
 	// Mine enough blocks for the period to pass and the contracts to expire.
@@ -1328,12 +1334,12 @@ func TestRenterCancelAllowance(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	// Try downloading the file; should fail.
 	if _, err := renter.DownloadByStream(rf2); err == nil {
-		t.Fatal("downloading file succeeded even though it shouldnt", err)
+		t.Error("downloading file succeeded even though it shouldnt", err)
 	}
 
 	// The uploaded files should have 0x redundancy now.
@@ -1348,7 +1354,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
ContractUtilities are potentially reset every time `managedMarkContractsUtility` is run. If we cancel the allowance or set a contract to `!goodForUpload` or `!goodForRenew` because it failed to renew too many times, we don't want `managedMarkContractsUtility` to reset those fields to true again.
This PR introduces the `locked` field that prevents those fields from being reset to `true`. 

Note: previously we depended on `threadedContractMaintenance` not being run when the allowance was canceled and the renew code to setting the fields back to `false` right after resetting them but those are not well-known assumptions. In fact I forgot about those myself when I locked at the code a few weeks later so I think we should make stronger guarantees for those fields not to be changed.