### PR TITLE
Fix host collateral error when renewing contracts

### DIFF
--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -48,7 +48,8 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 	// Calculate the payouts for the renter, host, and whole contract.
 	renterPayout := funding.Sub(host.ContractPrice).Sub(txnFee).Sub(basePrice) // renter payout is pre-tax
 	maxStorageSize := renterPayout.Div(host.StoragePrice)
-	hostCollateral := maxStorageSize.Mul(host.Collateral).Add(baseCollateral)
+	maxCollateral := maxStorageSize.Mul(host.Collateral) // max collateral the renter can afford with renterPayout
+	hostCollateral := maxCollateral.Add(baseCollateral)
 	if hostCollateral.Cmp(host.MaxCollateral) > 0 {
 		hostCollateral = host.MaxCollateral
 	}

--- a/modules/renter/proto/renew.go
+++ b/modules/renter/proto/renew.go
@@ -28,8 +28,8 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 	var basePrice, baseCollateral types.Currency
 	if endHeight+host.WindowSize > lastRev.NewWindowEnd {
 		timeExtension := uint64((endHeight + host.WindowSize) - lastRev.NewWindowEnd)
-		basePrice = host.StoragePrice.Mul64(lastRev.NewFileSize).Mul64(timeExtension)    // cost of data already covered by contract, i.e. lastrevision.Filesize
-		baseCollateral = host.Collateral.Mul64(lastRev.NewFileSize).Mul64(timeExtension) // same but collateral
+		basePrice = host.StoragePrice.Mul64(lastRev.NewFileSize).Mul64(timeExtension)    // cost of already uploaded data.
+		baseCollateral = host.Collateral.Mul64(lastRev.NewFileSize).Mul64(timeExtension) // collateral for already uploaded data.
 	}
 
 	// Calculate the anticipated transaction fee.
@@ -48,7 +48,7 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 	// Calculate the payouts for the renter, host, and whole contract.
 	renterPayout := funding.Sub(host.ContractPrice).Sub(txnFee).Sub(basePrice) // renter payout is pre-tax
 	maxStorageSize := renterPayout.Div(host.StoragePrice)
-	hostCollateral := maxStorageSize.Mul(host.Collateral)
+	hostCollateral := maxStorageSize.Mul(host.Collateral).Add(baseCollateral)
 	if hostCollateral.Cmp(host.MaxCollateral) > 0 {
 		hostCollateral = host.MaxCollateral
 	}
@@ -60,8 +60,6 @@ func (cs *ContractSet) Renew(oldContract *SafeContract, params ContractParams, t
 	// check for negative currency
 	if types.PostTax(startHeight, totalPayout).Cmp(hostPayout) < 0 {
 		return modules.RenterContract{}, errors.New("insufficient funds to pay both siafund fee and also host payout")
-	} else if hostCollateral.Cmp(baseCollateral) < 0 {
-		return modules.RenterContract{}, errors.New("new collateral smaller than base collateral")
 	}
 
 	// create file contract


### PR DESCRIPTION
I'm not 100% sure if this math makes sense but I'm pretty confident. 
The comments were a bit misleading since it sounded like `basePrice` and `baseCollateral` are already covered by the last contract while they are actually the minimum amount of money that has to be put in the contract to cover the existing data on the host.

In my opinion the `hostCollateral` should also be the possible max collateral + the `baseCollateral`. That way we don't end up with a potential underflow later. It's also a bit more correct since `baseCollateral` is not a subset of the `hostCollateral` but rather the `hostCollateral` is the sum of the `baseCollateral` (collateral for existing data) plus the `maxCollateral` (the maximum additional collateral that will be put into the contract by the host if the renter spends all of the `renterPayout` for storage).