### PR TITLE
Don't aggregate inputs via a parent tx when sending Siacoins

### DIFF
--- a/modules/wallet.go
+++ b/modules/wallet.go
@@ -115,6 +115,13 @@ type (
 	//
 	// Transaction builders are not thread safe.
 	TransactionBuilder interface {
+		// FundSiacoinForOutputs will aggregate enough inputs to cover the
+		// total value of the outputs and the miner fee if any. A refund
+		// output will be generated if necessary. All the outputs will be
+		// added to the transaction being built along with a miner fee if
+		// one is passed. The transaction will not be signed.
+		FundSiacoinsForOutputs(outputs []types.SiacoinOutput, fee types.Currency) error
+
 		// FundSiacoins will add a siacoin input of exactly 'amount' to the
 		// transaction. A parent transaction may be needed to achieve an input
 		// with the correct value. The siacoin input will not be signed until

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -195,24 +195,10 @@ func (w *Wallet) SendSiacoinsMulti(outputs []types.SiacoinOutput) (txns []types.
 	_, tpoolFee := w.tpool.FeeEstimation()
 	tpoolFee = tpoolFee.Mul64(2)                              // We don't want send-to-many transactions to fail.
 	tpoolFee = tpoolFee.Mul64(1000 + 60*uint64(len(outputs))) // Estimated transaction size in bytes
-	txnBuilder.AddMinerFee(tpoolFee)
 
-	// Calculate total cost to wallet.
-	//
-	// NOTE: we only want to call FundSiacoins once; that way, it will
-	// (ideally) fund the entire transaction with a single input, instead of
-	// many smaller ones.
-	totalCost := tpoolFee
-	for _, sco := range outputs {
-		totalCost = totalCost.Add(sco.Value)
-	}
-	err = txnBuilder.FundSiacoins(totalCost)
+	err = txnBuilder.FundSiacoinsForOutputs(outputs, tpoolFee)
 	if err != nil {
 		return nil, build.ExtendErr("unable to fund transaction", err)
-	}
-
-	for _, sco := range outputs {
-		txnBuilder.AddSiacoinOutput(sco)
 	}
 
 	txnSet, err := txnBuilder.Sign(true)

--- a/modules/wallet/money.go
+++ b/modules/wallet/money.go
@@ -138,13 +138,11 @@ func (w *Wallet) SendSiacoins(amount types.Currency, dest types.UnlockHash) (txn
 			txnBuilder.Drop()
 		}
 	}()
-	err = txnBuilder.FundSiacoins(amount.Add(tpoolFee))
+	err = txnBuilder.FundSiacoinsForOutputs([]types.SiacoinOutput{output}, tpoolFee)
 	if err != nil {
 		w.log.Println("Attempt to send coins has failed - failed to fund transaction:", err)
 		return nil, build.ExtendErr("unable to fund transaction", err)
 	}
-	txnBuilder.AddMinerFee(tpoolFee)
-	txnBuilder.AddSiacoinOutput(output)
 	txnSet, err := txnBuilder.Sign(true)
 	if err != nil {
 		w.log.Println("Attempt to send coins has failed - failed to sign transaction:", err)

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -112,6 +112,136 @@ func (w *Wallet) checkOutput(tx *bolt.Tx, currentHeight types.BlockHeight, id ty
 	return nil
 }
 
+// FundSiacoinsForOutputs will add enough inputs to cover the outputs to be
+// sent in the transaction. In contrast to FundSiacoins, FundSiacoinsForOutputs
+// does not aggregate inputs into one output equaling 'amount' - with a refund,
+// potentially - for later use by an output or other transaction fee. Rather,
+// it aggregates enough inputs to cover the outputs, adds the inputs and outputs
+// to the transaction, and also generates a refund output if necessary. A miner
+// fee of 0 or greater is also taken into account in the input aggregation and
+// added to the transaction if necessary.
+func (tb *transactionBuilder) FundSiacoinsForOutputs(outputs []types.SiacoinOutput, fee types.Currency) error {
+	// dustThreshold has to be obtained separate from the lock
+	dustThreshold, err := tb.wallet.DustThreshold()
+	if err != nil {
+		return err
+	}
+
+	tb.wallet.mu.Lock()
+	defer tb.wallet.mu.Unlock()
+
+	consensusHeight, err := dbGetConsensusHeight(tb.wallet.dbTx)
+	if err != nil {
+		return err
+	}
+
+	// Calculate the total amount we need to send
+	var amount types.Currency
+	for i := range outputs {
+		output := outputs[i]
+		amount = amount.Add(output.Value)
+	}
+
+	// Add a miner fee if the passed fee was greater than 0. The fee also
+	// needs to be added to the input amount we need to aggregate.
+	if fee.Cmp64(0) > 0 {
+		tb.transaction.MinerFees = append(tb.transaction.MinerFees, fee)
+		amount = amount.Add(fee)
+	}
+
+	// Collect a value-sorted set of siacoin outputs.
+	var so sortedOutputs
+	err = dbForEachSiacoinOutput(tb.wallet.dbTx, func(scoid types.SiacoinOutputID, sco types.SiacoinOutput) {
+		so.ids = append(so.ids, scoid)
+		so.outputs = append(so.outputs, sco)
+	})
+	if err != nil {
+		return err
+	}
+	// Add all of the unconfirmed outputs as well.
+	for _, upt := range tb.wallet.unconfirmedProcessedTransactions {
+		for i, sco := range upt.Transaction.SiacoinOutputs {
+			// Determine if the output belongs to the wallet.
+			_, exists := tb.wallet.keys[sco.UnlockHash]
+			if !exists {
+				continue
+			}
+			so.ids = append(so.ids, upt.Transaction.SiacoinOutputID(uint64(i)))
+			so.outputs = append(so.outputs, sco)
+		}
+	}
+	sort.Sort(sort.Reverse(so))
+
+	var fund types.Currency
+	// potentialFund tracks the balance of the wallet including outputs that
+	// have been spent in other unconfirmed transactions recently. This is to
+	// provide the user with a more useful error message in the event that they
+	// are overspending.
+	var potentialFund types.Currency
+	var spentScoids []types.SiacoinOutputID
+	for i := range so.ids {
+		scoid := so.ids[i]
+		sco := so.outputs[i]
+		// Check that the output can be spent.
+		if err := tb.wallet.checkOutput(tb.wallet.dbTx, consensusHeight, scoid, sco, dustThreshold); err != nil {
+			if err == errSpendHeightTooHigh {
+				potentialFund = potentialFund.Add(sco.Value)
+			}
+			continue
+		}
+
+		// Add a siacoin input for this output.
+		sci := types.SiacoinInput{
+			ParentID:         scoid,
+			UnlockConditions: tb.wallet.keys[sco.UnlockHash].UnlockConditions,
+		}
+		tb.transaction.SiacoinInputs = append(tb.transaction.SiacoinInputs, sci)
+		tb.siacoinInputs = append(tb.siacoinInputs, len(tb.transaction.SiacoinInputs))
+		spentScoids = append(spentScoids, scoid)
+
+		// Add the output to the total fund
+		fund = fund.Add(sco.Value)
+		potentialFund = potentialFund.Add(sco.Value)
+		if fund.Cmp(amount) >= 0 {
+			break
+		}
+	}
+	if potentialFund.Cmp(amount) >= 0 && fund.Cmp(amount) < 0 {
+		return modules.ErrIncompleteTransactions
+	}
+	if fund.Cmp(amount) < 0 {
+		return modules.ErrLowBalance
+	}
+
+	// Add the outputs to the transaction
+	for i := range outputs {
+		output := outputs[i]
+		tb.transaction.SiacoinOutputs = append(tb.transaction.SiacoinOutputs, output)
+	}
+
+	// Create a refund output if needed.
+	if !amount.Equals(fund) {
+		refundUnlockConditions, err := tb.wallet.nextPrimarySeedAddress(tb.wallet.dbTx)
+		if err != nil {
+			return err
+		}
+		refundOutput := types.SiacoinOutput{
+			Value:      fund.Sub(amount),
+			UnlockHash: refundUnlockConditions.UnlockHash(),
+		}
+		tb.transaction.SiacoinOutputs = append(tb.transaction.SiacoinOutputs, refundOutput)
+	}
+
+	// Mark all outputs that were spent as spent.
+	for _, scoid := range spentScoids {
+		err = dbPutSpentOutput(tb.wallet.dbTx, types.OutputID(scoid), consensusHeight)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // FundSiacoins will add a siacoin input of exactly 'amount' to the
 // transaction. A parent transaction may be needed to achieve an input with the
 // correct value. The siacoin input will not be signed until 'Sign' is called

--- a/modules/wallet/transactionbuilder.go
+++ b/modules/wallet/transactionbuilder.go
@@ -195,8 +195,8 @@ func (tb *transactionBuilder) FundSiacoinsForOutputs(outputs []types.SiacoinOutp
 			ParentID:         scoid,
 			UnlockConditions: tb.wallet.keys[sco.UnlockHash].UnlockConditions,
 		}
-		tb.transaction.SiacoinInputs = append(tb.transaction.SiacoinInputs, sci)
 		tb.siacoinInputs = append(tb.siacoinInputs, len(tb.transaction.SiacoinInputs))
+		tb.transaction.SiacoinInputs = append(tb.transaction.SiacoinInputs, sci)
 		spentScoids = append(spentScoids, scoid)
 
 		// Add the output to the total fund

--- a/modules/wallet/transactionbuilder_test.go
+++ b/modules/wallet/transactionbuilder_test.go
@@ -562,3 +562,70 @@ func TestUnconfirmedParents(t *testing.T) {
 		}
 	}
 }
+
+func TestFundSiacoinsForOutputs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	wt, err := createWalletTester(t.Name(), &modules.ProductionDependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wt.closeWt()
+
+	b, err := wt.wallet.StartTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uc1, err := wt.wallet.NextAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uc2, err := wt.wallet.NextAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	amount1 := types.NewCurrency64(1000)
+	amount2 := types.NewCurrency64(2000)
+	output1 := types.SiacoinOutput{
+		Value:      amount1,
+		UnlockHash: uc1.UnlockHash(),
+	}
+	output2 := types.SiacoinOutput{
+		Value:      amount2,
+		UnlockHash: uc2.UnlockHash(),
+	}
+	minerFee := types.NewCurrency64(750)
+
+	// Wallet starts off with large inputs from mining blocks, larger than our
+	// combined outputs and miner fees
+	err = b.FundSiacoinsForOutputs([]types.SiacoinOutput{output1, output2}, minerFee)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unfinishedTxn, _ := b.View()
+
+	// Here we should have 3 outputs, the two specified plus a refund
+	if len(unfinishedTxn.SiacoinOutputs) != 3 {
+		t.Fatal("incorrect number of outputs generated")
+	}
+	if len(unfinishedTxn.MinerFees) != 1 {
+		t.Fatal("miner fees were not generated but should have been")
+	}
+	if unfinishedTxn.MinerFees[0].Cmp(minerFee) != 0 {
+		t.Fatal("miner fees were not generated but should have been")
+	}
+
+	// General construction seems ok, let's sign and submit it to the tpool
+	txSet, err := b.Sign(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// If the tpool accepts it, everything looks good
+	err = wt.tpool.AcceptTransactionSet(txSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Currently the wallet module builds 2 transactions each time a user wants to send Siacoins. It does this via the `FundSiacoins` function. The first transaction aggregates all inputs into an output equalling the desired amount to be sent (and potentially a refund). The second transaction spends the desired amount output from the first transaction and creates an output to the actual desired recipient.

To the best of my knowledge, `FundSiacoins` is built this way to conveniently support transactions without outputs. In the frequent case where someone just wants to send Siacoins elsewhere, `SendSiacoins` and `SendSiacoinsMulti` in their current form seem to create twice as many transactions as necessary. This unnecessarily bloats the blockchain and can slow down the 2nd party's receipt of the Siacoins.

This PR creates a specialized function `FundSiacoinsForOutputs` to be used in the special case of a transaction that just sends Siacoins to an output or a set of outputs. `FundSiacoinsForOutputs` eliminates the double transaction issue.

Please let me know if I've missed an intentional design reason for the way the old code worked!