### PR TITLE
Clean up siatest testrenter and improve runtime

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -90,7 +90,7 @@ type NodeParams struct {
 	SkipHostDiscovery bool
 
 	// The high level directory where all the persistence gets stored for the
-	// moudles.
+	// modules.
 	Dir string
 }
 
@@ -107,7 +107,7 @@ type Node struct {
 	Wallet          modules.Wallet
 
 	// The high level directory where all the persistence gets stored for the
-	// moudles.
+	// modules.
 	Dir string
 }
 

--- a/siatest/dependencies.go
+++ b/siatest/dependencies.go
@@ -1,6 +1,7 @@
 package siatest
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -34,9 +35,11 @@ func (d *DependencyInterruptOnceOnKeyword) Disrupt(s string) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.f && s == d.str {
+		fmt.Println("True")
 		d.f = false
 		return true
 	}
+	fmt.Println("False")
 	return false
 }
 

--- a/siatest/dependencies.go
+++ b/siatest/dependencies.go
@@ -1,7 +1,6 @@
 package siatest
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/NebulousLabs/Sia/modules"
@@ -35,11 +34,9 @@ func (d *DependencyInterruptOnceOnKeyword) Disrupt(s string) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.f && s == d.str {
-		fmt.Println("True")
 		d.f = false
 		return true
 	}
-	fmt.Println("False")
 	return false
 }
 

--- a/siatest/renter/dependencies.go
+++ b/siatest/renter/dependencies.go
@@ -42,7 +42,7 @@ func newDependencyInterruptDownloadBeforeSendingRevision() *siatest.DependencyIn
 }
 
 // newDependencyInterruptDownloadAfterSendingRevision creates a new dependency
-// thta interrupts the download on the renter side right after receiving the
+// that interrupts the download on the renter side right after receiving the
 // signed revision from the host.
 func newDependencyInterruptDownloadAfterSendingRevision() *siatest.DependencyInterruptOnceOnKeyword {
 	return siatest.NewDependencyInterruptOnceOnKeyword("InterruptDownloadAfterSendingRevision")
@@ -56,7 +56,7 @@ func newDependencyInterruptUploadBeforeSendingRevision() *siatest.DependencyInte
 }
 
 // newDependencyInterruptUploadAfterSendingRevision creates a new dependency
