### PR TITLE
Siatest persistence cleanup

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -90,7 +90,7 @@ type NodeParams struct {
 	SkipHostDiscovery bool
 
 	// The high level directory where all the persistence gets stored for the
-	// moudles.
+	// modules.
 	Dir string
 }
 

--- a/siatest/consensus/consensus_test.go
+++ b/siatest/consensus/consensus_test.go
@@ -14,13 +14,10 @@ func TestApiHeight(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testdir, err := siatest.TestDir(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	testDir := consensusTestDir(t)
 
 	// Create a new server
-	testNode, err := siatest.NewNode(node.AllModules(testdir))
+	testNode, err := siatest.NewNode(node.AllModules(testDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +60,7 @@ func TestConsensusBlocksIDGet(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(groupParams)
+	tg, err := siatest.NewGroupFromTemplate(consensusTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}

--- a/siatest/consensus/consensus_test.go
+++ b/siatest/consensus/consensus_test.go
@@ -14,7 +14,7 @@ func TestApiHeight(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	testDir := consensusTestDir(t)
+	testDir := consensusTestDir(t.Name())
 
 	// Create a new server
 	testNode, err := siatest.NewNode(node.AllModules(testDir))
@@ -60,7 +60,7 @@ func TestConsensusBlocksIDGet(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(consensusTestDir(t), groupParams)
+	tg, err := siatest.NewGroupFromTemplate(consensusTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}

--- a/siatest/consensus/consts.go
+++ b/siatest/consensus/consts.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"os"
-	"testing"
 
 	"github.com/NebulousLabs/Sia/siatest"
 )
@@ -10,8 +9,8 @@ import (
 // consensusTestDir creates a temporary testing directory for a consensus. This
 // should only every be called once per test. Otherwise it will delete the
 // directory again.
-func consensusTestDir(t *testing.T) string {
-	path := siatest.TestDir("consensus", t.Name())
+func consensusTestDir(testName string) string {
+	path := siatest.TestDir("consensus", testName)
 	if err := os.MkdirAll(path, 0777); err != nil {
 		panic(err)
 	}

--- a/siatest/consensus/consts.go
+++ b/siatest/consensus/consts.go
@@ -1,0 +1,19 @@
+package consensus
+
+import (
+	"os"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/siatest"
+)
+
+// consensusTestDir creates a temporary testing directory for a consensus. This
+// should only every be called once per test. Otherwise it will delete the
+// directory again.
+func consensusTestDir(t *testing.T) string {
+	path := siatest.TestDir("consensus", t.Name())
+	if err := os.MkdirAll(path, 0777); err != nil {
+		panic(err)
+	}
+	return path
+}

--- a/siatest/dir.go
+++ b/siatest/dir.go
@@ -3,7 +3,6 @@ package siatest
 import (
 	"os"
 	"path/filepath"
-	"testing"
 )
 
 var (
@@ -26,8 +25,8 @@ func TestDir(dirs ...string) string {
 
 // siatestTestDir creates a testing directory for tests within the siatest
 // module.
-func siatestTestDir(t *testing.T) string {
-	path := TestDir("siatest", t.Name())
+func siatestTestDir(testName string) string {
+	path := TestDir("siatest", testName)
 	if err := os.MkdirAll(path, 0777); err != nil {
 		panic(err)
 	}

--- a/siatest/dir.go
+++ b/siatest/dir.go
@@ -34,10 +34,19 @@ func siatestTestDir(t *testing.T) string {
 	return path
 }
 
-// DataDir returns a temporary directory that will be used to create temporary
-// files for uploading.
-func DataDir() string {
-	path := filepath.Join(SiaTestingDir, "siatest", "data")
+// filesDir returns the path to the files directory of the TestNode. The files
+// directory is where new files are stored before being uploaded.
+func (tn *TestNode) filesDir() string {
+	path := filepath.Join(tn.Dir, "files")
+	if err := os.MkdirAll(path, 0777); err != nil {
+		panic(err)
+	}
+	return path
+}
+
+// downloadsDir returns the path to the download directory of the TestNode.
+func (tn *TestNode) downloadsDir() string {
+	path := filepath.Join(tn.Dir, "downloads")
 	if err := os.MkdirAll(path, 0777); err != nil {
 		panic(err)
 	}

--- a/siatest/dir.go
+++ b/siatest/dir.go
@@ -3,6 +3,7 @@ package siatest
 import (
 	"os"
 	"path/filepath"
+	"testing"
 )
 
 var (
@@ -14,11 +15,31 @@ var (
 // TestDir joins the provided directories and prefixes them with the Sia
 // testing directory, removing any files or directories that previously existed
 // at that location.
-func TestDir(dirs ...string) (string, error) {
-	path := filepath.Join(SiaTestingDir, filepath.Join(dirs...))
+func TestDir(dirs ...string) string {
+	path := filepath.Join(SiaTestingDir, "siatest", filepath.Join(dirs...))
 	err := os.RemoveAll(path)
 	if err != nil {
-		return "", err
+		panic(err)
 	}
-	return path, nil
+	return path
+}
+
+// siatestTestDir creates a testing directory for tests within the siatest
+// module.
+func siatestTestDir(t *testing.T) string {
+	path := TestDir("siatest", t.Name())
+	if err := os.MkdirAll(path, 0777); err != nil {
+		panic(err)
+	}
+	return path
+}
+
+// DataDir returns a temporary directory that will be used to create temporary
+// files for uploading.
+func DataDir() string {
+	path := filepath.Join(SiaTestingDir, "siatest", "data")
+	if err := os.MkdirAll(path, 0777); err != nil {
+		panic(err)
+	}
+	return path
 }

--- a/siatest/localfile.go
+++ b/siatest/localfile.go
@@ -23,9 +23,9 @@ type (
 
 // NewFile creates and returns a new LocalFile. It will write size random bytes
 // to the file and give the file a random name.
-func NewFile(size int) (*LocalFile, error) {
+func (tn *TestNode) NewFile(size int) (*LocalFile, error) {
 	fileName := fmt.Sprintf("%dbytes-%s", size, hex.EncodeToString(fastrand.Bytes(4)))
-	path := filepath.Join(DataDir(), fileName)
+	path := filepath.Join(tn.filesDir(), fileName)
 	bytes := fastrand.Bytes(size)
 	err := ioutil.WriteFile(path, bytes, 0600)
 	return &LocalFile{

--- a/siatest/localfile.go
+++ b/siatest/localfile.go
@@ -1,11 +1,11 @@
 package siatest
 
 import (
+	"encoding/hex"
+	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/errors"
@@ -24,8 +24,8 @@ type (
 // NewFile creates and returns a new LocalFile. It will write size random bytes
 // to the file and give the file a random name.
 func NewFile(size int) (*LocalFile, error) {
-	fileName := strconv.Itoa(fastrand.Intn(math.MaxInt32))
-	path := filepath.Join(SiaTestingDir, fileName)
+	fileName := fmt.Sprintf("%dbytes-%s", size, hex.EncodeToString(fastrand.Bytes(4)))
+	path := filepath.Join(DataDir(), fileName)
 	bytes := fastrand.Bytes(size)
 	err := ioutil.WriteFile(path, bytes, 0600)
 	return &LocalFile{

--- a/siatest/renter.go
+++ b/siatest/renter.go
@@ -1,11 +1,10 @@
 package siatest
 
 import (
+	"encoding/hex"
 	"fmt"
-	"math"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"time"
 
 	"github.com/NebulousLabs/Sia/crypto"
@@ -24,8 +23,8 @@ func (tn *TestNode) DownloadToDisk(rf *RemoteFile, async bool) (*LocalFile, erro
 		return nil, errors.AddContext(err, "failed to retrieve FileInfo")
 	}
 	// Create a random destination for the download
-	fileName := strconv.Itoa(fastrand.Intn(math.MaxInt32))
-	dest := filepath.Join(SiaTestingDir, fileName)
+	fileName := fmt.Sprintf("%dbytes-%s", fi.Filesize, hex.EncodeToString(fastrand.Bytes(4)))
+	dest := filepath.Join(DataDir(), fileName)
 	if err := tn.RenterDownloadGet(rf.siaPath, dest, 0, fi.Filesize, async); err != nil {
 		return nil, errors.AddContext(err, "failed to download file")
 	}

--- a/siatest/renter.go
+++ b/siatest/renter.go
@@ -24,7 +24,7 @@ func (tn *TestNode) DownloadToDisk(rf *RemoteFile, async bool) (*LocalFile, erro
 	}
 	// Create a random destination for the download
 	fileName := fmt.Sprintf("%dbytes-%s", fi.Filesize, hex.EncodeToString(fastrand.Bytes(4)))
-	dest := filepath.Join(DataDir(), fileName)
+	dest := filepath.Join(tn.downloadsDir(), fileName)
 	if err := tn.RenterDownloadGet(rf.siaPath, dest, 0, fi.Filesize, async); err != nil {
 		return nil, errors.AddContext(err, "failed to download file")
 	}
@@ -185,7 +185,7 @@ func (tn *TestNode) Upload(lf *LocalFile, dataPieces, parityPieces uint64) (*Rem
 // UploadNewFile initiates the upload of a filesize bytes large file.
 func (tn *TestNode) UploadNewFile(filesize int, dataPieces uint64, parityPieces uint64) (*LocalFile, *RemoteFile, error) {
 	// Create file for upload
-	localFile, err := NewFile(filesize)
+	localFile, err := tn.NewFile(filesize)
 	if err != nil {
 		return nil, nil, errors.AddContext(err, "failed to create file")
 	}

--- a/siatest/renter/consts.go
+++ b/siatest/renter/consts.go
@@ -2,7 +2,6 @@ package renter
 
 import (
 	"os"
-	"testing"
 
 	"github.com/NebulousLabs/Sia/siatest"
 )
@@ -10,8 +9,8 @@ import (
 // renterTestDir creates a temporary testing directory for a renter test. This
 // should only every be called once per test. Otherwise it will delete the
 // directory again.
-func renterTestDir(t *testing.T) string {
-	path := siatest.TestDir("renter", t.Name())
+func renterTestDir(testName string) string {
+	path := siatest.TestDir("renter", testName)
 	if err := os.MkdirAll(path, 0777); err != nil {
 		panic(err)
 	}

--- a/siatest/renter/consts.go
+++ b/siatest/renter/consts.go
@@ -1,0 +1,19 @@
+package renter
+
+import (
+	"os"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/siatest"
+)
+
+// renterTestDir creates a temporary testing directory for a renter test. This
+// should only every be called once per test. Otherwise it will delete the
+// directory again.
+func renterTestDir(t *testing.T) string {
+	path := siatest.TestDir("renter", t.Name())
+	if err := os.MkdirAll(path, 0777); err != nil {
+		panic(err)
+	}
+	return path
+}

--- a/siatest/renter/hostdb_test.go
+++ b/siatest/renter/hostdb_test.go
@@ -19,11 +19,7 @@ func TestInitialScanComplete(t *testing.T) {
 	}
 
 	// Get a directory for testing.
-	testDir, err := siatest.TestDir(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	testDir = filepath.Join(testDir, t.Name())
+	testDir := renterTestDir(t)
 
 	// Create a group. The renter should block the scanning thread using a
 	// dependency.
@@ -33,7 +29,7 @@ func TestInitialScanComplete(t *testing.T) {
 	renterTemplate.SkipHostDiscovery = true
 	renterTemplate.HostDBDeps = deps
 
-	tg, err := siatest.NewGroup(renterTemplate, node.Host(filepath.Join(testDir, "host")),
+	tg, err := siatest.NewGroup(testDir, renterTemplate, node.Host(filepath.Join(testDir, "host")),
 		siatest.Miner(filepath.Join(testDir, "miner")))
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)

--- a/siatest/renter/hostdb_test.go
+++ b/siatest/renter/hostdb_test.go
@@ -19,7 +19,7 @@ func TestInitialScanComplete(t *testing.T) {
 	}
 
 	// Get a directory for testing.
-	testDir := renterTestDir(t)
+	testDir := renterTestDir(t.Name())
 
 	// Create a group. The renter should block the scanning thread using a
 	// dependency.

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1622,7 +1622,8 @@ func TestRenterSpendingReporting(t *testing.T) {
 		Hosts:  2,
 		Miners: 1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t.Name()), groupParams)
+	testDir := renterTestDir(t.Name())
+	tg, err := siatest.NewGroupFromTemplate(testDir, groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -1633,11 +1634,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}()
 
 	// Add a Renter node
-	renterDir := filepath.Join(renterTestDir(t.Name()), "renter")
-	if err != nil {
-		t.Fatal(err)
-	}
-	renterParams := node.Renter(renterDir)
+	renterParams := node.Renter(filepath.Join(testDir, "renter"))
 	renterParams.SkipSetAllowance = true
 	nodes, err := tg.AddNodes(renterParams)
 	if err != nil {

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -35,7 +35,7 @@ func TestRenter(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -350,7 +350,7 @@ func testDownloadInterrupted(t *testing.T, deps *siatest.DependencyInterruptOnce
 	}
 
 	// Get a directory for testing.
-	testDir := renterTestDir(t)
+	testDir := renterTestDir(t.Name())
 
 	// Create a group with a single renter and two hosts using the dependencies
 	// for the renter.
@@ -422,7 +422,7 @@ func testUploadInterrupted(t *testing.T, deps *siatest.DependencyInterruptOnceOn
 	}
 
 	// Get a directory for testing.
-	testDir := renterTestDir(t)
+	testDir := renterTestDir(t.Name())
 
 	// Create a group with a single renter and two hosts using the dependencies
 	// for the renter.
@@ -576,7 +576,7 @@ func TestRenewFailing(t *testing.T) {
 		t.SkipNow()
 	}
 	// Create testing directory.
-	testDir := renterTestDir(t)
+	testDir := renterTestDir(t.Name())
 
 	// Create a group for the subtests
 	groupParams := siatest.GroupParams{
@@ -721,7 +721,7 @@ func TestRenterPersistData(t *testing.T) {
 	}
 
 	// Get test directory
-	testDir := renterTestDir(t)
+	testDir := renterTestDir(t.Name())
 
 	// Copying legacy file to test directory
 	renterDir := filepath.Join(testDir, "renter")
@@ -879,7 +879,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		Hosts:  2,
 		Miners: 1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -890,7 +890,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}()
 
 	// Add a Renter node
-	renterDir := filepath.Join(renterTestDir(t), "renter")
+	renterDir := filepath.Join(renterTestDir(t.Name()), "renter")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1115,7 +1115,7 @@ func TestRedundancyReporting(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -1218,7 +1218,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -1360,7 +1360,7 @@ func TestRenterResetAllowance(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -35,7 +35,7 @@ func TestRenter(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -350,16 +350,13 @@ func testDownloadInterrupted(t *testing.T, deps *siatest.DependencyInterruptOnce
 	}
 
 	// Get a directory for testing.
-	testDir, err := siatest.TestDir(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	testDir := renterTestDir(t)
 
 	// Create a group with a single renter and two hosts using the dependencies
 	// for the renter.
 	renterTemplate := node.Renter(testDir + "/renter")
 	renterTemplate.ContractSetDeps = deps
-	tg, err := siatest.NewGroup(renterTemplate, node.Host(testDir+"/host1"),
+	tg, err := siatest.NewGroup(testDir, renterTemplate, node.Host(testDir+"/host1"),
 		node.Host(testDir+"/host2"), siatest.Miner(testDir+"/miner"))
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
@@ -425,16 +422,13 @@ func testUploadInterrupted(t *testing.T, deps *siatest.DependencyInterruptOnceOn
 	}
 
 	// Get a directory for testing.
-	testDir, err := siatest.TestDir(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	testDir := renterTestDir(t)
 
 	// Create a group with a single renter and two hosts using the dependencies
 	// for the renter.
 	renterTemplate := node.Renter(testDir + "/renter")
 	renterTemplate.ContractSetDeps = deps
-	tg, err := siatest.NewGroup(renterTemplate, node.Host(testDir+"/host1"),
+	tg, err := siatest.NewGroup(testDir, renterTemplate, node.Host(testDir+"/host1"),
 		node.Host(testDir+"/host2"), siatest.Miner(testDir+"/miner"))
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
@@ -581,17 +575,15 @@ func TestRenewFailing(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	renterDir, err := siatest.TestDir(filepath.Join(t.Name(), "renter"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Create testing directory.
+	testDir := renterTestDir(t)
 
 	// Create a group for the subtests
 	groupParams := siatest.GroupParams{
 		Hosts:  3,
 		Miners: 1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(groupParams)
+	tg, err := siatest.NewGroupFromTemplate(testDir, groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -603,7 +595,7 @@ func TestRenewFailing(t *testing.T) {
 
 	// Add a renter with a custom allowance to give it plenty of time to renew
 	// the contract later.
-	renterParams := node.Renter(renterDir)
+	renterParams := node.Renter(filepath.Join(testDir, "renter"))
 	renterParams.Allowance = siatest.DefaultAllowance
 	renterParams.Allowance.Hosts = uint64(len(tg.Hosts()) - 1)
 	renterParams.Allowance.Period = 100
@@ -729,15 +721,12 @@ func TestRenterPersistData(t *testing.T) {
 	}
 
 	// Get test directory
-	testdir, err := siatest.TestDir(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	testDir := renterTestDir(t)
 
 	// Copying legacy file to test directory
-	renterDir := filepath.Join(testdir, "renter")
+	renterDir := filepath.Join(testDir, "renter")
 	destination := filepath.Join(renterDir, "renter.json")
-	err = os.MkdirAll(renterDir, 0700)
+	err := os.MkdirAll(renterDir, 0700)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -761,7 +750,7 @@ func TestRenterPersistData(t *testing.T) {
 	}
 
 	// Create new node from legacy renter.json persistence file
-	r, err := siatest.NewNode(node.AllModules(testdir))
+	r, err := siatest.NewNode(node.AllModules(testDir))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -890,7 +879,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		Hosts:  2,
 		Miners: 1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -901,7 +890,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}()
 
 	// Add a Renter node
-	renterDir, err := siatest.TestDir(filepath.Join(t.Name(), "renter"))
+	renterDir := filepath.Join(renterTestDir(t), "renter")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1126,7 +1115,7 @@ func TestRedundancyReporting(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -1229,7 +1218,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -1371,7 +1360,7 @@ func TestRenterResetAllowance(t *testing.T) {
 		Renters: 1,
 		Miners:  1,
 	}
-	tg, err := siatest.NewGroupFromTemplate(groupParams)
+	tg, err := siatest.NewGroupFromTemplate(renterTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -1,7 +1,6 @@
 package siatest
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -13,9 +12,9 @@ import (
 	"github.com/NebulousLabs/Sia/modules"
 	"github.com/NebulousLabs/Sia/node"
 	"github.com/NebulousLabs/Sia/node/api/client"
+	"github.com/NebulousLabs/Sia/persist"
 	"github.com/NebulousLabs/Sia/types"
 	"github.com/NebulousLabs/errors"
-	"github.com/NebulousLabs/fastrand"
 )
 
 type (
@@ -302,7 +301,7 @@ func randomNodeDir(parentDir string, nodeParams *node.NodeParams) {
 	if nodeParams.Miner != nil || nodeParams.CreateMiner {
 		nodeDir += "m"
 	}
-	nodeDir += fmt.Sprintf("-%s", hex.EncodeToString(fastrand.Bytes(4)))
+	nodeDir += fmt.Sprintf("-%s", persist.RandomSuffix())
 	nodeParams.Dir = filepath.Join(parentDir, nodeDir)
 }
 

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -1,9 +1,11 @@
 package siatest
 
 import (
+	"encoding/hex"
+	"fmt"
 	"math"
+	"path/filepath"
 	"reflect"
-	"strconv"
 	"sync"
 	"time"
 
@@ -48,13 +50,15 @@ var (
 
 // NewGroup creates a group of TestNodes from node params. All the nodes will
 // be connected, synced and funded. Hosts nodes are also announced.
-func NewGroup(nodeParams ...node.NodeParams) (*TestGroup, error) {
+func NewGroup(groupDir string, nodeParams ...node.NodeParams) (*TestGroup, error) {
 	// Create and init group
 	tg := &TestGroup{
 		nodes:   make(map[*TestNode]struct{}),
 		hosts:   make(map[*TestNode]struct{}),
 		renters: make(map[*TestNode]struct{}),
 		miners:  make(map[*TestNode]struct{}),
+
+		dir: groupDir,
 	}
 
 	// Create node and add it to the correct groups
@@ -97,21 +101,24 @@ func NewGroup(nodeParams ...node.NodeParams) (*TestGroup, error) {
 
 // NewGroupFromTemplate will create hosts, renters and miners according to the
 // settings in groupParams.
-func NewGroupFromTemplate(groupParams GroupParams) (*TestGroup, error) {
+func NewGroupFromTemplate(groupDir string, groupParams GroupParams) (*TestGroup, error) {
 	var params []node.NodeParams
 	// Create host params
 	for i := 0; i < groupParams.Hosts; i++ {
-		params = append(params, node.Host(randomDir()))
+		params = append(params, node.HostTemplate)
+		randomNodeDir(groupDir, &params[len(params)-1])
 	}
 	// Create renter params
 	for i := 0; i < groupParams.Renters; i++ {
-		params = append(params, node.Renter(randomDir()))
+		params = append(params, node.RenterTemplate)
+		randomNodeDir(groupDir, &params[len(params)-1])
 	}
 	// Create miner params
 	for i := 0; i < groupParams.Miners; i++ {
-		params = append(params, Miner(randomDir()))
+		params = append(params, MinerTemplate)
+		randomNodeDir(groupDir, &params[len(params)-1])
 	}
-	return NewGroup(params...)
+	return NewGroup(groupDir, params...)
 }
 
 // addStorageFolderToHosts adds a single storage folder to each host.
@@ -267,13 +274,36 @@ func mapToSlice(m map[*TestNode]struct{}) []*TestNode {
 	return tns
 }
 
-// randomDir is a helper functions that returns a random directory path
-func randomDir() string {
-	dir, err := TestDir(strconv.Itoa(fastrand.Intn(math.MaxInt32)))
-	if err != nil {
-		panic(errors.AddContext(err, "failed to create testing directory"))
+// randomNodeDir generates a random directory for the provided node params if
+// Dir wasn't set using the provided parentDir and a randomized suffix.
+func randomNodeDir(parentDir string, nodeParams *node.NodeParams) {
+	if nodeParams.Dir != "" {
+		return
 	}
-	return dir
+	nodeDir := ""
+	if nodeParams.Gateway != nil || nodeParams.CreateGateway {
+		nodeDir += "g"
+	}
+	if nodeParams.ConsensusSet != nil || nodeParams.CreateConsensusSet {
+		nodeDir += "c"
+	}
+	if nodeParams.TransactionPool != nil || nodeParams.CreateTransactionPool {
+		nodeDir += "t"
+	}
+	if nodeParams.Wallet != nil || nodeParams.CreateWallet {
+		nodeDir += "w"
+	}
+	if nodeParams.Renter != nil || nodeParams.CreateRenter {
+		nodeDir += "r"
+	}
+	if nodeParams.Host != nil || nodeParams.CreateHost {
+		nodeDir += "h"
+	}
+	if nodeParams.Miner != nil || nodeParams.CreateMiner {
+		nodeDir += "m"
+	}
+	nodeDir += fmt.Sprintf("-%s", hex.EncodeToString(fastrand.Bytes(4)))
+	nodeParams.Dir = filepath.Join(parentDir, nodeDir)
 }
 
 // setRenterAllowances sets the allowance of each renter
@@ -421,9 +451,7 @@ func (tg *TestGroup) AddNodes(nps ...node.NodeParams) error {
 	newRenters := make(map[*TestNode]struct{})
 	for _, np := range nps {
 		// Create the nodes and add them to the group.
-		if np.Dir == "" {
-			np.Dir = randomDir()
-		}
+		randomNodeDir(tg.dir, &np)
 		node, err := NewCleanNode(np)
 		if err != nil {
 			return build.ExtendErr("failed to create host", err)

--- a/siatest/testgroup_test.go
+++ b/siatest/testgroup_test.go
@@ -1,6 +1,7 @@
 package siatest
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NebulousLabs/Sia/build"
@@ -19,7 +20,7 @@ func TestNewGroup(t *testing.T) {
 		Miners:  2,
 	}
 	// Create the group
-	tg, err := NewGroupFromTemplate(siatestTestDir(t), groupParams)
+	tg, err := NewGroupFromTemplate(siatestTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -71,7 +72,7 @@ func TestNewGroupNoMiner(t *testing.T) {
 		Miners:  0,
 	}
 	// Create the group
-	_, err := NewGroupFromTemplate(siatestTestDir(t), groupParams)
+	_, err := NewGroupFromTemplate(siatestTestDir(t.Name()), groupParams)
 	if err == nil {
 		t.Fatal("Creating a group without miners should fail: ", err)
 	}
@@ -89,7 +90,7 @@ func TestNewGroupNoRenterHost(t *testing.T) {
 		Miners:  5,
 	}
 	// Create the group
-	tg, err := NewGroupFromTemplate(siatestTestDir(t), groupParams)
+	tg, err := NewGroupFromTemplate(siatestTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -111,7 +112,7 @@ func TestAddNewNode(t *testing.T) {
 		Renters: 2,
 		Miners:  1,
 	}
-	tg, err := NewGroupFromTemplate(groupParams)
+	tg, err := NewGroupFromTemplate(siatestTestDir(t.Name()), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -125,11 +126,8 @@ func TestAddNewNode(t *testing.T) {
 	oldRenters := tg.Renters()
 
 	// Test adding a node
-	testDir, err := TestDir(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	renterTemplate := node.Renter(testDir + "/renter")
+	testDir := TestDir(t.Name())
+	renterTemplate := node.Renter(filepath.Join(testDir, "/renter"))
 	nodes, err := tg.AddNodes(renterTemplate)
 	if err != nil {
 		t.Fatal(err)

--- a/siatest/testgroup_test.go
+++ b/siatest/testgroup_test.go
@@ -18,7 +18,7 @@ func TestNewGroup(t *testing.T) {
 		Miners:  2,
 	}
 	// Create the group
-	tg, err := NewGroupFromTemplate(groupParams)
+	tg, err := NewGroupFromTemplate(siatestTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}
@@ -70,7 +70,7 @@ func TestNewGroupNoMiner(t *testing.T) {
 		Miners:  0,
 	}
 	// Create the group
-	_, err := NewGroupFromTemplate(groupParams)
+	_, err := NewGroupFromTemplate(siatestTestDir(t), groupParams)
 	if err == nil {
 		t.Fatal("Creating a group without miners should fail: ", err)
 	}
@@ -88,7 +88,7 @@ func TestNewGroupNoRenterHost(t *testing.T) {
 		Miners:  5,
 	}
 	// Create the group
-	tg, err := NewGroupFromTemplate(groupParams)
+	tg, err := NewGroupFromTemplate(siatestTestDir(t), groupParams)
 	if err != nil {
 		t.Fatal("Failed to create group: ", err)
 	}

--- a/siatest/wallet/consts.go
+++ b/siatest/wallet/consts.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"os"
-	"testing"
 
 	"github.com/NebulousLabs/Sia/siatest"
 )
@@ -10,8 +9,8 @@ import (
 // walletTestDir creates a temporary testing directory for a wallet test. This
 // should only every be called once per test. Otherwise it will delete the
 // directory again.
-func walletTestDir(t *testing.T) string {
-	path := siatest.TestDir("wallet", t.Name())
+func walletTestDir(testName string) string {
+	path := siatest.TestDir("wallet", testName)
 	if err := os.MkdirAll(path, 0777); err != nil {
 		panic(err)
 	}

--- a/siatest/wallet/consts.go
+++ b/siatest/wallet/consts.go
@@ -1,0 +1,19 @@
+package wallet
+
+import (
+	"os"
+	"testing"
+
+	"github.com/NebulousLabs/Sia/siatest"
+)
+
+// walletTestDir creates a temporary testing directory for a wallet test. This
+// should only every be called once per test. Otherwise it will delete the
+// directory again.
+func walletTestDir(t *testing.T) string {
+	path := siatest.TestDir("wallet", t.Name())
+	if err := os.MkdirAll(path, 0777); err != nil {
+		panic(err)
+	}
+	return path
+}

--- a/siatest/wallet/wallet_test.go
+++ b/siatest/wallet/wallet_test.go
@@ -18,10 +18,8 @@ func TestTransactionReorg(t *testing.T) {
 		t.SkipNow()
 	}
 
-	testdir, err := siatest.TestDir(t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Create testing directory.
+	testdir := walletTestDir(t)
 
 	// Create two miners
 	miner1, err := siatest.NewNode(siatest.Miner(filepath.Join(testdir, "miner1")))

--- a/siatest/wallet/wallet_test.go
+++ b/siatest/wallet/wallet_test.go
@@ -19,7 +19,7 @@ func TestTransactionReorg(t *testing.T) {
 	}
 
 	// Create testing directory.
-	testdir := walletTestDir(t)
+	testdir := walletTestDir(t.Name())
 
 	// Create two miners
 	miner1, err := siatest.NewNode(siatest.Miner(filepath.Join(testdir, "miner1")))


### PR DESCRIPTION
This PR cleans up the madness in the `/tmp/SiaTesting` folder for the `siatest` framework.
`siatest`- Tests will create the following folder structure in the `/tmp/SiaTesting` directory.

`/tmp/SiaTesting/siatest/<packageName>/<testName>/<nodeName>`

The <nodeName> is the the folder name specified in the `Dir` field of the `NodeParams` struct.
If no `Dir` field is specified (e.g. when creating a whole group at once) the node name will be an encoded string of the enabled modules plus a random 4 byte, hex-encoded suffix. So for example a renter node could have the name `gctwr-deadbeef`.

One exception to this structure is the `/tmp/SiaTesting/siatest/data` folder. It contains all the randomly generated files of all `siatest` tests. The files follow the encoding `<sizeInBytes>bytes-<4byte-hex-suffix>`. e.g. `100bytes-deadbeef`