### PR TITLE
Contract maintenance

### DIFF
--- a/modules/renter.go
+++ b/modules/renter.go
@@ -24,6 +24,13 @@ const (
 	// RenterDir is the name of the directory that is used to store the
 	// renter's persistent data.
 	RenterDir = "renter"
+
+	// EstimatedFileContractTransactionSetSize is the estimated blockchain size
+	// of a transaction set between a renter and a host that contains a file
+	// contract. This transaction set will contain a setup transaction from each
+	// the host and the renter, and will also contain a file contract and file
+	// contract revision that have each been signed by all parties.
+	EstimatedFileContractTransactionSetSize = 2048
 )
 
 // An ErasureCoder is an error-correcting encoder and decoder.

--- a/modules/renter/contractor/consts.go
+++ b/modules/renter/contractor/consts.go
@@ -35,8 +35,16 @@ var (
 var (
 	maxCollateral    = types.SiacoinPrecision.Mul64(1e3) // 1k SC
 	maxDownloadPrice = maxStoragePrice.Mul64(3 * 4320)
-	maxStoragePrice  = types.SiacoinPrecision.Mul64(30e3).Div(modules.BlockBytesPerMonthTerabyte) // 30k SC / TB / Month
-	maxUploadPrice   = maxStoragePrice.Mul64(3 * 4320)                                            // 3 months of storage
+	maxStoragePrice  = build.Select(build.Var{
+		Dev:      types.SiacoinPrecision.Mul64(30e4).Div(modules.BlockBytesPerMonthTerabyte), // 1 order of magnitude greater
+		Standard: types.SiacoinPrecision.Mul64(30e3).Div(modules.BlockBytesPerMonthTerabyte), // 30k SC / TB / Month
+		Testing:  types.SiacoinPrecision.Mul64(30e5).Div(modules.BlockBytesPerMonthTerabyte), // 2 orders of magnitude greater
+	}).(types.Currency)
+	maxUploadPrice = build.Select(build.Var{
+		Dev:      maxStoragePrice.Mul64(30 * 4320),  // 1 order of magnitude greater
+		Standard: maxStoragePrice.Mul64(3 * 4320),   // 3 months of storage
+		Testing:  maxStoragePrice.Mul64(300 * 4320), // 2 orders of magnitude greater
+	}).(types.Currency)
 
 	// scoreLeeway defines the factor by which a host can miss the goal score
 	// for a set of hosts. To determine the goal score, a new set of hosts is

--- a/modules/renter/contractor/consts.go
+++ b/modules/renter/contractor/consts.go
@@ -8,6 +8,22 @@ import (
 
 // Constants related to contract formation parameters.
 var (
+	// consecutiveRenewalsBeforeReplacement is the number of times a contract
+	// attempt to be renewed before it is marked as !goodForRenew.
+	consecutiveRenewalsBeforeReplacement = build.Select(build.Var{
+		Dev:      types.BlockHeight(12),
+		Standard: types.BlockHeight(12), // ~2h
+		Testing:  types.BlockHeight(12),
+	}).(types.BlockHeight)
+
+	// fileContractMinimumFunding is the lowest percentage of an allowace (on a
+	// per-contract basis) that is allowed to go into funding a contract. If the
+	// allowance is 100 SC per contract (5,000 SC total for 50 contracts, or
+	// 2,000 SC total for 20 contracts, etc.), then the minimum amount of funds
+	// that a contract would be allowed to have is fileContractMinimumFunding *
+	// 100SC.
+	fileContractMinimumFunding = float64(0.15)
+
 	// minContractFundRenewalThreshold defines the ratio of remaining funds to
 	// total contract cost below which the contractor will prematurely renew a
 	// contract.
@@ -20,14 +36,6 @@ var (
 		Standard: 10,
 		Testing:  1,
 	}).(int)
-
-	// consecutiveRenewalsBeforeReplacement is the number of times a contract
-	// attempt to be renewed before it is marked as !goodForRenew.
-	consecutiveRenewalsBeforeReplacement = build.Select(build.Var{
-		Dev:      types.BlockHeight(12),
-		Standard: types.BlockHeight(12), // ~2h
-		Testing:  types.BlockHeight(12),
-	}).(types.BlockHeight)
 )
 
 // Constants related to the safety values for when the contractor is forming

--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -541,8 +541,8 @@ func (c *Contractor) threadedContractMaintenance() {
 		return
 	}
 
-	// Create the renewSet and refreshSet, each a list of contracts that need to
-	// be renewed, paired with the amount of money to use in each renewal.
+	// Create the renewSet and refreshSet. Each is a list of contracts that need
+	// to be renewed, paired with the amount of money to use in each renewal.
 	//
 	// The renewSet is specifically contracts which are being renewed because
 	// they are about to expire. And the refreshSet is contracts that are being

--- a/modules/renter/contractor/contracts.go
+++ b/modules/renter/contractor/contracts.go
@@ -113,8 +113,9 @@ func (c *Contractor) managedEstimateRenewFundingRequirements(contract modules.Re
 	estimatedCost = estimatedCost.Add(estimatedCost.Div64(3))
 
 	// Check for a sane minimum. The contractor should not be forming contracts
-	// with less than 20% / (num contracts) of the value of the allowance.
-	minimum := allowance.Funds.Div64(5).Div64(allowance.Hosts)
+	// with less than 'fileContractMinimumFunding / (num contracts)' of the
+	// value of the allowance.
+	minimum := allowance.Funds.MulFloat(fileContractMinimumFunding).Div64(allowance.Hosts)
 	if estimatedCost.Cmp(minimum) < 0 {
 		estimatedCost = minimum
 	}

--- a/modules/renter/proto/formcontract.go
+++ b/modules/renter/proto/formcontract.go
@@ -11,12 +11,6 @@ import (
 	"github.com/NebulousLabs/errors"
 )
 
-const (
-	// estTxnSize is the estimated size of an encoded file contract
-	// transaction set.
-	estTxnSize = 2048
-)
-
 // FormContract forms a contract with a host and submits the contract
 // transaction to tpool. The contract is added to the ContractSet and its
 // metadata is returned.
@@ -37,7 +31,7 @@ func (cs *ContractSet) FormContract(params ContractParams, txnBuilder transactio
 
 	// Calculate the anticipated transaction fee.
 	_, maxFee := tpool.FeeEstimation()
-	txnFee := maxFee.Mul64(estTxnSize)
+	txnFee := maxFee.Mul64(modules.EstimatedFileContractTransactionSetSize)
 
 	// Underflow check.
 	if funding.Cmp(host.ContractPrice.Add(txnFee)) <= 0 {

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -34,7 +34,7 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 
 	// Calculate the anticipated transaction fee.
 	_, maxFee := tpool.FeeEstimation()
-	txnFee := maxFee.Mul64(estTxnSize)
+	txnFee := maxFee.Mul64(modules.EstimatedFileContractTransactionSetSize)
 
 	// Underflow check.
 	if funding.Cmp(host.ContractPrice.Add(txnFee).Add(basePrice)) <= 0 {

--- a/siatest/renter/renter_test.go
+++ b/siatest/renter/renter_test.go
@@ -2284,8 +2284,8 @@ func renewContractsByRenewWindow(renter *siatest.TestNode, tg *siatest.TestGroup
 func renewContractsBySpending(renter *siatest.TestNode, tg *siatest.TestGroup) (startingUploadSpend types.Currency, err error) {
 	// Renew contracts by running out of funds
 	// Set upload price to max price
-	maxStoragePrice := types.SiacoinPrecision.Mul64(30e3).Div(modules.BlockBytesPerMonthTerabyte) // 30k SC / TB / Month
-	maxUploadPrice := maxStoragePrice.Mul64(3 * 4320)
+	maxStoragePrice := types.SiacoinPrecision.Mul64(30e5).Div(modules.BlockBytesPerMonthTerabyte) // 30k SC / TB / Month
+	maxUploadPrice := maxStoragePrice.Mul64(30 * 4320)
 	hosts := tg.Hosts()
 	for _, h := range hosts {
 		err := h.HostModifySettingPost(client.HostParamMinUploadBandwidthPrice, maxUploadPrice)


### PR DESCRIPTION
The `threadedContractMaintenance` thread was pretty opaque, and had some areas related to funding that were not very understandable, and probably not correct. I refactored the way that the loop checks for funds remaining, and I broke some of the more complex pieces of logic out into their own functions.

I think the tests are passing, though they actually keep timing out on my machine. The siatest renter tests seem to be taking more than 500 seconds, but not because one is deadlocked, rather by the time the later tests are going, the earlier tests have already pushed the timer over 400 seconds.