### PR TITLE
Change siac wallet send siacoins documentation to remove the legacy 10 SC fee

### DIFF
--- a/cmd/siac/walletcmd.go
+++ b/cmd/siac/walletcmd.go
@@ -136,7 +136,7 @@ By default the wallet encryption / unlock password is the same as the generated 
 'amount' can be specified in units, e.g. 1.23KS. Run 'wallet --help' for a list of units.
 If no unit is supplied, hastings will be assumed.
 
-A miner fee of 10 SC is levied on all transactions.`,
+A dynamic transaction fee is applied depending on the size of the transaction and how busy the network is.`,
 		Run: wrap(walletsendsiacoinscmd),
 	}
 


### PR DESCRIPTION
The 10 SC transaction fee was replaced with a dynamic fee a long time ago, but the siac documentation still mentioned the old fee.