### PR TITLE
Fix the type of currentperiod in the Renter API document

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -909,7 +909,7 @@ returns the current settings along with metrics on the renter's spending.
     "uploadspending":   "5678", // hastings
     "unspent":          "1234"  // hastings
   },
-  "currentperiod": "200"
+  "currentperiod": 200
 }
 ```
 

--- a/doc/api/Renter.md
+++ b/doc/api/Renter.md
@@ -102,7 +102,7 @@ returns the current settings along with metrics on the renter's spending.
     "unspent": "1234" // hastings
   },
   // Height at which the current allowance period began.
-  "currentperiod": "200"
+  "currentperiod": 200
 }
 ```
 


### PR DESCRIPTION
This commit fixes #3135.