### PR TITLE
Update initial current period to be set in the past when allowance is created

### DIFF
--- a/modules/renter/contractor/allowance.go
+++ b/modules/renter/contractor/allowance.go
@@ -65,7 +65,7 @@ func (c *Contractor) SetAllowance(a modules.Allowance) error {
 	// set the current period to the blockheight if the existing allowance is
 	// empty
 	if reflect.DeepEqual(c.allowance, modules.Allowance{}) {
-		c.currentPeriod = c.blockHeight
+		c.currentPeriod = c.blockHeight - a.RenewWindow
 	}
 	c.allowance = a
 	err := c.saveSync()

--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -25,7 +25,7 @@ var (
 // contractEndHeight returns the height at which the Contractor's contracts
 // end. If there are no contracts, it returns zero.
 func (c *Contractor) contractEndHeight() types.BlockHeight {
-	return c.currentPeriod + c.allowance.Period
+	return c.currentPeriod + c.allowance.Period + c.allowance.RenewWindow
 }
 
 // managedContractUtility returns the ContractUtility for a contract with a given id.
@@ -346,14 +346,13 @@ func (c *Contractor) threadedContractMaintenance() {
 	var renewSet []renewal
 
 	c.mu.RLock()
-	currentPeriod := c.currentPeriod
 	allowance := c.allowance
 	blockHeight := c.blockHeight
 	c.mu.RUnlock()
 
 	// Grab the end height that should be used for the contracts created
 	// in the current period.
-	endHeight = currentPeriod + allowance.Period
+	endHeight = c.contractEndHeight()
 
 	// Determine how many funds have been used already in this billing
 	// cycle, and how many funds are remaining. We have to calculate these
@@ -562,7 +561,7 @@ func (c *Contractor) threadedContractMaintenance() {
 			}
 
 			// Calculate endHeight for renewed contracts
-			endHeight = currentPeriod + allowance.Period
+			endHeight = c.contractEndHeight()
 
 			// Perform the actual renew. If the renew fails, return the
 			// contract. If the renew fails we check how often it has failed

--- a/modules/renter/contractor/update.go
+++ b/modules/renter/contractor/update.go
@@ -56,12 +56,8 @@ func (c *Contractor) ProcessConsensusChange(cc modules.ConsensusChange) {
 	}
 
 	// If we have entered the next period, update currentPeriod
-	// NOTE: "period" refers to the duration of contracts, whereas "cycle"
-	// refers to how frequently the period metrics are reset.
-	// TODO: How to make this more explicit.
-	cycleLen := c.allowance.Period - c.allowance.RenewWindow
-	if c.blockHeight >= c.currentPeriod+cycleLen {
-		c.currentPeriod += cycleLen
+	if c.blockHeight >= c.currentPeriod+c.allowance.Period {
+		c.currentPeriod += c.allowance.Period
 		// COMPATv1.0.4-lts
 		// if we were storing a special metrics contract, it will be invalid
 		// after we enter the next period.

--- a/modules/renter/contractor/update_test.go
+++ b/modules/renter/contractor/update_test.go
@@ -79,7 +79,7 @@ func TestIntegrationAutoRenew(t *testing.T) {
 
 	// check renewed contract
 	contract = c.Contracts()[0]
-	endHeight := c.CurrentPeriod() + c.allowance.Period
+	endHeight := c.contractEndHeight()
 	if contract.EndHeight != endHeight {
 		t.Fatalf("Wrong end height, expected %v got %v\n", endHeight, contract.EndHeight)
 	}
@@ -147,7 +147,7 @@ func TestIntegrationRenewInvalidate(t *testing.T) {
 
 	// check renewed contract
 	contract = c.Contracts()[0]
-	endHeight := c.CurrentPeriod() + c.allowance.Period
+	endHeight := c.contractEndHeight()
 	c.mu.Lock()
 	if contract.EndHeight != endHeight {
 		t.Fatalf("Wrong end height, expected %v got %v\n", endHeight, contract.EndHeight)

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -452,7 +452,9 @@ func testSingleFileGet(t *testing.T, tg *siatest.TestGroup) {
 		if err != nil {
 			t.Fatal("Failed to request single file", err)
 		}
-		if file != f {
+		if !reflect.DeepEqual(f, file) {
+			t.Log(f)
+			t.Log(file)
 			t.Fatal("Single file queries does not match file previously requested.")
 		}
 	}
@@ -1225,6 +1227,19 @@ func TestRenterContractEndHeight(t *testing.T) {
 	renewWindow := rg.Settings.Allowance.RenewWindow
 	numRenewals := 0
 
+	// Check if the current period was set in the past
+	cg, err := r.ConsensusGet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currentPeriodStart > cg.Height-renewWindow {
+		t.Fatalf(`Current period not set in the past as expected.
+		CP: %v
+		BH: %v
+		RW: %v
+		`, currentPeriodStart, cg.Height, renewWindow)
+	}
+
 	// Get contracts
 	rc, err := r.RenterContractsGet()
 	if err != nil {
@@ -1248,11 +1263,12 @@ func TestRenterContractEndHeight(t *testing.T) {
 
 	// Confirm contract end heights were set properly
 	for _, c := range rc.Contracts {
-		if c.EndHeight != currentPeriodStart+period {
+		if c.EndHeight != currentPeriodStart+period+renewWindow {
 			t.Log("Endheight:", c.EndHeight)
 			t.Log("Allowance Period:", period)
+			t.Log("Renew Window:", renewWindow)
 			t.Log("Current Period:", currentPeriodStart)
-			t.Fatal("Contract endheight not set to Current period + Allowance Period")
+			t.Fatal("Contract endheight not set to Current period + Allowance Period + Renew Window")
 		}
 	}
 
@@ -1290,12 +1306,12 @@ func TestRenterContractEndHeight(t *testing.T) {
 		t.Fatal("Could not get renter contracts:", err)
 	}
 	for _, c := range rc.Contracts {
-		if c.EndHeight != currentPeriodStart+(2*period)-renewWindow && c.GoodForRenew {
+		if c.EndHeight != currentPeriodStart+(2*period)+renewWindow && c.GoodForRenew {
 			t.Log("Endheight:", c.EndHeight)
 			t.Log("Allowance Period:", period)
 			t.Log("Renew Window:", renewWindow)
 			t.Log("Current Period:", currentPeriodStart)
-			t.Fatal("Contract endheight not set to Current period + 2 * Allowance Period - Renew Window")
+			t.Fatal("Contract endheight not set to Current period + 2 * Allowance Period + Renew Window")
 		}
 	}
 


### PR DESCRIPTION
`TestRenterSpendingReporting` is failing in the siatest package, but I want #3131 to be merged so I can rebase before debugging.

This resolves #3117 