### PR TITLE
Updates on Spend Reporting PR 3087

### DIFF
--- a/cmd/siac/export.go
+++ b/cmd/siac/export.go
@@ -30,7 +30,7 @@ var (
 // renterexportcontracttxnscmd is the handler for the command `siac renter export contract-txns`.
 // Exports the current contract set to JSON.
 func renterexportcontracttxnscmd(destination string) {
-	cs, err := httpClient.RenterActiveContractsGet()
+	cs, err := httpClient.RenterContractsGet()
 	if err != nil {
 		die("Could not retrieve contracts:", err)
 	}

--- a/cmd/siac/export.go
+++ b/cmd/siac/export.go
@@ -35,8 +35,7 @@ func renterexportcontracttxnscmd(destination string) {
 		die("Could not retrieve contracts:", err)
 	}
 	var contractTxns []types.Transaction
-	contracts := append(cs.Contracts, cs.OldContracts...)
-	for _, c := range contracts {
+	for _, c := range cs.Contracts {
 		contractTxns = append(contractTxns, c.LastTransaction)
 	}
 	destination = abs(destination)

--- a/cmd/siac/export.go
+++ b/cmd/siac/export.go
@@ -30,8 +30,7 @@ var (
 // renterexportcontracttxnscmd is the handler for the command `siac renter export contract-txns`.
 // Exports the current contract set to JSON.
 func renterexportcontracttxnscmd(destination string) {
-	getAllContracts := false
-	cs, err := httpClient.RenterContractsGet(getAllContracts)
+	cs, err := httpClient.RenterActiveContractsGet()
 	if err != nil {
 		die("Could not retrieve contracts:", err)
 	}

--- a/cmd/siac/export.go
+++ b/cmd/siac/export.go
@@ -30,7 +30,8 @@ var (
 // renterexportcontracttxnscmd is the handler for the command `siac renter export contract-txns`.
 // Exports the current contract set to JSON.
 func renterexportcontracttxnscmd(destination string) {
-	cs, err := httpClient.RenterContractsGet()
+	getAllContracts := false
+	cs, err := httpClient.RenterContractsGet(getAllContracts)
 	if err != nil {
 		die("Could not retrieve contracts:", err)
 	}

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -424,12 +424,13 @@ func rentercontractscmd() {
 			activeTotalSpent = activeTotalSpent.Add(c.TotalCost.Sub(c.RenterFunds).Sub(c.Fees))
 			activeTotalFees = activeTotalFees.Add(c.Fees)
 		}
-		fmt.Printf(`Active Contract Summary:
-			Number of Contracts:  %v
-			Total stored:         %9s
-			Total Remaining:      %v
-			Total Spent:          %v
-			Total Fees:           %v
+		fmt.Printf(`
+Active Contract Summary:
+Number of Contracts:  %v
+Total stored:         %9s
+Total Remaining:      %v
+Total Spent:          %v
+Total Fees:           %v
 			
 			`, len(rc.ActiveContracts), filesizeUnits(int64(activeTotalStored)), currencyUnits(activeTotalRemaining), currencyUnits(activeTotalSpent), currencyUnits(activeTotalFees))
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
@@ -450,6 +451,7 @@ func rentercontractscmd() {
 				c.GoodForUpload,
 				c.GoodForRenew)
 		}
+		w.Flush()
 
 		// Display Inactive Contracts
 		sort.Sort(byValue(rc.InactiveContracts))
@@ -461,12 +463,13 @@ func rentercontractscmd() {
 			inactiveTotalSpent = inactiveTotalSpent.Add(c.TotalCost.Sub(c.RenterFunds).Sub(c.Fees))
 			inactiveTotalFees = inactiveTotalFees.Add(c.Fees)
 		}
-		fmt.Printf(`Inactive Contract Summary:
-			Number of Contracts:  %v
-			Total stored:         %9s
-			Total Remaining:      %v
-			Total Spent:          %v
-			Total Fees:           %v
+		fmt.Printf(`
+Inactive Contract Summary:
+Number of Contracts:  %v
+Total stored:         %9s
+Total Remaining:      %v
+Total Spent:          %v
+Total Fees:           %v
 			
 			`, len(rc.InactiveContracts), filesizeUnits(int64(inactiveTotalStored)), currencyUnits(inactiveTotalRemaining), currencyUnits(inactiveTotalSpent), currencyUnits(inactiveTotalFees))
 		w = tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
@@ -513,12 +516,12 @@ func rentercontractscmd() {
 			expiredTotalFees = expiredTotalFees.Add(c.Fees)
 		}
 		fmt.Printf(`
-		Expired Contract Summary:
-		Number of Contracts:  %v
-		Total stored:         %9s
-		Total Remaining:      %v
-		Total Spent:          %v
-		Total Fees:           %v
+Expired Contract Summary:
+Number of Contracts:  %v
+Total stored:         %9s
+Total Remaining:      %v
+Total Spent:          %v
+Total Fees:           %v
 		
 		`, len(rce.ExpiredContracts), filesizeUnits(int64(expiredTotalStored)), currencyUnits(expiredTotalWithheld), currencyUnits(expiredTotalSpent), currencyUnits(expiredTotalFees))
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -379,7 +379,7 @@ func (s byValue) Less(i, j int) bool {
 // rentercontractscmd is the handler for the comand `siac renter contracts`.
 // It lists the Renter's contracts.
 func rentercontractscmd() {
-	rc, err := httpClient.RenterContractsGet()
+	rc, err := httpClient.RenterContractsGet(renterAllContracts)
 	if err != nil {
 		die("Could not get contracts:", err)
 	}
@@ -477,7 +477,8 @@ func rentercontractscmd() {
 // rentercontractsviewcmd is the handler for the command `siac renter contracts <id>`.
 // It lists details of a specific contract.
 func rentercontractsviewcmd(cid string) {
-	rc, err := httpClient.RenterContractsGet()
+	getAllContracts := true
+	rc, err := httpClient.RenterContractsGet(getAllContracts)
 	if err != nil {
 		die("Could not get contract details: ", err)
 	}

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -431,8 +431,8 @@ Total stored:         %9s
 Total Remaining:      %v
 Total Spent:          %v
 Total Fees:           %v
-			
-			`, len(rc.ActiveContracts), filesizeUnits(int64(activeTotalStored)), currencyUnits(activeTotalRemaining), currencyUnits(activeTotalSpent), currencyUnits(activeTotalFees))
+
+`, len(rc.ActiveContracts), filesizeUnits(int64(activeTotalStored)), currencyUnits(activeTotalRemaining), currencyUnits(activeTotalSpent), currencyUnits(activeTotalFees))
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "Host\tRemaining Funds\tSpent Funds\tSpent Fees\tData\tEnd Height\tID\tGoodForUpload\tGoodForRenew")
 		for _, c := range rc.ActiveContracts {
@@ -471,7 +471,7 @@ Total Remaining:      %v
 Total Spent:          %v
 Total Fees:           %v
 			
-			`, len(rc.InactiveContracts), filesizeUnits(int64(inactiveTotalStored)), currencyUnits(inactiveTotalRemaining), currencyUnits(inactiveTotalSpent), currencyUnits(inactiveTotalFees))
+`, len(rc.InactiveContracts), filesizeUnits(int64(inactiveTotalStored)), currencyUnits(inactiveTotalRemaining), currencyUnits(inactiveTotalSpent), currencyUnits(inactiveTotalFees))
 		w = tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "Host\tRemaining Funds\tSpent Funds\tSpent Fees\tData\tEnd Height\tID\tGoodForUpload\tGoodForRenew")
 		for _, c := range rc.InactiveContracts {
@@ -523,7 +523,7 @@ Total Remaining:      %v
 Total Spent:          %v
 Total Fees:           %v
 		
-		`, len(rce.ExpiredContracts), filesizeUnits(int64(expiredTotalStored)), currencyUnits(expiredTotalWithheld), currencyUnits(expiredTotalSpent), currencyUnits(expiredTotalFees))
+`, len(rce.ExpiredContracts), filesizeUnits(int64(expiredTotalStored)), currencyUnits(expiredTotalWithheld), currencyUnits(expiredTotalSpent), currencyUnits(expiredTotalFees))
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "Host\tWithheld Funds\tSpent Funds\tSpent Fees\tData\tEnd Height\tID\tGoodForUpload\tGoodForRenew")
 		for _, c := range rce.ExpiredContracts {

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -383,7 +383,7 @@ func rentercontractscmd() {
 	if err != nil {
 		die("Could not get contracts:", err)
 	}
-	if len(rc.Contracts) == 0 && len(rc.OldContracts) == 0 {
+	if len(rc.Contracts) == 0 && len(rc.ExpiredContracts) == 0 {
 		fmt.Println("No contracts have been formed.")
 		return
 	}
@@ -429,14 +429,14 @@ func rentercontractscmd() {
 		w.Flush()
 	}
 	if renterAllContracts {
-		if len(rc.OldContracts) == 0 {
+		if len(rc.ExpiredContracts) == 0 {
 			fmt.Println("No expired contracts")
 			return
 		}
-		sort.Sort(byValue(rc.OldContracts))
+		sort.Sort(byValue(rc.ExpiredContracts))
 		var totalStored uint64
 		var totalWithheld, totalSpent, totalFees types.Currency
-		for _, c := range rc.OldContracts {
+		for _, c := range rc.ExpiredContracts {
 			totalStored += c.Size
 			totalWithheld = totalWithheld.Add(c.RenterFunds)
 			totalSpent = totalSpent.Add(c.TotalCost.Sub(c.RenterFunds).Sub(c.Fees))
@@ -449,10 +449,10 @@ func rentercontractscmd() {
 		"Total Remaining:      %v
 		"Total Spent:          %v
 		"Total Fees:           %v
-		`, len(rc.OldContracts), filesizeUnits(int64(totalStored)), currencyUnits(totalWithheld), currencyUnits(totalSpent), currencyUnits(totalFees))
+		`, len(rc.ExpiredContracts), filesizeUnits(int64(totalStored)), currencyUnits(totalWithheld), currencyUnits(totalSpent), currencyUnits(totalFees))
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "Host\tWithheld Funds\tSpent Funds\tSpent Fees\tData\tEnd Height\tID\tGoodForUpload\tGoodForRenew")
-		for _, c := range rc.OldContracts {
+		for _, c := range rc.ExpiredContracts {
 			address := c.NetAddress
 			if address == "" {
 				address = "Host Removed"
@@ -479,7 +479,7 @@ func rentercontractsviewcmd(cid string) {
 	if err != nil {
 		die("Could not get contract details: ", err)
 	}
-	contracts := append(rc.Contracts, rc.OldContracts...)
+	contracts := append(rc.Contracts, rc.ExpiredContracts...)
 
 	for _, rc := range contracts {
 		if rc.ID.String() == cid {

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -402,12 +402,13 @@ func rentercontractscmd() {
 			totalFees = totalFees.Add(c.Fees)
 		}
 		fmt.Printf(`Active Contract Summary:
-		"Number of Contracts:  %v
-		"Total stored:         %9s
-		"Total Remaining:      %v
-		"Total Spent:          %v
-		"Total Fees:           %v
-		`, len(rc.Contracts), filesizeUnits(int64(totalStored)), currencyUnits(totalRemaining), currencyUnits(totalSpent), currencyUnits(totalFees))
+			Number of Contracts:  %v
+			Total stored:         %9s
+			Total Remaining:      %v
+			Total Spent:          %v
+			Total Fees:           %v
+			
+			`, len(rc.Contracts), filesizeUnits(int64(totalStored)), currencyUnits(totalRemaining), currencyUnits(totalSpent), currencyUnits(totalFees))
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "Host\tRemaining Funds\tSpent Funds\tSpent Fees\tData\tEnd Height\tID\tGoodForUpload\tGoodForRenew")
 		for _, c := range rc.Contracts {
@@ -444,11 +445,12 @@ func rentercontractscmd() {
 		}
 		fmt.Printf(`
 		Expired Contract Summary:
-		"Number of Contracts:  %v
-		"Total stored:         %9s
-		"Total Remaining:      %v
-		"Total Spent:          %v
-		"Total Fees:           %v
+		Number of Contracts:  %v
+		Total stored:         %9s
+		Total Remaining:      %v
+		Total Spent:          %v
+		Total Fees:           %v
+		
 		`, len(rc.ExpiredContracts), filesizeUnits(int64(totalStored)), currencyUnits(totalWithheld), currencyUnits(totalSpent), currencyUnits(totalFees))
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "Host\tWithheld Funds\tSpent Funds\tSpent Fees\tData\tEnd Height\tID\tGoodForUpload\tGoodForRenew")

--- a/cmd/siac/rentercmd.go
+++ b/cmd/siac/rentercmd.go
@@ -411,12 +411,12 @@ func rentercontractscmd() {
 	if err != nil {
 		die("Could not get inactive contracts:", err)
 	}
-	if len(rcActive.Contracts) == 0 && len(rcActive.Contracts) == 0 && !renterAllContracts {
+	if len(rcActive.Contracts) == 0 && len(rcInactive.Contracts) == 0 && !renterAllContracts {
 		fmt.Println("No contracts in the current period.")
 		return
 	}
 
-	if len(rcActive.Contracts) != 0 && len(rcActive.Contracts) != 0 {
+	if len(rcActive.Contracts) != 0 && len(rcInactive.Contracts) != 0 {
 		// Display Active Contracts
 		fmt.Println("Contracts in the Current Period")
 		sort.Sort(byValue(rcActive.Contracts))
@@ -456,10 +456,10 @@ func rentercontractscmd() {
 		}
 
 		// Display Inactive Contracts
-		sort.Sort(byValue(rcActive.Contracts))
+		sort.Sort(byValue(rcInactive.Contracts))
 		var inactiveTotalStored uint64
 		var inactiveTotalRemaining, inactiveTotalSpent, inactiveTotalFees types.Currency
-		for _, c := range rcActive.Contracts {
+		for _, c := range rcInactive.Contracts {
 			inactiveTotalStored += c.Size
 			inactiveTotalRemaining = inactiveTotalRemaining.Add(c.RenterFunds)
 			inactiveTotalSpent = inactiveTotalSpent.Add(c.TotalCost.Sub(c.RenterFunds).Sub(c.Fees))
@@ -475,7 +475,7 @@ func rentercontractscmd() {
 			`, len(rcInactive.Contracts), filesizeUnits(int64(inactiveTotalStored)), currencyUnits(inactiveTotalRemaining), currencyUnits(inactiveTotalSpent), currencyUnits(inactiveTotalFees))
 		w = tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "Host\tRemaining Funds\tSpent Funds\tSpent Fees\tData\tEnd Height\tID\tGoodForUpload\tGoodForRenew")
-		for _, c := range rcActive.Contracts {
+		for _, c := range rcInactive.Contracts {
 			address := c.NetAddress
 			if address == "" {
 				address = "Host Removed"

--- a/doc/API.md
+++ b/doc/API.md
@@ -935,17 +935,16 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns all, active, inactive, or expired contracts.  Active contracts are
-contracts that the Renter is currently using to store, upload, and download.
-Inactive contracts are contracts where the end height of the contract is greater
-than the current block height but the contract is either !goodForUpload,
-!goodForRenew, or was renewed due to running out of funds.  Expired contracts
-are contracts with an end height less than the current block height.
+returns the renter's contracts.  Active contracts are contracts that the Renter
+is currently using to store, upload, and download data, and are returned by
+default. Inactive contracts are contracts that are in the current period but are
+marked as not good for renew, these contracts have the potential to become
+active again but currently are not storing data.  Expired contracts are
+contracts not in the current period, where not more data is being stored and
+excess funds have been released to the renter.
 
 ###### Contract Parameters [(with comments)](/doc/api/Renter.md#contract-parameters)
 ```
-all        // true or false - Optional
-active     // true or false - Optional
 inactive   // true or false - Optional
 expired    // true or false - Optional
 ```
@@ -953,7 +952,7 @@ expired    // true or false - Optional
 ###### JSON Response [(with comments)](/doc/api/Renter.md#json-response-1)
 ```javascript
 {
-  "contracts": [
+  "activecontracts": [
     {
       "downloadspending": "1234", // hastings
       "endheight": 50000, // block height
@@ -976,6 +975,8 @@ expired    // true or false - Optional
       "goodforrenew": false,
     }
   ],
+  "inactivecontracts": [],
+  "expiredcontracts": [],
 }
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -935,7 +935,7 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns active contracts. Expired contracts are not included.
+returns active contracts and expired contracts.
 
 ###### JSON Response [(with comments)](/doc/api/Renter.md#json-response-1)
 ```javascript
@@ -962,7 +962,30 @@ returns active contracts. Expired contracts are not included.
       "goodforupload": true,
       "goodforrenew": false,
     }
-  ]
+  ],
+  "expiredcontracts": [
+    {
+      "downloadspending": "1234", // hastings
+      "endheight": 50000, // block height
+      "fees": "1234", // hastings
+      "hostpublickey": {
+        "algorithm": "ed25519",
+        "key": "RW50cm9weSBpc24ndCB3aGF0IGl0IHVzZWQgdG8gYmU="
+      },
+      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "lasttransaction": {},
+      "netaddress": "12.34.56.78:9",
+      "renterfunds": "1234", // hastings
+      "size": 8192, // bytes
+      "startheight": 50000, // block height
+      "StorageSpending": "1234",
+      "storagespending": "1234", // hastings
+      "totalcost": "1234", // hastings
+      "uploadspending": "1234" // hastings
+      "goodforupload": true,
+      "goodforrenew": false,
+    }
+  ],
 }
 ```
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -935,7 +935,12 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns active contracts and expired contracts.
+returns active contracts and expired contracts if requested.
+
+###### Contract Parameters [(with comments)](/doc/api/Renter.md#contract-parameters)
+```
+expired    // true or false - Optional
+```
 
 ###### JSON Response [(with comments)](/doc/api/Renter.md#json-response-1)
 ```javascript

--- a/doc/API.md
+++ b/doc/API.md
@@ -935,10 +935,18 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns active contracts and expired contracts if requested.
+returns all, active, inactive, or expired contracts.  Active contracts are
+contracts that the Renter is currently using to store, upload, and download.
+Inactive contracts are contracts where the end height of the contract is greater
+than the current block height but the contract is either !goodForUpload,
+!goodForRenew, or was renewed due to running out of funds.  Expired contracts
+are contracts with an end height less than the current block height.
 
 ###### Contract Parameters [(with comments)](/doc/api/Renter.md#contract-parameters)
 ```
+all        // true or false - Optional
+active     // true or false - Optional
+inactive   // true or false - Optional
 expired    // true or false - Optional
 ```
 
@@ -946,29 +954,6 @@ expired    // true or false - Optional
 ```javascript
 {
   "contracts": [
-    {
-      "downloadspending": "1234", // hastings
-      "endheight": 50000, // block height
-      "fees": "1234", // hastings
-      "hostpublickey": {
-        "algorithm": "ed25519",
-        "key": "RW50cm9weSBpc24ndCB3aGF0IGl0IHVzZWQgdG8gYmU="
-      },
-      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-      "lasttransaction": {},
-      "netaddress": "12.34.56.78:9",
-      "renterfunds": "1234", // hastings
-      "size": 8192, // bytes
-      "startheight": 50000, // block height
-      "StorageSpending": "1234",
-      "storagespending": "1234", // hastings
-      "totalcost": "1234", // hastings
-      "uploadspending": "1234" // hastings
-      "goodforupload": true,
-      "goodforrenew": false,
-    }
-  ],
-  "expiredcontracts": [
     {
       "downloadspending": "1234", // hastings
       "endheight": 50000, // block height

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -148,17 +148,16 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns all, active, inactive, or expired contracts.  Active contracts are
-contracts that the Renter is currently using to store, upload, and download.
-Inactive contracts are contracts where the end height of the contract is greater
-than the current block height but the contract is either !goodForUpload,
-!goodForRenew, or was renewed due to running out of funds.  Expired contracts
-are contracts with an end height less than the current block height.
+returns the renter's contracts.  Active contracts are contracts that the Renter
+is currently using to store, upload, and download data, and are returned by
+default. Inactive contracts are contracts that are in the current period but are
+marked as not good for renew, these contracts have the potential to become
+active again but currently are not storing data.  Expired contracts are
+contracts not in the current period, where not more data is being stored and
+excess funds have been released to the renter.
 
 ###### Contract Parameters
 ```
-all        // true or false - Optional
-active     // true or false - Optional
 inactive   // true or false - Optional
 expired    // true or false - Optional
 ```
@@ -166,7 +165,7 @@ expired    // true or false - Optional
 ###### JSON Response
 ```javascript
 {
-  "contracts": [
+  "activecontracts": [
     {
       // Amount of contract funds that have been spent on downloads.
       "downloadspending": "1234", // hastings
@@ -227,6 +226,8 @@ expired    // true or false - Optional
       "goodforrenew": false,
     }
   ],
+  "inactivecontracts": [],
+  "expiredcontracts": [],
 }
 ```
 

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -63,11 +63,11 @@ returns the current settings along with metrics on the renter's spending.
       // Is always nonzero.
       "renewwindow": 3024 // blocks
     }, 
-    // MaxUploadSpeed by defaul is unlimited but can be set by the user to 
+    // MaxUploadSpeed by default is unlimited but can be set by the user to 
     // manage bandwidth
     "maxuploadspeed":     1234, // bytes per second
 
-    // MaxDownloadSpeed by defaul is unlimited but can be set by the user to 
+    // MaxDownloadSpeed by default is unlimited but can be set by the user to 
     // manage bandwidth
     "maxdownloadspeed":   1234, // bytes per second
 

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -148,12 +148,73 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns active contracts. Expired contracts are not included.
+returns active contracts and expired contracts.
 
 ###### JSON Response
 ```javascript
 {
   "contracts": [
+    {
+      // Amount of contract funds that have been spent on downloads.
+      "downloadspending": "1234", // hastings
+
+      // Block height that the file contract ends on.
+      "endheight": 50000, // block height
+
+      // Fees paid in order to form the file contract.
+      "fees": "1234", // hastings
+
+      // Public key of the host the contract was formed with.
+      "hostpublickey": {
+        "algorithm": "ed25519",
+        "key": "RW50cm9weSBpc24ndCB3aGF0IGl0IHVzZWQgdG8gYmU="
+      },
+
+      // ID of the file contract.
+      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
+      // A signed transaction containing the most recent contract revision.
+      "lasttransaction": {},
+
+      // Address of the host the file contract was formed with.
+      "netaddress": "12.34.56.78:9",
+
+      // Remaining funds left for the renter to spend on uploads & downloads.
+      "renterfunds": "1234", // hastings
+
+      // Size of the file contract, which is typically equal to the number of
+      // bytes that have been uploaded to the host.
+      "size": 8192, // bytes
+
+      // Block height that the file contract began on.
+      "startheight": 50000, // block height
+
+      // DEPRECATED: This is the exact same value as StorageSpending, but it has
+      // incorrect capitalization. This was fixed in 1.3.2, but this field is kept
+      // to preserve backwards compatibility on clients who depend on the
+      // incorrect capitalization. This field will be removed in the future, so
+      // clients should switch to the StorageSpending field (above) with the
+      // correct lowercase name.
+      "StorageSpending": 0,
+
+      // Amount of contract funds that have been spent on storage.
+      "storagespending": "1234", // hastings
+
+      // Total cost to the wallet of forming the file contract.
+      // This includes both the fees and the funds allocated in the contract.
+      "totalcost": "1234", // hastings
+
+      // Amount of contract funds that have been spent on uploads.
+      "uploadspending": "1234" // hastings
+
+      // Signals if contract is good for uploading data
+      "goodforupload": true,
+
+      // Signals if contract is good for a renewal
+      "goodforrenew": false,
+    }
+  ],
+  "expiredcontracts": [
     {
       // Amount of contract funds that have been spent on downloads.
       "downloadspending": "1234", // hastings

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -148,7 +148,12 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns active contracts and expired contracts.
+returns active contracts and expired contracts if requested.
+
+###### Contract Parameters
+```
+expired    // true or false - Optional
+```
 
 ###### JSON Response
 ```javascript

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -148,10 +148,18 @@ standard success or error response. See
 
 #### /renter/contracts [GET]
 
-returns active contracts and expired contracts if requested.
+returns all, active, inactive, or expired contracts.  Active contracts are
+contracts that the Renter is currently using to store, upload, and download.
+Inactive contracts are contracts where the end height of the contract is greater
+than the current block height but the contract is either !goodForUpload,
+!goodForRenew, or was renewed due to running out of funds.  Expired contracts
+are contracts with an end height less than the current block height.
 
 ###### Contract Parameters
 ```
+all        // true or false - Optional
+active     // true or false - Optional
+inactive   // true or false - Optional
 expired    // true or false - Optional
 ```
 
@@ -219,67 +227,6 @@ expired    // true or false - Optional
       "goodforrenew": false,
     }
   ],
-  "expiredcontracts": [
-    {
-      // Amount of contract funds that have been spent on downloads.
-      "downloadspending": "1234", // hastings
-
-      // Block height that the file contract ends on.
-      "endheight": 50000, // block height
-
-      // Fees paid in order to form the file contract.
-      "fees": "1234", // hastings
-
-      // Public key of the host the contract was formed with.
-      "hostpublickey": {
-        "algorithm": "ed25519",
-        "key": "RW50cm9weSBpc24ndCB3aGF0IGl0IHVzZWQgdG8gYmU="
-      },
-
-      // ID of the file contract.
-      "id": "1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-
-      // A signed transaction containing the most recent contract revision.
-      "lasttransaction": {},
-
-      // Address of the host the file contract was formed with.
-      "netaddress": "12.34.56.78:9",
-
-      // Remaining funds left for the renter to spend on uploads & downloads.
-      "renterfunds": "1234", // hastings
-
-      // Size of the file contract, which is typically equal to the number of
-      // bytes that have been uploaded to the host.
-      "size": 8192, // bytes
-
-      // Block height that the file contract began on.
-      "startheight": 50000, // block height
-
-      // DEPRECATED: This is the exact same value as StorageSpending, but it has
-      // incorrect capitalization. This was fixed in 1.3.2, but this field is kept
-      // to preserve backwards compatibility on clients who depend on the
-      // incorrect capitalization. This field will be removed in the future, so
-      // clients should switch to the StorageSpending field (above) with the
-      // correct lowercase name.
-      "StorageSpending": 0,
-
-      // Amount of contract funds that have been spent on storage.
-      "storagespending": "1234", // hastings
-
-      // Total cost to the wallet of forming the file contract.
-      // This includes both the fees and the funds allocated in the contract.
-      "totalcost": "1234", // hastings
-
-      // Amount of contract funds that have been spent on uploads.
-      "uploadspending": "1234" // hastings
-
-      // Signals if contract is good for uploading data
-      "goodforupload": true,
-
-      // Signals if contract is good for a renewal
-      "goodforrenew": false,
-    }
-  ]
 }
 ```
 

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -325,8 +325,8 @@ type Renter interface {
 	// Contracts returns the active contracts formed by the renter.
 	Contracts() []RenterContract
 
-	// OldContracts returns the old contracts formed by the renter.
-	OldContracts() []RenterContract
+	// ExpiredContracts returns the expired contracts formed by the renter.
+	ExpiredContracts() []RenterContract
 
 	// ContractUtility provides the contract utility for a given host key.
 	ContractUtility(pk types.SiaPublicKey) (ContractUtility, bool)

--- a/modules/renter.go
+++ b/modules/renter.go
@@ -322,11 +322,11 @@ type Renter interface {
 	// Close closes the Renter.
 	Close() error
 
-	// Contracts returns the active contracts formed by the renter.
+	// Contracts returns the staticContracts of the renter's hostContractor.
 	Contracts() []RenterContract
 
-	// ExpiredContracts returns the expired contracts formed by the renter.
-	ExpiredContracts() []RenterContract
+	// OldContracts returns the oldContracts of the renter's hostContractor.
+	OldContracts() []RenterContract
 
 	// ContractUtility provides the contract utility for a given host key.
 	ContractUtility(pk types.SiaPublicKey) (ContractUtility, bool)

--- a/modules/renter/contractor/contractor.go
+++ b/modules/renter/contractor/contractor.go
@@ -159,9 +159,9 @@ func (c *Contractor) Contracts() []modules.RenterContract {
 	return c.staticContracts.ViewAll()
 }
 
-// ExpiredContracts returns the contracts formed by the contractor that have
+// OldContracts returns the contracts formed by the contractor that have
 // expired
-func (c *Contractor) ExpiredContracts() []modules.RenterContract {
+func (c *Contractor) OldContracts() []modules.RenterContract {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	contracts := make([]modules.RenterContract, 0, len(c.oldContracts))

--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -355,10 +355,10 @@ func (c *Contractor) threadedContractMaintenance() {
 	// in the current period.
 	endHeight = currentPeriod + allowance.Period
 
-	// Determine how many funds have been used already in this billing
-	// cycle, and how many funds are remaining. We have to calculate these
-	// numbers separately to avoid underflow, and then re-join them later to
-	// get the full picture for how many funds are available.
+	// Determine how many funds have been used already in this billing cycle,
+	// and how many funds are remaining. We have to calculate these numbers
+	// separately to avoid underflow, and then re-join them later to get the
+	// full picture for how many funds are available.
 	var fundsUsed types.Currency
 	for _, contract := range c.staticContracts.ViewAll() {
 		// Calculate the cost of the contract line.
@@ -367,33 +367,33 @@ func (c *Contractor) threadedContractMaintenance() {
 		// Check if the contract is expiring. The funds in the contract are
 		// handled differently based on this information.
 		if blockHeight+allowance.RenewWindow >= contract.EndHeight {
-			// The contract is expiring. Some of the funds are locked down
-			// to renew the contract, and then the remaining funds can be
-			// allocated to 'availableFunds'.
+			// The contract is expiring. Some of the funds are locked down to
+			// renew the contract, and then the remaining funds can be allocated
+			// to 'availableFunds'.
 			fundsUsed = fundsUsed.Add(contractLineCost).Sub(contract.RenterFunds)
 			fundsAvailable = fundsAvailable.Add(contract.RenterFunds)
 		} else {
-			// The contract is not expiring. None of the funds in the
-			// contract are available to renew or form contracts.
+			// The contract is not expiring. None of the funds in the contract
+			// are available to renew or form contracts.
 			fundsUsed = fundsUsed.Add(contractLineCost)
 		}
 	}
 
-	// Add any unspent funds from the allowance to the available funds. If
-	// the allowance has been decreased, it's possible that we actually need
-	// to reduce the number of funds available to compensate.
+	// Add any unspent funds from the allowance to the available funds. If the
+	// allowance has been decreased, it's possible that we actually need to
+	// reduce the number of funds available to compensate.
 	if fundsAvailable.Add(allowance.Funds).Cmp(fundsUsed) > 0 {
 		fundsAvailable = fundsAvailable.Add(allowance.Funds).Sub(fundsUsed)
 	} else {
-		// Figure out how much we need to remove from fundsAvailable to
-		// clear the allowance.
+		// Figure out how much we need to remove from fundsAvailable to clear
+		// the allowance.
 		overspend := fundsUsed.Sub(allowance.Funds).Sub(fundsAvailable)
 		if fundsAvailable.Cmp(overspend) > 0 {
 			// We still have some funds available.
 			fundsAvailable = fundsAvailable.Sub(overspend)
 		} else {
-			// The overspend exceeds the available funds, set available
-			// funds to zero.
+			// The overspend exceeds the available funds, set available funds to
+			// zero.
 			fundsAvailable = types.ZeroCurrency
 		}
 	}
@@ -406,22 +406,21 @@ func (c *Contractor) threadedContractMaintenance() {
 			continue
 		}
 		if blockHeight+allowance.RenewWindow >= contract.EndHeight {
-			// This contract needs to be renewed because it is going to
-			// expire soon. First step is to calculate how much money should
-			// be used in the renewal, based on how much of the contract
-			// funds (including previous contracts this billing cycle due to
-			// financial resets) were spent throughout this billing cycle.
+			// This contract needs to be renewed because it is going to expire
+			// soon. First step is to calculate how much money should be used in
+			// the renewal, based on how much of the contract funds (including
+			// previous contracts this billing cycle due to financial resets)
+			// were spent throughout this billing cycle.
 			//
-			// The amount we care about is the total amount that was spent
-			// on uploading, downloading, and storage throughout the billing
-			// cycle. This is calculated by starting with the total cost and
-			// subtracting out all of the fees, and then all of the unused
-			// money that was allocated (the RenterFunds).
+			// The amount we care about is the total amount that was spent on
+			// uploading, downloading, and storage throughout the billing cycle.
+			// This is calculated by starting with the total cost and
+			// subtracting out all of the fees, and then all of the unused money
+			// that was allocated (the RenterFunds).
 			//
 			// In order to accurately fund contracts based on variable spending,
-			// the cost per block is calculated based on the total spent
-			// over the length of time that the contract was active before
-			// renewal.
+			// the cost per block is calculated based on the total spent over
+			// the length of time that the contract was active before renewal.
 			oldContractSpent := contract.TotalCost.Sub(contract.ContractFee).Sub(contract.TxnFee).Sub(contract.SiafundFee).Sub(contract.RenterFunds)
 			oldContractLength := blockHeight - contract.StartHeight
 			if oldContractLength == 0 {
@@ -430,8 +429,7 @@ func (c *Contractor) threadedContractMaintenance() {
 			spentPerBlock := oldContractSpent.Div64(uint64(oldContractLength))
 			renewAmount := spentPerBlock.Mul64(uint64(allowance.Period))
 
-			// Get an estimate for how much the fees will cost.
-			// Txn Fee
+			// Get an estimate for how much the fees will cost. Txn Fee
 			_, maxTxnFee := c.tpool.FeeEstimation()
 
 			// SiafundFee
@@ -447,8 +445,8 @@ func (c *Contractor) threadedContractMaintenance() {
 			estimatedFees := host.ContractPrice.Add(maxTxnFee).Add(siafundFee)
 			renewAmount = renewAmount.Add(estimatedFees)
 
-			// Determine if there is enough funds available to supplement
-			// with a 33% bonus, and if there is, add a 33% bonus.
+			// Determine if there is enough funds available to supplement with a
+			// 33% bonus, and if there is, add a 33% bonus.
 			moneyBuffer := renewAmount.Div64(3)
 			if moneyBuffer.Cmp(fundsAvailable) < 0 {
 				renewAmount = renewAmount.Add(moneyBuffer)
@@ -457,8 +455,8 @@ func (c *Contractor) threadedContractMaintenance() {
 				c.log.Println("WARN: performing a limited renew due to low allowance")
 			}
 
-			// The contract needs to be renewed because it is going to
-			// expire soon, and we need to refresh the time.
+			// The contract needs to be renewed because it is going to expire
+			// soon, and we need to refresh the time.
 			renewSet = append(renewSet, renewal{
 				id:     contract.ID,
 				amount: renewAmount,
@@ -469,8 +467,8 @@ func (c *Contractor) threadedContractMaintenance() {
 			host, _ := c.hdb.Host(contract.HostPublicKey)
 
 			// Skip this host if its prices are too high.
-			// managedMarkContractsUtility should make this redundant, but
-			// this is here for extra safety.
+			// managedMarkContractsUtility should make this redundant, but this
+			// is here for extra safety.
 			if host.StoragePrice.Cmp(maxStoragePrice) > 0 || host.UploadBandwidthPrice.Cmp(maxUploadPrice) > 0 {
 				continue
 			}
@@ -481,9 +479,9 @@ func (c *Contractor) threadedContractMaintenance() {
 			sectorPrice := sectorStoragePrice.Add(sectorBandwidthPrice)
 			percentRemaining, _ := big.NewRat(0, 1).SetFrac(contract.RenterFunds.Big(), contract.TotalCost.Big()).Float64()
 			if contract.RenterFunds.Cmp(sectorPrice.Mul64(3)) < 0 || percentRemaining < minContractFundRenewalThreshold {
-				// This contract does need to be refreshed. Make sure there
-				// are enough funds available to perform the refresh, and
-				// then execute.
+				// This contract does need to be refreshed. Make sure there are
+				// enough funds available to perform the refresh, and then
+				// execute.
 				oldDuration := blockHeight - contract.StartHeight
 				newDuration := endHeight - blockHeight
 				spendPerBlock := contract.TotalCost.Div64(uint64(oldDuration))

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -113,8 +113,8 @@ type hostContractor interface {
 	// Contracts returns the active contracts formed by the contractor.
 	Contracts() []modules.RenterContract
 
-	// Contracts returns the old contracts formed by the contractor.
-	OldContracts() []modules.RenterContract
+	// Expired Contracts returns the Expired contracts formed by the contractor.
+	ExpiredContracts() []modules.RenterContract
 
 	// ContractByPublicKey returns the contract associated with the host key.
 	ContractByPublicKey(types.SiaPublicKey) (modules.RenterContract, bool)
@@ -391,8 +391,10 @@ func (r *Renter) EstimateHostScore(e modules.HostDBEntry) modules.HostScoreBreak
 // Contracts returns an array of host contractor's active contracts
 func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
 
-// OldContracts returns an array of host contractor's old contracts
-func (r *Renter) OldContracts() []modules.RenterContract { return r.hostContractor.OldContracts() }
+// ExpiredContracts returns an array of host contractor's expired contracts
+func (r *Renter) ExpiredContracts() []modules.RenterContract {
+	return r.hostContractor.ExpiredContracts()
+}
 
 // CurrentPeriod returns the host contractor's current period
 func (r *Renter) CurrentPeriod() types.BlockHeight { return r.hostContractor.CurrentPeriod() }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -110,10 +110,10 @@ type hostContractor interface {
 	// Close closes the hostContractor.
 	Close() error
 
-	// Contracts returns the active contracts formed by the contractor.
+	// Contracts returns the staticContracts of the renter's hostContractor.
 	Contracts() []modules.RenterContract
 
-	// OldContracts returns the Expired contracts formed by the contractor.
+	// OldContracts returns the oldContracts of the renter's hostContractor.
 	OldContracts() []modules.RenterContract
 
 	// ContractByPublicKey returns the contract associated with the host key.
@@ -388,10 +388,10 @@ func (r *Renter) EstimateHostScore(e modules.HostDBEntry) modules.HostScoreBreak
 	return r.hostDB.EstimateHostScore(e)
 }
 
-// Contracts returns an array of host contractor's active contracts
+// Contracts returns an array of host contractor's staticContracts
 func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
 
-// OldContracts returns an array of host contractor's expired contracts
+// OldContracts returns an array of host contractor's oldContracts
 func (r *Renter) OldContracts() []modules.RenterContract {
 	return r.hostContractor.OldContracts()
 }

--- a/modules/renter/renter.go
+++ b/modules/renter/renter.go
@@ -113,8 +113,8 @@ type hostContractor interface {
 	// Contracts returns the active contracts formed by the contractor.
 	Contracts() []modules.RenterContract
 
-	// Expired Contracts returns the Expired contracts formed by the contractor.
-	ExpiredContracts() []modules.RenterContract
+	// OldContracts returns the Expired contracts formed by the contractor.
+	OldContracts() []modules.RenterContract
 
 	// ContractByPublicKey returns the contract associated with the host key.
 	ContractByPublicKey(types.SiaPublicKey) (modules.RenterContract, bool)
@@ -391,9 +391,9 @@ func (r *Renter) EstimateHostScore(e modules.HostDBEntry) modules.HostScoreBreak
 // Contracts returns an array of host contractor's active contracts
 func (r *Renter) Contracts() []modules.RenterContract { return r.hostContractor.Contracts() }
 
-// ExpiredContracts returns an array of host contractor's expired contracts
-func (r *Renter) ExpiredContracts() []modules.RenterContract {
-	return r.hostContractor.ExpiredContracts()
+// OldContracts returns an array of host contractor's expired contracts
+func (r *Renter) OldContracts() []modules.RenterContract {
+	return r.hostContractor.OldContracts()
 }
 
 // CurrentPeriod returns the host contractor's current period

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -18,16 +18,16 @@ func (c *Client) RenterContractsGet() (rc api.RenterContracts, err error) {
 	return
 }
 
-// RenterInactiveContractsGet requests the /renter/contracts resource and returns
-// the inactive contracts
+// RenterInactiveContractsGet requests the /renter/contracts resource with the
+// inactive flag set to true
 func (c *Client) RenterInactiveContractsGet() (rc api.RenterContracts, err error) {
 	query := fmt.Sprintf("?inactive=%v", true)
 	err = c.get("/renter/contracts"+query, &rc)
 	return
 }
 
-// RenterExpiredContractsGet requests the /renter/contracts resource and returns
-// the expired contracts
+// RenterExpiredContractsGet requests the /renter/contracts resource with the
+// expired flag set to true
 func (c *Client) RenterExpiredContractsGet() (rc api.RenterContracts, err error) {
 	query := fmt.Sprintf("?expired=%v", true)
 	err = c.get("/renter/contracts"+query, &rc)

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -11,9 +11,34 @@ import (
 	"github.com/NebulousLabs/Sia/node/api"
 )
 
-// RenterContractsGet requests the /renter/contracts resource
-func (c *Client) RenterContractsGet(expired bool) (rc api.RenterContracts, err error) {
-	query := fmt.Sprintf("?expired=%v", expired)
+// RenterContractsGet requests the /renter/contracts resource and returns all
+// contracts
+func (c *Client) RenterContractsGet() (rc api.RenterContracts, err error) {
+	query := fmt.Sprintf("?all=%v", true)
+	err = c.get("/renter/contracts"+query, &rc)
+	return
+}
+
+// RenterActiveContractsGet requests the /renter/contracts resource and returns
+// the active contracts
+func (c *Client) RenterActiveContractsGet() (rc api.RenterContracts, err error) {
+	query := fmt.Sprintf("?active=%v", true)
+	err = c.get("/renter/contracts"+query, &rc)
+	return
+}
+
+// RenterInactiveContractsGet requests the /renter/contracts resource and returns
+// the inactive contracts
+func (c *Client) RenterInactiveContractsGet() (rc api.RenterContracts, err error) {
+	query := fmt.Sprintf("?inactive=%v", true)
+	err = c.get("/renter/contracts"+query, &rc)
+	return
+}
+
+// RenterExpiredContractsGet requests the /renter/contracts resource and returns
+// the expired contracts
+func (c *Client) RenterExpiredContractsGet() (rc api.RenterContracts, err error) {
+	query := fmt.Sprintf("?expired=%v", true)
 	err = c.get("/renter/contracts"+query, &rc)
 	return
 }

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -12,8 +12,9 @@ import (
 )
 
 // RenterContractsGet requests the /renter/contracts resource
-func (c *Client) RenterContractsGet() (rc api.RenterContracts, err error) {
-	err = c.get("/renter/contracts", &rc)
+func (c *Client) RenterContractsGet(expired bool) (rc api.RenterContracts, err error) {
+	query := fmt.Sprintf("?expired=%v", expired)
+	err = c.get("/renter/contracts"+query, &rc)
 	return
 }
 

--- a/node/api/client/renter.go
+++ b/node/api/client/renter.go
@@ -11,19 +11,10 @@ import (
 	"github.com/NebulousLabs/Sia/node/api"
 )
 
-// RenterContractsGet requests the /renter/contracts resource and returns all
-// contracts
+// RenterContractsGet requests the /renter/contracts resource and returns
+// Contracts and ActiveContracts
 func (c *Client) RenterContractsGet() (rc api.RenterContracts, err error) {
-	query := fmt.Sprintf("?all=%v", true)
-	err = c.get("/renter/contracts"+query, &rc)
-	return
-}
-
-// RenterActiveContractsGet requests the /renter/contracts resource and returns
-// the active contracts
-func (c *Client) RenterActiveContractsGet() (rc api.RenterContracts, err error) {
-	query := fmt.Sprintf("?active=%v", true)
-	err = c.get("/renter/contracts"+query, &rc)
+	err = c.get("/renter/contracts", &rc)
 	return
 }
 

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -115,8 +115,8 @@ type (
 
 	// RenterContracts contains the renter's contracts.
 	RenterContracts struct {
-		Contracts    []RenterContract `json:"contracts"`
-		OldContracts []RenterContract `json:"oldcontracts"`
+		Contracts        []RenterContract `json:"contracts"`
+		ExpiredContracts []RenterContract `json:"expiredcontracts"`
 	}
 
 	// RenterDownloadQueue contains the renter's download queue.
@@ -316,8 +316,8 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 			UploadSpending:            c.UploadSpending,
 		})
 	}
-	oldContracts := []RenterContract{}
-	for _, c := range api.renter.OldContracts() {
+	expiredContracts := []RenterContract{}
+	for _, c := range api.renter.ExpiredContracts() {
 		var size uint64
 		if len(c.Transaction.FileContractRevisions) != 0 {
 			size = c.Transaction.FileContractRevisions[0].NewFileSize
@@ -338,7 +338,7 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 			goodForRenew = utility.GoodForRenew
 		}
 
-		oldContracts = append(oldContracts, RenterContract{
+		expiredContracts = append(expiredContracts, RenterContract{
 			DownloadSpending:          c.DownloadSpending,
 			EndHeight:                 c.EndHeight,
 			Fees:                      c.TxnFee.Add(c.SiafundFee).Add(c.ContractFee),
@@ -358,8 +358,8 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 		})
 	}
 	WriteJSON(w, RenterContracts{
-		Contracts:    contracts,
-		OldContracts: oldContracts,
+		Contracts:        contracts,
+		ExpiredContracts: expiredContracts,
 	})
 }
 

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -272,7 +272,17 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 	WriteSuccess(w)
 }
 
-// renterContractsHandler handles the API call to request the Renter's contracts.
+// renterContractsHandler handles the API call to request the Renter's
+// contracts.
+//
+// Active contracts are contracts that the renter is actively using to store
+// data and can upload, download, and renew
+//
+// Inactive contracts are contracts that are not currently being used by the
+// renter because they are either !goodForUpload or !goodForRenew, but have
+// endheights that are in the future so could potentially become active again
+//
+// Expired contracts are contracts who's endheights are in the past
 func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	// Parse flags
 	active, err := scanBool(req.FormValue("active"))

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -387,7 +387,7 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request,
 			}
 			if expired && (c.EndHeight <= currentPeriod || currentPeriod == 0) {
 				contracts = append(contracts, contract)
-			} else if inactive && c.EndHeight > currentPeriod {
+			} else if inactive && c.EndHeight > currentPeriod && currentPeriod != 0 {
 				contracts = append(contracts, contract)
 			} else if all {
 				contracts = append(contracts, contract)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -335,9 +335,9 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request,
 			TotalCost:                 c.TotalCost,
 			UploadSpending:            c.UploadSpending,
 		}
-		if active && goodForRenew && goodForUpload && c.StartHeight >= currentPeriod {
+		if active && goodForRenew && goodForUpload && c.EndHeight > currentPeriod {
 			contracts = append(contracts, contract)
-		} else if inactive && (!goodForRenew || !goodForUpload) && c.StartHeight >= currentPeriod {
+		} else if inactive && (!goodForRenew || !goodForUpload) && c.EndHeight > currentPeriod {
 			contracts = append(contracts, contract)
 		} else if all {
 			contracts = append(contracts, contract)
@@ -385,9 +385,9 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request,
 				TotalCost:                 c.TotalCost,
 				UploadSpending:            c.UploadSpending,
 			}
-			if expired && c.EndHeight <= currentPeriod {
+			if expired && (c.EndHeight <= currentPeriod || currentPeriod == 0) {
 				contracts = append(contracts, contract)
-			} else if inactive && (!goodForRenew || !goodForUpload) && c.StartHeight >= currentPeriod {
+			} else if inactive && c.EndHeight > currentPeriod {
 				contracts = append(contracts, contract)
 			} else if all {
 				contracts = append(contracts, contract)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -274,7 +274,15 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 }
 
 // renterContractsHandler handles the API call to request the Renter's contracts.
-func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	// Parse the expired parameter.
+	expiredparam := req.FormValue("expired")
+	expiredresp, err := scanBool(expiredparam)
+	if err != nil {
+		return
+	}
+
+	// Get active contracts
 	contracts := []RenterContract{}
 	for _, c := range api.renter.Contracts() {
 		var size uint64
@@ -316,46 +324,50 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, _ *http.Request, _
 			UploadSpending:            c.UploadSpending,
 		})
 	}
+
+	// Get expired contracts
 	expiredContracts := []RenterContract{}
-	for _, c := range api.renter.ExpiredContracts() {
-		var size uint64
-		if len(c.Transaction.FileContractRevisions) != 0 {
-			size = c.Transaction.FileContractRevisions[0].NewFileSize
-		}
+	if expiredresp {
+		for _, c := range api.renter.ExpiredContracts() {
+			var size uint64
+			if len(c.Transaction.FileContractRevisions) != 0 {
+				size = c.Transaction.FileContractRevisions[0].NewFileSize
+			}
 
-		// Fetch host address
-		var netAddress modules.NetAddress
-		hdbe, exists := api.renter.Host(c.HostPublicKey)
-		if exists {
-			netAddress = hdbe.NetAddress
-		}
+			// Fetch host address
+			var netAddress modules.NetAddress
+			hdbe, exists := api.renter.Host(c.HostPublicKey)
+			if exists {
+				netAddress = hdbe.NetAddress
+			}
 
-		// Fetch utilities for contract
-		var goodForUpload bool
-		var goodForRenew bool
-		if utility, ok := api.renter.ContractUtility(c.HostPublicKey); ok {
-			goodForUpload = utility.GoodForUpload
-			goodForRenew = utility.GoodForRenew
-		}
+			// Fetch utilities for contract
+			var goodForUpload bool
+			var goodForRenew bool
+			if utility, ok := api.renter.ContractUtility(c.HostPublicKey); ok {
+				goodForUpload = utility.GoodForUpload
+				goodForRenew = utility.GoodForRenew
+			}
 
-		expiredContracts = append(expiredContracts, RenterContract{
-			DownloadSpending:          c.DownloadSpending,
-			EndHeight:                 c.EndHeight,
-			Fees:                      c.TxnFee.Add(c.SiafundFee).Add(c.ContractFee),
-			GoodForUpload:             goodForUpload,
-			GoodForRenew:              goodForRenew,
-			HostPublicKey:             c.HostPublicKey,
-			ID:                        c.ID,
-			LastTransaction:           c.Transaction,
-			NetAddress:                netAddress,
-			RenterFunds:               c.RenterFunds,
-			Size:                      size,
-			StartHeight:               c.StartHeight,
-			StorageSpending:           c.StorageSpending,
-			StorageSpendingDeprecated: c.StorageSpending,
-			TotalCost:                 c.TotalCost,
-			UploadSpending:            c.UploadSpending,
-		})
+			expiredContracts = append(expiredContracts, RenterContract{
+				DownloadSpending:          c.DownloadSpending,
+				EndHeight:                 c.EndHeight,
+				Fees:                      c.TxnFee.Add(c.SiafundFee).Add(c.ContractFee),
+				GoodForUpload:             goodForUpload,
+				GoodForRenew:              goodForRenew,
+				HostPublicKey:             c.HostPublicKey,
+				ID:                        c.ID,
+				LastTransaction:           c.Transaction,
+				NetAddress:                netAddress,
+				RenterFunds:               c.RenterFunds,
+				Size:                      size,
+				StartHeight:               c.StartHeight,
+				StorageSpending:           c.StorageSpending,
+				StorageSpendingDeprecated: c.StorageSpending,
+				TotalCost:                 c.TotalCost,
+				UploadSpending:            c.UploadSpending,
+			})
+		}
 	}
 	WriteJSON(w, RenterContracts{
 		Contracts:        contracts,

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -292,8 +292,8 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	// Get current period for reference
-	currentPeriod := api.renter.CurrentPeriod()
+	// Get current block height for reference
+	blockHeight := api.cs.Height()
 
 	// Get active contracts
 	contracts := []RenterContract{}
@@ -335,9 +335,9 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request,
 			TotalCost:                 c.TotalCost,
 			UploadSpending:            c.UploadSpending,
 		}
-		if active && goodForRenew && goodForUpload && c.EndHeight > currentPeriod {
+		if active && goodForRenew && goodForUpload {
 			contracts = append(contracts, contract)
-		} else if inactive && (!goodForRenew || !goodForUpload) && c.EndHeight > currentPeriod {
+		} else if inactive && (!goodForRenew || !goodForUpload) {
 			contracts = append(contracts, contract)
 		} else if all {
 			contracts = append(contracts, contract)
@@ -385,9 +385,9 @@ func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request,
 				TotalCost:                 c.TotalCost,
 				UploadSpending:            c.UploadSpending,
 			}
-			if expired && (c.EndHeight <= currentPeriod || currentPeriod == 0) {
+			if expired && c.EndHeight < blockHeight {
 				contracts = append(contracts, contract)
-			} else if inactive && c.EndHeight > currentPeriod && currentPeriod != 0 {
+			} else if inactive && c.EndHeight >= blockHeight {
 				contracts = append(contracts, contract)
 			} else if all {
 				contracts = append(contracts, contract)

--- a/node/api/renter.go
+++ b/node/api/renter.go
@@ -282,8 +282,8 @@ func (api *API) renterHandlerPOST(w http.ResponseWriter, req *http.Request, _ ht
 // data and can upload, download, and renew
 //
 // Inactive contracts are contracts that are not currently being used by the
-// renter because they are either !goodForUpload or !goodForRenew, but have
-// endheights that are in the future so could potentially become active again
+// renter because they are !goodForRenew, but have endheights that are in the
+// future so could potentially become active again
 //
 // Expired contracts are contracts who's endheights are in the past
 func (api *API) renterContractsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -2636,6 +2636,9 @@ func renewContractsByRenewWindow(renter *siatest.TestNode, tg *siatest.TestGroup
 
 // renewContractsBySpending uploads files until the contracts renew due to
 // running out of funds
+//
+// NOTE: this function only guarantee that one contract will be renewed due to
+// spending
 func renewContractsBySpending(renter *siatest.TestNode, tg *siatest.TestGroup) (startingUploadSpend types.Currency, err error) {
 	// Renew contracts by running out of funds
 	// Set upload price to max price

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1466,29 +1466,29 @@ func checkBalanceVsSpending(r *siatest.TestNode, initialBalance types.Currency) 
 }
 
 // checkContracts confirms that contracts are renewed as expected
-func checkContracts(numHosts, numRenewals int, ExpiredContracts, renewedContracts []api.RenterContract) error {
+func checkContracts(numHosts, numRenewals int, expiredContracts, renewedContracts []api.RenterContract) error {
 	if len(renewedContracts) != numHosts {
 		err := fmt.Sprintf("Incorrect number of Active contracts: have %v expected %v", len(renewedContracts), numHosts)
 		return errors.New(err)
 	}
-	if len(ExpiredContracts) == 0 && numRenewals == 0 {
+	if len(expiredContracts) == 0 && numRenewals == 0 {
 		return nil
 	}
 	// Confirm contracts were renewed, this will also mean there are old contracts
-	// Verify there are not more renewedContracts than there are ExpiredContracts
+	// Verify there are not more renewedContracts than there are expiredContracts
 	// This would mean contracts are not getting archived
-	if len(ExpiredContracts) < len(renewedContracts) {
+	if len(expiredContracts) < len(renewedContracts) {
 		return errors.New("Too many renewed contracts")
 	}
-	if len(ExpiredContracts) != numHosts*numRenewals {
-		err := fmt.Sprintf("Incorrect number of Old contracts: have %v expected %v", len(ExpiredContracts), numHosts*numRenewals)
+	if len(expiredContracts) != numHosts*numRenewals {
+		err := fmt.Sprintf("Incorrect number of Old contracts: have %v expected %v", len(expiredContracts), numHosts*numRenewals)
 		return errors.New(err)
 	}
 
 	// Create Maps for comparison
 	initialContractIDMap := make(map[types.FileContractID]struct{})
 	initialContractKeyMap := make(map[crypto.Hash]struct{})
-	for _, c := range ExpiredContracts {
+	for _, c := range expiredContracts {
 		initialContractIDMap[c.ID] = struct{}{}
 		initialContractKeyMap[crypto.HashBytes(c.HostPublicKey.Key)] = struct{}{}
 	}
@@ -1498,12 +1498,12 @@ func checkContracts(numHosts, numRenewals int, ExpiredContracts, renewedContract
 		// were renewed
 		if c.GoodForRenew {
 			if _, ok := initialContractIDMap[c.ID]; ok {
-				return errors.New("ID from renewedContracts found in ExpiredContracts")
+				return errors.New("ID from renewedContracts found in expiredContracts")
 			}
 			// Verifying that Renewed Contracts have the same HostPublicKey
 			// as an initial contract
 			if _, ok := initialContractKeyMap[crypto.HashBytes(c.HostPublicKey.Key)]; !ok {
-				return errors.New("Host Public Key from renewedContracts not found in ExpiredContracts")
+				return errors.New("Host Public Key from renewedContracts not found in expiredContracts")
 			}
 		}
 	}
@@ -1529,7 +1529,7 @@ func checkRenewedContracts(renewedContracts []api.RenterContract) error {
 
 // checkContractVsReportedSpending confirms that the spending recorded in
 // the renter's contracts matches the reported spending for the renter
-func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.BlockHeight, ExpiredContracts, renewedContracts []api.RenterContract) error {
+func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.BlockHeight, expiredContracts, renewedContracts []api.RenterContract) error {
 	// Get Current BlockHeight
 	cg, err := r.ConsensusGet()
 	if err != nil {
@@ -1560,7 +1560,7 @@ func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.Block
 
 	// Check renter financial metrics against contract spending
 	var spending modules.ContractorSpending
-	for _, contract := range ExpiredContracts {
+	for _, contract := range expiredContracts {
 		if contract.StartHeight >= rg.CurrentPeriod {
 			// Calculate ContractFees
 			spending.ContractFees = spending.ContractFees.Add(contract.Fees)
@@ -2122,10 +2122,10 @@ func TestRenterExpiredContracts(t *testing.T) {
 	}
 
 	// Record old contracts and current contracts that are good for renew
-	ExpiredContracts := rc.ExpiredContracts
+	expiredContracts := rc.ExpiredContracts
 	for _, c := range rc.Contracts {
 		if c.GoodForRenew {
-			ExpiredContracts = append(ExpiredContracts, c)
+			expiredContracts = append(expiredContracts, c)
 		}
 	}
 
@@ -2147,13 +2147,13 @@ func TestRenterExpiredContracts(t *testing.T) {
 			return errors.AddContext(err, "could not get contracts")
 		}
 		// Check ExpiredContracts against recorded old contracts
-		if len(ExpiredContracts) != len(rc.ExpiredContracts) {
-			return errors.New(fmt.Sprintf("Number of old contracts don't match, expected %v got %v", len(ExpiredContracts), len(rc.ExpiredContracts)))
+		if len(expiredContracts) != len(rc.ExpiredContracts) {
+			return errors.New(fmt.Sprintf("Number of old contracts don't match, expected %v got %v", len(expiredContracts), len(rc.ExpiredContracts)))
 		}
 
 		// Create Maps for comparison
 		initialContractIDMap := make(map[types.FileContractID]struct{})
-		for _, c := range ExpiredContracts {
+		for _, c := range expiredContracts {
 			initialContractIDMap[c.ID] = struct{}{}
 		}
 
@@ -2161,7 +2161,7 @@ func TestRenterExpiredContracts(t *testing.T) {
 			// Verify that all the contracts marked as GoodForRenew
 			// were renewed
 			if _, ok := initialContractIDMap[c.ID]; !ok {
-				return errors.New("ID from rc.ExpiredContracts not found in ExpiredContracts")
+				return errors.New("ID from rc.ExpiredContracts not found in expiredContracts")
 			}
 		}
 		return nil

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -943,7 +943,7 @@ func TestRenterContractEndHeight(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.OldContracts, rc.Contracts); err != nil {
+		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
 			return err
 		}
 		return nil
@@ -975,7 +975,7 @@ func TestRenterContractEndHeight(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.OldContracts, rc.Contracts); err != nil {
+		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
 			return err
 		}
 		if err = checkRenewedContracts(rc.Contracts); err != nil {
@@ -1097,7 +1097,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.OldContracts, rc.Contracts); err != nil {
+		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
 			return err
 		}
 		return nil
@@ -1169,7 +1169,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.OldContracts, rc.Contracts); err != nil {
+		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
 			return err
 		}
 		if err = checkRenewedContracts(rc.Contracts); err != nil {
@@ -1197,7 +1197,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
-	if err = checkContractVsReportedSpending(r, windowSize, rc.OldContracts, rc.Contracts); err != nil {
+	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1258,7 +1258,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "Could not get contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.OldContracts, rc.Contracts); err != nil {
+		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
 			return err
 		}
 		if err = checkRenewedContracts(rc.Contracts); err != nil {
@@ -1285,7 +1285,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
-	if err = checkContractVsReportedSpending(r, windowSize, rc.OldContracts, rc.Contracts); err != nil {
+	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1325,7 +1325,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "Could not get contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.OldContracts, rc.Contracts); err != nil {
+		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
 			return err
 		}
 		if err = checkRenewedContracts(rc.Contracts); err != nil {
@@ -1353,7 +1353,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		t.Fatal("Could not get contracts:", err)
 	}
 
-	if err = checkContractVsReportedSpending(r, windowSize, rc.OldContracts, rc.Contracts); err != nil {
+	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1382,7 +1382,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.OldContracts, rc.Contracts); err != nil {
+		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
 			return err
 		}
 		if err = checkRenewedContracts(rc.Contracts); err != nil {
@@ -1409,7 +1409,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
-	if err = checkContractVsReportedSpending(r, windowSize, rc.OldContracts, rc.Contracts); err != nil {
+	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1466,29 +1466,29 @@ func checkBalanceVsSpending(r *siatest.TestNode, initialBalance types.Currency) 
 }
 
 // checkContracts confirms that contracts are renewed as expected
-func checkContracts(numHosts, numRenewals int, oldContracts, renewedContracts []api.RenterContract) error {
+func checkContracts(numHosts, numRenewals int, ExpiredContracts, renewedContracts []api.RenterContract) error {
 	if len(renewedContracts) != numHosts {
 		err := fmt.Sprintf("Incorrect number of Active contracts: have %v expected %v", len(renewedContracts), numHosts)
 		return errors.New(err)
 	}
-	if len(oldContracts) == 0 && numRenewals == 0 {
+	if len(ExpiredContracts) == 0 && numRenewals == 0 {
 		return nil
 	}
 	// Confirm contracts were renewed, this will also mean there are old contracts
-	// Verify there are not more renewedContracts than there are oldContracts
+	// Verify there are not more renewedContracts than there are ExpiredContracts
 	// This would mean contracts are not getting archived
-	if len(oldContracts) < len(renewedContracts) {
+	if len(ExpiredContracts) < len(renewedContracts) {
 		return errors.New("Too many renewed contracts")
 	}
-	if len(oldContracts) != numHosts*numRenewals {
-		err := fmt.Sprintf("Incorrect number of Old contracts: have %v expected %v", len(oldContracts), numHosts*numRenewals)
+	if len(ExpiredContracts) != numHosts*numRenewals {
+		err := fmt.Sprintf("Incorrect number of Old contracts: have %v expected %v", len(ExpiredContracts), numHosts*numRenewals)
 		return errors.New(err)
 	}
 
 	// Create Maps for comparison
 	initialContractIDMap := make(map[types.FileContractID]struct{})
 	initialContractKeyMap := make(map[crypto.Hash]struct{})
-	for _, c := range oldContracts {
+	for _, c := range ExpiredContracts {
 		initialContractIDMap[c.ID] = struct{}{}
 		initialContractKeyMap[crypto.HashBytes(c.HostPublicKey.Key)] = struct{}{}
 	}
@@ -1498,12 +1498,12 @@ func checkContracts(numHosts, numRenewals int, oldContracts, renewedContracts []
 		// were renewed
 		if c.GoodForRenew {
 			if _, ok := initialContractIDMap[c.ID]; ok {
-				return errors.New("ID from renewedContracts found in oldContracts")
+				return errors.New("ID from renewedContracts found in ExpiredContracts")
 			}
 			// Verifying that Renewed Contracts have the same HostPublicKey
 			// as an initial contract
 			if _, ok := initialContractKeyMap[crypto.HashBytes(c.HostPublicKey.Key)]; !ok {
-				return errors.New("Host Public Key from renewedContracts not found in oldContracts")
+				return errors.New("Host Public Key from renewedContracts not found in ExpiredContracts")
 			}
 		}
 	}
@@ -1529,7 +1529,7 @@ func checkRenewedContracts(renewedContracts []api.RenterContract) error {
 
 // checkContractVsReportedSpending confirms that the spending recorded in
 // the renter's contracts matches the reported spending for the renter
-func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.BlockHeight, oldContracts, renewedContracts []api.RenterContract) error {
+func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.BlockHeight, ExpiredContracts, renewedContracts []api.RenterContract) error {
 	// Get Current BlockHeight
 	cg, err := r.ConsensusGet()
 	if err != nil {
@@ -1560,7 +1560,7 @@ func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.Block
 
 	// Check renter financial metrics against contract spending
 	var spending modules.ContractorSpending
-	for _, contract := range oldContracts {
+	for _, contract := range ExpiredContracts {
 		if contract.StartHeight >= rg.CurrentPeriod {
 			// Calculate ContractFees
 			spending.ContractFees = spending.ContractFees.Add(contract.Fees)
@@ -1574,8 +1574,8 @@ func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.Block
 			// Calculated funds that are being withheld in contracts
 			spending.WithheldFunds = spending.WithheldFunds.Add(contract.RenterFunds)
 			// Record the largest window size for worst case when reporting the spending
-			if WindowSize >= spending.ReleaseBlock {
-				spending.ReleaseBlock = WindowSize
+			if contract.EndHeight+WindowSize+types.MaturityDelay >= spending.ReleaseBlock {
+				spending.ReleaseBlock = contract.EndHeight + WindowSize + types.MaturityDelay
 			}
 			// Calculate Previous spending
 			spending.PreviousSpending = spending.PreviousSpending.Add(contract.Fees).
@@ -1728,11 +1728,11 @@ func renewContractsBySpending(renter *siatest.TestNode, tg *siatest.TestGroup) (
 		return types.ZeroCurrency, errors.AddContext(err, "could not get renter contracts")
 	}
 	startingUploadSpend = rc.Contracts[0].UploadSpending
-	numberOldContracts := len(rc.OldContracts)
+	numberExpiredContracts := len(rc.ExpiredContracts)
 
 	// Upload files to force contract renewal due to running out of funds
 LOOP:
-	for len(rc.OldContracts) == numberOldContracts {
+	for len(rc.ExpiredContracts) == numberExpiredContracts {
 		// To protect against contracts not renewing during uploads
 		for _, c := range rc.Contracts {
 			percentRemaining, _ := big.NewRat(0, 1).SetFrac(c.RenterFunds.Big(), c.TotalCost.Big()).Float64()
@@ -2091,8 +2091,8 @@ func TestRenterResetAllowance(t *testing.T) {
 	}
 }
 
-// TestRenterOldContracts tests the API endpoint for old contracts
-func TestRenterOldContracts(t *testing.T) {
+// TestRenterExpiredContracts tests the API endpoint for old contracts
+func TestRenterExpiredContracts(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -2122,10 +2122,10 @@ func TestRenterOldContracts(t *testing.T) {
 	}
 
 	// Record old contracts and current contracts that are good for renew
-	oldContracts := rc.OldContracts
+	ExpiredContracts := rc.ExpiredContracts
 	for _, c := range rc.Contracts {
 		if c.GoodForRenew {
-			oldContracts = append(oldContracts, c)
+			ExpiredContracts = append(ExpiredContracts, c)
 		}
 	}
 
@@ -2146,22 +2146,22 @@ func TestRenterOldContracts(t *testing.T) {
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
-		// Check OldContracts against recorded old contracts
-		if len(oldContracts) != len(rc.OldContracts) {
-			return errors.New(fmt.Sprintf("Number of old contracts don't match, expected %v got %v", len(oldContracts), len(rc.OldContracts)))
+		// Check ExpiredContracts against recorded old contracts
+		if len(ExpiredContracts) != len(rc.ExpiredContracts) {
+			return errors.New(fmt.Sprintf("Number of old contracts don't match, expected %v got %v", len(ExpiredContracts), len(rc.ExpiredContracts)))
 		}
 
 		// Create Maps for comparison
 		initialContractIDMap := make(map[types.FileContractID]struct{})
-		for _, c := range oldContracts {
+		for _, c := range ExpiredContracts {
 			initialContractIDMap[c.ID] = struct{}{}
 		}
 
-		for _, c := range rc.OldContracts {
+		for _, c := range rc.ExpiredContracts {
 			// Verify that all the contracts marked as GoodForRenew
 			// were renewed
 			if _, ok := initialContractIDMap[c.ID]; !ok {
-				return errors.New("ID from rc.OldContracts not found in oldContracts")
+				return errors.New("ID from rc.ExpiredContracts not found in ExpiredContracts")
 			}
 		}
 		return nil

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1383,7 +1383,7 @@ func TestRenterContractsEndpoint(t *testing.T) {
 	}
 	tg, err := siatest.NewGroupFromTemplate(groupParams)
 	if err != nil {
-		t.Fatal("Failed to get files")
+		t.Fatal("Failed to create group: ", err)
 	}
 	defer func() {
 		if err := tg.Close(); err != nil {
@@ -1727,8 +1727,8 @@ func TestRenterPersistData(t *testing.T) {
 	}
 }
 
-// TestRenterCancelAllowance tests that setting an empty allowance causes
-// uploads, downloads, and renewals to cease.
+// TestRenterResetAllowance tests that resetting the allowance after the
+// allowance was cancelled will trigger the correct contract formation.
 func TestRenterResetAllowance(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
@@ -1852,10 +1852,11 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 	renterParams := node.Renter(renterDir)
 	renterParams.SkipSetAllowance = true
-	_, err = tg.AddNodes(renterParams)
+	nodes, err := tg.AddNodes(renterParams)
 	if err != nil {
 		t.Fatal(err)
 	}
+	r := nodes[0]
 
 	// Get largest WindowSize from Hosts
 	var windowSize types.BlockHeight
@@ -1870,7 +1871,6 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Get renter's initial siacoin balance
-	r := tg.Renters()[0]
 	wg, err := r.WalletGet()
 	if err != nil {
 		t.Fatal("Failed to get wallet:", err)
@@ -2250,6 +2250,8 @@ func TestRenterSpendingReporting(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// The following are helper functions for the renter tests
 
 // checkBalanceVsSpending checks the renters confirmed siacoin balance in their
 // wallet against their reported spending

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -2533,7 +2533,7 @@ func renewContractsBySpending(renter *siatest.TestNode, tg *siatest.TestGroup) (
 	// Upload once to show upload spending
 	_, _, err = renter.UploadNewFileBlocking(int(chunkSize), dataPieces, parityPieces)
 	if err != nil {
-		return types.ZeroCurrency, errors.AddContext(err, "failed to upload a file for testing")
+		return types.ZeroCurrency, errors.AddContext(err, "failed to upload first file in renewContractsBySpending")
 	}
 
 	// Get current upload spend, previously contracts had zero upload spend
@@ -2555,7 +2555,9 @@ LOOP:
 		}
 		_, _, err = renter.UploadNewFileBlocking(int(chunkSize), dataPieces, parityPieces)
 		if err != nil {
-			return types.ZeroCurrency, errors.AddContext(err, "failed to upload a file for testing")
+			pr, _ := big.NewRat(0, 1).SetFrac(rc.ActiveContracts[0].RenterFunds.Big(), rc.ActiveContracts[0].TotalCost.Big()).Float64()
+			s := fmt.Sprintf("failed to upload file in renewContractsBySpending loop, percentRemaining: %v", pr)
+			return types.ZeroCurrency, errors.AddContext(err, s)
 		}
 
 		rc, err = renter.RenterContractsGet()

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -633,7 +633,7 @@ func TestRenewFailing(t *testing.T) {
 	renter := tg.Renters()[0]
 
 	// All the contracts of the renter should be goodForRenew.
-	rcg, err := renter.RenterContractsGet(false)
+	rcg, err := renter.RenterActiveContractsGet()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -687,7 +687,7 @@ func TestRenewFailing(t *testing.T) {
 	}
 
 	// contracts should still be goodForRenew.
-	rcg, err = renter.RenterContractsGet(false)
+	rcg, err = renter.RenterActiveContractsGet()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -710,7 +710,7 @@ func TestRenewFailing(t *testing.T) {
 	replaced := false
 	err = build.Retry(int(rcg.Contracts[0].EndHeight-blockHeight), 5*time.Second, func() error {
 		// contract should be !goodForRenew now.
-		rcg, err = renter.RenterContractsGet(false)
+		rcg, err = renter.RenterActiveContractsGet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1898,7 +1898,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 	// Give it some time to mark the contracts as !goodForUpload and
 	// !goodForRenew.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet(false)
+		rc, err := renter.RenterActiveContractsGet()
 		if err != nil {
 			return err
 		}
@@ -1964,7 +1964,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 
 	// All contracts should be archived.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet(false)
+		rc, err := renter.RenterActiveContractsGet()
 		if err != nil {
 			return err
 		}
@@ -2032,7 +2032,7 @@ func TestRenterResetAllowance(t *testing.T) {
 	// Give it some time to mark the contracts as !goodForUpload and
 	// !goodForRenew.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet(false)
+		rc, err := renter.RenterActiveContractsGet()
 		if err != nil {
 			return err
 		}
@@ -2067,7 +2067,7 @@ func TestRenterResetAllowance(t *testing.T) {
 	// Give it some time to mark the contracts as goodForUpload and
 	// goodForRenew again.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet(false)
+		rc, err := renter.RenterActiveContractsGet()
 		if err != nil {
 			return err
 		}

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -1107,11 +1107,19 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were created as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := r.RenterContractsGet(true)
+		rcActive, err := r.RenterActiveContractsGet()
 		if err != nil {
-			return errors.AddContext(err, "could not get contracts")
+			return errors.AddContext(err, "could not get active contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
+		rcInactive, err := r.RenterInactiveContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get Inactive contracts")
+		}
+		rcExpired, err := r.RenterExpiredContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get expired contracts")
+		}
+		if err = checkContracts(len(tg.Hosts()), numRenewals, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 			return err
 		}
 		return nil
@@ -1152,12 +1160,6 @@ func TestRenterSpendingReporting(t *testing.T) {
 		}
 	}
 
-	// Get initial Contracts to check for contract renewal later
-	rc, err := r.RenterContractsGet(true)
-	if err != nil {
-		t.Fatal("Could not get contracts:", err)
-	}
-
 	// Check to confirm upload and download spending was captured correctly
 	// and reflected in the wallet balance
 	err = build.Retry(600, 100*time.Millisecond, func() error {
@@ -1179,14 +1181,22 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet(true)
+		rcActive, err := r.RenterActiveContractsGet()
 		if err != nil {
-			return errors.AddContext(err, "could not get contracts")
+			return errors.AddContext(err, "could not get active contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
+		rcInactive, err := r.RenterInactiveContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get Inactive contracts")
+		}
+		rcExpired, err := r.RenterExpiredContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get expired contracts")
+		}
+		if err = checkContracts(len(tg.Hosts()), numRenewals, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 			return err
 		}
-		if err = checkRenewedContracts(rc.Contracts); err != nil {
+		if err = checkRenewedContracts(rcActive.Contracts); err != nil {
 			return err
 		}
 		return nil
@@ -1207,11 +1217,19 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet(true)
+	rcActive, err := r.RenterActiveContractsGet()
 	if err != nil {
-		t.Fatal("Could not get contracts:", err)
+		t.Fatal(err)
 	}
-	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
+	rcInactive, err := r.RenterInactiveContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcExpired, err := r.RenterExpiredContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = checkContractVsReportedSpending(r, windowSize, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1238,7 +1256,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	// Mine blocks to force contract renewal and new period
 	cg, _ := r.ConsensusGet()
 	blockHeight := cg.Height
-	endHeight := rc.Contracts[0].EndHeight
+	endHeight := rcActive.Contracts[0].EndHeight
 	rg, err := r.RenterGet()
 	if err != nil {
 		t.Fatal("Failed to get renter:", err)
@@ -1268,14 +1286,22 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet(true)
+		rcActive, err := r.RenterActiveContractsGet()
 		if err != nil {
-			return errors.AddContext(err, "Could not get contracts")
+			return errors.AddContext(err, "could not get active contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
+		rcInactive, err := r.RenterInactiveContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get Inactive contracts")
+		}
+		rcExpired, err := r.RenterExpiredContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get expired contracts")
+		}
+		if err = checkContracts(len(tg.Hosts()), numRenewals, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 			return err
 		}
-		if err = checkRenewedContracts(rc.Contracts); err != nil {
+		if err = checkRenewedContracts(rcActive.Contracts); err != nil {
 			return err
 		}
 		return nil
@@ -1295,11 +1321,19 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet(true)
+	rcActive, err = r.RenterActiveContractsGet()
 	if err != nil {
-		t.Fatal("Could not get contracts:", err)
+		t.Fatal(err)
 	}
-	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
+	rcInactive, err = r.RenterInactiveContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcExpired, err = r.RenterExpiredContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = checkContractVsReportedSpending(r, windowSize, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1335,14 +1369,22 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet(true)
+		rcActive, err := r.RenterActiveContractsGet()
 		if err != nil {
-			return errors.AddContext(err, "Could not get contracts")
+			return errors.AddContext(err, "could not get active contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
+		rcInactive, err := r.RenterInactiveContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get Inactive contracts")
+		}
+		rcExpired, err := r.RenterExpiredContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get expired contracts")
+		}
+		if err = checkContracts(len(tg.Hosts()), numRenewals, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 			return err
 		}
-		if err = checkRenewedContracts(rc.Contracts); err != nil {
+		if err = checkRenewedContracts(rcActive.Contracts); err != nil {
 			return err
 		}
 		return nil
@@ -1362,12 +1404,19 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet(true)
+	rcActive, err = r.RenterActiveContractsGet()
 	if err != nil {
-		t.Fatal("Could not get contracts:", err)
+		t.Fatal(err)
 	}
-
-	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
+	rcInactive, err = r.RenterInactiveContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcExpired, err = r.RenterExpiredContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = checkContractVsReportedSpending(r, windowSize, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1392,14 +1441,22 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet(true)
+		rcActive, err := r.RenterActiveContractsGet()
 		if err != nil {
-			return errors.AddContext(err, "could not get contracts")
+			return errors.AddContext(err, "could not get active contracts")
 		}
-		if err = checkContracts(len(tg.Hosts()), numRenewals, rc.ExpiredContracts, rc.Contracts); err != nil {
+		rcInactive, err := r.RenterInactiveContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get Inactive contracts")
+		}
+		rcExpired, err := r.RenterExpiredContractsGet()
+		if err != nil {
+			return errors.AddContext(err, "could not get expired contracts")
+		}
+		if err = checkContracts(len(tg.Hosts()), numRenewals, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 			return err
 		}
-		if err = checkRenewedContracts(rc.Contracts); err != nil {
+		if err = checkRenewedContracts(rcActive.Contracts); err != nil {
 			return err
 		}
 		return nil
@@ -1419,11 +1476,19 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet(true)
+	rcActive, err = r.RenterActiveContractsGet()
 	if err != nil {
-		t.Fatal("Could not get contracts:", err)
+		t.Fatal(err)
 	}
-	if err = checkContractVsReportedSpending(r, windowSize, rc.ExpiredContracts, rc.Contracts); err != nil {
+	rcInactive, err = r.RenterInactiveContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcExpired, err = r.RenterExpiredContractsGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = checkContractVsReportedSpending(r, windowSize, append(rcInactive.Contracts, rcExpired.Contracts...), rcActive.Contracts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1479,30 +1544,32 @@ func checkBalanceVsSpending(r *siatest.TestNode, initialBalance types.Currency) 
 	return nil
 }
 
-// checkContracts confirms that contracts are renewed as expected
-func checkContracts(numHosts, numRenewals int, expiredContracts, renewedContracts []api.RenterContract) error {
+// checkContracts confirms that contracts are renewed as expected, renewed
+// contracts should be the renter's active contracts and oldContracts should be
+// the renter's inactive and expired contracts
+func checkContracts(numHosts, numRenewals int, oldContracts, renewedContracts []api.RenterContract) error {
 	if len(renewedContracts) != numHosts {
 		err := fmt.Sprintf("Incorrect number of Active contracts: have %v expected %v", len(renewedContracts), numHosts)
 		return errors.New(err)
 	}
-	if len(expiredContracts) == 0 && numRenewals == 0 {
+	if len(oldContracts) == 0 && numRenewals == 0 {
 		return nil
 	}
 	// Confirm contracts were renewed, this will also mean there are old contracts
-	// Verify there are not more renewedContracts than there are expiredContracts
+	// Verify there are not more renewedContracts than there are oldContracts
 	// This would mean contracts are not getting archived
-	if len(expiredContracts) < len(renewedContracts) {
+	if len(oldContracts) < len(renewedContracts) {
 		return errors.New("Too many renewed contracts")
 	}
-	if len(expiredContracts) != numHosts*numRenewals {
-		err := fmt.Sprintf("Incorrect number of Old contracts: have %v expected %v", len(expiredContracts), numHosts*numRenewals)
+	if len(oldContracts) != numHosts*numRenewals {
+		err := fmt.Sprintf("Incorrect number of Old contracts: have %v expected %v", len(oldContracts), numHosts*numRenewals)
 		return errors.New(err)
 	}
 
 	// Create Maps for comparison
 	initialContractIDMap := make(map[types.FileContractID]struct{})
 	initialContractKeyMap := make(map[crypto.Hash]struct{})
-	for _, c := range expiredContracts {
+	for _, c := range oldContracts {
 		initialContractIDMap[c.ID] = struct{}{}
 		initialContractKeyMap[crypto.HashBytes(c.HostPublicKey.Key)] = struct{}{}
 	}
@@ -1510,40 +1577,39 @@ func checkContracts(numHosts, numRenewals int, expiredContracts, renewedContract
 	for _, c := range renewedContracts {
 		// Verify that all the contracts marked as GoodForRenew
 		// were renewed
-		if c.GoodForRenew {
-			if _, ok := initialContractIDMap[c.ID]; ok {
-				return errors.New("ID from renewedContracts found in expiredContracts")
-			}
-			// Verifying that Renewed Contracts have the same HostPublicKey
-			// as an initial contract
-			if _, ok := initialContractKeyMap[crypto.HashBytes(c.HostPublicKey.Key)]; !ok {
-				return errors.New("Host Public Key from renewedContracts not found in expiredContracts")
-			}
+		if _, ok := initialContractIDMap[c.ID]; ok {
+			return errors.New("ID from renewedContracts found in oldContracts")
+		}
+		// Verifying that Renewed Contracts have the same HostPublicKey
+		// as an initial contract
+		if _, ok := initialContractKeyMap[crypto.HashBytes(c.HostPublicKey.Key)]; !ok {
+			return errors.New("Host Public Key from renewedContracts not found in oldContracts")
 		}
 	}
 	return nil
 }
 
-// checkRenewedContracts confirms that renewed contracts have zero upload and download spending
+// checkRenewedContracts confirms that renewed contracts have zero upload and
+// download spending. Renewed contracts should be the renter's active contracts
 func checkRenewedContracts(renewedContracts []api.RenterContract) error {
 	for _, c := range renewedContracts {
-		if c.GoodForRenew {
-			if c.UploadSpending.Cmp(types.ZeroCurrency) != 0 && c.GoodForUpload {
-				err := fmt.Sprintf("Upload spending on renewed contract equal to %v, expected zero", c.UploadSpending.HumanString())
-				return errors.New(err)
-			}
-			if c.DownloadSpending.Cmp(types.ZeroCurrency) != 0 {
-				err := fmt.Sprintf("Download spending on renewed contract equal to %v, expected zero", c.DownloadSpending.HumanString())
-				return errors.New(err)
-			}
+		if c.UploadSpending.Cmp(types.ZeroCurrency) != 0 && c.GoodForUpload {
+			err := fmt.Sprintf("Upload spending on renewed contract equal to %v, expected zero", c.UploadSpending.HumanString())
+			return errors.New(err)
+		}
+		if c.DownloadSpending.Cmp(types.ZeroCurrency) != 0 {
+			err := fmt.Sprintf("Download spending on renewed contract equal to %v, expected zero", c.DownloadSpending.HumanString())
+			return errors.New(err)
 		}
 	}
 	return nil
 }
 
-// checkContractVsReportedSpending confirms that the spending recorded in
-// the renter's contracts matches the reported spending for the renter
-func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.BlockHeight, expiredContracts, renewedContracts []api.RenterContract) error {
+// checkContractVsReportedSpending confirms that the spending recorded in the
+// renter's contracts matches the reported spending for the renter. Renewed
+// contracts should be the renter's active contracts and oldContracts should be
+// the renter's inactive and expired contracts
+func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.BlockHeight, oldContracts, renewedContracts []api.RenterContract) error {
 	// Get Current BlockHeight
 	cg, err := r.ConsensusGet()
 	if err != nil {
@@ -1574,7 +1640,7 @@ func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.Block
 
 	// Check renter financial metrics against contract spending
 	var spending modules.ContractorSpending
-	for _, contract := range expiredContracts {
+	for _, contract := range oldContracts {
 		if contract.StartHeight >= rg.CurrentPeriod {
 			// Calculate ContractFees
 			spending.ContractFees = spending.ContractFees.Add(contract.Fees)
@@ -1682,6 +1748,9 @@ func checkContractVsReportedSpending(r *siatest.TestNode, WindowSize types.Block
 }
 
 // renewContractByRenewWindow mines blocks to force contract renewal
+//
+// TODO: remove excess tg.Sync() calls in the test since it is called in this
+// function
 func renewContractsByRenewWindow(renter *siatest.TestNode, tg *siatest.TestGroup) error {
 	rg, err := renter.RenterGet()
 	if err != nil {
@@ -1737,18 +1806,29 @@ func renewContractsBySpending(renter *siatest.TestNode, tg *siatest.TestGroup) (
 	}
 
 	// Get current upload spend, previously contracts had zero upload spend
-	rc, err := renter.RenterContractsGet(true)
+	rcActive, err := renter.RenterActiveContractsGet()
 	if err != nil {
-		return types.ZeroCurrency, errors.AddContext(err, "could not get renter contracts")
+		return types.ZeroCurrency, errors.AddContext(err, "could not get renter active contracts")
 	}
-	startingUploadSpend = rc.Contracts[0].UploadSpending
-	numberExpiredContracts := len(rc.ExpiredContracts)
+	rcInactive, err := renter.RenterInactiveContractsGet()
+	if err != nil {
+		return types.ZeroCurrency, errors.AddContext(err, "could not get renter inactive contracts")
+	}
+	rcExpired, err := renter.RenterExpiredContractsGet()
+	if err != nil {
+		return types.ZeroCurrency, errors.AddContext(err, "could not get renter expired contracts")
+	}
+	startingUploadSpend = rcActive.Contracts[0].UploadSpending
+	numberExpiredContracts := len(rcInactive.Contracts) + len(rcExpired.Contracts)
 
 	// Upload files to force contract renewal due to running out of funds
+	//
+	// TODO: Can the for loop condition be removed so only the internal break
+	// check is used.  This would save time by eliminating two API calls
 LOOP:
-	for len(rc.ExpiredContracts) == numberExpiredContracts {
+	for len(rcInactive.Contracts)+len(rcExpired.Contracts) == numberExpiredContracts {
 		// To protect against contracts not renewing during uploads
-		for _, c := range rc.Contracts {
+		for _, c := range rcActive.Contracts {
 			percentRemaining, _ := big.NewRat(0, 1).SetFrac(c.RenterFunds.Big(), c.TotalCost.Big()).Float64()
 			if percentRemaining < float64(0.03) {
 				break LOOP
@@ -1759,9 +1839,17 @@ LOOP:
 			return types.ZeroCurrency, errors.AddContext(err, "failed to upload a file for testing")
 		}
 
-		rc, err = renter.RenterContractsGet(true)
+		rcActive, err = renter.RenterActiveContractsGet()
 		if err != nil {
-			return types.ZeroCurrency, errors.AddContext(err, "could not get contracts")
+			return types.ZeroCurrency, errors.AddContext(err, "could not get renter active contracts")
+		}
+		rcInactive, err = renter.RenterInactiveContractsGet()
+		if err != nil {
+			return types.ZeroCurrency, errors.AddContext(err, "could not get renter inactive contracts")
+		}
+		rcExpired, err = renter.RenterExpiredContractsGet()
+		if err != nil {
+			return types.ZeroCurrency, errors.AddContext(err, "could not get renter expired contracts")
 		}
 	}
 	return startingUploadSpend, nil
@@ -2132,16 +2220,16 @@ func TestRenterContractsEndpoint(t *testing.T) {
 	r := tg.Renters()[0]
 
 	// Renter should only have active contracts
-	rcAll, err := RenterContractsGet()
+	rcAll, err := r.RenterContractsGet()
 	if err != nil {
 		t.Fatal(err)
 	}
-	rcActive, err := RenterActiveContractsGet()
+	rcActive, err := r.RenterActiveContractsGet()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(rcAll.Contracts) != len(rcActive.Contracts) {
-		t.Fatalf("Expected the same number for active and all contracts: %v for active and %v for all", len(rcActive), len(rcAll))
+		t.Fatalf("Expected the same number for active and all contracts: %v for active and %v for all", len(rcActive.Contracts), len(rcAll.Contracts))
 	}
 	// Create Maps for comparison
 	ContractIDMap := make(map[types.FileContractID]struct{})
@@ -2154,14 +2242,14 @@ func TestRenterContractsEndpoint(t *testing.T) {
 			t.Fatal("ID from rcActive found in rcAll")
 		}
 	}
-	rcInactive, err := RenterInactiveContractsGet()
+	rcInactive, err := r.RenterInactiveContractsGet()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(rcInactive.Contracts) != 0 {
 		t.Fatal("Expected zero inactive contracts, got", len(rcInactive.Contracts))
 	}
-	rcExpired, err := RenterExpiredContractsGet()
+	rcExpired, err := r.RenterExpiredContractsGet()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2230,7 +2318,7 @@ func TestRenterContractsEndpoint(t *testing.T) {
 
 	// Record current active and expired contracts
 	rcActive, err = r.RenterActiveContractsGet()
-	activeContacts := rcActive.Contracts
+	activeContracts := rcActive.Contracts
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2279,18 +2367,18 @@ func TestRenterContractsEndpoint(t *testing.T) {
 
 		// Check for the same number of contracts
 		if len(rcActive.Contracts) != len(rcExpired.Contracts) || len(rcActive.Contracts) != len(rcInactive.Contracts) {
-			err = fmt.Sprintf(`
+			errStr := fmt.Sprintf(`
 				Expected the same number of contracts, instead got:
 				Active:   %v
 				Inactive: %v
 				Expired:  %v
 				`, len(rcActive.Contracts), len(rcInactive.Contracts), len(rcExpired.Contracts))
-			return errors.New(err)
+			return errors.New(errStr)
 		}
 
 		// Confirm active and inactive contracts
-		if len(activeContacts) != len(rcInactive.Contracts) {
-			return errors.New(fmt.Sprintf("Didn't get expected number of inactive contracts, expected %v got %v", len(activeContacts), len(rcInactive.Contracts)))
+		if len(activeContracts) != len(rcInactive.Contracts) {
+			return errors.New(fmt.Sprintf("Didn't get expected number of inactive contracts, expected %v got %v", len(activeContracts), len(rcInactive.Contracts)))
 		}
 		for _, c := range rcInactive.Contracts {
 			if _, ok := activeContractIDMap[c.ID]; !ok {

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -633,7 +633,7 @@ func TestRenewFailing(t *testing.T) {
 	renter := tg.Renters()[0]
 
 	// All the contracts of the renter should be goodForRenew.
-	rcg, err := renter.RenterContractsGet()
+	rcg, err := renter.RenterContractsGet(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -687,7 +687,7 @@ func TestRenewFailing(t *testing.T) {
 	}
 
 	// contracts should still be goodForRenew.
-	rcg, err = renter.RenterContractsGet()
+	rcg, err = renter.RenterContractsGet(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -710,7 +710,7 @@ func TestRenewFailing(t *testing.T) {
 	replaced := false
 	err = build.Retry(int(rcg.Contracts[0].EndHeight-blockHeight), 5*time.Second, func() error {
 		// contract should be !goodForRenew now.
-		rcg, err = renter.RenterContractsGet()
+		rcg, err = renter.RenterContractsGet(false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -931,15 +931,9 @@ func TestRenterContractEndHeight(t *testing.T) {
 	renewWindow := rg.Settings.Allowance.RenewWindow
 	numRenewals := 0
 
-	// Get contracts
-	rc, err := r.RenterContractsGet()
-	if err != nil {
-		t.Fatal("Could not get renter contracts:", err)
-	}
-
 	// Confirm Contracts were created as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet()
+		rc, err := r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
@@ -950,6 +944,11 @@ func TestRenterContractEndHeight(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	rc, err := r.RenterContractsGet(true)
+	if err != nil {
+		t.Fatal(err, "could not get contracts")
 	}
 
 	// Confirm contract end heights were set properly
@@ -971,7 +970,7 @@ func TestRenterContractEndHeight(t *testing.T) {
 	// Confirm Contracts were renewed as expected, all original
 	// contracts should have been renewed if GoodForRenew = true
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet()
+		rc, err = r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
@@ -991,7 +990,7 @@ func TestRenterContractEndHeight(t *testing.T) {
 	// End height should be the end of the next period as
 	// the contracts are renewed due to reaching the renew
 	// window
-	rc, err = r.RenterContractsGet()
+	rc, err = r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal("Could not get renter contracts:", err)
 	}
@@ -1017,7 +1016,7 @@ func TestRenterContractEndHeight(t *testing.T) {
 	// Confirm contract end heights were set properly
 	// End height should not have changed since the renewal
 	// was due to running out of funds
-	rc, err = r.RenterContractsGet()
+	rc, err = r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal("Could not get renter contracts:", err)
 	}
@@ -1093,7 +1092,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were created as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := r.RenterContractsGet()
+		rc, err := r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
@@ -1139,7 +1138,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Get initial Contracts to check for contract renewal later
-	rc, err := r.RenterContractsGet()
+	rc, err := r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
@@ -1165,7 +1164,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet()
+		rc, err = r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
@@ -1193,7 +1192,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet()
+	rc, err = r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
@@ -1254,7 +1253,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet()
+		rc, err = r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "Could not get contracts")
 		}
@@ -1281,7 +1280,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet()
+	rc, err = r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
@@ -1321,7 +1320,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet()
+		rc, err = r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "Could not get contracts")
 		}
@@ -1348,7 +1347,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet()
+	rc, err = r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
@@ -1378,7 +1377,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 
 	// Confirm Contracts were renewed as expected
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet()
+		rc, err = r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}
@@ -1405,7 +1404,7 @@ func TestRenterSpendingReporting(t *testing.T) {
 	}
 
 	// Check contract spending against reported spending
-	rc, err = r.RenterContractsGet()
+	rc, err = r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal("Could not get contracts:", err)
 	}
@@ -1723,7 +1722,7 @@ func renewContractsBySpending(renter *siatest.TestNode, tg *siatest.TestGroup) (
 	}
 
 	// Get current upload spend, previously contracts had zero upload spend
-	rc, err := renter.RenterContractsGet()
+	rc, err := renter.RenterContractsGet(true)
 	if err != nil {
 		return types.ZeroCurrency, errors.AddContext(err, "could not get renter contracts")
 	}
@@ -1745,7 +1744,7 @@ LOOP:
 			return types.ZeroCurrency, errors.AddContext(err, "failed to upload a file for testing")
 		}
 
-		rc, err = renter.RenterContractsGet()
+		rc, err = renter.RenterContractsGet(true)
 		if err != nil {
 			return types.ZeroCurrency, errors.AddContext(err, "could not get contracts")
 		}
@@ -1899,7 +1898,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 	// Give it some time to mark the contracts as !goodForUpload and
 	// !goodForRenew.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet()
+		rc, err := renter.RenterContractsGet(false)
 		if err != nil {
 			return err
 		}
@@ -1965,7 +1964,7 @@ func TestRenterCancelAllowance(t *testing.T) {
 
 	// All contracts should be archived.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet()
+		rc, err := renter.RenterContractsGet(false)
 		if err != nil {
 			return err
 		}
@@ -2033,7 +2032,7 @@ func TestRenterResetAllowance(t *testing.T) {
 	// Give it some time to mark the contracts as !goodForUpload and
 	// !goodForRenew.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet()
+		rc, err := renter.RenterContractsGet(false)
 		if err != nil {
 			return err
 		}
@@ -2068,7 +2067,7 @@ func TestRenterResetAllowance(t *testing.T) {
 	// Give it some time to mark the contracts as goodForUpload and
 	// goodForRenew again.
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err := renter.RenterContractsGet()
+		rc, err := renter.RenterContractsGet(false)
 		if err != nil {
 			return err
 		}
@@ -2116,7 +2115,7 @@ func TestRenterExpiredContracts(t *testing.T) {
 
 	// Get renter and current contracts
 	r := tg.Renters()[0]
-	rc, err := r.RenterContractsGet()
+	rc, err := r.RenterContractsGet(true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2142,7 +2141,7 @@ func TestRenterExpiredContracts(t *testing.T) {
 	// Confirm Contracts were renewed as expected, all original
 	// contracts should have been renewed if GoodForRenew = true
 	err = build.Retry(600, 100*time.Millisecond, func() error {
-		rc, err = r.RenterContractsGet()
+		rc, err = r.RenterContractsGet(true)
 		if err != nil {
 			return errors.AddContext(err, "could not get contracts")
 		}

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -375,12 +375,12 @@ func waitForContracts(miner *TestNode, renters map[*TestNode]struct{}, hosts map
 			numRetries++
 			contracts := uint64(0)
 			// Get the renter's contracts.
-			rc, err := renter.RenterActiveContractsGet()
+			rc, err := renter.RenterContractsGet()
 			if err != nil {
 				return err
 			}
 			// Count number of contracts
-			for _, c := range rc.Contracts {
+			for _, c := range rc.ActiveContracts {
 				if _, exists := hostMap[string(c.HostPublicKey.Key)]; exists {
 					contracts++
 				}

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -375,7 +375,7 @@ func waitForContracts(miner *TestNode, renters map[*TestNode]struct{}, hosts map
 			numRetries++
 			contracts := uint64(0)
 			// Get the renter's contracts.
-			rc, err := renter.RenterContractsGet(false)
+			rc, err := renter.RenterActiveContractsGet()
 			if err != nil {
 				return err
 			}

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -406,7 +406,7 @@ func waitForContracts(miner *TestNode, renters map[*TestNode]struct{}, hosts map
 }
 
 // AddNodeN adds n nodes of a given template to the group.
-func (tg *TestGroup) AddNodeN(np node.NodeParams, n int) error {
+func (tg *TestGroup) AddNodeN(np node.NodeParams, n int) ([]*TestNode, error) {
 	nps := make([]node.NodeParams, n)
 	for i := 0; i < n; i++ {
 		nps[i] = np
@@ -415,7 +415,7 @@ func (tg *TestGroup) AddNodeN(np node.NodeParams, n int) error {
 }
 
 // AddNodes creates a node and adds it to the group.
-func (tg *TestGroup) AddNodes(nps ...node.NodeParams) error {
+func (tg *TestGroup) AddNodes(nps ...node.NodeParams) ([]*TestNode, error) {
 	newNodes := make(map[*TestNode]struct{})
 	newHosts := make(map[*TestNode]struct{})
 	newRenters := make(map[*TestNode]struct{})
@@ -426,7 +426,7 @@ func (tg *TestGroup) AddNodes(nps ...node.NodeParams) error {
 		}
 		node, err := NewCleanNode(np)
 		if err != nil {
-			return build.ExtendErr("failed to create host", err)
+			return mapToSlice(newNodes), build.ExtendErr("failed to create host", err)
 		}
 		// Add node to nodes
 		tg.nodes[node] = struct{}{}
@@ -447,7 +447,7 @@ func (tg *TestGroup) AddNodes(nps ...node.NodeParams) error {
 		newNodes[node] = struct{}{}
 	}
 
-	return tg.setupNodes(newHosts, newNodes, newRenters)
+	return mapToSlice(newNodes), tg.setupNodes(newHosts, newNodes, newRenters)
 }
 
 // setupNodes does the set up required for creating a test group

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -375,7 +375,7 @@ func waitForContracts(miner *TestNode, renters map[*TestNode]struct{}, hosts map
 			numRetries++
 			contracts := uint64(0)
 			// Get the renter's contracts.
-			rc, err := renter.RenterContractsGet()
+			rc, err := renter.RenterContractsGet(false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Removed old contracts from Export to avoid breaking backwards compatibility.

Updated releaseblock calculation.

@DavidVorick if there are other edits you find during your review please add TODO's to this PR so we can merge them in.