### PR TITLE
Eliminate nonsense logic during contract negotation

### DIFF
--- a/modules/host/negotiateformcontract.go
+++ b/modules/host/negotiateformcontract.go
@@ -29,11 +29,11 @@ func contractCollateral(settings modules.HostExternalSettings, fc types.FileCont
 }
 
 // managedAddCollateral adds the host's collateral to the file contract
-// transaction set, returning the new inputs and outputs that get added to the
+// transaction set, returning the new inputs that get added to the
 // transaction, as well as any new parents that get added to the transaction
 // set. The builder that is used to add the collateral is also returned,
 // because the new transaction has not yet been signed.
-func (h *Host) managedAddCollateral(settings modules.HostExternalSettings, txnSet []types.Transaction) (builder modules.TransactionBuilder, newParents []types.Transaction, newInputs []types.SiacoinInput, newOutputs []types.SiacoinOutput, err error) {
+func (h *Host) managedAddCollateral(settings modules.HostExternalSettings, txnSet []types.Transaction) (builder modules.TransactionBuilder, newParents []types.Transaction, newInputs []types.SiacoinInput, err error) {
 	txn := txnSet[len(txnSet)-1]
 	parents := txnSet[:len(txnSet)-1]
 	fc := txn.FileContracts[0]
@@ -45,11 +45,11 @@ func (h *Host) managedAddCollateral(settings modules.HostExternalSettings, txnSe
 	err = builder.FundSiacoins(hostPortion)
 	if err != nil {
 		builder.Drop()
-		return nil, nil, nil, nil, extendErr("could not add collateral: ", ErrorInternal(err.Error()))
+		return nil, nil, nil, extendErr("could not add collateral: ", ErrorInternal(err.Error()))
 	}
 
 	// Return which inputs and outputs have been added by the collateral call.
-	newParentIndices, newInputIndices, newOutputIndices, _ := builder.ViewAdded()
+	newParentIndices, newInputIndices, _, _ := builder.ViewAdded()
 	updatedTxn, updatedParents := builder.View()
 	for _, parentIndex := range newParentIndices {
 		newParents = append(newParents, updatedParents[parentIndex])
@@ -57,10 +57,7 @@ func (h *Host) managedAddCollateral(settings modules.HostExternalSettings, txnSe
 	for _, inputIndex := range newInputIndices {
 		newInputs = append(newInputs, updatedTxn.SiacoinInputs[inputIndex])
 	}
-	for _, outputIndex := range newOutputIndices {
-		newOutputs = append(newOutputs, updatedTxn.SiacoinOutputs[outputIndex])
-	}
-	return builder, newParents, newInputs, newOutputs, nil
+	return builder, newParents, newInputs, nil
 }
 
 // managedRPCFormContract accepts a file contract from a renter, checks the
@@ -119,13 +116,13 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 		return extendErr("contract verification failed: ", err)
 	}
 	// The host adds collateral to the transaction.
-	txnBuilder, newParents, newInputs, newOutputs, err := h.managedAddCollateral(settings, txnSet)
+	txnBuilder, newParents, newInputs, err := h.managedAddCollateral(settings, txnSet)
 	if err != nil {
 		modules.WriteNegotiationRejection(conn, err) // Error ignored to preserve type in extendErr
 		return extendErr("failed to add collateral: ", err)
 	}
 	// The host indicates acceptance, and then sends any new parent
-	// transactions, inputs and outputs that were added to the transaction.
+	// transactions and inputs that were added to the transaction.
 	err = modules.WriteNegotiationAcceptance(conn)
 	if err != nil {
 		return extendErr("accepting verified contract failed: ", ErrorConnection(err.Error()))
@@ -137,10 +134,6 @@ func (h *Host) managedRPCFormContract(conn net.Conn) error {
 	err = encoding.WriteObject(conn, newInputs)
 	if err != nil {
 		return extendErr("failed to write new inputs: ", ErrorConnection(err.Error()))
-	}
-	err = encoding.WriteObject(conn, newOutputs)
-	if err != nil {
-		return extendErr("failed to write new outputs: ", ErrorConnection(err.Error()))
 	}
 
 	// The renter will now send a negotiation response, followed by transaction

--- a/modules/renter/proto/formcontract.go
+++ b/modules/renter/proto/formcontract.go
@@ -163,24 +163,17 @@ func (cs *ContractSet) FormContract(params ContractParams, txnBuilder transactio
 	// were added to the transaction.
 	var newParents []types.Transaction
 	var newInputs []types.SiacoinInput
-	var newOutputs []types.SiacoinOutput
 	if err = encoding.ReadObject(conn, &newParents, types.BlockSizeLimit); err != nil {
 		return modules.RenterContract{}, errors.New("couldn't read the host's added parents: " + err.Error())
 	}
 	if err = encoding.ReadObject(conn, &newInputs, types.BlockSizeLimit); err != nil {
 		return modules.RenterContract{}, errors.New("couldn't read the host's added inputs: " + err.Error())
 	}
-	if err = encoding.ReadObject(conn, &newOutputs, types.BlockSizeLimit); err != nil {
-		return modules.RenterContract{}, errors.New("couldn't read the host's added outputs: " + err.Error())
-	}
 
 	// Merge txnAdditions with txnSet.
 	txnBuilder.AddParents(newParents)
 	for _, input := range newInputs {
 		txnBuilder.AddSiacoinInput(input)
-	}
-	for _, output := range newOutputs {
-		txnBuilder.AddSiacoinOutput(output)
 	}
 
 	// Sign the txn.


### PR DESCRIPTION
This one left me scratching my head for a couple days.

The 3rd field returned by `TransactionBuilder.ViewAdded()` is a slice of SiafundInput indices.

When the host sets up the collateral transaction, the code was taking this (empty) list of SiafundInputs indices and treating them as SiacoinOutput indices. The host was then gathering up an empty slice of SiacoinOutputs based on these indices and sending it back to the renter, which was trying to put them into the final transaction to be submitted to the blockchain with the FileContract. 

None of it really makes any sense to me, as there shouldn't be any SiacoinOutputs in that FileContract transaction.

The code was harmless in execution but it should be eliminated from the codebase because it is very confusing.