### PR TITLE
Moving encoding helpers into encoding package

### DIFF
--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -80,7 +80,7 @@ func ReadSignedObject(r io.Reader, obj interface{}, maxLen uint64, pk PublicKey)
 		return err
 	}
 	// read the encoded object
-	encObj, err := encoding.ReadPrefix(r, maxLen)
+	encObj, err := encoding.ReadPrefixedBytes(r, maxLen)
 	if err != nil {
 		return err
 	}

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -51,24 +51,24 @@ type (
 )
 
 func (t test5) MarshalSia(w io.Writer) error {
-	return WritePrefix(w, []byte(t.s))
+	return NewEncoder(w).WritePrefix([]byte(t.s))
 }
 
 func (t *test5) UnmarshalSia(r io.Reader) error {
-	b, err := ReadPrefix(r, 256)
-	t.s = string(b)
-	return err
+	d := NewDecoder(r)
+	t.s = string(d.ReadPrefix())
+	return d.Err()
 }
 
 // same as above methods, but with a pointer receiver
 func (t *test6) MarshalSia(w io.Writer) error {
-	return WritePrefix(w, []byte(t.s))
+	return NewEncoder(w).WritePrefix([]byte(t.s))
 }
 
 func (t *test6) UnmarshalSia(r io.Reader) error {
-	b, err := ReadPrefix(r, 256)
-	t.s = string(b)
-	return err
+	d := NewDecoder(r)
+	t.s = string(d.ReadPrefix())
+	return d.Err()
 }
 
 var testStructs = []interface{}{
@@ -357,6 +357,7 @@ func TestReadWriteFile(t *testing.T) {
 
 // i5-4670K, 9a90f86: 33 MB/s
 func BenchmarkEncode(b *testing.B) {
+	b.ReportAllocs()
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(buf)
 	for i := 0; i < b.N; i++ {
@@ -373,6 +374,7 @@ func BenchmarkEncode(b *testing.B) {
 
 // i5-4670K, 9a90f86: 26 MB/s
 func BenchmarkDecode(b *testing.B) {
+	b.ReportAllocs()
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	var numBytes int64
 	for i := 0; i < b.N; i++ {
@@ -390,6 +392,7 @@ func BenchmarkDecode(b *testing.B) {
 
 // i5-4670K, 2059112: 44 MB/s
 func BenchmarkMarshalAll(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = MarshalAll(testStructs...)
 	}
@@ -398,6 +401,7 @@ func BenchmarkMarshalAll(b *testing.B) {
 
 // i5-4670K, 2059112: 36 MB/s
 func BenchmarkUnmarshalAll(b *testing.B) {
+	b.ReportAllocs()
 	var emptyStructs = []interface{}{&test0{}, &test1{}, &test2{}, &test3{}, &test4{}, &test5{}, &test6{}}
 	structBytes := bytes.Join(testEncodings, nil)
 	for i := 0; i < b.N; i++ {

--- a/encoding/marshal_test.go
+++ b/encoding/marshal_test.go
@@ -51,23 +51,23 @@ type (
 )
 
 func (t test5) MarshalSia(w io.Writer) error {
-	return NewEncoder(w).WritePrefix([]byte(t.s))
+	return NewEncoder(w).WritePrefixedBytes([]byte(t.s))
 }
 
 func (t *test5) UnmarshalSia(r io.Reader) error {
 	d := NewDecoder(r)
-	t.s = string(d.ReadPrefix())
+	t.s = string(d.ReadPrefixedBytes())
 	return d.Err()
 }
 
 // same as above methods, but with a pointer receiver
 func (t *test6) MarshalSia(w io.Writer) error {
-	return NewEncoder(w).WritePrefix([]byte(t.s))
+	return NewEncoder(w).WritePrefixedBytes([]byte(t.s))
 }
 
 func (t *test6) UnmarshalSia(r io.Reader) error {
 	d := NewDecoder(r)
-	t.s = string(d.ReadPrefix())
+	t.s = string(d.ReadPrefixedBytes())
 	return d.Err()
 }
 

--- a/encoding/prefix.go
+++ b/encoding/prefix.go
@@ -5,10 +5,10 @@ import (
 	"io"
 )
 
-// ReadPrefix reads an 8-byte length prefixes, followed by the number of bytes
+// ReadPrefixedBytes reads an 8-byte length prefixes, followed by the number of bytes
 // specified in the prefix. The operation is aborted if the prefix exceeds a
 // specified maximum length.
-func ReadPrefix(r io.Reader, maxLen uint64) ([]byte, error) {
+func ReadPrefixedBytes(r io.Reader, maxLen uint64) ([]byte, error) {
 	prefix := make([]byte, 8)
 	if _, err := io.ReadFull(r, prefix); err != nil {
 		return nil, err
@@ -25,15 +25,15 @@ func ReadPrefix(r io.Reader, maxLen uint64) ([]byte, error) {
 
 // ReadObject reads and decodes a length-prefixed and marshalled object.
 func ReadObject(r io.Reader, obj interface{}, maxLen uint64) error {
-	data, err := ReadPrefix(r, maxLen)
+	data, err := ReadPrefixedBytes(r, maxLen)
 	if err != nil {
 		return err
 	}
 	return Unmarshal(data, obj)
 }
 
-// WritePrefix writes a length-prefixed byte slice to w.
-func WritePrefix(w io.Writer, data []byte) error {
+// WritePrefixedBytes writes a length-prefixed byte slice to w.
+func WritePrefixedBytes(w io.Writer, data []byte) error {
 	err := WriteInt(w, len(data))
 	if err != nil {
 		return err
@@ -47,5 +47,5 @@ func WritePrefix(w io.Writer, data []byte) error {
 
 // WriteObject writes a length-prefixed object to w.
 func WriteObject(w io.Writer, v interface{}) error {
-	return WritePrefix(w, Marshal(v))
+	return WritePrefixedBytes(w, Marshal(v))
 }

--- a/modules/gateway/rpc.go
+++ b/modules/gateway/rpc.go
@@ -242,7 +242,7 @@ func (g *Gateway) Broadcast(name string, obj interface{}, peers []modules.Peer) 
 	// only encode obj once, instead of using WriteObject
 	enc := encoding.Marshal(obj)
 	fn := func(conn modules.PeerConn) error {
-		return encoding.WritePrefix(conn, enc)
+		return encoding.WritePrefixedBytes(conn, enc)
 	}
 
 	var wg sync.WaitGroup

--- a/types/block.go
+++ b/types/block.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/Sia/crypto"
+	"github.com/NebulousLabs/Sia/encoding"
 )
 
 const (
@@ -118,7 +119,7 @@ func (b Block) ID() BlockID {
 func (b Block) MerkleRoot() crypto.Hash {
 	tree := crypto.NewTree()
 	var buf bytes.Buffer
-	e := encoder(&buf)
+	e := encoding.NewEncoder(&buf)
 	for _, payout := range b.MinerPayouts {
 		payout.MarshalSia(e)
 		tree.Push(buf.Bytes())

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -276,7 +276,7 @@ zeros:
 func (c *Currency) UnmarshalSia(r io.Reader) error {
 	d := encoding.NewDecoder(r)
 	var dec Currency
-	dec.i.SetBytes(d.ReadPrefix())
+	dec.i.SetBytes(d.ReadPrefixedBytes())
 	*c = dec
 	return d.Err()
 }
@@ -591,7 +591,7 @@ func (sfoid *SiafundOutputID) UnmarshalJSON(b []byte) error {
 func (spk SiaPublicKey) MarshalSia(w io.Writer) error {
 	e := encoding.NewEncoder(w)
 	e.Write(spk.Algorithm[:])
-	e.WritePrefix(spk.Key)
+	e.WritePrefixedBytes(spk.Key)
 	return e.Err()
 }
 
@@ -599,7 +599,7 @@ func (spk SiaPublicKey) MarshalSia(w io.Writer) error {
 func (spk *SiaPublicKey) UnmarshalSia(r io.Reader) error {
 	d := encoding.NewDecoder(r)
 	d.ReadFull(spk.Algorithm[:])
-	spk.Key = d.ReadPrefix()
+	spk.Key = d.ReadPrefixedBytes()
 	return d.Err()
 }
 
@@ -742,7 +742,7 @@ func (t Transaction) marshalSiaNoSignatures(w io.Writer) {
 	}
 	e.WriteInt(len((t.ArbitraryData)))
 	for i := range t.ArbitraryData {
-		e.WritePrefix(t.ArbitraryData[i])
+		e.WritePrefixedBytes(t.ArbitraryData[i])
 	}
 }
 
@@ -848,7 +848,7 @@ func (t *Transaction) UnmarshalSia(r io.Reader) error {
 	}
 	t.ArbitraryData = make([][]byte, d.NextPrefix(unsafe.Sizeof([]byte{})))
 	for i := range t.ArbitraryData {
-		t.ArbitraryData[i] = d.ReadPrefix()
+		t.ArbitraryData[i] = d.ReadPrefixedBytes()
 	}
 	t.TransactionSignatures = make([]TransactionSignature, d.NextPrefix(unsafe.Sizeof(TransactionSignature{})))
 	for i := range t.TransactionSignatures {
@@ -879,7 +879,7 @@ func (ts TransactionSignature) MarshalSia(w io.Writer) error {
 	e.WriteUint64(ts.PublicKeyIndex)
 	e.WriteUint64(uint64(ts.Timelock))
 	ts.CoveredFields.MarshalSia(e)
-	e.WritePrefix(ts.Signature)
+	e.WritePrefixedBytes(ts.Signature)
 	return e.Err()
 }
 
@@ -890,7 +890,7 @@ func (ts *TransactionSignature) UnmarshalSia(r io.Reader) error {
 	ts.PublicKeyIndex = d.NextUint64()
 	ts.Timelock = BlockHeight(d.NextUint64())
 	ts.CoveredFields.UnmarshalSia(d)
-	ts.Signature = d.ReadPrefix()
+	ts.Signature = d.ReadPrefixedBytes()
 	return d.Err()
 }
 

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -163,7 +163,7 @@ func Ed25519PublicKey(pk crypto.PublicKey) SiaPublicKey {
 // protected by having random public keys next to them.
 func (uc UnlockConditions) UnlockHash() UnlockHash {
 	var buf bytes.Buffer
-	e := encoder(&buf)
+	e := encoding.NewEncoder(&buf)
 	tree := crypto.NewTree()
 	e.WriteUint64(uint64(uc.Timelock))
 	tree.Push(buf.Bytes())

--- a/types/signatures.go
+++ b/types/signatures.go
@@ -214,7 +214,7 @@ func (t Transaction) SigHash(i int) (hash crypto.Hash) {
 			t.MinerFees[minerFee].MarshalSia(h)
 		}
 		for _, arbData := range cf.ArbitraryData {
-			encoding.WritePrefix(h, t.ArbitraryData[arbData])
+			encoding.WritePrefixedBytes(h, t.ArbitraryData[arbData])
 		}
 	}
 


### PR DESCRIPTION
These helpers are really nice for writing clean and efficient `MarshalSia`/`UnmarshalSia` methods, so there's no reason to hide them in the `types` package. Moving them into `encoding` also allows the `Marshal` and `Unmarshal` functions to make use of them.

This is a low-priority PR. It brings a nice performance benefit (approx. half as many allocations when encoding/decoding types without custom marshaler methods), and will be useful any time we want to write `MarshalSia`/`UnmarshalSia` methods down the line, but it certainly isn't blocking anything.