-// thta interrupts the upload on the renter side right after receiving the
+// that interrupts the upload on the renter side right after receiving the
 // signed revision from the host.
 func newDependencyInterruptUploadAfterSendingRevision() *siatest.DependencyInterruptOnceOnKeyword {
 	return siatest.NewDependencyInterruptOnceOnKeyword("InterruptUploadAfterSendingRevision")

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -447,8 +447,7 @@ func TestRenterInterrupt(t *testing.T) {
 
 	// Create a group for the subtests
 	groupParams := siatest.GroupParams{
-		Hosts: 5,
-		// Renters: 1,
+		Hosts:  5,
 		Miners: 1,
 	}
 	tg, err := siatest.NewGroupFromTemplate(groupParams)
@@ -479,13 +478,6 @@ func TestRenterInterrupt(t *testing.T) {
 	}
 }
 
-// testDownloadInterruptedBeforeSendingRevision runs testDownloadInterrupted
-// with a dependency that interrupts the download before sending the signed
-// revision to the host.
-func testDownloadInterruptedBeforeSendingRevision(t *testing.T, tg *siatest.TestGroup) {
-	testDownloadInterrupted(t, tg, newDependencyInterruptDownloadBeforeSendingRevision())
-}
-
 // testDownloadInterruptedAfterSendingRevision runs testDownloadInterrupted with
 // a dependency that interrupts the download after sending the signed revision
 // to the host.
@@ -493,11 +485,11 @@ func testDownloadInterruptedAfterSendingRevision(t *testing.T, tg *siatest.TestG
 	testDownloadInterrupted(t, tg, newDependencyInterruptDownloadAfterSendingRevision())
 }
 
-// testUploadInterruptedBeforeSendingRevision runs testUploadInterrupted with a
-// dependency that interrupts the upload before sending the signed revision to
-// the host.
-func testUploadInterruptedBeforeSendingRevision(t *testing.T, tg *siatest.TestGroup) {
-	testUploadInterrupted(t, tg, newDependencyInterruptUploadBeforeSendingRevision())
+// testDownloadInterruptedBeforeSendingRevision runs testDownloadInterrupted
+// with a dependency that interrupts the download before sending the signed
+// revision to the host.
+func testDownloadInterruptedBeforeSendingRevision(t *testing.T, tg *siatest.TestGroup) {
+	testDownloadInterrupted(t, tg, newDependencyInterruptDownloadBeforeSendingRevision())
 }
 
 // testUploadInterruptedAfterSendingRevision runs testUploadInterrupted with a
@@ -505,6 +497,13 @@ func testUploadInterruptedBeforeSendingRevision(t *testing.T, tg *siatest.TestGr
 // the host.
 func testUploadInterruptedAfterSendingRevision(t *testing.T, tg *siatest.TestGroup) {
 	testUploadInterrupted(t, tg, newDependencyInterruptUploadAfterSendingRevision())
+}
+
+// testUploadInterruptedBeforeSendingRevision runs testUploadInterrupted with a
+// dependency that interrupts the upload before sending the signed revision to
+// the host.
+func testUploadInterruptedBeforeSendingRevision(t *testing.T, tg *siatest.TestGroup) {
+	testUploadInterrupted(t, tg, newDependencyInterruptUploadBeforeSendingRevision())
 }
 
 // testDownloadInterrupted interrupts a download using the provided dependencies.
@@ -515,7 +514,7 @@ func testDownloadInterrupted(t *testing.T, tg *siatest.TestGroup, deps *siatest.
 		t.Fatal(err)
 	}
 	renterTemplate := node.Renter(testDir + "/renter")
-	renterTemplate.ContractorDeps = deps
+	renterTemplate.ContractSetDeps = deps
 	nodes, err := tg.AddNodes(renterTemplate)
 	if err != nil {
 		t.Fatal(err)
@@ -555,7 +554,6 @@ func testDownloadInterrupted(t *testing.T, tg *siatest.TestGroup, deps *siatest.
 	// Try downloading the file 5 times.
 	for i := 0; i < 5; i++ {
 		if _, err := renter.DownloadByStream(remoteFile); err == nil {
-			fmt.Println(i)
 			t.Fatal("Download shouldn't succeed since it was interrupted")
 		}
 	}
@@ -578,7 +576,7 @@ func testUploadInterrupted(t *testing.T, tg *siatest.TestGroup, deps *siatest.De
 		t.Fatal(err)
 	}
 	renterTemplate := node.Renter(testDir + "/renter")
-	renterTemplate.ContractorDeps = deps
+	renterTemplate.ContractSetDeps = deps
 	nodes, err := tg.AddNodes(renterTemplate)
 	if err != nil {
 		t.Fatal(err)

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -416,7 +416,6 @@ func (tg *TestGroup) AddNodeN(np node.NodeParams, n int) ([]*TestNode, error) {
 
 // AddNodes creates a node and adds it to the group.
 func (tg *TestGroup) AddNodes(nps ...node.NodeParams) ([]*TestNode, error) {
-	nodes := []*TestNode{}
 	newNodes := make(map[*TestNode]struct{})
 	newHosts := make(map[*TestNode]struct{})
 	newRenters := make(map[*TestNode]struct{})
@@ -428,7 +427,7 @@ func (tg *TestGroup) AddNodes(nps ...node.NodeParams) ([]*TestNode, error) {
 		}
 		node, err := NewCleanNode(np)
 		if err != nil {
-			return nodes, build.ExtendErr("failed to create host", err)
+			return mapToSlice(newNodes), build.ExtendErr("failed to create host", err)
 		}
 		// Add node to nodes
 		tg.nodes[node] = struct{}{}
@@ -450,12 +449,7 @@ func (tg *TestGroup) AddNodes(nps ...node.NodeParams) ([]*TestNode, error) {
 		}
 	}
 
-	nodes = append(nodes, mapToSlice(newNodes)...)
-	nodes = append(nodes, mapToSlice(newHosts)...)
-	nodes = append(nodes, mapToSlice(newRenters)...)
-	nodes = append(nodes, mapToSlice(newMiners)...)
-
-	return nodes, tg.setupNodes(newHosts, newNodes, newRenters)
+	return mapToSlice(newNodes), tg.setupNodes(newHosts, newNodes, newRenters)
 }
 
 // setupNodes does the set up required for creating a test group

--- a/siatest/testgroup.go
+++ b/siatest/testgroup.go
@@ -614,3 +614,28 @@ func (tg *TestGroup) Renters() []*TestNode {
 func (tg *TestGroup) Miners() []*TestNode {
 	return mapToSlice(tg.miners)
 }
+
+// FindNewNode finds a newly added node to the test group, this return the first
+// new node found so should be used after adding a single node
+func (tg *TestGroup) FindNewNode(oldNodes, newNodes []*TestNode) (*TestNode, error) {
+	// Check for new nodes
+	if len(newNodes) == 0 {
+		return new(TestNode), errors.New("no nodes to check against")
+	}
+
+	// Check for first node condition
+	if len(oldNodes) == 0 {
+		return newNodes[0], nil
+	}
+
+	old := make(map[*TestNode]struct{})
+	for _, node := range oldNodes {
+		old[node] = struct{}{}
+	}
+	for _, node := range newNodes {
+		if _, exists := old[node]; !exists {
+			return node, nil
+		}
+	}
+	return new(TestNode), errors.New("No new node found")
+}

--- a/siatest/testgroup_test.go
+++ b/siatest/testgroup_test.go
@@ -134,6 +134,9 @@ func TestAddNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(nodes) != 1 {
+		t.Fatalf("More nodes returned than expected; expected 1 got %v", len(nodes))
+	}
 	renter := nodes[0]
 	for _, oldRenter := range oldRenters {
 		if oldRenter.primarySeed == renter.primarySeed {

--- a/siatest/testgroup_test.go
+++ b/siatest/testgroup_test.go
@@ -100,8 +100,8 @@ func TestNewGroupNoRenterHost(t *testing.T) {
 	}()
 }
 
-// TestFindNewNode tests FindNewNode to confirm the correct node is found
-func TestFindNewNode(t *testing.T) {
+// TestAddNewNode tests that the added node is returned when AddNodes is called
+func TestAddNewNode(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -130,16 +130,11 @@ func TestFindNewNode(t *testing.T) {
 		t.Fatal(err)
 	}
 	renterTemplate := node.Renter(testDir + "/renter")
-	if err = tg.AddNodes(renterTemplate); err != nil {
-		t.Fatal(err)
-	}
-
-	// Upload a file that's 1 chunk large.
-	renter, err := tg.FindNewNode(oldRenters, tg.Renters())
+	nodes, err := tg.AddNodes(renterTemplate)
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	renter := nodes[0]
 	for _, oldRenter := range oldRenters {
 		if oldRenter.primarySeed == renter.primarySeed {
 			t.Fatal("Returned renter is not the new renter")


### PR DESCRIPTION
Summary of edits:
`renter_test.go` - reordered tests so that they are cleanly grouped and alphabetized so it is easier to work with.  combined interrupt tests into `TestRenterInterrupt` so that as a group they can be run in parallel to improve the runtime and not error out due to `too many files open`

`testgroup.go` - updated `AddNodes` to return the nodes added.  Needed this in order to combine the interrupt tests.

`testgroup_test.go` - added unit test for `AddNodes` to confirm the node added was returned.